### PR TITLE
Changed MongoDB messaging property to false

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/CLIStandalone.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIStandalone.java
@@ -2,6 +2,8 @@ package org.vcell.cli;
 
 import org.vcell.cli.run.ExecuteCommand;
 import org.vcell.cli.vcml.ConvertCommand;
+
+import cbit.vcell.mongodb.VCMongoMessage;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -10,6 +12,7 @@ import picocli.CommandLine.Command;
 public class CLIStandalone {
 
     public static void main(String[] args) {
+        VCMongoMessage.enabled = false;
         int exitCode = new CommandLine(new CLIStandalone()).execute(args);
         System.exit(exitCode);
     }


### PR DESCRIPTION
Enabling MongoDB message was causing missing properties exceptions.