### PR TITLE
Avoid duplicate manifest entries during OMEX export

### DIFF
--- a/vcell-client/src/main/java/org/vcell/util/gui/exporter/OmexExtensionFilter.java
+++ b/vcell-client/src/main/java/org/vcell/util/gui/exporter/OmexExtensionFilter.java
@@ -38,11 +38,11 @@ public class OmexExtensionFilter extends SelectorExtensionFilter {
 			throw new RuntimeException("unsupported Document Type " + Objects.requireNonNull(bioModel).getClass().getName() + " for SedML export");
 		}
 		if (sExt.equals("omex")) {
-			sedmlExporter.createManifest(sPath, sFile);
+			//sedmlExporter.createManifest(sPath, sFile);
 			String sedmlFileName = Paths.get(sPath, sFile + ".sedml").toString();
 			XmlUtil.writeXMLStringToFile(resultString, sedmlFileName, true);
 			sedmlExporter.addSedmlFileToList(sFile + ".sedml");
-			sedmlExporter.addSedmlFileToList("manifest.xml");
+			// sedmlExporter.addSedmlFileToList("manifest.xml");
 			sedmlExporter.createOmexArchive(sPath, sFile);
 			return;
 		}

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -58,10 +58,7 @@ import org.jlibsedml.modelsupport.SUPPORTED_LANGUAGE;
 import org.jmathml.ASTCi;
 import org.jmathml.ASTNode;
 import org.jmathml.MathMLReader;
-import org.sbml.libcombine.CombineArchive;
-import org.sbml.libcombine.KnownFormats;
-import org.sbml.libcombine.OmexDescription;
-import org.sbml.libcombine.VCard;
+import org.sbml.libcombine.*;
 import org.vcell.sbml.SbmlException;
 import org.vcell.sbml.SimSpec;
 import org.vcell.sbml.vcell.SBMLExporter;
@@ -1064,8 +1061,8 @@ public class SEDMLExporter {
 			archive.addFile(
 					Paths.get(srcFolder, sd).toString(),
 					sd, // target file name
-					KnownFormats.lookupFormat("xml")
-//					true // mark file as master
+					KnownFormats.lookupFormat("xml"),
+					true // mark file as master
 			);
     	}
 


### PR DESCRIPTION
Closes #36 
libCombine library adds its own default  manifest file while writing the archive because in our current code the custom generated manifest file is added like a regular SED-ML file(.xml)
So I comment on the code to generate a custom manifest file and tested with the default manifest file and it works fine