### PR TITLE
Replace SBO terms with more specific ones

### DIFF
--- a/biosimulators.json
+++ b/biosimulators.json
@@ -1061,7 +1061,7 @@
       "modelingFrameworks": [
         {
           "namespace": "SBO",
-          "id": "SBO_0000293"
+          "id": "SBO_0000691"
         }
       ],
       "modelFormats": [
@@ -1214,7 +1214,7 @@
       "modelingFrameworks": [
         {
           "namespace": "SBO",
-          "id": "SBO_0000293"
+          "id": "SBO_0000691"
         }
       ],
       "modelFormats": [
@@ -1367,7 +1367,7 @@
       "modelingFrameworks": [
         {
           "namespace": "SBO",
-          "id": "SBO_0000293"
+          "id": "SBO_0000691"
         }
       ],
       "modelFormats": [
@@ -1808,7 +1808,7 @@
       "modelingFrameworks": [
         {
           "namespace": "SBO",
-          "id": "SBO_0000292"
+          "id": "SBO_0000678"
         }
       ],
       "modelFormats": [


### PR DESCRIPTION
Replaced SBO terms for hybrid methods and Smoldyn method with new terms that are more specific
- New term for hybrid stochastic continuous-discrete non-spatial framework
- New term for particle-based discrete spatial simulation

Closes #88