### PR TITLE
added backup library loader to OmexHandler and NativeLib

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/run/OmexHandler.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/OmexHandler.java
@@ -24,18 +24,24 @@ public class OmexHandler {
     CombineArchive archive;
 
     // Assuming omexPath will always be absolute path
+    // NB: Need to convert class to use Log4j2
     public OmexHandler(String omexPath, String outDir) throws IOException {
         try {
-            ResourceUtil.setNativeLibraryDirectory();
-            NativeLib.combinej.load();
-//            System.load("combinej");
+            try {
+                ResourceUtil.setNativeLibraryDirectory();
+                NativeLib.combinej.load();
+            } catch (Exception e){
+                System.err.println("Unable to link to native 'libCombine' lib, check native lib. Attemping alternate solution...");
+                NativeLib.combinej.directLoad();
+            }
         } catch (UnsatisfiedLinkError ex) {
             System.err.println("Unable to link to native 'libCombine' lib, check native lib: " + ex.getMessage());
-            System.exit(1);
-        } catch (Exception e) {
-            System.err.println("Error occurred while importing libCombine: " + e.getMessage());
-            System.exit(1);
+            throw ex;
+        } catch (Exception ex) {
+            System.err.println("Error occurred while importing libCombine: " + ex.getMessage());
+            throw ex;
         }
+        
         this.omexPath = omexPath;
         this.outDirPath = outDir;
 


### PR DESCRIPTION
### Background
When setting up my new workstation, I came across the same native library bug I had encountered on my old system. After discovering a work around with the help of Jim, I created a simple "backup" loader in case @gmarupilla's code fails. 

### VERIFICATION NEEDED
This hasn't been tested on all platforms. It currently has only been tested on Linux (Ubuntu 20); Before this branch is accepted, we need confirmation that it works on:
- Windows (10)
- Mac

Once we have confirmation, we can pull this in.

When we have some time to tackle tech debt, this whole system may be moved to its own class that is called near time of execution (or at least somewhere more appropriate than buried where it is).