### PR TITLE
SBMLExporter validate compares transformed SimContext (e.g. stochastic)

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/math/MathDescription.java
+++ b/vcell-core/src/main/java/cbit/vcell/math/MathDescription.java
@@ -1520,7 +1520,8 @@ public HashSet<String> getStateVariableNames() {
 	for (int i = 0; i < variableList.size(); i++){
 		Variable var = variableList.get(i);
 		if (var instanceof VolVariable || var instanceof MemVariable || var instanceof FilamentVariable ||
-			var instanceof VolumeRegionVariable || var instanceof MembraneRegionVariable || var instanceof FilamentRegionVariable){
+			var instanceof VolumeRegionVariable || var instanceof MembraneRegionVariable || var instanceof FilamentRegionVariable ||
+			var instanceof ParticleVariable || var instanceof StochVolVariable || var instanceof PointVariable){
 			stateVarNameSet.add(var.getName());
 		}
 	}


### PR DESCRIPTION
SBMLExporter performs round-trip testing to make sure re-imported SBML models have and equivalent mathematical representation.  SBMLImporter chooses between non-spatial deterministic and spatial deterministic.  But while exporting stochastic applications (SimulationContexts), we must transform the SimulationContext to also be stochastic or the maths will be of different type.

This is now performed in SBMLExporter.roundTripValidation() - so we can validate the exporting and reimporting of stochastic applications.