### PR TITLE
use 'mvn --batch-mode' to make maven logs shorter in CI (for debugging)

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           mvn -version
           java -version
-          mvn clean install dependency:copy-dependencies
+          mvn --batch-mode clean install dependency:copy-dependencies
 
       - name: Test building of docker image
         run: |
@@ -65,7 +65,7 @@ jobs:
         run: |
           mvn -version
           java -version
-          mvn clean install dependency:copy-dependencies
+          mvn --batch-mode clean install dependency:copy-dependencies
 
       - name: Build Docker image and push with latest tag
         run: |


### PR DESCRIPTION
use mvn --batch-mode to avoid progress lines showing up in CI logs.  This will make it easier to scan build and test failures and make the logs more readable.

For example:
>> mvn clean install ...
Downloading from scijava.public: https://maven.scijava.org/content/groups/public/org/scijava/pom-scijava/31.1.0/pom-scijava-31.1.0.pom
Progress (1): 4.1 kB
Progress (1): 8.2 kB
Progress (1): 12 kB 
Progress (1): 16 kB
... total of 43 'Progress' lines ...