### PR TITLE
clone orig BioModel Expressions before transforming in SBML Export

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -139,8 +139,6 @@ public class SimulationContext implements SimulationOwner, Versionable, Matchabl
 	public static final String PROPERTY_NAME_RATE_RULE_CHANGE = "rateRuleChange";
 	public static final String PROPERTY_NAME_ASSIGNMENT_RULE_CHANGE = "assignmentRuleChange";
 
-	public final SimulationContextOverridesResolver mathOverridesResolver = new SimulationContextOverridesResolver();
-
 	public enum Kind {
 		GEOMETRY_KIND,
 		SPECIFICATIONS_KIND,
@@ -1557,7 +1555,7 @@ public OutputFunctionContext getOutputFunctionContext() {
 
 	@Override
 	public MathOverridesResolver getMathOverridesResolver() {
-		return mathOverridesResolver;
+		return new SimulationContextOverridesResolver();
 	}
 
 	/**


### PR DESCRIPTION
some BioModel expressions were subject to Expression.substituteInPlace() during SBML Export (should have been cloned).  Impacted only SBMLExporter round-trip, but was poor form.