### PR TITLE
introduce maven caching into CI-full and ci_cd workflows

### DIFF
--- a/.github/workflows/CI-full.yml
+++ b/.github/workflows/CI-full.yml
@@ -32,11 +32,12 @@ jobs:
         cd ..
         sudo tar -xvf deploy/deploy_dir.tar
         sudo chmod 777 -R deploy
-    - name: setup java 8
+    - name: setup java 8 with maven cache
       uses: actions/setup-java@v2
       with:
         java-version: '8'
         distribution: 'adopt'
+        cache: 'maven'
     - name: Install Singularity # to make singularity image for cluster
       uses: eWaterCycle/setup-singularity@v6
       with:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -17,10 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-java@v3
+      - name: setup java 8 with maven cache
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '8'
+          cache: 'maven'
 
       - name: Add Linux dependencies
         shell: bash
@@ -47,10 +49,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-java@v3
+      - name: setup java 8 with maven cache
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '8'
+          cache: 'maven'
 
       - name: Get the VCell version from tags
         id: version


### PR DESCRIPTION
in CI (GitHub actions/workflows) considered introducing a separate cache action for maven dependency downloads, but found that the build-in `actions/setup-java` action has a `cache: maven` option already configured.

saves a minute or two off the of the build time in CI.