### PR TITLE
fix: fixed schema for BioSimulators logs

### DIFF
--- a/vcell-cli-utils/vcell_cli_utils/status.py
+++ b/vcell-cli-utils/vcell_cli_utils/status.py
@@ -75,10 +75,10 @@ def status_yml(omex_file: str, out_dir: str):
             #outputs_dict["outputs"][report].update({"status": "QUEUED"})
 
         for task in task_list:
-            exception = {"category":None, "message":None}
+            exception = {"type":None, "message":None}
             tasks_dict["tasks"].append({"id":task ,"status": "QUEUED", "exception": exception, "skipReason": None, "output": None, "duration": None, "algorithm": None,"simulatorDetails":None})
 
-        exception = {"category":None, "message":None}
+        exception = {"type":None, "message":None}
         sed_doc_dict = {"location":sedml, "status":"QUEUED", "exception":exception, "skipReason":None, "output":None, "duration":None}
         sed_doc_dict.update(outputs_dict)
         sed_doc_dict.update(tasks_dict)
@@ -234,7 +234,7 @@ def set_output_message(sedmlAbsolutePath:str, entityId:str, out_dir:str, entityT
     # Convert json to yaml # Save new yaml
     dump_yaml_dict(status_yaml_path, yaml_dict=yaml_dict, out_dir=out_dir)
 
-def set_exception_message(sedmlAbsolutePath:str, entityId:str, out_dir:str, entityType:str, category:str, message:str):
+def set_exception_message(sedmlAbsolutePath:str, entityId:str, out_dir:str, entityType:str, type:str, message:str):
 
     yaml_dict = get_yaml_as_str(os.path.join(out_dir, "log.yml"))
     for sedml_list in yaml_dict['sedDocuments']:
@@ -246,7 +246,7 @@ def set_exception_message(sedmlAbsolutePath:str, entityId:str, out_dir:str, enti
             if entityType == 'sedml':
                 if sedml_name_nested == entityId:
                     exc = sedml_list['exception']
-                    exc['category'] = category
+                    exc['type'] = type
                     exc['message'] = message
             
             # Update task status
@@ -254,7 +254,7 @@ def set_exception_message(sedmlAbsolutePath:str, entityId:str, out_dir:str, enti
                 for taskList in sedml_list['tasks']:
                     if taskList['id'] == entityId:
                         exc = taskList['exception']
-                        exc['category'] = category
+                        exc['type'] = type
                         exc['message'] = message
     status_yaml_path = os.path.join(out_dir, "log.yml")
 

--- a/vcell-cli/src/main/java/org/vcell/cli/CLIStandalone.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIStandalone.java
@@ -262,10 +262,10 @@ public class CLIStandalone {
             } catch (Exception e) {
             	String prefix = "SED-ML processing for " + sedmlLocation + " failed with error: ";
             	logDocumentError = prefix + e.getMessage();
-            	String category = e.getClass().getSimpleName();
+            	String type = e.getClass().getSimpleName();
                 CLIUtils.setOutputMessage(sedmlLocation, sedmlName, outputDir, "sedml", logDocumentMessage);
-                CLIUtils.setExceptionMessage(sedmlLocation, sedmlName, outputDir, "sedml", category, logDocumentError);
-                writeDetailedErrorList(outputBaseDir, bioModelBaseName + ",  doc:    " + category + ": " + logDocumentError);
+                CLIUtils.setExceptionMessage(sedmlLocation, sedmlName, outputDir, "sedml", type, logDocumentError);
+                writeDetailedErrorList(outputBaseDir, bioModelBaseName + ",  doc:    " + type + ": " + logDocumentError);
             	
                 System.err.println(prefix + e.getMessage());
                 e.printStackTrace(System.err);
@@ -324,20 +324,20 @@ public class CLIStandalone {
             	} catch (Exception e) {
                     somethingFailed = true;
                 	logDocumentError += e.getMessage();
-                	String category = e.getClass().getSimpleName();
+                	String type = e.getClass().getSimpleName();
                     CLIUtils.setOutputMessage(sedmlLocation, sedmlName, outputDir, "sedml", logDocumentMessage);
-                    CLIUtils.setExceptionMessage(sedmlLocation, sedmlName, outputDir, "sedml", category, logDocumentError);
-                    writeDetailedErrorList(outputBaseDir, bioModelBaseName + ",  doc:    " + category + ": " + logDocumentError);
+                    CLIUtils.setExceptionMessage(sedmlLocation, sedmlName, outputDir, "sedml", type, logDocumentError);
+                    writeDetailedErrorList(outputBaseDir, bioModelBaseName + ",  doc:    " + type + ": " + logDocumentError);
                     org.apache.commons.io.FileUtils.deleteDirectory(new File(String.valueOf(sedmlPath2d3d)));	// removing temp path generated from python
                     continue;
             	}
             } else {           	// no data in the hash -> no results to show
             	Exception e = new RuntimeException("Failure executing the tasks within the sed document. ");
             	logDocumentError += e.getMessage();
-            	String category = e.getClass().getSimpleName();
+            	String type = e.getClass().getSimpleName();
                 CLIUtils.setOutputMessage(sedmlLocation, sedmlName, outputDir, "sedml", logDocumentMessage);
-                CLIUtils.setExceptionMessage(sedmlLocation, sedmlName, outputDir, "sedml", category, logDocumentError);
-                writeDetailedErrorList(outputBaseDir, bioModelBaseName + ",  doc:    " + category + ": " + logDocumentError);
+                CLIUtils.setExceptionMessage(sedmlLocation, sedmlName, outputDir, "sedml", type, logDocumentError);
+                writeDetailedErrorList(outputBaseDir, bioModelBaseName + ",  doc:    " + type + ": " + logDocumentError);
                 CLIUtils.updateSedmlDocStatusYml(sedmlLocation, Status.FAILED, outputDir);
                 org.apache.commons.io.FileUtils.deleteDirectory(new File(String.valueOf(sedmlPath2d3d)));	// removing temp path generated from python
                 continue;		// no point to create h5 or zip files with no data

--- a/vcell-cli/src/main/java/org/vcell/cli/CLIUtils.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIUtils.java
@@ -691,10 +691,10 @@ public class CLIUtils {
         Process process = execShellCommand(new String[]{python, statusPath.toString(), "setOutputMessage", sedmlAbsolutePath, entityId, outDir, entityType, message}).start();
         printProcessErrors(process, "","Failed updating task status YAML\n");
     }
-    // category - exception class, ex RuntimeException
+    // type - exception class, ex RuntimeException
     // message  - exception message
-    public static void setExceptionMessage(String sedmlAbsolutePath, String entityId, String outDir, String entityType, String category , String message) throws IOException, InterruptedException {
-        Process process = execShellCommand(new String[]{python, statusPath.toString(), "setExceptionMessage", sedmlAbsolutePath, entityId, outDir, entityType, category, message}).start();
+    public static void setExceptionMessage(String sedmlAbsolutePath, String entityId, String outDir, String entityType, String type , String message) throws IOException, InterruptedException {
+        Process process = execShellCommand(new String[]{python, statusPath.toString(), "setExceptionMessage", sedmlAbsolutePath, entityId, outDir, entityType, type, message}).start();
         printProcessErrors(process, "","Failed updating task status YAML\n");
     }
 

--- a/vcell-cli/src/main/java/org/vcell/cli/SolverHandler.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/SolverHandler.java
@@ -202,9 +202,9 @@ public class SolverHandler {
                     } else {
                     	logTaskError += (error + ". ");
                     }
-                    String category = e.getClass().getSimpleName();
+                    String type = e.getClass().getSimpleName();
                     CLIUtils.setOutputMessage(sedmlLocation, sim.getImportedTaskID(), outDir, "task", logTaskMessage);
-                    CLIUtils.setExceptionMessage(sedmlLocation, sim.getImportedTaskID(), outDir, "task", category, logTaskError);
+                    CLIUtils.setExceptionMessage(sedmlLocation, sim.getImportedTaskID(), outDir, "task", type, logTaskError);
                     String sdl = "";
                     if(sd != null && sd.getShortDisplayLabel() != null && !sd.getShortDisplayLabel().isEmpty()) {
                     	sdl = sd.getShortDisplayLabel();
@@ -215,11 +215,11 @@ public class SolverHandler {
                     	if(bTimeoutFound == false) {		// don't repeat this for each task
                     		String str = logTaskError.substring(0, logTaskError.indexOf("Process timed out"));
                     		str += "Process timed out";		// truncate the rest of the spam
-                        	CLIStandalone.writeDetailedErrorList(outputBaseDir, bioModelBaseName + ",  solver: " + sdl + ": " + category + ": " + str);
+                        	CLIStandalone.writeDetailedErrorList(outputBaseDir, bioModelBaseName + ",  solver: " + sdl + ": " + type + ": " + str);
                         	bTimeoutFound = true;
                     	}
                     } else {
-                    	CLIStandalone.writeDetailedErrorList(outputBaseDir, bioModelBaseName + ",  solver: " + sdl + ": " + category + ": " + logTaskError);
+                    	CLIStandalone.writeDetailedErrorList(outputBaseDir, bioModelBaseName + ",  solver: " + sdl + ": " + type + ": " + logTaskError);
                     }
                     CLIUtils.drawBreakLine("-", 100);
                 }


### PR DESCRIPTION
The schema for logs uses `type` rather than `category`. We previously documented this incorrectly. 

A tool for validating logs is now available here. This is also now incorporated into the BioSimulators test suite.
https://api.biosimulations.org/#/Logs/LogsController_validateLog

@moraru @danv61 please merge and release another version of VCell