### PR TITLE
Centralized log functions in VCellUtils, cleanup, and bonus BioSim fix

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/CLIPythonManager.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIPythonManager.java
@@ -264,7 +264,7 @@ public class CLIPythonManager {
 
         ){ // Report an error:
             String resultString = (errString != null && errString.length() > 0) ? String.format("Result: %s\n", errString) : "";
-            System.err.printf("Python error caught: <%s>\n%s", returnedString, resultString);
+            System.err.printf("Python error caught: <\n%s\n>\n%s\n[ Stack Trace:\n%s\n]", returnedString, resultString, this.getCurrentStackTrace(new Exception()));
             hasPassed = false;
         } else {
             String resultString = (outString != null && outString.length() > 0) ? String.format("Result: %s\n", outString) : "";
@@ -287,6 +287,13 @@ public class CLIPythonManager {
         }
         adjArgLength = argList.length() == 0 ? 0 : argList.length() - 1;
         return argList.substring(0, adjArgLength);
+    }
+
+    private String getCurrentStackTrace(Throwable dummyThrowable){
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw, true);
+        dummyThrowable.printStackTrace(pw);
+        return sw.getBuffer().toString();
     }
 
     public static String stripString(String str){

--- a/vcell-cli/src/main/java/org/vcell/cli/CLIUtils.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIUtils.java
@@ -83,9 +83,60 @@ public class CLIUtils {
         return isDirectory || bForceKeepLogs;
     }
 
+    public static void createHeader(File outputFilePath, boolean bForceLogFiles) {
+        /**
+         * Header Components:
+         *  * base name of the omex file
+         *  *   foreach sed-ml file:
+         *  *   - (current) sed-ml file name
+         *  *   - error(s) (if any)
+         *  *   - number of models
+         *  *   - number of sims
+         *  *   - number of tasks
+         *  *   - number of outputs
+         *  *   - number of biomodels
+         *  *   - number of succesful sims that we managed to run
+         *  *   (NB: we assume that the # of failures = # of tasks - # of successful simulations)
+         *  *   (NB: if multiple sedml files in the omex, we display on multiple rows, one for each sedml)
+         */
+
+        String header = "BaseName,SedML,Error,Models,Sims,Tasks,Outputs,BioModels,NumSimsSuccessful";
+        try {
+            CLIUtils.writeDetailedResultList(outputFilePath.getAbsolutePath(), header, bForceLogFiles);
+        } catch (IOException e1) {
+            // not big deal, we just failed to make the header; we'll find out later what went wrong
+            e1.printStackTrace();
+        }
+    }
+
     public static void writeDetailedErrorList(String outputBaseDir, String s, boolean bForceKeepLogs) throws IOException {
         if (isBatchExecution(outputBaseDir, bForceKeepLogs)) {
             String dest = outputBaseDir + File.separator + "detailedErrorLog.txt";
+            java.nio.file.Files.write(Paths.get(dest), (s + "\n").getBytes(),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        }
+    }
+
+    public static void writeFullSuccessList(String outputBaseDir, String s, boolean bForceLogFiles) throws IOException {
+        if (CLIUtils.isBatchExecution(outputBaseDir, bForceLogFiles)) {
+            String dest = outputBaseDir + File.separator + "fullSuccessLog.txt";
+            java.nio.file.Files.write(Paths.get(dest), (s + "\n").getBytes(),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        }
+    }
+
+    // we just make a list with the omex files that failed
+    public static void writeErrorList(String outputBaseDir, String s, boolean bForceLogFiles) throws IOException {
+        if (CLIUtils.isBatchExecution(outputBaseDir, bForceLogFiles)) {
+            String dest = outputBaseDir + File.separator + "errorLog.txt";
+            java.nio.file.Files.write(Paths.get(dest), (s + "\n").getBytes(),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        }
+    }
+
+    public static void writeDetailedResultList(String outputBaseDir, String s, boolean bForceLogFiles) throws IOException {
+        if (CLIUtils.isBatchExecution(outputBaseDir, bForceLogFiles)) {
+            String dest = outputBaseDir + File.separator + "detailedResultLog.txt";
             java.nio.file.Files.write(Paths.get(dest), (s + "\n").getBytes(),
                     StandardOpenOption.CREATE, StandardOpenOption.APPEND);
         }

--- a/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteCommand.java
@@ -62,9 +62,12 @@ public class ExecuteCommand implements Callable<Integer> {
             Executable.setTimeoutMS(EXECUTABLE_MAX_WALLCLOCK_MILLIS);
 
             if (inputFilePath.isDirectory()) {
+                CLIUtils.createHeader(outputFilePath, bForceLogFiles);
                 ExecuteImpl.batchMode(inputFilePath, outputFilePath, bKeepTempFiles, bExactMatchOnly, bForceLogFiles);
             } else {
                 File archiveToProcess = inputFilePath;
+                if (bForceLogFiles) CLIUtils.createHeader(outputFilePath, bForceLogFiles);
+
                 if (archiveToProcess.getName().endsWith("vcml")) {
                     ExecuteImpl.singleExecVcml(archiveToProcess, outputFilePath);
                 } else { // archiveToProcess.getName().endsWith("omex")

--- a/vcell-cli/src/main/java/org/vcell/cli/run/PythonCalls.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/PythonCalls.java
@@ -1,7 +1,6 @@
 package org.vcell.cli.run;
 
 import org.vcell.cli.CLIPythonManager;
-import org.vcell.cli.CLIUtils;
 import org.vcell.cli.PythonStreamException;
 
 import java.io.IOException;
@@ -63,7 +62,7 @@ public class PythonCalls {
     // message  - exception message
     public static void setExceptionMessage(String sedmlAbsolutePath, String entityId, String outDir, String entityType, String type , String message) throws PythonStreamException {
         CLIPythonManager cliPythonManager = CLIPythonManager.getInstance();
-        String results = cliPythonManager.callPython("setExceptionMessage", sedmlAbsolutePath, entityId, outDir, entityType, type, message);
+        String results = cliPythonManager.callPython("setExceptionMessage", sedmlAbsolutePath, entityId, outDir, entityType, type, stripIllegalChars(message));
         cliPythonManager.printPythonErrors(results, "", "Failed updating task status YAML\n");
     }
 
@@ -76,7 +75,7 @@ public class PythonCalls {
                          --report_formats | --plot_formats | --log | --indent
         * */
         // handle exceptions here
-        if (cliPythonManager.checkPythonInstallationError() == 0) {
+        if (CLIPythonManager.checkPythonInstallationError() == 0) {
             String results = cliPythonManager.callPython("execSedDoc", omexFilePath, outputDir);
             cliPythonManager.printPythonErrors(results, "HDF conversion successful\n","HDF conversion failed\n");
         }
@@ -155,6 +154,14 @@ public class PythonCalls {
 //        cliPythonManager.printPythonErrors(results);
     }
 
+    private static String stripIllegalChars(String s){
+        String fStr = "";
+        for (char c : s.toCharArray()){
+            char cAppend = ((int)c) < 16 ? ' ' : c;
+            fStr += cAppend;
+        }
+        return fStr;
+    }
 
 
 }


### PR DESCRIPTION
Turns out log files were being made, however some were missing their header and buried in a subdirectory. The header issue has been fixed, but the files can't be moved without serious refactoring of pathing in VCell CLI. In the process of fixing the header, all VCell CLI local logging functions were moved to CLIUtils.

Bonus BioSim fix refers to how error messages were obscured before by errors in the error pipeline