### PR TITLE
round-trip export/import for COMBINE archives (.omex files)

### DIFF
--- a/vcell-cli/pom.xml
+++ b/vcell-cli/pom.xml
@@ -79,6 +79,20 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.17.1</version>
+        </dependency>        <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
             <version>4.6.3</version>

--- a/vcell-cli/src/main/java/org/vcell/cli/CLIUtils.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIUtils.java
@@ -1,5 +1,6 @@
 package org.vcell.cli;
 
+import cbit.util.xml.VCLogger;
 import cbit.vcell.export.server.ExportConstants;
 import cbit.vcell.export.server.ExportFormat;
 import cbit.vcell.export.server.ExportOutput;
@@ -89,6 +90,21 @@ public class CLIUtils {
                     StandardOpenOption.CREATE, StandardOpenOption.APPEND);
         }
     }
+
+    public static class LocalLogger extends VCLogger {
+        @Override
+        public void sendMessage(Priority p, ErrorType et, String message) throws Exception {
+            System.out.println("LOGGER: msgLevel=" + p + ", msgType=" + et + ", " + message);
+        }
+
+        public void sendAllMessages() {
+        }
+
+        public boolean hasMessages() {
+            return false;
+        }
+    }
+
 
 
 }

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/ConvertCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/ConvertCommand.java
@@ -1,6 +1,8 @@
 package org.vcell.cli.vcml;
 
+import cbit.util.xml.VCLogger;
 import cbit.vcell.resource.PropertyLoader;
+import org.vcell.cli.CLIUtils;
 import org.vcell.util.DataAccessException;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -12,8 +14,8 @@ import java.util.concurrent.Callable;
 
 @Command(name = "convert", description = "convert from VCML to COMBINE archive (.omex)")
 public class ConvertCommand implements Callable<Integer> {
-    @Option(names = "-m", defaultValue = "SBML")
-    private ModelFormat outputModelFormat;
+    @Option(names = { "-m", "--outputModelFormat" }, defaultValue = "SBML", description = "expecting SBML or VCML")
+    private ModelFormat outputModelFormat = ModelFormat.SBML;
 
     @Option(names = { "-i", "--inputFilePath" })
     private File inputFilePath;
@@ -33,13 +35,18 @@ public class ConvertCommand implements Callable<Integer> {
     @Option(names = "--forceLogFiles")
     boolean bForceLogFiles;
 
+    @Option(names = "--validate")
+    boolean bValidateOmex;
+
     public Integer call() {
         try {
             PropertyLoader.loadProperties();
+            VCLogger vcLogger = new CLIUtils.LocalLogger();
 
             try (CLIDatabaseService cliDatabaseService = new CLIDatabaseService()) {
                 VcmlOmexConverter.convertFiles(cliDatabaseService, inputFilePath, outputFilePath,
-                        outputModelFormat, bHasDataOnly, bMakeLogsOnly, bNonSpatialOnly, bForceLogFiles);
+                        outputModelFormat, bHasDataOnly, bMakeLogsOnly, bNonSpatialOnly, bForceLogFiles, bValidateOmex,
+                        vcLogger);
             } catch (IOException | SQLException | DataAccessException e) {
                 e.printStackTrace(System.err);
             }

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
@@ -67,7 +67,9 @@ public class VcmlOmexConverter {
 									boolean bHasDataOnly,
 									boolean bMakeLogsOnly,
 									boolean bNonSpatialOnly,
-									boolean bForceLogFiles)
+									boolean bForceLogFiles,
+									boolean bValidateOmex,
+									VCLogger vcLogger)
 			throws IOException, SQLException, DataAccessException {
 
 		VCInfoContainer vcic;
@@ -137,8 +139,8 @@ public class VcmlOmexConverter {
                 try {
                     if (inputFile.endsWith(".vcml")) {
                         boolean isCreated = vcmlToOmexConversion(file.toString(), outputDir.getAbsolutePath(), outputDir.getAbsolutePath(), cliDatabaseService,
-								hasNonSpatialSet, hasSpatialSet, modelFormat, bHasDataOnly, bNonSpatialOnly, bMakeLogsOnly, bForceLogFiles);
-                        if (isCreated) {
+								hasNonSpatialSet, hasSpatialSet, modelFormat, bHasDataOnly, bNonSpatialOnly, bMakeLogsOnly, bForceLogFiles, bValidateOmex);
+						if (isCreated) {
                         	logger.info("Combine archive created for file(s) `" + inputFile + "`");
                         }
                         else {
@@ -159,7 +161,7 @@ public class VcmlOmexConverter {
                 if (input.toString().endsWith(".vcml")) {
                     boolean isCreated = vcmlToOmexConversion(input.getAbsolutePath(), null,
 							outputDir.getAbsolutePath(), cliDatabaseService, hasNonSpatialSet, hasSpatialSet,
-							modelFormat, bHasDataOnly, bNonSpatialOnly, bMakeLogsOnly, bForceLogFiles);
+							modelFormat, bHasDataOnly, bNonSpatialOnly, bMakeLogsOnly, bForceLogFiles, bValidateOmex);
                     if (isCreated) {
 						logger.info("Combine archive created for `" + input + "`");
 					} else {
@@ -181,7 +183,8 @@ public class VcmlOmexConverter {
 												boolean bHasDataOnly,
 												boolean bNonSpatialOnly,
 												boolean bMakeLogsOnly,
-												boolean bForceLogFiles
+												boolean bForceLogFiles,
+												boolean bValidate
 	) throws XmlParseException, IOException, DataAccessException, SQLException {
 
         // Get VCML file path from -i flag
@@ -373,7 +376,7 @@ public class VcmlOmexConverter {
         int connectionTimeout = 10000;
         int readTimeout = 20000;
         try {
-        FileUtils.copyURLToFile(source, destination, connectionTimeout, readTimeout);		// diagram
+       	 	FileUtils.copyURLToFile(source, destination, connectionTimeout, readTimeout);		// diagram
         } catch(FileNotFoundException e) {
         	logger.warn("Diagram not present in source="+sourcePath);
         }
@@ -483,6 +486,10 @@ public class VcmlOmexConverter {
 //        	File srcFile = new File(inputVcmlFile);
 //        	FileUtils.copyFileToDirectory(srcFile, destDir);
 
+			if (bValidate){
+				XmlHelper.readOmex(omexFile, new CLIUtils.LocalLogger());
+			}
+
             // Removing all other files(like SEDML, XML, SBML) after archiving
             removeOtherFiles(outputDir, files);
 
@@ -520,7 +527,7 @@ public class VcmlOmexConverter {
     			SesameRioUtil.writeRDFToStream(System.out, graph, nsMap, RDFFormat.RDFXML);
     		} catch (RDFHandlerException e) {
     			logger.error(e);
-    		}
+			}
     		return ret;
         }
         PublicationInfo[] publicationInfos = bioModelInfo.getPublicationInfos();
@@ -534,7 +541,7 @@ public class VcmlOmexConverter {
     			SesameRioUtil.writeRDFToStream(System.out, graph, nsMap, RDFFormat.RDFXML);
     		} catch (RDFHandlerException e) {
     			logger.error(e);
-    		}
+			}
     		return ret;
         }
         

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
@@ -693,8 +693,7 @@ public class VcmlOmexConverter {
 		ret += PubMet.EndModified;
 		
 		ret += end;
-		System.out.println(ret);
-		System.out.println("");
+		logger.trace(ret);
 		return(ret);
     }
     

--- a/vcell-cli/src/main/resources/log4j2.xml
+++ b/vcell-cli/src/main/resources/log4j2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" name="XMLConfigTest" packages="org.vcell.*">
+    <Properties>
+        <Property name="filename">vcell.log</Property>
+    </Properties>
+    <ThresholdFilter level="trace"/>
+
+    <Appenders>
+        <Console name="console">
+            <PatternLayout pattern="%5p (%F:%L) - %m%n"/>
+        </Console>
+        <File name="file" fileName="${filename}">
+            <PatternLayout>
+                <pattern>%d %p %C{1.} [%t] %m%n</pattern>
+            </PatternLayout>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.vcell" level="info" additivity="false">
+            <AppenderRef ref="console"/>
+            <AppenderRef ref="file"/>
+        </Logger>
+
+        <Root level="info">
+            <AppenderRef ref="console"/>
+            <AppenderRef ref="file"/>
+        </Root>
+    </Loggers>
+
+</Configuration>

--- a/vcell-core/src/main/java/cbit/vcell/mapping/FastSystemAnalyzer.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/FastSystemAnalyzer.java
@@ -214,8 +214,8 @@ private void refreshInvarianceMatrix() throws MathException, ExpressionException
 	}
 	
 	// Print
-	System.out.println("origMatrix");
-	matrix.show();
+//	System.out.println("origMatrix");
+//	matrix.show();
 	
 	//
 	// gaussian elimination on the matrix give the following representation
@@ -227,7 +227,7 @@ private void refreshInvarianceMatrix() throws MathException, ExpressionException
 	//   |00i1iccc|        (i)'s are the coefficients for dependent vars in terms of independent vars
 	//
 	// Print
-	System.out.println("reducedMatrix");
+//	System.out.println("reducedMatrix");
 	if (rows > 0){
 		try {
 			matrix.gaussianElimination(new RationalExpMatrix(rows,rows));
@@ -236,11 +236,11 @@ private void refreshInvarianceMatrix() throws MathException, ExpressionException
 			throw new MathException(e.getMessage());
 		}
 	}
-	matrix.show();
-	for (int i=0;i<vars.length;i++){
-		System.out.print(vars[i].getName()+"  ");
-	}
-	System.out.println("");
+//	matrix.show();
+//	for (int i=0;i<vars.length;i++){
+//		System.out.print(vars[i].getName()+"  ");
+//	}
+//	System.out.println("");
 
 	//
 	// re-ordering of columns (to get N-r x N-r identity matrix at left)
@@ -276,11 +276,11 @@ private void refreshInvarianceMatrix() throws MathException, ExpressionException
 		}
 	}
 	// Print
-	for (int i=0;i<vars.length;i++){
-		System.out.print(vars[i].getName()+"  ");
-	}
-	System.out.println("");
-	matrix.show();
+//	for (int i=0;i<vars.length;i++){
+//		System.out.print(vars[i].getName()+"  ");
+//	}
+//	System.out.println("");
+//	matrix.show();
 	
 	//
 	// separate into dependent and indepent variables, and chop off identity matrix (left N-r columns)
@@ -309,18 +309,18 @@ private void refreshInvarianceMatrix() throws MathException, ExpressionException
 	}
 
 	// Print
-	System.out.println("\n\nDEPENDENCY MATRIX");
-	dependencyMatrix.show();
-	System.out.print("dependent vars: ");
-	for (int i=0;i<dependentVarList.size();i++){
-		System.out.print(((Variable)dependentVarList.elementAt(i)).getName()+"  ");
-	}
-	System.out.println("");			
-	System.out.print("independent vars: ");
-	for (int i=0;i<independentVarList.size();i++){
-		System.out.print(((Variable)independentVarList.elementAt(i)).getName()+"  ");
-	}
-	System.out.println("");			
+//	System.out.println("\n\nDEPENDENCY MATRIX");
+//	dependencyMatrix.show();
+//	System.out.print("dependent vars: ");
+//	for (int i=0;i<dependentVarList.size();i++){
+//		System.out.print(((Variable)dependentVarList.elementAt(i)).getName()+"  ");
+//	}
+//	System.out.println("");
+//	System.out.print("independent vars: ");
+//	for (int i=0;i<independentVarList.size();i++){
+//		System.out.print(((Variable)independentVarList.elementAt(i)).getName()+"  ");
+//	}
+//	System.out.println("");
 
 }
 

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -139,6 +139,10 @@ import cbit.vcell.solver.SimulationInfo;
 import cbit.vcell.solver.SimulationOwner;
 import cbit.vcell.solver.VCSimulationIdentifier;
 import cbit.vcell.units.VCUnitDefinition;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 /**
  * This type was created in VisualAge.
  */
@@ -146,7 +150,9 @@ import cbit.vcell.units.VCUnitDefinition;
 public class SimulationContext implements SimulationOwner, Versionable, Matchable, BioNetGenUpdaterCallback,
 	ScopedSymbolTable, PropertyChangeListener, VetoableChangeListener, Serializable, IssueSource,
 	Displayable, Identifiable {
-	
+
+	private final static Logger logger = LogManager.getLogger(SimulationContext.class);
+
 	public interface MathMappingCallback {
 		public void setMessage(String message);
 		public void setProgressFraction(float fractionDone);
@@ -687,12 +693,6 @@ public Application getApplicationType() {
 	return applicationType;
 }
 
-/**
- * Sets the analysisTasks index property (cbit.vcell.modelopt.AnalysisTask[]) value.
- * @param index The index value into the property array.
- * @param analysisTasks The new value for the property.
- * @see #getAnalysisTasks
- */
 public void addAnalysisTask(AnalysisTask analysisTask) throws PropertyVetoException {
 	if (fieldAnalysisTasks==null){
 		setAnalysisTasks(new AnalysisTask[] { analysisTask });
@@ -719,12 +719,6 @@ public BioEvent addBioEvent(BioEvent bioEvent) throws PropertyVetoException {
 	return bioEvent;
 }
 
-/**
- * Sets the simulations property (cbit.vcell.solver.Simulation[]) value.
- * @param simulations The new value for the property.
- * @exception java.beans.PropertyVetoException The exception description.
- * @see #getSimulations
- */
 public Simulation addNewSimulation(String simNamePrefix, MathMappingCallback callback, NetworkGenerationRequirements networkGenerationRequirements) throws java.beans.PropertyVetoException {
 	refreshMathDescription(callback, networkGenerationRequirements);
 	if (bioModel==null){
@@ -796,7 +790,7 @@ public void refreshMathDescription(MathMappingCallback callback, NetworkGenerati
 		try {
 			setMathDescription(createNewMathMapping(callback, networkGenerationRequirements).getMathDescription());
 		} catch (Exception e) {
-			e.printStackTrace();
+			logger.error(e);
 			throw new RuntimeException(
 				"Application '"+getName()+"' has no generated Math\n"+
 				"Failed to generate new Math\n"+
@@ -815,12 +809,6 @@ public synchronized void addPropertyChangeListener(java.beans.PropertyChangeList
 }
 
 
-/**
- * Sets the simulations property (cbit.vcell.solver.Simulation[]) value.
- * @param simulations The new value for the property.
- * @exception java.beans.PropertyVetoException The exception description.
- * @see #getSimulations
- */
 public void addSimulation(Simulation newSimulation) throws java.beans.PropertyVetoException {
 	if (newSimulation.getMathDescription() == null){
 		throw new IllegalArgumentException("cannot add simulation '"+newSimulation.getName()+"', has no MathDescription");
@@ -963,12 +951,6 @@ public boolean compareEqual(Matchable object) {
 }
 
 
-/**
- * Insert the method's description here.
- * Creation date: (3/19/2001 10:37:02 PM)
- * @return boolean
- * @param structure cbit.vcell.model.Structure
- */
 public boolean contains(SimulationContextParameter scParameter) {
 	for (int i=0;i<fieldSimulationContextParameters.length;i++){
 		if (fieldSimulationContextParameters[i].equals(scParameter)){
@@ -978,12 +960,6 @@ public boolean contains(SimulationContextParameter scParameter) {
 	return false;
 }
 
-/**
- * Sets the simulations property (cbit.vcell.solver.Simulation[]) value.
- * @param simulations The new value for the property.
- * @exception java.beans.PropertyVetoException The exception description.
- * @see #getSimulations
- */
 public AnalysisTask copyAnalysisTask(AnalysisTask analysisTask) throws java.beans.PropertyVetoException, ExpressionException, MappingException, MathException {
 
 	if (analysisTask instanceof ParameterEstimationTask){
@@ -1011,12 +987,6 @@ public AnalysisTask copyAnalysisTask(AnalysisTask analysisTask) throws java.bean
 	}
 }
 
-/**
- * Sets the simulations property (cbit.vcell.solver.Simulation[]) value.
- * @param simulations The new value for the property.
- * @exception java.beans.PropertyVetoException The exception description.
- * @see #getSimulations
- */
 public Simulation copySimulation(Simulation simulation) throws java.beans.PropertyVetoException {
 	if (getMathDescription()==null){
 		throw new RuntimeException("Application "+getName()+" has no generated Math, cannot add simulation");
@@ -1584,12 +1554,6 @@ public MembraneContext getMembraneContext() {
 	return membraneContext;
 }
 
-/**
- * Insert the method's description here.
- * Creation date: (3/19/2001 10:37:02 PM)
- * @return boolean
- * @param structure cbit.vcell.model.Structure
- */
 public SimulationContextParameter getSimulationContextParameter(String parameterName){
 	for (int i=0;i<fieldSimulationContextParameters.length;i++){
 		if (fieldSimulationContextParameters[i].getName().equals(parameterName)){
@@ -1620,22 +1584,10 @@ public SimulationContext.SimulationContextParameter getSimulationContextParamete
 }
 
 
-/**
- * Gets the simulations property (cbit.vcell.solver.Simulation[]) value.
- * @return The simulations property value.
- * @see #setSimulations
- */
 public Simulation[] getSimulations() {
 	return extractLocalSimulations(bioModel.getSimulations());
 }
 
-
-/**
- * Gets the simulations index property (cbit.vcell.solver.Simulation) value.
- * @return The simulations property value.
- * @param index The index value into the property array.
- * @see #setSimulations
- */
 public Simulation getSimulations(int index) {
 	return getSimulations()[index];
 }
@@ -2169,13 +2121,6 @@ private void refreshElectrodes(){
 	}
 }
 
-
-/**
- * Sets the analysisTasks index property (cbit.vcell.modelopt.AnalysisTask[]) value.
- * @param index The index value into the property array.
- * @param analysisTasks The new value for the property.
- * @see #getAnalysisTasks
- */
 public void removeAnalysisTask(AnalysisTask analysisTask) throws PropertyVetoException {
 	boolean bFound = false;
 	for (int i = 0; fieldAnalysisTasks!=null && i < fieldAnalysisTasks.length; i++){
@@ -2214,13 +2159,6 @@ public synchronized void removePropertyChangeListener(java.beans.PropertyChangeL
 	getPropertyChange().removePropertyChangeListener(listener);
 }
 
-
-/**
- * Sets the simulations property (cbit.vcell.solver.Simulation[]) value.
- * @param simulations The new value for the property.
- * @exception java.beans.PropertyVetoException The exception description.
- * @see #getSimulations
- */
 public void removeSimulation(Simulation simulation) throws java.beans.PropertyVetoException {
 	if (simulation.getMathDescription() != getMathDescription()){
 		throw new IllegalArgumentException("cannot remove simulation '"+simulation.getName()+"', has different MathDescription");
@@ -2531,20 +2469,20 @@ public void refreshSpatialObjects() {
 		try {
 			for (SpatialObject unmappedSpatialObject : unmappedSpatialObjects){
 				if (unmappedSpatialObject instanceof VolumeRegionObject){
-					System.err.println("volume region spatial object '"+unmappedSpatialObject.getName()+"' not found in geometry, delete.");
+					logger.error("volume region spatial object '"+unmappedSpatialObject.getName()+"' not found in geometry, delete.");
 					removeSpatialObject(unmappedSpatialObject);
 				}
 				if (unmappedSpatialObject instanceof SurfaceRegionObject){
-					System.err.println("surface region spatial object '"+unmappedSpatialObject.getName()+"' not found in geometry, delete.");
+					logger.error("surface region spatial object '"+unmappedSpatialObject.getName()+"' not found in geometry, delete.");
 					removeSpatialObject(unmappedSpatialObject);
 				}
 				if (unmappedSpatialObject instanceof PointObject){
-					System.err.println("point spatial object '"+unmappedSpatialObject.getName()+"' not found in geometry, this is expected.");
+					logger.error("point spatial object '"+unmappedSpatialObject.getName()+"' not found in geometry, this is expected.");
 //					removeSpatialObject(unmappedSpatialObject);
 				}
 			}
 		} catch (PropertyVetoException e) {
-			e.printStackTrace();
+			logger.error(e);
 		}
 	}
 }
@@ -2571,11 +2509,6 @@ public void setGroundElectrode(Electrode groundElectrode) throws java.beans.Prop
 //	bRuleBased = newIsRuleBased;
 //}
 
-
-/**
- * This method was created in VisualAge.
- * @param mathDesc cbit.vcell.math.MathDescription
- */
 public void setMathDescription(MathDescription argMathDesc) throws PropertyVetoException {
 	Object oldValue = this.mathDesc;
 	fireVetoableChange("mathDescription",oldValue,argMathDesc);

--- a/vcell-core/src/main/java/cbit/vcell/mapping/StructureAnalyzer.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/StructureAnalyzer.java
@@ -439,7 +439,7 @@ public static StructureAnalyzer.Dependency[] refreshTotalDependancies(RationalMa
 		}
 	}
 				
-	System.out.println("there are "+nullSpaceMatrix.getNumRows()+" dependencies, " + nullSpaceMatrix.getNumCols() + " columns.");
+	//System.out.println("there are "+nullSpaceMatrix.getNumRows()+" dependencies, " + nullSpaceMatrix.getNumCols() + " columns.");
 	long startTime = System.currentTimeMillis();
 
 	Vector<Dependency> dependencyList = new Vector<Dependency>();
@@ -555,7 +555,7 @@ public static StructureAnalyzer.Dependency[] refreshTotalDependancies(RationalMa
 	}
 	long endTime = System.currentTimeMillis();
 	long elapsedTime = endTime - startTime;
-	System.out.println("     " + elapsedTime + " milliseconds");
+//	System.out.println("     " + elapsedTime + " milliseconds");
 	
 	return (StructureAnalyzer.Dependency[])BeanUtils.getArray(dependencyList,StructureAnalyzer.Dependency.class);
 }

--- a/vcell-core/src/main/java/cbit/vcell/xml/XmlHelper.java
+++ b/vcell-core/src/main/java/cbit/vcell/xml/XmlHelper.java
@@ -45,30 +45,8 @@ import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Namespace;
 import org.jdom.Text;
-import org.jlibsedml.AbstractTask;
-import org.jlibsedml.Algorithm;
-import org.jlibsedml.AlgorithmParameter;
-import org.jlibsedml.ArchiveComponents;
-import org.jlibsedml.Change;
-import org.jlibsedml.ChangeAttribute;
-import org.jlibsedml.DataGenerator;
-import org.jlibsedml.Libsedml;
-import org.jlibsedml.Model;
-import org.jlibsedml.OneStep;
-import org.jlibsedml.Output;
-import org.jlibsedml.Range;
-import org.jlibsedml.RepeatedTask;
-import org.jlibsedml.SedML;
-import org.jlibsedml.SedMLValidationReport;
-import org.jlibsedml.SetValue;
-import org.jlibsedml.SteadyState;
-import org.jlibsedml.SubTask;
-import org.jlibsedml.Task;
-import org.jlibsedml.UniformRange;
+import org.jlibsedml.*;
 import org.jlibsedml.UniformRange.UniformType;
-import org.jlibsedml.UniformTimeCourse;
-import org.jlibsedml.VectorRange;
-import org.jlibsedml.XPathTarget;
 import org.jlibsedml.execution.ArchiveModelResolver;
 import org.jlibsedml.execution.FileModelResolver;
 import org.jlibsedml.execution.ModelResolver;
@@ -1534,24 +1512,32 @@ public class XmlHelper {
 			return false;
 		}
 	}
-	
+
 	@Deprecated
 	// variant of updateXML(), never worked
 	public static String updateXML2(String xml, String xpathExpression, String newValue) {
 	try {
 //		String xpathExpression = "/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id=\"A\"]";
 
-		xpathExpression = "/*:sbml/*:model/*:listOfSpecies/*:species[@id=\"A\"]";
+		/**
+		 * the following statement with xpath gives 'unexpected token' error in intellij/IDEA - not used anyway
+		 * commenting it out for now.
+		 *
+		 * "/*:sbml/*:model/*:listOfSpecies/*:species[@id=\"A\"]"
+		 * complains about the first ':' character as an unexpected token ... bug in IDE it seems.
+		 */
+//		xpathExpression = "/*:sbml/*:model/*:listOfSpecies/*:species[@id=\"A\"]";
+
 		//Creating document builder
 		DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
 		javax.xml.parsers.DocumentBuilder builder = builderFactory.newDocumentBuilder();
 		StringReader sr = new StringReader(xml);
 		InputSource is = new org.xml.sax.InputSource(sr);
 		org.w3c.dom.Document document = builder.parse(is);
-	      
+
 		//Evaluating xpath expression using Element
 		XPath xpath = XPathFactory.newInstance().newXPath();
-		
+
 		// here follow 4 different ways to apply the change, none works
 //		DTMNodeList dtmNodeList = (DTMNodeList)xpath.evaluate(xpathExpression, document, XPathConstants.NODESET);
 //		Node node = dtmNodeList.item(0);
@@ -1559,16 +1545,16 @@ public class XmlHelper {
 
 //		org.w3c.dom.Element element = (org.w3c.dom.Element)xpath.evaluate(xpathExpression, document, XPathConstants.NODE);
 //		element.setTextContent(newValue);
-		
+
 //		Node node = (Node) xpath.compile(xpathExpression).evaluate(document, XPathConstants.NODE);
-		
+
 		Node node = (Node) xpath.evaluate(xpathExpression, document, XPathConstants.NODE);
 		node.setNodeValue(newValue);
 
 //		NodeList myNodeList = (NodeList) xpath.compile(xpathExpression).evaluate(document, XPathConstants.NODESET);
 //		Node node = myNodeList.item(0);
 //		node.setNodeValue(newValue);
-		
+
 		//Transformation of document to xml
 		StringWriter stringWriter = new StringWriter();
 		Transformer xformer = TransformerFactory.newInstance().newTransformer();

--- a/vcell-core/src/main/java/cbit/vcell/xml/XmlHelper.java
+++ b/vcell-core/src/main/java/cbit/vcell/xml/XmlHelper.java
@@ -10,69 +10,6 @@
 
 package cbit.vcell.xml;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.print.Doc;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
-
-import cbit.vcell.solver.*;
-import cbit.vcell.solver.Simulation;
-import cbit.vcell.solver.SolverDescription.AlgorithmParameterDescription;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.xml.dtm.ref.DTMNodeList;
-import org.jdom.Comment;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.Namespace;
-import org.jdom.Text;
-import org.jlibsedml.*;
-import org.jlibsedml.UniformRange.UniformType;
-import org.jlibsedml.execution.ArchiveModelResolver;
-import org.jlibsedml.execution.FileModelResolver;
-import org.jlibsedml.execution.ModelResolver;
-import org.jlibsedml.modelsupport.KisaoOntology;
-import org.jlibsedml.modelsupport.KisaoTerm;
-import org.jlibsedml.modelsupport.SBMLSupport;
-import org.jlibsedml.modelsupport.SUPPORTED_LANGUAGE;
-import org.sbml.jsbml.SBMLException;
-import org.vcell.cellml.CellQuanVCTranslator;
-import org.vcell.sbml.SbmlException;
-import org.vcell.sbml.vcell.MathModel_SBMLExporter;
-import org.vcell.sbml.vcell.SBMLAnnotationUtil;
-import org.vcell.sbml.vcell.SBMLExporter;
-import org.vcell.sbml.vcell.SBMLImporter;
-import org.vcell.sedml.RelativeFileModelResolver;
-import org.vcell.sedml.SEDMLUtil;
-import org.vcell.util.Extent;
-import org.vcell.util.FileUtils;
-import org.vcell.util.Pair;
-import org.vcell.util.TokenMangler;
-import org.vcell.util.document.VCDocument;
-import org.vcell.util.document.VCellSoftwareVersion;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
-
 import cbit.image.VCImage;
 import cbit.util.xml.VCLogger;
 import cbit.util.xml.XmlUtil;
@@ -100,9 +37,52 @@ import cbit.vcell.model.Parameter;
 import cbit.vcell.model.ReactionStep;
 import cbit.vcell.parser.Expression;
 import cbit.vcell.parser.ExpressionException;
+import cbit.vcell.solver.Simulation;
+import cbit.vcell.solver.*;
+import cbit.vcell.solver.SolverDescription.AlgorithmParameterDescription;
 import cbit.xml.merge.NodeInfo;
 import cbit.xml.merge.XmlTreeDiff;
 import cbit.xml.merge.XmlTreeDiff.DiffConfiguration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdom.*;
+import org.jlibsedml.*;
+import org.jlibsedml.UniformRange.UniformType;
+import org.jlibsedml.execution.ArchiveModelResolver;
+import org.jlibsedml.execution.FileModelResolver;
+import org.jlibsedml.execution.ModelResolver;
+import org.jlibsedml.modelsupport.SBMLSupport;
+import org.jlibsedml.modelsupport.SUPPORTED_LANGUAGE;
+import org.sbml.jsbml.SBMLException;
+import org.vcell.cellml.CellQuanVCTranslator;
+import org.vcell.sbml.SbmlException;
+import org.vcell.sbml.vcell.MathModel_SBMLExporter;
+import org.vcell.sbml.vcell.SBMLAnnotationUtil;
+import org.vcell.sbml.vcell.SBMLExporter;
+import org.vcell.sbml.vcell.SBMLImporter;
+import org.vcell.sedml.RelativeFileModelResolver;
+import org.vcell.sedml.SEDMLUtil;
+import org.vcell.util.Extent;
+import org.vcell.util.FileUtils;
+import org.vcell.util.Pair;
+import org.vcell.util.TokenMangler;
+import org.vcell.util.document.VCDocument;
+import org.vcell.util.document.VCellSoftwareVersion;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import java.io.*;
+import java.util.*;
 
 /**
  This class represents the 'API' of the XML framework for all VC classes, outside that framework. Most of the methods of
@@ -169,7 +149,6 @@ public class XmlHelper {
 //			element = XmlUtil.setDefaultNamespace(element, Namespace.getNamespace(XMLTags.VCML_NS));
 //			xmlString = XmlUtil.xmlToString(element);
 		} catch (Exception e) {
-			e.printStackTrace();
 			throw new XmlParseException("Unable to generate Biomodel XML: ", e);
 		}
 		if (lg.isTraceEnabled()) {
@@ -209,7 +188,6 @@ public class XmlHelper {
 			// Return the result
 			return merger;                                               //return the tree-diff instead of the root node.
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new XmlParseException(e);
 		}
 
@@ -271,14 +249,12 @@ public class XmlHelper {
 				sbmlSTring = SBMLAnnotationUtil.postProcessCleanup(sbmlSTring);
 				return new Pair(sbmlSTring, sbmlExporter.getLocalToGlobalTranslationMap());
 			} catch (SbmlException | SBMLException | XMLStreamException | ExpressionException e) {
-				e.printStackTrace(System.out);
 				throw new XmlParseException(e);
 			}
 		} else if (vcDoc instanceof MathModel) {
 			try {
 				return new Pair(MathModel_SBMLExporter.getSBMLString((MathModel)vcDoc, level, version), null);
 			} catch (ExpressionException | IOException | SBMLException | XMLStreamException e) {
-				e.printStackTrace(System.out);
 				throw new XmlParseException(e);
 			}
 		} else{
@@ -357,8 +333,7 @@ public class XmlHelper {
 					}	// end  - for moConstNames
 				} 	// end if (sim has MathOverrides)
 			} catch (Exception e) {
-				e.printStackTrace(System.out);
-				throw new RuntimeException("Could not apply overrides from simulation to application parameters : " + e.getMessage());
+				throw new RuntimeException("Could not apply overrides from simulation to application parameters : " + e.getMessage(), e);
 			}
 		}	// end if (simJob != null)
 		return overriddenSimContext;
@@ -489,7 +464,7 @@ public class XmlHelper {
 //    }
 
 		vcDoc.refreshDependencies();
-		System.out.println("Succesful model import: SBML file "+sbmlFile);
+		logger.info("Succesful model import: SBML file "+sbmlFile);
 		return vcDoc;
 	}
 
@@ -566,7 +541,7 @@ public class XmlHelper {
 			Element geomElement = xmlProducer.getXML(geom);
 			container.addContent(geomElement);
 		} else {
-			System.err.println("No corresponding geometry for the simulation: " + sim.getName());
+			logger.error("No corresponding geometry for the simulation: " + sim.getName());
 		}
 		container.addContent(mathElement);
 		container.addContent(simElement);
@@ -617,31 +592,32 @@ public class XmlHelper {
 	        // iterate through all the elements and show them at the console
 	        List<org.jlibsedml.Model> mmm = sedml.getModels();
 	        for(Model mm : mmm) {
-	            System.out.println(mm.toString());
+	            logger.trace("sedml model: "+mm.toString());
 	            List<Change> listOfChanges = mm.getListOfChanges();
-	            System.out.println("There are " + listOfChanges.size() + " changes.");
+	            logger.debug("There are " + listOfChanges.size() + " changes in model "+mm.getId());
 	        }
 	        List<org.jlibsedml.Simulation> sss = sedml.getSimulations();
 	        for(org.jlibsedml.Simulation ss : sss) {
-	            System.out.println(ss.toString());
+	            logger.trace("sedml simulaton: "+ss.toString());
 	        }
 	        List<AbstractTask> ttt = sedml.getTasks();
 	        if (ttt.isEmpty()) {
 	        	throw new Exception("No tasks found in SED-ML document");
 	        }
 	        for(AbstractTask tt : ttt) {
-	            System.out.println(tt.toString());
+	            logger.trace("sedml task: "+tt.toString());
 	        }
 	        List<DataGenerator> ddd = sedml.getDataGenerators();
 	        for(DataGenerator dd : ddd) {
-	            System.out.println(dd.toString());
+	            logger.trace("sedml dataGenerator: "+dd.toString());
 	        }
 	        List<Output> ooo = sedml.getOutputs();
 	        for(Output oo : ooo) {
-	            System.out.println(oo.toString());
+	            logger.trace("sedml output: "+oo.toString());
 	        }
 	        if(ooo.isEmpty()) {
-	        	System.err.println("List of outputs cannot be empty!");
+	        	logger.error("List of outputs cannot be empty!");
+				// TODO: should we add an 'issue' or throw an exception??
 	        }
 
 			if (tasks == null || tasks.isEmpty()) {
@@ -707,7 +683,7 @@ public class XmlHelper {
 				} else {
 					// give it a try anyway with our deterministic default solver
 					solverDescription = SolverDescription.CombinedSundials;
-					System.err.println("Task (id='"+selectedTask.getId()+")' is not compatible, no equivalent solver found in ontology for requested algorithm '"+kisaoID + "'; trying with deterministic default solver "+solverDescription);
+					logger.error("Task (id='"+selectedTask.getId()+")' is not compatible, no equivalent solver found in ontology for requested algorithm '"+kisaoID + "'; trying with deterministic default solver "+solverDescription);
 				}
 				// find out everything else we need about the application we're going to use,
 				// some of the info will be needed when we parse the sbml file
@@ -765,7 +741,7 @@ public class XmlHelper {
 						try {
 							bioModel.getVCMetaData().createBioPaxObjects(bioModel);
 						} catch (Exception e) {
-							e.printStackTrace();
+							logger.error("failed to make BioPax objects", e);
 						}
 					} else {				// we assume it's sbml, if it's neither import will fail
 						XMLSource sbmlSource = new XMLSource(newMdl);		// sbmlSource with all the changes applied
@@ -782,13 +758,14 @@ public class XmlHelper {
 					Simulation theSimulation = null;
 					for (Simulation sim : bioModel.getSimulations()) {
 						if (sim.getName().equals(selectedTask.getName())) {
-							System.out.println(" --- selected task - name: " + selectedTask.getName() + ", id: " + selectedTask.getId());
+							logger.trace(" --- selected task - name: " + selectedTask.getName() + ", id: " + selectedTask.getId());
 							sim.setImportedTaskID(selectedTask.getId());
 							theSimulation = sim;
 							break;	// found the one, no point to continue the for loop
 						}
 					}if(theSimulation == null) {
-						System.err.println("Couldn't match sedml task '" + selectedTask.getName() + "' with any biomodel simulation");
+						logger.error("Couldn't match sedml task '" + selectedTask.getName() + "' with any biomodel simulation");
+						// TODO: should we throw an exception?
 						continue;	// should never happen
 					}
 					if(!(sedmlSimulation instanceof UniformTimeCourse)) {
@@ -901,7 +878,7 @@ public class XmlHelper {
 					String apKisaoID = sedmlAlgorithmParameter.getKisaoID();
 					String apValue = sedmlAlgorithmParameter.getValue();
 					if(apKisaoID == null || apKisaoID.isEmpty()) {
-						System.err.println("Undefined KisaoID algorithm parameter for algorithm '" + kisaoID + "'");
+						logger.error("Undefined KisaoID algorithm parameter for algorithm '" + kisaoID + "'");
 					}
 
 					// we don't check if the recognized algorithm parameters are valid for our algorithm
@@ -929,7 +906,7 @@ public class XmlHelper {
 							int value = Integer.parseInt(apValue);
 							nssso.setCustomSeed(value);
 						} else {
-							System.err.println("Algorithm parameter '" + AlgorithmParameterDescription.Seed.getDescription() +"' is only supported for nonspatial stochastic simulations");
+							logger.error("Algorithm parameter '" + AlgorithmParameterDescription.Seed.getDescription() +"' is only supported for nonspatial stochastic simulations");
 						}
 						// some arguments used only for non-spatial hybrid solvers
 					} else if(apKisaoID.contentEquals(AlgorithmParameterDescription.Epsilon.getKisao())) {
@@ -945,7 +922,7 @@ public class XmlHelper {
 						NonspatialStochHybridOptions nssho = simTaskDesc.getStochHybridOpt();
 						nssho.setSDETolerance(Double.parseDouble(apValue));
 					} else {
-						System.err.println("Algorithm parameter with kisao id '" + apKisaoID + "' not supported at this time, skipping.");
+						logger.error("Algorithm parameter with kisao id '" + apKisaoID + "' not supported at this time, skipping.");
 					}
 				}
 				simTaskDesc.setErrorTolerance(errorTolerance);
@@ -966,11 +943,11 @@ public class XmlHelper {
 				if (selectedTask instanceof RepeatedTask) {
 					RepeatedTask rt = (RepeatedTask)selectedTask;
 					if (!rt.getResetModel() || rt.getSubTasks().size() != 1) {
-						System.err.println("sequential RepeatedTask not yet supported, task "+SEDMLUtil.getName(selectedTask)+" is being skipped");
+						logger.error("sequential RepeatedTask not yet supported, task "+SEDMLUtil.getName(selectedTask)+" is being skipped");
 						continue;
 					}
 					if (rt.getChanges().size() != 1) {
-						System.err.println("lockstep multiple parameter scans are not yet supported, task "+SEDMLUtil.getName(selectedTask)+" is being skipped");
+						logger.error("lockstep multiple parameter scans are not yet supported, task "+SEDMLUtil.getName(selectedTask)+" is being skipped");
 						continue;
 					}
 					AbstractTask referredTask;
@@ -1005,7 +982,7 @@ public class XmlHelper {
 						}
 						scanSpec = ConstantArraySpec.createListSpec(constant, values);
 					} else {
-						System.err.println("unsupported Range class found, task "+SEDMLUtil.getName(selectedTask)+" is being skipped");
+						logger.error("unsupported Range class found, task "+SEDMLUtil.getName(selectedTask)+" is being skipped");
 						continue;						
 					}
 					MathOverrides mo = simulation.getMathOverrides();
@@ -1083,8 +1060,8 @@ public class XmlHelper {
 		//long l1 = System.currentTimeMillis();
 		bioModel.refreshDependencies();
 		//long l2 = System.currentTimeMillis();
-		//System.out.println("refresh-------- "+((double)(l2-l1))/1000);
-		//System.out.println("total-------- "+((double)(l2-l0))/1000);
+		//logger.trace("refresh-------- "+((double)(l2-l1))/1000);
+		//logger.trace("total-------- "+((double)(l2-l0))/1000);
 
 		return bioModel;
 	}
@@ -1289,7 +1266,6 @@ public class XmlHelper {
 			MathDescription md = reader.getMathDescription(mdElement, geom);
 			sim = reader.getSimulation(simElement, md);
 		} catch (Exception pve) {
-			pve.printStackTrace();
 			throw new XmlParseException("Unable to parse simulation string.", pve);
 		}
 
@@ -1355,7 +1331,7 @@ public class XmlHelper {
 			Element geomElement = xmlProducer.getXML(geom);
 			container.addContent(geomElement);
 		} else {
-			System.err.println("No corresponding geometry for the simulation: " + sim.getName());
+			logger.error("No corresponding geometry for the simulation: " + sim.getName());
 		}
 
 		container = XmlUtil.setDefaultNamespace(container, Namespace.getNamespace(XMLTags.VCML_NS));
@@ -1412,7 +1388,6 @@ public class XmlHelper {
 			return simTask;
 
 		} catch (Exception pve) {
-			pve.printStackTrace();
 			throw new XmlParseException("Unable to parse simulation string.", pve);
 		}
 	}
@@ -1447,7 +1422,7 @@ public class XmlHelper {
 				XPathTarget xPathTarget = change.getTargetXPath();
 				String xpath = xPathTarget.getTargetAsString();			// /sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='A']
 				String newValue = ((ChangeAttribute) change).getNewValue();
-				System.out.println(newValue + ", " + xpath);
+				logger.trace(newValue + ", " + xpath);
 				if(xpath == null || !isValidXPath(xpath)) {		// the validator only accepts species for now
 					continue;
 				}
@@ -1474,22 +1449,22 @@ public class XmlHelper {
 		
 			boolean replaced = false;
 			NodeList listOfSpecies = document.getElementsByTagName("species");
-			System.out.println(listOfSpecies.getLength());
+			logger.trace("there are "+listOfSpecies.getLength()+" species");
 			for (int i = 0; i < listOfSpecies.getLength(); i++) {
 				Node species = listOfSpecies.item(i);
 				if (species.getNodeType() == Node.ELEMENT_NODE) {
 					String id = species.getAttributes().getNamedItem("id").getTextContent();
-					System.out.println(id);
+					logger.trace("species id: "+id);
 					if(id.equals(target)) {
 						species.getAttributes().getNamedItem("initialAmount").setTextContent(newValue);
-						System.out.println("Changed entity " + xpathExpression);
+						logger.trace("Changed entity " + xpathExpression);
 						replaced = true;
 						break;		// we updated the only species with this id, no point to continue
 					}
 				}
 			}
 			if(replaced == false ) {
-				System.err.println("Unable to Change entity " + xpathExpression);
+				logger.error("Unable to Change entity " + xpathExpression);
 			}
 			
 			StringWriter stringWriter = new StringWriter();
@@ -1498,7 +1473,7 @@ public class XmlHelper {
 			
 			xml = stringWriter.toString();
 		} catch (Exception e) {
-			   e.printStackTrace();
+			logger.error(e);
 		}
 		return xml;
 	}
@@ -1508,7 +1483,7 @@ public class XmlHelper {
 		if(xpath.contains("listOfSpecies")) {
 			return true;
 		} else {
-			System.err.println("Only the Change of species is supported at this time");
+			logger.error("Only the Change of species is supported at this time");
 			return false;
 		}
 	}
@@ -1562,7 +1537,7 @@ public class XmlHelper {
 
 		xml = stringWriter.toString();
 	} catch (Exception e) 	{
-	   e.printStackTrace();
+		logger.error(e);
 	}
 	    return xml;
 	}

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
@@ -164,6 +164,8 @@ import scala.collection.mutable.SetBuilder;
  * @author: Anuradha Lakshminarayana
  */
 public class SBMLExporter {
+
+	Logger logger = LogManager.getLogger(SBMLExporter.class);
 	public static final String DOMAIN_TYPE_PREFIX = "domainType_";
 	private int sbmlLevel = 3;
 	private int sbmlVersion = 2;
@@ -695,7 +697,7 @@ protected void addReactions() throws SbmlException, XMLStreamException {
 							org.sbml.jsbml.LocalParameter sbmlKinParam = sbmlKLaw.createLocalParameter();
 							sbmlKinParam.setId(origParamName);
 							sbmlKinParam.setValue(vcKParam.getConstantValue());
-							System.out.println ("tis constant " + sbmlKinParam.isExplicitlySetConstant());
+							logger.trace("tis constant " + sbmlKinParam.isExplicitlySetConstant());
 							//sbmlKinParam.setConstant(true) ) ;
 							// Set SBML units for sbmlParam using VC units from vcParam  
 							if (!vcUnit.isTBD()) {
@@ -909,7 +911,7 @@ protected void addSpecies() throws XMLStreamException, SbmlException {
 		SpeciesContextSpec vcSpeciesContextsSpec = getSelectedSimContext().getReactionContext().getSpeciesContextSpec(vcSpeciesContexts[i]);
 		// since we are setting the substance units for species to 'molecule' or 'item', a unit that is originally in uM (or molecules/um2),
 		// we need to convert concentration from uM -> molecules/um3; this can be achieved by dividing by KMOLE.
-System.out.println("dummy");		
+		logger.trace("in SBMLExporter");
 		// for now we don't do this here and defer to the mechanisms built into the SimContext to convert and set amount instead of concentration
 		// TO-DO: change to export either concentrations or amounts depending on the type of SimContext and setting
 		SpeciesContextSpecParameter initConc = vcSpeciesContextsSpec.getInitialConcentrationParameter();

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
@@ -45,6 +45,8 @@ import java.util.Vector;
 
 import javax.xml.stream.XMLStreamException;
 
+import cbit.vcell.mapping.*;
+import cbit.vcell.parser.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -138,7 +140,6 @@ import cbit.vcell.geometry.AnalyticSubVolume;
 import cbit.vcell.geometry.CSGObject;
 import cbit.vcell.geometry.CSGPrimitive.PrimitiveType;
 import cbit.vcell.geometry.CSGSetOperator.OperatorType;
-import cbit.vcell.geometry.CompartmentSubVolume;
 import cbit.vcell.geometry.Geometry;
 import cbit.vcell.geometry.GeometryClass;
 import cbit.vcell.geometry.GeometrySpec;
@@ -151,21 +152,12 @@ import cbit.vcell.geometry.surface.GeometricRegion;
 import cbit.vcell.geometry.surface.GeometrySurfaceDescription;
 import cbit.vcell.geometry.surface.SurfaceGeometricRegion;
 import cbit.vcell.geometry.surface.VolumeGeometricRegion;
-import cbit.vcell.mapping.BioEvent;
 import cbit.vcell.mapping.BioEvent.BioEventParameterType;
 //import cbit.vcell.mapping.BioEvent.Delay;
 import cbit.vcell.mapping.BioEvent.EventAssignment;
 import cbit.vcell.mapping.BioEvent.TriggerType;
-import cbit.vcell.mapping.FeatureMapping;
-import cbit.vcell.mapping.GeometryContext;
-import cbit.vcell.mapping.MembraneMapping;
-import cbit.vcell.mapping.ReactionContext;
-import cbit.vcell.mapping.ReactionSpec;
-import cbit.vcell.mapping.SimulationContext;
 import cbit.vcell.mapping.SimulationContext.Application;
-import cbit.vcell.mapping.SpeciesContextSpec;
 import cbit.vcell.mapping.SpeciesContextSpec.SpeciesContextSpecParameter;
-import cbit.vcell.mapping.StructureMapping;
 import cbit.vcell.math.BoundaryConditionType;
 import cbit.vcell.model.DistributedKinetics;
 import cbit.vcell.model.Feature;
@@ -192,14 +184,6 @@ import cbit.vcell.model.Species;
 import cbit.vcell.model.SpeciesContext;
 import cbit.vcell.model.Structure;
 import cbit.vcell.model.StructureSorter;
-import cbit.vcell.parser.AbstractNameScope;
-import cbit.vcell.parser.DivideByZeroException;
-import cbit.vcell.parser.Expression;
-import cbit.vcell.parser.ExpressionBindingException;
-import cbit.vcell.parser.ExpressionException;
-import cbit.vcell.parser.ExpressionMathMLParser;
-import cbit.vcell.parser.LambdaFunction;
-import cbit.vcell.parser.SymbolTableEntry;
 import cbit.vcell.render.Vect3d;
 import cbit.vcell.units.VCUnitDefinition;
 import cbit.vcell.units.VCUnitSystem;
@@ -207,6 +191,9 @@ import cbit.vcell.xml.XMLTags;
 import cbit.vcell.xml.XmlParseException;
 
 public class SBMLImporter {
+
+	private final static Logger logger = LogManager.getLogger(SBMLImporter.class);
+
 	public static class SBMLIssueSource implements Issue.IssueSource {
 		private final SBase issueSource;
 
@@ -249,7 +236,7 @@ public class SBMLImporter {
 	// is model spatial?
 	private boolean bSpatial = false;
 
-	private VCLogger logger = null;
+	private VCLogger vcLogger = null;
 	// for VCell specific annotation
 	private static String RATE_NAME = XMLTags.ReactionRateTag;
 	private static String SPECIES_NAME = XMLTags.SpeciesTag;
@@ -310,7 +297,7 @@ public class SBMLImporter {
 			boolean isSpatial) {
 		super();
 		this.sbmlFileName = argSbmlFileName;
-		this.logger = argVCLogger;
+		this.vcLogger = argVCLogger;
 		this.bSpatial = isSpatial;
 	}
 	
@@ -383,15 +370,14 @@ public class SBMLImporter {
 				String msg = "Initial assignment for Structure '" + compartmentName + "' from expression '" + origExpr.infix() + "' was succesfully converted to a number.";
 				localIssueList.add(new Issue(vcBioModel, issueContext, IssueCategory.SBMLImport_RestrictedFeature, msg, Issue.Severity.WARNING));
 			} catch (ExpressionException e) {
-				e.printStackTrace(System.out);
 				String msg = "Failed to set the initial assignment for symbol '" + compartmentName + "' from expression '" + origExpr.infix() + "'. Ignored.";
+				logger.error(msg, e);
 				localIssueList.add(new Issue(vcBioModel, issueContext, IssueCategory.SBMLImport_UnsupportedAttributeOrElement, msg, Issue.Severity.WARNING));
 			}
 		}
 		try {
 			StructureSizeSolver.updateRelativeStructureSizes(vcBioModel.getSimulationContext(0));
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException("Error adding Feature to vcModel " + e.getMessage(), e);
 		}
 	}
@@ -426,7 +412,7 @@ public class SBMLImporter {
 					structureNameMap.put(compartmentName, membrane);
 				} else {
 					String msg = "Cannot deal with spatial dimension : " + compartment.getSpatialDimensions() + " for compartments at this time.";
-					logger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.CompartmentError, msg);
+					vcLogger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.CompartmentError, msg);
 					throw new SBMLImportException(msg);
 				}
 				if (compartment.isSetName()) {
@@ -490,7 +476,7 @@ public class SBMLImporter {
 					if (sizeExpr != null && !sizeExpr.isNumeric()) {
 						// We are NOT handling compartment sizes with assignment
 						// rules/initial Assignments that are NON-numeric at this time ...
-						logger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.CompartmentError,
+						vcLogger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.CompartmentError,
 							"Compartment '" + compartmentName + "' size has an assignment rule which is not a numeric value, cannot handle it at this time.");
 					}
 					// check if sizeExpr is null - no assignment rule for size -
@@ -509,7 +495,7 @@ public class SBMLImporter {
 //							"Compartment '" + compartmentName + "' size has an initial assignment which is not a numeric value, cannot handle it at this time.");
 // TODO: uncomment below to try and compute the expression later, in finalizeCompartment()
 						allSizesSet = false;
-						System.out.println(sizeExpr.infix());
+						logger.trace("sizeExpr = '"+sizeExpr.infix());
 						deferredStructureExpression.put(compartmentName, sizeExpr);
 						sizeExpr = new Expression(size);
 					}
@@ -536,7 +522,6 @@ public class SBMLImporter {
 				StructureSizeSolver.updateRelativeStructureSizes(vcBioModel.getSimulationContext(0));
 			}
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException("Error adding Feature to vcModel " + e.getMessage(), e);
 		}
 	}
@@ -657,7 +642,7 @@ public class SBMLImporter {
 							EventAssignment vcEvntAssgn = vcEvent.new EventAssignment(ste, evntAssgnExpr);
 							vcEvntAssgnList.add(vcEvntAssgn);
 						} else {
-							logger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.UnsupportedConstruct,
+							vcLogger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.UnsupportedConstruct,
 									"No symbolTableEntry for '" + vcVarName + "'; Cannot add event assignment.");
 						}
 					}
@@ -666,7 +651,6 @@ public class SBMLImporter {
 					vcEvent.bind();
 					vcBioModel.getSimulationContext(0).addBioEvent(vcEvent);
 				} catch (Exception e) {
-					e.printStackTrace(System.out);
 					throw new SBMLImportException(e.getMessage(), e);
 				} // end - try/catch
 			} // end - for(sbmlEvents)
@@ -701,7 +685,7 @@ public class SBMLImporter {
 		}
 		ListOf listofInitialAssgns = sbmlModel.getListOfInitialAssignments();
 		if (listofInitialAssgns == null || listofInitialAssgns.isEmpty()) {
-//			System.out.println("No Initial Assignments specified");
+			logger.debug("No Initial Assignments specified");
 			return;
 		}
 		SimulationContext simContext = vcBioModel.getSimulationContext(0);
@@ -729,7 +713,7 @@ public class SBMLImporter {
 							continue;	// nothing to do here
 						} else {
 							// it's missing from deferredStructureExpression map, this should never happen
-							logger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.CompartmentError,
+							vcLogger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.CompartmentError,
 							"compartment '" + sbmlInitAssgnSymbolName + "' size has an initial assignment, cannot handle it at this time.");
 							continue;
 						}
@@ -743,7 +727,7 @@ public class SBMLImporter {
 					if (initAssignMathExpr.hasSymbol(vcModel.getX().getName())
 							|| initAssignMathExpr.hasSymbol(vcModel.getY().getName())
 							|| initAssignMathExpr.hasSymbol(vcModel.getZ().getName())) {
-						logger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.SpeciesError,
+						vcLogger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.SpeciesError,
 							"species '" + sbmlInitAssgnSymbolName + "' initial assignment expression cannot contain 'x', 'y', 'z'.");
 					}
 				}
@@ -784,8 +768,7 @@ public class SBMLImporter {
 					// "Symbol '"+initAssgnSymbol+"' not a species or global parameter in VCell; initial assignment ignored..");
 				}
 			} catch (Exception e) {
-				e.printStackTrace(System.out);
-				throw new RuntimeException("Error reading InitialAssignment : " + e.getMessage());
+				throw new RuntimeException("Error reading InitialAssignment : " + e.getMessage(), e);
 			}
 		}
 	}
@@ -804,7 +787,7 @@ public class SBMLImporter {
 		}
 		ListOf<FunctionDefinition> listofFunctionDefinitions = sbmlModel.getListOfFunctionDefinitions();
 		if (listofFunctionDefinitions == null) {
-			System.out.println("No Function Definitions");
+			logger.debug("No Function Definitions");
 			return;
 		}
 		// The function definitions contain lambda function definition.
@@ -824,7 +807,7 @@ public class SBMLImporter {
 					math = fnDefn.getMath();
 					// Function body.
 					if (math.getNumChildren() == 0) {
-						System.out.println("(no function body defined)");
+						logger.debug("(no function body defined)");
 						continue;
 					}
 					// Add function arguments into vector, print args
@@ -845,7 +828,6 @@ public class SBMLImporter {
 				}
 			}
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException("Error adding Lambda function" + e.getMessage(), e);
 		}
 	}
@@ -863,7 +845,7 @@ public class SBMLImporter {
 	protected void addParameters( Map<String, String> vcToSbmlNameMap, Map<String, String> sbmlToVcNameMap) throws Exception {
 		ListOf listofGlobalParams = sbmlModel.getListOfParameters();
 		if (listofGlobalParams == null) {
-			System.out.println("No Global Parameters");
+			logger.debug("No Global Parameters");
 			return;
 		}
 		Model vcModel = vcBioModel.getSimulationContext(0).getModel();
@@ -1121,7 +1103,7 @@ public class SBMLImporter {
 		Model vcModel = simContext.getModel();
 		ModelParameter[] mps = vcModel.getModelParameters();
 		if (mps == null || mps.length == 0) {
-			System.out.println("SBML Import: no model parameters.");
+			logger.debug("SBML Import: no model parameters.");
 			return;
 		}
 		for (ModelParameter mp : mps) {
@@ -1147,7 +1129,7 @@ public class SBMLImporter {
 								throw new SBMLImportException("Unsupported use of a Reaction name '" + symbol + "' in the expression of Global Parameter '" + mp.getDisplayName() + "'.");
 							}
 						} else {
-							System.out.println("Symbol '" + symbol + "' still unresolved.");
+							logger.warn("Symbol '" + symbol + "' still unresolved.");
 						}
 					}
 				}
@@ -1461,7 +1443,7 @@ public class SBMLImporter {
 		}
 		ListOf listofRules = sbmlModel.getListOfRules();
 		if (listofRules == null) {
-			System.out.println("No Rules specified");
+			logger.debug("No Rules specified");
 			return;
 		}
 		assignmentRulesHash.clear();
@@ -1522,7 +1504,7 @@ public class SBMLImporter {
 	// check if any assignment rule variables or expressions contain x,y,z and substitute them
 	private void readAssignmentRules(Map<String, String> sbmlToVcNameMap) throws ExpressionException, PropertyVetoException {
 		if (assignmentRulesHash == null || assignmentRulesHash.isEmpty()) {
-			System.out.println("SBML Import: no assignment rules.");
+			logger.debug("SBML Import: no assignment rules.");
 			return;
 		}
 		SimulationContext simContext = vcBioModel.getSimulationContext(0);
@@ -1566,7 +1548,7 @@ public class SBMLImporter {
 	// if yes, we replace the reaction name with the expression of the reaction rate
 	private void processAssignmentRules() throws ExpressionException, PropertyVetoException {
 		if (assignmentRulesHash == null || assignmentRulesHash.isEmpty()) {
-			System.out.println("SBML Import: no assignment rules.");
+			logger.debug("SBML Import: no assignment rules.");
 			return;
 		}
 		SimulationContext simContext = vcBioModel.getSimulationContext(0);
@@ -1592,7 +1574,7 @@ public class SBMLImporter {
 								throw new RuntimeException("Unsupported use of a Reaction name '" + symbol + "' in the expression of an AssignmentRule variable '" + vcVariableName + "'.");
 							}
 						} else {
-							System.out.println("Symbol '" + symbol + "' still unresolved.");
+							logger.warn("Symbol '" + symbol + "' still unresolved.");
 						}
 					}
 				}
@@ -1602,7 +1584,7 @@ public class SBMLImporter {
 		}
 		assignmentRulesHash = destMap;
 	}
-	
+
 	private void finalizeAssignmentRules() {
 		SimulationContext simContext = vcBioModel.getSimulationContext(0);
 		Model vcModel = simContext.getModel();
@@ -1644,19 +1626,18 @@ public class SBMLImporter {
 					}
 				}
 			} catch (PropertyVetoException | ExpressionException e) {
-				e.printStackTrace(System.out);
-				throw new SBMLImportException("Unable to create and add assignment rule to VC model : " + e.getMessage());
+				throw new SBMLImportException("Unable to create and add assignment rule to VC model : " + e.getMessage(), e);
 			}
 		}
 		if (foundConstStructureSize) {
 			try {
 				StructureSizeSolver.updateRelativeStructureSizes(simContext);
 				String msg = "One or more AssignmentRule variables of StructureSize type evaluated to constant and were used as initial assignment for the Feature (Structure)";
+				logger.warn(msg);
 				localIssueList.add(new Issue(vcModel, issueContext, IssueCategory.SBMLImport_RestrictedFeature, msg, Issue.Severity.WARNING));
 			} catch (Exception e) {
-				e.printStackTrace(System.out);
 				String msg = "Error initializing a Feature from an assignment rule StructureSize variable. ";
-				throw new SBMLImportException(msg + e.getMessage(), e);
+				throw new SBMLImportException(msg + ": " + e.getMessage(), e);
 			}
 		}
 	}
@@ -1667,7 +1648,7 @@ public class SBMLImporter {
 		}
 		ListOf<Rule> listofRules = sbmlModel.getListOfRules();
 		if (listofRules == null) {
-			System.out.println("No Rules specified");
+			logger.debug("No Rules specified");
 			return;
 		}
 		rateRulesHash.clear();
@@ -1711,7 +1692,7 @@ public class SBMLImporter {
 	// if yes, we replace the reaction name with the expression of the reaction rate
 	private void processRateRules() throws ExpressionException, PropertyVetoException {
 		if (rateRulesHash == null || rateRulesHash.isEmpty()) {
-//			System.out.println("SBML Import: no rate rules.");
+			logger.debug("SBML Import: no rate rules.");
 			return;
 		}
 		SimulationContext simContext = vcBioModel.getSimulationContext(0);
@@ -1738,7 +1719,7 @@ public class SBMLImporter {
 								throw new RuntimeException("Unsupported use of a Reaction name '" + symbol + "' in the expression of RateRule variable '" + vcVariableName + "'.");
 							}
 						} else {
-							System.out.println("Symbol '" + symbol + "' still unresolved.");
+							logger.warn("Symbol '" + symbol + "' still unresolved.");
 						}
 					}
 				}
@@ -1824,17 +1805,16 @@ public class SBMLImporter {
 					simContext.addRateRule(vcRule);
 				}
 			} catch (PropertyVetoException | ExpressionException e) {
-				e.printStackTrace(System.out);
-				throw new SBMLImportException("Unable to create and add rate rule to VC model : " + e.getMessage());
+				throw new SBMLImportException("Unable to create and add rate rule to VC model : " + e.getMessage(), e);
 			}
 		}
 		if (foundConstStructureSize) {
 			try {
 				StructureSizeSolver.updateRelativeStructureSizes(simContext);
 				String msg = "One or more RateRule variables of StructureSize type evaluated to constant and were used as initial assignment for the Feature (Structure)";
+				logger.warn(msg);
 				localIssueList.add(new Issue(vcModel, issueContext, IssueCategory.SBMLImport_RestrictedFeature, msg, Issue.Severity.WARNING));
 			} catch (Exception e) {
-				e.printStackTrace(System.out);
 				String msg = "Error initializing a Feature from a RateRule StructureSize variable. ";
 				throw new SBMLImportException(msg + e.getMessage(), e);
 			}
@@ -1847,7 +1827,7 @@ public class SBMLImporter {
 		}
 		ListOf listOfSpecies = sbmlModel.getListOfSpecies();
 		if (listOfSpecies == null) {
-			System.out.println("No Spcecies");
+			logger.debug("No Spcecies");
 			return;
 		}
 		HashMap<String, Species> vcSpeciesHash = new HashMap<String, Species>();
@@ -1876,7 +1856,7 @@ public class SBMLImporter {
 							vcSpecies = vcSpeciesHash.get(vcSpeciesName);
 							if (vcSpecies == null) {
 								if(isRestrictedXYZT(vcSpeciesName)) {
-									System.out.println("Here too?");
+									logger.warn("Here too?  --- species name "+vcSpeciesName+" is restricted");
 								}
 								vcSpecies = new Species(vcSpeciesName, vcSpeciesName);
 								vcSpeciesHash.put(vcSpeciesName, vcSpecies);
@@ -1930,7 +1910,7 @@ public class SBMLImporter {
 					dimension = (int) sbmlCompartment.getSpatialDimensions();
 				}
 				if (dimension == 0 || dimension == 1) {
-					logger.sendMessage(VCLogger.Priority.HighPriority,
+					vcLogger.sendMessage(VCLogger.Priority.HighPriority,
 							VCLogger.ErrorType.UnitError, dimension
 									+ " dimensional compartment "
 									+ compartmentId + " not supported");
@@ -1951,11 +1931,7 @@ public class SBMLImporter {
 				sbmlAnnotationUtil.readAnnotation(vcSpecies, sbmlSpecies);
 				sbmlAnnotationUtil.readNotes(vcSpecies, sbmlSpecies);
 			}
-		} catch (ModelPropertyVetoException e) {
-			throw new SBMLImportException("Error adding species context; "
-					+ e.getMessage(), e);
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException("Error adding species context; "
 					+ e.getMessage(), e);
 		}
@@ -2009,7 +1985,7 @@ public class SBMLImporter {
 						if (compartmentSize != 0.0) {
 							initConcentration = new Expression(initAmount / compartmentSize);
 						} else {
-							logger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.UnitError,
+							vcLogger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.UnitError,
 								"compartment '"	+ compartment.getId() + "' has zero size, unable to determine initial concentration for species " + speciesName);
 						}
 						// check if initConc is set by a (assignment) rule. That
@@ -2020,7 +1996,7 @@ public class SBMLImporter {
 							initExpr = new Expression(initConcentration);
 						}
 					} else {
-						logger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.SpeciesError,
+						vcLogger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.SpeciesError,
 							" Compartment '" + compartment.getId() + "' size not set or is defined by a rule; cannot calculate initConc.");
 					}
 				} else {
@@ -2059,7 +2035,6 @@ public class SBMLImporter {
 				speciesContextSpec.setConstant(sbmlSpecies.getBoundaryCondition() || sbmlSpecies.getConstant());
 			}
 		} catch (Throwable e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException("Error setting initial condition for species context; " + e.getMessage(), e);
 		}
 	}
@@ -2116,10 +2091,6 @@ public class SBMLImporter {
 	 * import a VCell model that has been exported to SBML, if the user has
 	 * changed the rate name in a reaction, it is stored in the reaction
 	 * annotation. This has to be retrieved and set as reaction rate name.
-	 * 
-	 * @param sbmlRxn
-	 * @param newKinetics
-	 * @throws ExpressionException
 	 */
 	private void resolveRxnParameterNameConflicts(Reaction sbmlRxn,
 			Kinetics vcKinetics, Element sbmlImportElement)
@@ -2244,13 +2215,6 @@ public class SBMLImporter {
 		}
 	}
 
-	/**
-	 * substituteGlobalParamRulesInPlace:
-	 * 
-	 * @param sbmlExpr
-	 * @param expandedExpr
-	 * @throws ExpressionException
-	 */
 	private void substituteGlobalParamRulesInPlace(Expression sbmlExpr, boolean bReplaceValues) throws ExpressionException {
 		boolean bParamChanged = true;
 		while (bParamChanged) {
@@ -2407,8 +2371,7 @@ public class SBMLImporter {
 				msgPackages += "'qual', ";
 			}
 		} catch(Exception e) {
-			e.printStackTrace(System.out);
-			throw new SBMLImportException("Unable to check the SBML file package requirements.");
+			throw new SBMLImportException("Unable to check the SBML file package requirements.", e);
 		}
 		String ext = "extension";
 		String is = "is";
@@ -2436,7 +2399,7 @@ public class SBMLImporter {
 				msgPackages += "'render', ";
 			}
 		} catch(Exception e) {
-			e.printStackTrace(System.out);	// we're going to ignore these packages anyway
+			logger.error("we are going to ignore groups/layout/render packages anyway", e);
 		}
 		if(numPackages > 0) {
 			if(numPackages > 1) {
@@ -2462,7 +2425,6 @@ public class SBMLImporter {
 		try {
 			modelUnitSystem = createSBMLUnitSystemForVCModel();
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException("Inconsistent unit system. Cannot import SBML model into VCell.", Category.INCONSISTENT_UNIT, e);
 		}
 		try {
@@ -2473,7 +2435,6 @@ public class SBMLImporter {
 			simulationContext.setName(vcBioModel.getSimulationContext(0).getModel().getName());
 			// vcBioModel.getSimulationContext(0).setName(vcBioModel.getSimulationContext(0).getModel().getName()+"_"+vcBioModel.getSimulationContext(0).getGeometry().getName());
 		} catch (Exception e) {		// PropertyVetoException
-			e.printStackTrace(System.out);
 			throw new SBMLImportException("Could not create simulation context corresponding to the input SBML model.\n", e);
 		}
 		try {
@@ -2502,7 +2463,6 @@ public class SBMLImporter {
 			}
 
 		} catch(Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException("Could not create Biomodel corresponding to the input SBML model.\n", e);
 		}
 
@@ -2519,9 +2479,10 @@ public class SBMLImporter {
 			}
 			if (issueCount > 0) {
 				try {
-					logger.sendMessage(VCLogger.Priority.MediumPriority, VCLogger.ErrorType.OverallWarning, messageBuffer.toString());
+					logger.warn(messageBuffer.toString());
+					vcLogger.sendMessage(VCLogger.Priority.MediumPriority, VCLogger.ErrorType.OverallWarning, messageBuffer.toString());
 				} catch (Exception e) {
-					e.printStackTrace(System.out);
+					logger.error("failed to report issue", e);
 				}
 			}
 		}
@@ -2535,9 +2496,9 @@ public class SBMLImporter {
 				BioModel convertedBioModel = ModelUnitConverter.createBioModelWithNewUnitSystem(vcBioModel,
 						vcUnitSystem);
 				return convertedBioModel;
-			} catch (ExpressionException | XmlParseException e) {
+			} catch (Exception e) {
+				logger.error("failed to convert imported SBML model into default VCell Unit System - continuing anyway!!",e);
 				// TODO maybe alert user? for now fail silently...
-				e.printStackTrace();
 				return vcBioModel;
 			} 
 		}
@@ -2550,7 +2511,7 @@ public class SBMLImporter {
 		}
 		ListOf listofUnitDefns = sbmlModel.getListOfUnitDefinitions();
 		if (listofUnitDefns == null) {
-			System.out.println("No Unit Definitions");
+			logger.warn("No Unit Definitions in SBML model, using default VCell Unit System");
 			// if < level 3, use SBML default units to create unit system; else,
 			// return a default VC modelUnitSystem.
 			// @TODO: deal with SBML level < 3.
@@ -2655,7 +2616,7 @@ public class SBMLImporter {
 		for (int i = 0; i < sbmlModel.getNumUnitDefinitions(); i++) {
 			UnitDefinition ud = (org.sbml.jsbml.UnitDefinition) listofUnitDefns.get(i);
 			String unitName = ud.getId();
-//			System.out.println("sbml id: " + unitName);
+//			logger.trace("sbml id: " + unitName);
 			VCUnitDefinition vcUnitDef = SBMLUnitTranslator.getVCUnitDefinition(ud, tempVCUnitSystem);
 			sbmlUnitIdentifierHash.put(unitName, vcUnitDef);
 		}
@@ -3144,7 +3105,7 @@ public class SBMLImporter {
 			for (int i = 0; i < sbmlModel.getNumRules(); i++) {
 				Rule rule = (org.sbml.jsbml.Rule) sbmlModel.getRule(i);
 				if (rule instanceof AlgebraicRule) {
-					logger.sendMessage(VCLogger.Priority.HighPriority,
+					vcLogger.sendMessage(VCLogger.Priority.HighPriority,
 							VCLogger.ErrorType.UnsupportedConstruct,
 							"Algebraic rules are not handled in the Virtual Cell at this time");
 				}
@@ -3160,7 +3121,7 @@ public class SBMLImporter {
 				
 				if (level > 2) {
 					// level 3+ does not have default value for spatialDimension. So cannot assume a value.
-					logger.sendMessage(
+					vcLogger.sendMessage(
 							VCLogger.Priority.MediumPriority,
 							VCLogger.ErrorType.CompartmentError,
 							"Compartment '" + comp.getId() + "' spatial dimension is not set; assuming 3.");
@@ -3171,7 +3132,7 @@ public class SBMLImporter {
 				
 				if (level > 2) {
 					// level 3+ does not have default value for size. So cannot assume a value.
-					logger.sendMessage(
+					vcLogger.sendMessage(
 							VCLogger.Priority.MediumPriority,
 							VCLogger.ErrorType.CompartmentError,
 							"Compartment '"	+ comp.getId() + "' size is not set; assuming 1.");
@@ -3179,7 +3140,7 @@ public class SBMLImporter {
 			}
 			
 			if (comp.getSpatialDimensions() == 0 || comp.getSpatialDimensions() == 1) {
-				logger.sendMessage(
+				vcLogger.sendMessage(
 						VCLogger.Priority.HighPriority,
 						VCLogger.ErrorType.CompartmentError,
 						"Compartment " + comp.getId() + " has spatial dimension 0; this is not supported in VCell");
@@ -3190,7 +3151,7 @@ public class SBMLImporter {
 		// events are not supported in a spatial VCell model.
 		if (bSpatial) {
 			if (sbmlModel.getNumEvents() > 0) {
-				logger.sendMessage(
+				vcLogger.sendMessage(
 						VCLogger.Priority.HighPriority,
 						VCLogger.ErrorType.UnsupportedConstruct,
 						"Events are not supported in a spatial Virtual Cell model at this time, they are only supported in a non-spatial model.");
@@ -3210,7 +3171,6 @@ public class SBMLImporter {
 		try {
 			checkForUnsupportedVCellFeaturesAndApplyDefaults();
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException(e.getMessage(), e);
 		}
 
@@ -3230,7 +3190,6 @@ public class SBMLImporter {
 		} catch (SBMLImportException sie) {
 			throw sie;
 		} catch (Exception ee) {
-			ee.printStackTrace(System.out);
 			throw new SBMLImportException(ee.getMessage(), ee);
 		}
 		// Add features/compartments
@@ -3244,7 +3203,6 @@ public class SBMLImporter {
 		try {
 			addParameters(vcToSbmlNameMap, sbmlToVcNameMap);
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException(e.getMessage(), e);
 		}
 		
@@ -3253,7 +3211,6 @@ public class SBMLImporter {
 		try {
 			readAssignmentRules(sbmlToVcNameMap);
 		} catch (ExpressionException | PropertyVetoException e) {
-			e.printStackTrace();
 			throw new SBMLImportException(e.getMessage(), e);
 		}
 		// Set initial conditions on species
@@ -3288,7 +3245,6 @@ public class SBMLImporter {
 			processAssignmentRules();
 			processRateRules();
 		} catch (ExpressionException | SBMLException | XMLStreamException | PropertyVetoException e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException(e.getMessage(), e);
 		}
 		
@@ -3302,7 +3258,6 @@ public class SBMLImporter {
 		try {
 			vcBioModel.getSimulationContext(0).getModel().setStructures(sortedStructures);
 		} catch (PropertyVetoException e1) {
-			e1.printStackTrace(System.out);
 			throw new SBMLImportException("Error while sorting compartments: " + e1.getMessage(), e1);
 		}
 
@@ -3313,7 +3268,6 @@ public class SBMLImporter {
 		try {
 			checkIdentifiersNameLength();
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException(e.getMessage(), e);
 		}
 
@@ -3712,7 +3666,7 @@ public class SBMLImporter {
 				// set the reaction kinetics, and add reaction to the vcell
 				// model.
 				kinetics.resolveUndefinedUnits();
-				// System.out.println("ADDED SBML REACTION : \"" + rxnName +
+				// logger.trace("ADDED SBML REACTION : \"" + rxnName +
 				// "\" to VCModel");
 				vcReactionList.add(vcReaction);
 				if (sbmlRxn.isSetFast() && sbmlRxn.getFast()) {
@@ -3732,7 +3686,6 @@ public class SBMLImporter {
 		} catch (ModelPropertyVetoException mpve) {
 			throw new SBMLImportException(mpve.getMessage(), mpve);
 		} catch (Exception e1) {
-			e1.printStackTrace(System.out);
 			throw new SBMLImportException(e1.getMessage(), e1);
 		}
 	}
@@ -4052,7 +4005,7 @@ public class SBMLImporter {
 				}
 			}
 			try {
-				//System.out.println("ident " + sf.getId() + " " + sf.getName());
+				// logger.trace("ident " + sf.getId() + " " + sf.getName());
 				VCImage vcImage = null;
 				CompressionKind ck = sf.getCompression();
 				DataKind dk = sf.getDataType();
@@ -4100,10 +4053,9 @@ public class SBMLImporter {
 				// now create image geometry
 				vcGeometry = new Geometry("spatialGeom", vcImage);
 			} catch (Exception e) {
-				e.printStackTrace(System.out);
 				throw new RuntimeException(
 						"Unable to create image from SampledFieldGeometry : "
-								+ e.getMessage());
+								+ e.getMessage(), e);
 			}
 		}
 		GeometrySpec vcGeometrySpec = vcGeometry.getGeometrySpec();
@@ -4111,7 +4063,6 @@ public class SBMLImporter {
 		try {
 			vcGeometrySpec.setExtent(vcExtent);
 		} catch (PropertyVetoException e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException(
 					"Unable to set extent on VC geometry : " + e.getMessage(),
 					e);
@@ -4182,7 +4133,6 @@ public class SBMLImporter {
 						Expression subVolExpr = getExpressionFromFormula(analyticVol.getMath());
 						asv.setExpression(subVolExpr);
 					} catch (ExpressionException e) {
-						e.printStackTrace(System.out);
 						throw new SBMLImportException(
 								"Unable to set expression on subVolume '"
 										+ asv.getName() + "'. "
@@ -4252,7 +4202,6 @@ public class SBMLImporter {
 			vcGeometry.precomputeAll(new GeometryThumbnailImageFactoryAWT(),
 					true, true);
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException(
 					"Unable to create VC subVolumes from SBML domainTypes : "
 							+ e.getMessage(), e);
@@ -4539,7 +4488,7 @@ public class SBMLImporter {
 							}
 						} // sm != null
 						else {
-							logger.sendMessage(
+							vcLogger.sendMessage(
 									VCLogger.Priority.MediumPriority,
 									VCLogger.ErrorType.OverallWarning,
 									"No structure " + s.getName()
@@ -4553,7 +4502,6 @@ public class SBMLImporter {
 			vcBioModel.getSimulationContext(0).getGeometryContext().refreshStructureMappings();
 			vcBioModel.getSimulationContext(0).refreshSpatialObjects();
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
 			throw new SBMLImportException(
 					"Unable to create VC structureMappings from SBML compartment mappings : "
 							+ e.getMessage(), e);

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLUnitTranslator.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLUnitTranslator.java
@@ -11,7 +11,8 @@
 package org.vcell.sbml.vcell;
 
 import java.util.ArrayList;
-
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.sbml.jsbml.Unit;
 import org.sbml.jsbml.Unit.Kind;
 import org.sbml.jsbml.UnitDefinition;
@@ -27,7 +28,7 @@ import cbit.vcell.units.VCUnitSystem;
  * @author: Anuradha Lakshminarayana
  */
 public class SBMLUnitTranslator {
-	
+	private final static Logger logger = LogManager.getLogger(SBMLUnitTranslator.class);
 /**
  *
  *   BaseUnit definitions copied from ucar.units_vcell.SI (as modified for Virtual Cell and SBML ... including item and molecules)
@@ -218,7 +219,7 @@ public static UnitDefinition getSBMLUnitDefinition(VCUnitDefinition vcUnitDefn, 
 					}
 					Unit sbmlUnit = new Unit(multiplier, scale, kind, exponent, level, version);
 					sbmlUnitDefn.addUnit(sbmlUnit);
-					System.err.println("kind = "+kind.name()+" is equivalent to vcUnit = "+vcUnit.getSymbol()+",  SBML unit is "+sbmlUnit);
+					logger.warn("kind = "+kind.name()+" is equivalent to vcUnit = "+vcUnit.getSymbol()+",  SBML unit is "+sbmlUnit);
 				}
 				bFoundMatch = true;
 				break;
@@ -242,7 +243,7 @@ public static UnitDefinition getSBMLUnitDefinition(VCUnitDefinition vcUnitDefn, 
 					}
 					sbmlUnitDefn.addUnit(new Unit(multiplier, scale, Kind.MOLE, exponent, level, version));
 					sbmlUnitDefn.addUnit(new Unit(1, 0, Kind.LITRE, -exponent, level, version));
-					System.err.println("matched to liter ... had to create a replacement for molar, vcUnit = "+vcUnit.getSymbol()+",  SBML unit is "+sbmlUnitDefn);
+					logger.warn("matched to liter ... had to create a replacement for molar, vcUnit = "+vcUnit.getSymbol()+",  SBML unit is "+sbmlUnitDefn);
 				}
 				bFoundMatch = true;
 			}

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -1184,7 +1184,7 @@ public class SEDMLExporter {
 				targetXpath = new XPathTarget(sbmlSupport.getXPathForCompartment(speciesId));
 			} else if (speciesAttr.equalsIgnoreCase("initialConcentration") || speciesAttr.equalsIgnoreCase("initConc")) {
 				targetXpath = new XPathTarget(sbmlSupport.getXPathForSpecies(speciesId, SpeciesAttribute.initialConcentration));
-			} else if (speciesAttr.equalsIgnoreCase("initialCount")) {
+			} else if (speciesAttr.equalsIgnoreCase("initialCount") || speciesAttr.equalsIgnoreCase("initCount")) {
 				targetXpath = new XPathTarget(sbmlSupport.getXPathForSpecies(speciesId, SpeciesAttribute.initialAmount));
 			} else {
 				throw new RuntimeException("Unknown species attribute '" + speciesAttr + "'; cannot get xpath target for species '" + speciesId + "'.");

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -1016,8 +1016,7 @@ public class SEDMLExporter {
 	
 
 		} catch (Exception e) {
-			e.printStackTrace(System.out);
-			throw new RuntimeException("Error adding model to SEDML document : " + e.getMessage());
+			throw new RuntimeException("Error adding model to SEDML document : " + e.getMessage(), e);
 		}
 	}
 
@@ -1157,8 +1156,12 @@ public class SEDMLExporter {
 				targetXpath = new XPathTarget(sbmlSupport.getXPathForGlobalParameter(value, ParameterAttribute.value));
 			}
 		} else {
-			System.err.println("Entity should be SpeciesContext, Structure, ModelParameter : " + ste.getClass());
-			throw new RuntimeException("Unknown entity in SBML model");
+			if(ste instanceof Membrane.MembraneVoltage) {
+				String msg = "Export failed: This VCell model has membrane voltage; cannot be exported to SBML at this time";
+				throw new RuntimeException(msg);
+			} else {
+				throw new RuntimeException("Unsupported entity in SBML model export: "+ste.getClass());
+			}
 		}
 		return targetXpath;
 	}
@@ -1236,7 +1239,7 @@ public class SEDMLExporter {
 				throw new RuntimeException(msg);
 			} else {
 				System.err.println("Entity should be SpeciesContext, Structure, ModelParameter : " + ste.getClass());
-				throw new RuntimeException("Unknown entity in SBML model");
+				throw new RuntimeException("Unsupported entity in SBML model export: "+ste.getClass());
 			}
 		}
 		return targetXpath;


### PR DESCRIPTION
- introduced logging (using log4j2) to replace verbose print statements in SBML/SEDML import/export classes.
- omex file validation by immediately re-reading the exported omex files to perform basic validation (omex file parse doesn't fail).
- fixed SEDML export of "initCount" parameters (for stochastic VCell applications).
- better error message for SBML export with membrane voltage.
- fixed SBML import of 2D/3D geometries with respect to subvolumes and membranes.

see https://github.com/virtualcell/vcell/issues/229