### PR TITLE
Kmole round trip

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
@@ -482,6 +482,7 @@ public class VcmlOmexConverter {
 				reread_BioModel_sbml_units.refreshDependencies();
 
 				BioModel reread_BioModel_sbml_units_cloned = XmlHelper.cloneBioModel(reread_BioModel_sbml_units);
+				reread_BioModel_sbml_units_cloned.refreshDependencies();
 				//
 				// transform re-read BioModel back to original unit system before comparing with original model
 				//

--- a/vcell-core/src/main/java/cbit/vcell/biomodel/ModelUnitConverter.java
+++ b/vcell-core/src/main/java/cbit/vcell/biomodel/ModelUnitConverter.java
@@ -347,6 +347,7 @@ public class ModelUnitConverter {
 				if (!conversionFactor.isOne()){
 					Expression spcSymbol = new Expression(newSTE, newSTE.getNameScope());
 					expr.substituteInPlace(spcSymbol, Expression.mult(new Expression(conversionFactor), spcSymbol));
+					expr.substituteInPlace(expr, expr.flattenFactors(KMOLE.getName()));
 				}
 			}
 		}
@@ -362,8 +363,9 @@ public class ModelUnitConverter {
 		if (!conversionFactor.isOne()){
 			Expression oldExp = new Expression(expr);
 			expr.substituteInPlace(oldExp, Expression.mult(new Expression(conversionFactor), oldExp));
+			expr.substituteInPlace(expr, expr.flattenFactors(KMOLE.getName()));
 		}
-		Expression flattened = expr.flatten();
+		Expression flattened = expr.flattenFactors(KMOLE.getName());
 		Expression origExp = new Expression(expr);
 		expr.substituteInPlace(origExp,flattened);
 	}

--- a/vcell-core/src/main/java/cbit/vcell/biomodel/ModelUnitConverter.java
+++ b/vcell-core/src/main/java/cbit/vcell/biomodel/ModelUnitConverter.java
@@ -1,31 +1,22 @@
 package cbit.vcell.biomodel;
 
-import cbit.vcell.mapping.AssignmentRule;
-import cbit.vcell.mapping.BioEvent;
+import cbit.vcell.mapping.*;
 import cbit.vcell.mapping.BioEvent.EventAssignment;
-import cbit.vcell.mapping.ElectricalStimulus;
-import cbit.vcell.mapping.RateRule;
-import cbit.vcell.mapping.SimulationContext;
-import cbit.vcell.mapping.SpeciesContextSpec;
-import cbit.vcell.mapping.StructureMapping;
+import cbit.vcell.math.MathDescription;
 import cbit.vcell.matrix.RationalExp;
 import cbit.vcell.matrix.RationalNumber;
-import cbit.vcell.model.Model;
-import cbit.vcell.model.ModelUnitSystem;
-import cbit.vcell.model.Parameter;
-import cbit.vcell.model.ReactionRule;
-import cbit.vcell.model.ReactionStep;
-import cbit.vcell.model.SpeciesContext;
-import cbit.vcell.model.Structure;
+import cbit.vcell.model.*;
 import cbit.vcell.parser.*;
 import cbit.vcell.units.VCUnitDefinition;
 import cbit.vcell.xml.XMLSource;
 import cbit.vcell.xml.XmlHelper;
 import cbit.vcell.xml.XmlParseException;
-
-import java.math.BigInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ModelUnitConverter {
+
+	private final static Logger logger = LogManager.getLogger(ModelUnitConverter.class);
 
 	public static ModelUnitSystem createSbmlModelUnitSystem() {
 		String volumeSubstanceSymbol = "umol";			// InternalUnitDefinition.UNIT_umol
@@ -187,6 +178,19 @@ public class ModelUnitConverter {
 				}
 			}
 		}	// end  for - simulationContext
+		newBioModel.refreshDependencies();
+		for (SimulationContext simContext : newBioModel.getSimulationContexts()){
+			//
+			// force new math generation
+			//
+			MathMapping mathMapping = simContext.createNewMathMapping();
+			try {
+				MathDescription mathDesc = mathMapping.getMathDescription();
+				simContext.setMathDescription(mathDesc);
+			}catch (Exception e){
+				throw new RuntimeException("failed to generated math for application "+simContext.getName()+": "+e.getMessage(), e);
+			}
+		}
 		return newBioModel;
 	}
 
@@ -300,38 +304,26 @@ public class ModelUnitConverter {
 		String[] symbols = expr.getSymbols();
 		if (symbols != null) {
 			for (String s : symbols) {
-				SymbolTableEntry boundSTE = expr.getSymbolBinding(s);
-				
 				SymbolTableEntry newSTE = newSymbolTable.getEntry(s);
 				SymbolTableEntry oldSTE = oldSymbolTable.getEntry(s);
 				
-				if (boundSTE == null){
-					System.err.println("symbol '"+s+"' in expression "+expr.infix() + " was not bound to the model");
-					continue;
-				}
-	
 				if (oldSTE == null){
-					System.err.println("symbol '"+s+"' in expression "+expr.infix() + " was not found in the new symbol table");
+					logger.error("symbol '"+s+"' in expression "+expr.infix() + " was not found in the new symbol table");
 					continue;
 				}
 	
 				if (newSTE == null){
-					System.err.println("symbol '"+s+"' in expression "+expr.infix() + " was not bound to the old symbol table");
+					logger.error("symbol '"+s+"' in expression "+expr.infix() + " was not bound to the old symbol table");
 					continue;
 				}
 	
-				if (newSTE != boundSTE){
-					System.err.println("symbol '"+s+"' in expression "+expr.infix() + " is not bound properly (binding doesn't match new symbol table)");
-					continue;
-				}
-				
 				if (oldSTE.getUnitDefinition() == null){
-					System.err.println("symbol '"+s+"' in expression "+expr.infix() + " is has a null unit in old model, can't convert");
+					logger.error("symbol '"+s+"' in expression "+expr.infix() + " is has a null unit in old model, can't convert");
 					continue;
 				}
 				
 				if (newSTE.getUnitDefinition() == null){
-					System.err.println("symbol '"+s+"' in expression "+expr.infix() + " is has a null unit in new model, can't convert");
+					logger.error("symbol '"+s+"' in expression "+expr.infix() + " is has a null unit in new model, can't convert");
 					continue;
 				}
 	
@@ -342,7 +334,6 @@ public class ModelUnitConverter {
 					continue;
 				}
 				VCUnitDefinition oldToNewConversionUnit = oldSTE.getUnitDefinition().divideBy(newSTE.getUnitDefinition());
-//				UnitConversion unitConversion = getDimensionlessScaleFactor(oldToNewConversionUnit, KMOLE);
 				Expression conversionFactor = getDimensionlessScaleFactor(oldToNewConversionUnit, dimensionless, KMOLE);
 				if (!conversionFactor.isOne()){
 					Expression spcSymbol = new Expression(newSTE, newSTE.getNameScope());

--- a/vcell-core/src/main/java/cbit/vcell/mapping/AbstractStochMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/AbstractStochMathMapping.java
@@ -75,7 +75,7 @@ public abstract class AbstractStochMathMapping extends AbstractMathMapping {
 				ModelUnitSystem unitSystem = getSimulationContext().getModel().getUnitSystem();
 				VCUnitDefinition substanceUnit = unitSystem.getSubstanceUnit(structure);
 				Expression unitFactor = getUnitFactor(unitSystem.getStochasticSubstanceUnit().divideBy(substanceUnit));
-				Expression particlesExpr = Expression.mult(unitFactor, exp);
+				Expression particlesExpr = Expression.mult(unitFactor, exp).flattenFactors("KMOLE");
 				return particlesExpr;
 			}
 
@@ -95,7 +95,7 @@ public abstract class AbstractStochMathMapping extends AbstractMathMapping {
 				VCUnitDefinition substanceUnit = unitSystem.getSubstanceUnit(structure);
 				Expression unitFactor = getUnitFactor(substanceUnit.divideBy(unitSystem.getStochasticSubstanceUnit()));
 				Expression scStructureSize = new Expression(structure.getStructureSize(), getNameScope());
-				Expression concentrationExpr = Expression.mult(unitFactor, particlesExpr, Expression.invert(scStructureSize));
+				Expression concentrationExpr = Expression.mult(unitFactor, particlesExpr, Expression.invert(scStructureSize)).flattenFactors("KMOLE");
 				return concentrationExpr;
 			}
 

--- a/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
@@ -865,7 +865,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 				VCUnitDefinition concUnit = initConcParm.getUnitDefinition();
 				VCUnitDefinition countDensityUnit = initCountParm.getUnitDefinition().divideBy(speciesContext.getStructure().getStructureSize().getUnitDefinition());
 				Expression unitFactor = getUnitFactor(concUnit.divideBy(countDensityUnit));
-				initConcExpr = Expression.mult(unitFactor, Expression.div(new Expression(initCountParm,getNameScope()),structureSizeExpr));
+				initConcExpr = Expression.mult(unitFactor, Expression.div(new Expression(initCountParm,getNameScope()),structureSizeExpr)).flattenFactors("KMOLE");
 			}
 			StructureMapping sm = simContext.getGeometryContext().getStructureMapping(speciesContext.getStructure());
 			String[] symbols = initConcExpr.getSymbols();
@@ -2011,13 +2011,13 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 				int dimension = 3;
 				VCUnitDefinition desiredConcUnits = model.getUnitSystem().getInstance("molecules").divideBy(model.getUnitSystem().getLengthUnit().raiseTo(new ucar.units_vcell.RationalNumber(dimension)));
 				Expression unitFactor = getUnitFactor(desiredConcUnits.divideBy(mappedSpeciesContextUnit));
-				volumeConcExp = Expression.add(volumeConcExp,Expression.mult(unitFactor,mappedSpeciesContextExpression)).flatten();
+				volumeConcExp = Expression.add(volumeConcExp,Expression.mult(unitFactor,mappedSpeciesContextExpression)).flattenFactors("KMOLE");
 			}else if (geometryClass instanceof SurfaceClass){
 				// membrane function
 				int dimension = 2;
 				VCUnitDefinition desiredSurfaceDensityUnits = model.getUnitSystem().getInstance("molecules").divideBy(model.getUnitSystem().getLengthUnit().raiseTo(new ucar.units_vcell.RationalNumber(dimension)));
 				Expression unitFactor = getUnitFactor(desiredSurfaceDensityUnits.divideBy(mappedSpeciesContextUnit));
-				membraneDensityExp = Expression.add(membraneDensityExp,Expression.mult(unitFactor,mappedSpeciesContextExpression)).flatten();
+				membraneDensityExp = Expression.add(membraneDensityExp,Expression.mult(unitFactor,mappedSpeciesContextExpression)).flattenFactors("KMOLE");
 			}else{
 				throw new MathException("unsupported geometry mapping for microscopy measurement");
 			}

--- a/vcell-core/src/main/java/cbit/vcell/mapping/FeatureMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/FeatureMapping.java
@@ -138,7 +138,7 @@ public Expression getNormalizedConcentrationCorrection(SimulationContext simulat
 		// everything mapped to molecules/sq-um : need volume/area fraction and KMOLE
 		//
 		Expression unitFactor = unitFactorProvider.getUnitFactor(modelUnitSystem.getMembraneSubstanceUnit().divideBy(modelUnitSystem.getVolumeSubstanceUnit()));
-		Expression exp = Expression.mult(unitFactor, new Expression(getVolumePerUnitAreaParameter(),simulationContext.getNameScope()));
+		Expression exp = Expression.mult(unitFactor, new Expression(getVolumePerUnitAreaParameter(),simulationContext.getNameScope())).flattenFactors("KMOLE");
 		return exp;
 	}else{
 		throw new RuntimeException("structure "+getStructure().getName()+" not mapped");

--- a/vcell-core/src/main/java/cbit/vcell/mapping/MembraneMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/MembraneMapping.java
@@ -195,7 +195,7 @@ public Expression getNormalizedConcentrationCorrection(SimulationContext simulat
 	Expression exp = getSizeCorrection(simulationContext);
 	if (getGeometryClass() instanceof CompartmentSubVolume || getGeometryClass() instanceof SubVolume){
 		Expression unitFactor = unitFactorProvider.getUnitFactor(modelUnitSystem.getVolumeSubstanceUnit().divideBy(modelUnitSystem.getMembraneSubstanceUnit()));
-		exp = Expression.mult(unitFactor, exp);
+		exp = Expression.mult(unitFactor, exp).flattenFactors("KMOLE");
 	}
 	return exp;
 }

--- a/vcell-core/src/main/java/cbit/vcell/mapping/ParticleMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/ParticleMathMapping.java
@@ -590,7 +590,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 				Expression initialDistribution = scs.getInitialConcentrationParameter().getExpression() == null ? null : new Expression(getMathSymbol(scs.getInitialConcentrationParameter(),sm.getGeometryClass()));
 				if(particleVariable instanceof VolumeParticleVariable)
 				{
-					initialDistribution = Expression.mult(unitFactor, initialDistribution);
+					initialDistribution = Expression.mult(unitFactor, initialDistribution).flattenFactors("KMOLE");
 				}
 				pic = new ParticleInitialConditionConcentration(initialDistribution);
 			} else {
@@ -903,7 +903,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 						forwardUnitFactor = forwardUnitFactor.multiplyBy(reactantUnitFactor); // accumulate unit factors for all reactants
 					}
 
-					forwardRate = Expression.mult(forwardRate, getUnitFactor(forwardUnitFactor));
+					forwardRate = Expression.mult(forwardRate, getUnitFactor(forwardUnitFactor)).flattenFactors("KMOLE");
 					VCUnitDefinition smoldynExpectedForwardRateUnit = smoldynReactionRateUnit.divideBy(smoldynReactantsUnit);
 
 					// get probability
@@ -944,7 +944,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 						reverseUnitFactor = reverseUnitFactor.multiplyBy(productUnitFactor); // accumulate unit factors for all products
 					}
 
-					reverseRate = Expression.mult(reverseRate, getUnitFactor(reverseUnitFactor));
+					reverseRate = Expression.mult(reverseRate, getUnitFactor(reverseUnitFactor)).flattenFactors("KMOLE");
 					VCUnitDefinition smoldynExpectedReverseRateUnit = smoldynReactionRateUnit.divideBy(smoldynProductsUnit);
 							
 					// get probability

--- a/vcell-core/src/main/java/cbit/vcell/mapping/RulebasedMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/RulebasedMathMapping.java
@@ -815,7 +815,7 @@ protected RulebasedMathMapping(SimulationContext simContext, MathMappingCallback
 			e.printStackTrace();
 		}
 		
-		Expression forward_rateExp = Expression.mult(getUnitFactor(forward_substanceConversionUnit), new Expression(forward_rateParameter, getNameScope()),forward_sizeFactor).flatten();
+		Expression forward_rateExp = Expression.mult(getUnitFactor(forward_substanceConversionUnit), new Expression(forward_rateParameter, getNameScope()),forward_sizeFactor).flattenFactors("KMOLE");
 		VCUnitDefinition forward_rateUnit = forward_rateParameter.getUnitDefinition().multiplyBy(forward_sizeFactorUnit).multiplyBy(forward_substanceConversionUnit);
 		
 		ProbabilityParameter forward_probParm = addProbabilityParameter(PARAMETER_PROBABILITYRATE_PREFIX+jpName, forward_rateExp, PARAMETER_ROLE_P, forward_rateUnit,reactionRule);
@@ -898,7 +898,7 @@ protected RulebasedMathMapping(SimulationContext simContext, MathMappingCallback
 				e.printStackTrace();
 			}
 			
-			Expression reverse_rateExp = Expression.mult(new Expression(reverse_rateParameter, getNameScope()),reverse_sizeFactor,getUnitFactor(reverse_substanceConversionUnit)).flatten();
+			Expression reverse_rateExp = Expression.mult(new Expression(reverse_rateParameter, getNameScope()),reverse_sizeFactor,getUnitFactor(reverse_substanceConversionUnit)).flattenFactors("KMOLE");
 			VCUnitDefinition reverse_rateUnit = reverse_rateParameter.getUnitDefinition().multiplyBy(reverse_sizeFactorUnit).multiplyBy(reverse_substanceConversionUnit);
 			
 			// if the reaction has forward rate (Mass action,HMMs), or don't have either forward or reverse rate (some other rate laws--like general)

--- a/vcell-core/src/main/java/cbit/vcell/mapping/StochMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/StochMathMapping.java
@@ -104,7 +104,7 @@ private Expression getProbabilityRate(ReactionStep reactionStep, Expression rate
 	VCUnitDefinition reactionSubstanceUnit = model.getUnitSystem().getSubstanceUnit(reactionStep.getStructure());
 	VCUnitDefinition stochasticSubstanceUnit = model.getUnitSystem().getStochasticSubstanceUnit();
 	Expression reactionSubstanceUnitFactor = getUnitFactor(stochasticSubstanceUnit.divideBy(reactionSubstanceUnit));
-	Expression factorExpr = Expression.mult(reactionSubstanceUnitFactor, reactionStructureSize);
+	Expression factorExpr = Expression.mult(reactionSubstanceUnitFactor, reactionStructureSize).flattenFactors("KMOLE");
 
 	// Using the MassActionFunction to write out the math description 
 	MassActionSolver.MassActionFunction maFunc = null;
@@ -150,7 +150,7 @@ private Expression getProbabilityRate(ReactionStep reactionStep, Expression rate
 		stoichiometry = reacPart.get(i).getStoichiometry();
 		//******the following part is to form the s*(s-1)(s-2)..(s-stoi+1).portion of the probability rate.
 		Expression speciesStructureSize = new Expression(reacPart.get(i).getStructure().getStructureSize(), getNameScope());
-		Expression speciesFactor = Expression.div(speciesUnitFactor, speciesStructureSize);
+		Expression speciesFactor = Expression.div(speciesUnitFactor, speciesStructureSize).flattenFactors("KMOLE");
 		//s*(s-1)(s-2)..(s-stoi+1)
 		SpeciesCountParameter spCountParam = getSpeciesCountParameter(reacPart.get(i).getSpeciesContext());
 		Expression spCount_exp = new Expression(spCountParam, getNameScope());
@@ -758,7 +758,7 @@ private Expression getProbabilityRate(ReactionStep reactionStep, Expression rate
 					//create jump process for forward flux if it exists.
 					Expression rsStructureSize = new Expression(reactionStep.getStructure().getStructureSize(), getNameScope());
 					VCUnitDefinition probRateUnit = modelUnitSystem.getStochasticSubstanceUnit().divideBy(modelUnitSystem.getAreaUnit()).divideBy(modelUnitSystem.getTimeUnit());
-					Expression rsRateUnitFactor = getUnitFactor(probRateUnit.divideBy(modelUnitSystem.getFluxReactionUnit()));
+					Expression rsRateUnitFactor = getUnitFactor(probRateUnit.divideBy(modelUnitSystem.getFluxReactionUnit())).flattenFactors("KMOLE");
 					if(fluxFunc.getForwardRate() != null && !fluxFunc.getForwardRate().isZero()) 
 					{
 											

--- a/vcell-core/src/main/java/cbit/vcell/mapping/StructureAnalyzer.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/StructureAnalyzer.java
@@ -878,7 +878,7 @@ public Expression getCorrectedRateExpression(ReactionStep reactionStep, Reaction
 	}else if (rateType == RateType.ResolvedFluxRate){
 		unitFactor = mathMapping.getUnitFactor(speciesConcRateUnit.multiplyBy(unitSystem.getLengthUnit()).divideBy(correctedReactionRateUnit));
 	}
-	return Expression.mult(unitFactor,distribRateWithStoichFlux).flatten();
+	return Expression.mult(unitFactor,distribRateWithStoichFlux).flattenFactors("KMOLE");
 }
 
 }

--- a/vcell-core/src/main/java/cbit/vcell/mapping/potential/PotentialMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/potential/PotentialMapping.java
@@ -731,7 +731,7 @@ public Expression getOdeRHS(MembraneElectricalDevice capacitiveDevice, AbstractM
 	VCUnitDefinition unitFactor = potentialUnit.divideBy(timeUnit).multiplyBy(capacitanceParameter.getUnitDefinition()).divideBy(capacitiveDevice.getTotalCurrentSymbol().getUnitDefinition());
 	Expression unitFactorExp = fieldMathMapping.getUnitFactor(unitFactor);
 	
-	Expression exp = Expression.mult(Expression.div(unitFactorExp, totalCapacitance), Expression.add(totalCurrent, Expression.negate(transMembraneCurrent)));
+	Expression exp = Expression.mult(Expression.div(unitFactorExp, totalCapacitance), Expression.add(totalCurrent, Expression.negate(transMembraneCurrent))).flattenFactors("KMOLE");
 //	exp.bindExpression(mathMapping); 
 	return exp;
 }

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
@@ -2954,26 +2954,16 @@ public class SBMLImporter {
 					}
 
 					// set kinetics on VCell reaction - and determine assumed SBML rate units (may need to be converted)
-					final VCUnitDefinition sbmlRateUnit;
 					if (bSpatial) {
 						// if spatial SBML ('isSpatial' attribute set), create DistributedKinetics)
 						SpatialReactionPlugin ssrplugin = (SpatialReactionPlugin) sbmlReaction.getPlugin(SBMLUtils.SBML_SPATIAL_NS_PREFIX);
 						// (a) the requiredElements attributes should be 'spatial'
 						if (ssrplugin != null && ssrplugin.isSetIsLocal() && ssrplugin.getIsLocal()) {
-							if (reactionStructure instanceof Feature) {
-								sbmlRateUnit = vcModelUnitSystem.getVolumeReactionRateUnit();
-							}else if (reactionStructure instanceof Membrane) {
-								sbmlRateUnit = vcModelUnitSystem.getMembraneReactionRateUnit();
-							}else {
-								throw new SBMLImportException("unexpected reaction structure " + reactionStructure);
-							}
 							kinetics = new GeneralKinetics(vcReaction);
 						} else {
-							sbmlRateUnit = vcModelUnitSystem.getLumpedReactionRateUnit();
 							kinetics = new GeneralLumpedKinetics(vcReaction);
 						}
 					} else {
-						sbmlRateUnit = vcModelUnitSystem.getLumpedReactionRateUnit();
 						kinetics = new GeneralLumpedKinetics(vcReaction);
 					}
 
@@ -3008,14 +2998,6 @@ public class SBMLImporter {
 					KineticsParameter kp = kinetics.getAuthoritativeParameter();
 					if (logger.isDebugEnabled()) {
 						logger.debug("Setting " + kp.getName() + ":  " + vcRateExpression.infix());
-					}
-					VCUnitDefinition vcellRateUnit = kp.getUnitDefinition();
-					Expression factor = ModelUnitConverter.getDimensionlessScaleFactor(
-							vcellRateUnit.divideBy(sbmlRateUnit),
-							vcModelUnitSystem.getInstance_DIMENSIONLESS(),
-							vcModel.getKMOLE());
-					if (!factor.isOne()){
-						vcRateExpression = Expression.mult(factor, vcRateExpression).flattenFactors(vcModel.getKMOLE().getName());
 					}
 					kinetics.setParameterValue(kp, vcRateExpression);
 

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
@@ -810,7 +810,7 @@ public class SBMLImporter {
 				try {
 					KMOLE_value = KMOLE.getExpression().evaluateConstant();
 				} catch (Exception e){ throw new RuntimeException("unexpected exception: "+e.getMessage(),e); }
-				if (sbmlGlobalParam.equals(KMOLE.getName()) && sbmlGlobalParam.isSetValue() && sbmlGlobalParam.getValue()==KMOLE_value) {
+				if (sbmlGlobalParam.getId().equals(KMOLE.getName()) && sbmlGlobalParam.isSetValue() && sbmlGlobalParam.getValue()==KMOLE_value) {
 					sbmlSymbolMapping.putRuntime(sbmlGlobalParam, KMOLE);
 					continue;
 				}
@@ -3015,7 +3015,7 @@ public class SBMLImporter {
 							vcModelUnitSystem.getInstance_DIMENSIONLESS(),
 							vcModel.getKMOLE());
 					if (!factor.isOne()){
-						vcRateExpression = Expression.mult(factor, vcRateExpression);
+						vcRateExpression = Expression.mult(factor, vcRateExpression).flattenFactors(vcModel.getKMOLE().getName());
 					}
 					kinetics.setParameterValue(kp, vcRateExpression);
 

--- a/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
@@ -12,10 +12,7 @@ package cbit.vcell.parser;
 
 import java.io.IOException;
 import java.io.StreamTokenizer;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.Stack;
-import java.util.Vector;
+import java.util.*;
 
 import org.vcell.util.Issue.IssueSource;
 import org.vcell.util.Matchable;
@@ -287,6 +284,59 @@ public Expression flatten() throws ExpressionException {
 flattenCount++;////////////////////////
 	return new Expression((SimpleNode)rootNode.flatten());
 }
+
+	/**
+	 * cancel out terms of the type .... * KMOLE / KMOLE * ....
+	 * substitute in place will only work with (KMOLE / KMOLE) where the entire subtree is replaced
+	 * @param factorSymbol
+	 * @return
+	 * @throws ExpressionException
+	 */
+	public Expression flattenFactors(String factorSymbol) throws ExpressionException {
+		String[] symbols = this.getSymbols();
+		if (symbols==null || symbols.length==0){
+			return this.flatten();
+		}
+		if (Arrays.asList(symbols).contains(factorSymbol)) {
+			Expression mangledExpression = new Expression(this).flatten();
+			mangledExpression.substituteInPlace(new Expression(factorSymbol), new Expression("____"+factorSymbol+"____"));
+			String mangledInfix = mangledExpression.infix();
+			final String[][] patterns = {
+					{ "pow(____"+factorSymbol+"____,-1.0) * ____"+factorSymbol+"____", 				"1.0" },
+					{ "pow(____"+factorSymbol+"____, - 1.0) * ____"+factorSymbol+"____", 			"1.0" },
+					{ "____"+factorSymbol+"____ * pow(____"+factorSymbol+"____,-1.0)", 				"1.0" },
+					{ "____"+factorSymbol+"____ * pow(____"+factorSymbol+"____, - 1.0)", 			"1.0" },
+					{ "pow(____"+factorSymbol+"____, 2.0) * pow(____"+factorSymbol+"____, - 2.0)",	"1.0" },
+					{ "pow(____"+factorSymbol+"____,2.0) * pow(____"+factorSymbol+"____,-2.0)",		"1.0" },
+					{ "pow(____"+factorSymbol+"____, 3.0) * pow(____"+factorSymbol+"____, - 3.0)",	"1.0" },
+					{ "pow(____"+factorSymbol+"____,3.0) * pow(____"+factorSymbol+"____,-3.0)",		"1.0" },
+					{ "____"+factorSymbol+"____ / ____"+factorSymbol+"____",						"1.0" },
+					{ "/ ____"+factorSymbol+"____ * ____"+factorSymbol+"____", 						"* 1.0" }
+			};
+			boolean bReplaced = false;
+			for (String[] pattern : patterns) {
+				if (mangledInfix.contains(pattern[0])) {
+					mangledInfix = mangledInfix.replace(pattern[0], pattern[1]);
+					bReplaced = true;
+				}
+			}
+			if (bReplaced) {
+				Expression substitutedExpression = new Expression(mangledInfix);
+				SymbolTableEntry factorSte = this.getSymbolBinding(factorSymbol);
+				final Expression KMOLE_exp;
+				if (factorSte == null) {
+					KMOLE_exp = new Expression(factorSymbol);
+				}else{
+					KMOLE_exp = new Expression(factorSte, factorSte.getNameScope());
+				}
+				substitutedExpression.substituteInPlace(new Expression("____KMOLE____"), KMOLE_exp);
+				substitutedExpression = substitutedExpression.flatten();
+				return substitutedExpression;
+			}
+		}
+		return this.flatten();
+	}
+
 /**
  * This method was created by a SmartGuide.
  */

--- a/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
@@ -303,12 +303,8 @@ flattenCount++;////////////////////////
 			String mangledInfix = mangledExpression.infix();
 			final String[][] patterns = {
 					{ "pow(____"+factorSymbol+"____,-1.0) * ____"+factorSymbol+"____", 				"1.0" },
-					{ "pow(____"+factorSymbol+"____, - 1.0) * ____"+factorSymbol+"____", 			"1.0" },
 					{ "____"+factorSymbol+"____ * pow(____"+factorSymbol+"____,-1.0)", 				"1.0" },
-					{ "____"+factorSymbol+"____ * pow(____"+factorSymbol+"____, - 1.0)", 			"1.0" },
-					{ "pow(____"+factorSymbol+"____, 2.0) * pow(____"+factorSymbol+"____, - 2.0)",	"1.0" },
 					{ "pow(____"+factorSymbol+"____,2.0) * pow(____"+factorSymbol+"____,-2.0)",		"1.0" },
-					{ "pow(____"+factorSymbol+"____, 3.0) * pow(____"+factorSymbol+"____, - 3.0)",	"1.0" },
 					{ "pow(____"+factorSymbol+"____,3.0) * pow(____"+factorSymbol+"____,-3.0)",		"1.0" },
 					{ "____"+factorSymbol+"____ / ____"+factorSymbol+"____",						"1.0" },
 					{ "/ ____"+factorSymbol+"____ * ____"+factorSymbol+"____", 						"* 1.0" }

--- a/vcell-math/src/test/java/cbit/vcell/parser/ExpressionFlattenTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/ExpressionFlattenTest.java
@@ -28,7 +28,7 @@ public class ExpressionFlattenTest {
                 {new Expression("KMOLE/KMOLE"),
                         new Expression("1.0")},
                 {new Expression("KMOLE/KMOLE*KMOLE/KMOLE"),
-                        new Expression("1.0")},
+                        new Expression("KMOLE/KMOLE")},
                 {new Expression("KMOLE/KMOLE*KMOLE/KMOLE2"),
                         new Expression("KMOLE/KMOLE2")},
                 {new Expression("KMOLE*pow(KMOLE,-1)"),

--- a/vcell-math/src/test/java/cbit/vcell/parser/ExpressionFlattenTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/ExpressionFlattenTest.java
@@ -1,0 +1,55 @@
+package cbit.vcell.parser;
+
+import jscl.text.ParseException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class ExpressionFlattenTest {
+
+    private Expression expectedFlattenedExpression;
+    private Expression origExpression;
+
+    public ExpressionFlattenTest(Expression origExpression, Expression expectedFlattenedExpression) {
+        this.expectedFlattenedExpression = expectedFlattenedExpression;
+        this.origExpression = origExpression;
+    }
+
+
+
+    @Parameterized.Parameters
+    public static Collection<Expression[]> testCases() throws ExpressionException {
+        return Arrays.asList(new Expression[][]{
+                {new Expression("KMOLE/KMOLE"),
+                        new Expression("1.0")},
+                {new Expression("KMOLE/KMOLE*KMOLE/KMOLE"),
+                        new Expression("1.0")},
+                {new Expression("KMOLE/KMOLE*KMOLE/KMOLE2"),
+                        new Expression("KMOLE/KMOLE2")},
+                {new Expression("KMOLE*pow(KMOLE,-1)"),
+                        new Expression("1.0")},
+                {new Expression("5*KMOLE*pow(KMOLE,-1)"),
+                        new Expression("5.0")},
+                {new Expression("5/KMOLE*KMOLE"),
+                        new Expression("5.0")},
+                {new Expression("5*KMOLE*pow(KMOLE,-2)"),
+                        new Expression("5*KMOLE*pow(KMOLE,-2)")},
+                {new Expression("- (SCAfoldchange * KMOLE * pow(KMOLE,-1.0) * ERDensity_ER_SM * Jmax2_IP3R_flux * (1.0 - (Ca_spine / Ca_ER)) * pow((KMOLE * pow(KMOLE,-1.0) * h_ER_SM * IP3_spine * Ca_spine / (IP3_spine + dIP3_IP3R_flux) / (Ca_spine + Kact_IP3R_flux)),3.0))"),
+                 new Expression("- (SCAfoldchange                           * ERDensity_ER_SM * Jmax2_IP3R_flux * (1.0 - (Ca_spine / Ca_ER)) * pow((                          h_ER_SM * IP3_spine * Ca_spine / (IP3_spine + dIP3_IP3R_flux) / (Ca_spine + Kact_IP3R_flux)),3.0))")},
+        });
+    }
+
+    @Test
+    public void simplifySymbolFactorTest() throws ExpressionException, ParseException {
+        Expression flattenedExp = origExpression.flattenFactors("KMOLE");
+        Assert.assertTrue("expected='"+expectedFlattenedExpression.infix()+"', actual='"+flattenedExp.infix()+"'", expectedFlattenedExpression.compareEqual(flattenedExp));
+    }
+
+}
+
+


### PR DESCRIPTION
- with symbolic KMOLE in SBML importing and exporting (or any other place where we are moving between unit systems), terms such as KMOLE/KMOLE, KMOLE * pow(KMOLE,-1), etc can accumulate and obscure the expressions for the user, and make it hard to debug for the developer.
- Expression.flattenFactors(str) was added to accompany ModelUnitConverter.getDImensionlessScaleFactor() (which introduces symbolic KMOLE as needed).
- removed a FluxReaction unit conversion from SBMLImporter.  Absolutely no unit converters should be invoked in SBMLIMporter or SBMLExporter, instead all model unit conversions should be done in ModelUnitConverter!!!
- force math generation in ModelUnitConverter following change of units.
- NOW I GET CORRECT ROUND TRIPS WITH KMOLE.