### PR TITLE
Oracle schema synch to prep for Postgres

### DIFF
--- a/vcell-server/src/main/java/cbit/sql/CompareDatabaseSchema.java
+++ b/vcell-server/src/main/java/cbit/sql/CompareDatabaseSchema.java
@@ -15,8 +15,6 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import javax.swing.JFrame;
-
 import org.vcell.db.ConnectionFactory;
 import org.vcell.db.DatabaseService;
 import org.vcell.db.DatabaseSyntax;
@@ -184,22 +182,6 @@ public static void main(java.lang.String[] args) {
         String dbSchemaUser = args[2];
         String dbPassword = args[3];
         //
-        int ok =
-            javax.swing.JOptionPane.showConfirmDialog(
-                new JFrame(),
-                "Will compare VCell Software 'Tables' with Database Schema: "
-                    + "connectURL="
-                    + connectURL
-                    + "\nUser="
-                    + dbSchemaUser
-                    + "\npassword="
-                    + dbPassword,
-                "Confirm",
-                javax.swing.JOptionPane.OK_CANCEL_OPTION,
-                javax.swing.JOptionPane.WARNING_MESSAGE);
-        if (ok != javax.swing.JOptionPane.OK_OPTION) {
-            throw new RuntimeException("Aborted by user");
-        }
 
         ConnectionFactory conFactory = null;
         KeyFactory keyFactory = null;
@@ -208,11 +190,12 @@ public static void main(java.lang.String[] args) {
         //
         // get appropriate database factory objects
         //
+
         DatabaseSyntax dbSyntax = null;
         if (args[0].equalsIgnoreCase(oracle)) {
         	dbSyntax = DatabaseSyntax.ORACLE;
             String driverName = "oracle.jdbc.driver.OracleDriver";
-            conFactory = DatabaseService.getInstance().createConnectionFactory(
+			conFactory = DatabaseService.getInstance().createConnectionFactory(
                     driverName,
                     connectURL,
                     dbSchemaUser,

--- a/vcell-server/src/main/java/cbit/sql/Field.java
+++ b/vcell-server/src/main/java/cbit/sql/Field.java
@@ -36,6 +36,7 @@ public class Field {
 		number_as_integer("number","bigint",BasicDataType.BIGINT),
 		number_as_real("number","numeric",BasicDataType.NUMERIC),
 		varchar2_4000("varchar2(4000)","varchar(4000)",BasicDataType.VARCHAR),
+		varchar2_2000("varchar2(2000)","varchar(2000)",BasicDataType.VARCHAR),
 		varchar2_1024("varchar2(1024)","varchar(1024)",BasicDataType.VARCHAR),
 		varchar2_512("varchar2(512)","varchar(512)",BasicDataType.VARCHAR),
 		varchar2_256("varchar2(256)","varchar(256)",BasicDataType.VARCHAR),

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/MathVerifier.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/MathVerifier.java
@@ -147,12 +147,14 @@ public static class LoadModelsStatTable extends Table{
 	public final Field bSameCachedAndNotCachedXMLExc	= new Field("bSameCachedAndNotCachedXMLExc",SQLDataType.varchar2_255,	"");
 	public final Field bSameCachedAndNotCachedObjExc	= new Field("bSameCachedAndNotCachedObjExc",SQLDataType.varchar2_255,	"");
 	public final Field bSameSelfXMLCachedRoundtripExc	= new Field("bSameSelfXMLCachedRoundtripExc",SQLDataType.varchar2_255,	"");
-	
+	public final Field bIssuesErrors					= new Field("bIssuesErrors"					,SQLDataType.varchar2_255,	"");
+
 	private final Field fields[] =
 		{bioModelRef,mathModelRef,resultFlag,errorMessage,timeStamp,loadTime,softwareVers,
 			loadOriginalXMLTime,loadUnresolvedTime,
 			bSameCachedAndNotCachedXML,bSameCachedAndNotCachedObj,bSameSelfXMLCachedRoundtrip,
-			bSameCachedAndNotCachedXMLExc,bSameCachedAndNotCachedObjExc,bSameSelfXMLCachedRoundtripExc};
+			bSameCachedAndNotCachedXMLExc,bSameCachedAndNotCachedObjExc,bSameSelfXMLCachedRoundtripExc,
+			bIssuesErrors};
 	
 	public static final LoadModelsStatTable table = new LoadModelsStatTable();
 	/**

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/SpeciesContextModelTable.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/SpeciesContextModelTable.java
@@ -35,7 +35,7 @@ public class SpeciesContextModelTable extends cbit.sql.Table {
 	//public final Field diffRate		= new Field("diffRate",		"varchar(255)",			"NOT NULL");
 	//public final Field initCond		= new Field("initCond",		"varchar(255)",			"NOT NULL");
 	public final Field hasOverride	= new Field("hasOverride",	SQLDataType.varchar2_1,		"NOT NULL");// 'T' or 'F'
-	public final Field speciesPattern=new Field("speciesPattern",SQLDataType.varchar2_255,	"");
+	public final Field speciesPattern=new Field("speciesPattern",SQLDataType.varchar2_2000,	"");
 	public final Field sbmlName		= new Field("sbmlName",			SQLDataType.varchar_255,	"");
 	
 	private final Field fields[] = {modelRef,speciesRef,structRef,name,/*diffRate,initCond,*/hasOverride,speciesPattern, sbmlName};


### PR DESCRIPTION
In preparation for Postgres migration of VCell database, we aligned the Oracle Schema using Oracle DDL (Data Definition Language) calls (database introspection) to compare against VCell software's internal representation of the database (Java classes representing tables, fields, relationships).

A follow-up step will be to create an empty Postgres database which is aligned with the VCell software and migrate the data from Oracle to Postgres.