### PR TITLE
Update to biosimulators-utils 0.1.121

### DIFF
--- a/vcell-cli-utils/requirements.txt
+++ b/vcell-cli-utils/requirements.txt
@@ -1,4 +1,4 @@
-biosimulators_utils>=0.1.85
+biosimulators_utils>=0.1.121
 fire
 pyyaml
 pandas


### PR DESCRIPTION
0.1.121 adds validation for NumPy dtypes. 

~~This is going to fail until I push 0.1.121 to PyPI.~~

0.1.121 should be released to PyPI in a few minutes.