### PR TITLE
Restored deprecated single archive execution and added cleaning function

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/CLIUtils.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIUtils.java
@@ -39,6 +39,17 @@ public class CLIUtils {
         }
     }
 
+    public static void cleanRootDir(File outdir){
+        // If this could be done without hard coding it'd be preferable.
+        String[] filesToDelete = {"detailedResultLog.txt", "fullSuccessLog.txt", "log.json", "log.yml", "reports.h5", "reports.zip"};
+        for (String fileName : filesToDelete){
+            File instance = new File(outdir, fileName);
+            if (instance.exists()){
+                instance.delete();
+            }
+        }
+    }
+
     public static void setLogLevel(LoggerContext ctx, Level logLevel){
         Configuration config = ctx.getConfiguration();
         LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);

--- a/vcell-cli/src/main/java/org/vcell/cli/biosimulation/BiosimulationsCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/biosimulation/BiosimulationsCommand.java
@@ -89,7 +89,7 @@ public class BiosimulationsCommand implements Callable<Integer> {
 
             try {
                 CLIPythonManager.getInstance().instantiatePythonProcess();
-                ExecuteImpl.singleExecOmex(ARCHIVE, OUT_DIR, bKeepTempFiles, bExactMatchOnly, bForceLogFiles);
+                ExecuteImpl.singleExecOmex(ARCHIVE, OUT_DIR, bKeepTempFiles, bExactMatchOnly, bForceLogFiles, false);
                 return 0;
             } finally {
                 try {

--- a/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteCommand.java
@@ -37,6 +37,10 @@ public class ExecuteCommand implements Callable<Integer> {
     @Option(names = {"--exactMatchOnly"})
     private boolean bExactMatchOnly;
 
+    @Option(names = {"--encapsulateOutput"}, defaultValue = "true", description = 
+        "VCell will encapsulate output results in a sub directory when executing with a single input archive; has no effect when providing an input directory")
+    private boolean bEncapsulateOutput;
+
     @Option(names = {"--timeout_ms"}, defaultValue = "600000", description = "executable wall clock timeout in milliseconds")
     // timeout for compiled solver running long jobs; default 12 hours
     private long EXECUTABLE_MAX_WALLCLOCK_MILLIS;
@@ -82,7 +86,7 @@ public class ExecuteCommand implements Callable<Integer> {
                 if (archiveToProcess.getName().endsWith("vcml")) {
                     ExecuteImpl.singleExecVcml(archiveToProcess, outputFilePath);
                 } else { // archiveToProcess.getName().endsWith("omex")
-                    ExecuteImpl.singleExecOmex(archiveToProcess, outputFilePath, bKeepTempFiles, bExactMatchOnly, bForceLogFiles);
+                    ExecuteImpl.singleExecOmex(archiveToProcess, outputFilePath, bKeepTempFiles, bExactMatchOnly, bForceLogFiles, bEncapsulateOutput);
                 }
             }
 

--- a/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteImpl.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteImpl.java
@@ -113,14 +113,20 @@ public class ExecuteImpl {
     }
 
 
-    public static void singleExecOmex(File inputFile, File rootOutputDir,
-                                      boolean bKeepTempFiles, boolean bExactMatchOnly, boolean bForceLogFiles)
+    public static void singleExecOmex(File inputFile, File rootOutputDir, boolean bKeepTempFiles, 
+                                        boolean bExactMatchOnly, boolean bForceLogFiles) 
+            throws Exception {
+        ExecuteImpl.singleExecOmex(inputFile, rootOutputDir, bKeepTempFiles, bExactMatchOnly, bForceLogFiles, true);
+    }
+
+    public static void singleExecOmex(File inputFile, File rootOutputDir, boolean bKeepTempFiles, 
+                                        boolean bExactMatchOnly, boolean bForceLogFiles, boolean bEncapsulateOutput)
             throws Exception {
         int nModels, nSimulations, nSedml, nTasks, nOutputs, nReportsCount = 0, nPlots2DCount = 0, nPlots3DCount = 0;
         String inputFileName = inputFile.getAbsolutePath();
         String bioModelBaseName = FileUtils.getBaseName(inputFile.getName());
-        String outputDir = Paths.get(rootOutputDir.getAbsolutePath(), bioModelBaseName).toString();
         String outputBaseDir = rootOutputDir.getAbsolutePath(); // bioModelBaseName = input file without the path
+        String outputDir = bEncapsulateOutput ? Paths.get(outputBaseDir, bioModelBaseName).toString() : outputBaseDir;
         OmexHandler omexHandler = null;
         List<String> sedmlLocations;
         List<Output> outputs;
@@ -148,7 +154,8 @@ public class ExecuteImpl {
             throw new Exception(error);
         }
 
-        RunUtils.removeAndMakeDirs(new File(outputDir));
+        CLIUtils.cleanRootDir(new File(outputBaseDir));
+        if (bEncapsulateOutput) RunUtils.removeAndMakeDirs(new File(outputDir));
         PythonCalls.generateStatusYaml(inputFileName, outputDir);    // generate Status YAML
 
         // from here on, we need to collect errors, since some subtasks may succeed while other do not


### PR DESCRIPTION
Biosimulator's cli standard requires the ability to execute a single archive rather than a directory of n archives (n is a natural number). This feature had been recently deprecated accidentally, but will now be supported. Additionally, proper cleaning of output directory is performed.