### PR TITLE
Sedml roundtrip

### DIFF
--- a/vcell-core/src/main/java/org/jlibsedml/modelsupport/SBMLSupport.java
+++ b/vcell-core/src/main/java/org/jlibsedml/modelsupport/SBMLSupport.java
@@ -225,11 +225,11 @@ public class SBMLSupport implements IXPathToVariableIDResolver {
         return getXPathForListOfCompartments() + "/sbml:compartment[@id='"
                 + compartmentID + "']" + "/@" + compartmentAttribute;
     }
-    public String getXPathForCompartmentMapping(String compartmentID,
+    public String getXPathForCompartmentMapping(String compartmentID, String mappingID,
             CompartmentAttribute compartmentAttribute) {
    		return getXPathForListOfCompartments() + "/sbml:compartment[@id='"
-                + compartmentID + "']" + "/spatial:compartmentMapping"
-    			+ "/@spatial:" + compartmentAttribute;
+                + compartmentID + "']" + "/spatial:compartmentMapping[@id='"
+    			+ mappingID + "']/@spatial:" + compartmentAttribute;
     }
 
     String getXPathForListOfCompartments() {

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
@@ -3815,16 +3815,20 @@ public class SBMLImporter {
 							featureMapping.setGeometryClass(geometryClass);
 							if (geometryClass instanceof SubVolume) {
 								featureMapping.getVolumePerUnitVolumeParameter().setExpression(new Expression(unitSize));
+								sbmlSymbolMapping.putInitial(compMapping, featureMapping.getVolumePerUnitVolumeParameter());
 							} else if (geometryClass instanceof SurfaceClass) {
 								featureMapping.getVolumePerUnitAreaParameter().setExpression(new Expression(unitSize));
+								sbmlSymbolMapping.putInitial(compMapping, featureMapping.getVolumePerUnitAreaParameter());
 							}
 							structMappingsVector.add(featureMapping);
 						} else if (struct instanceof Membrane) {
 							MembraneMapping membraneMapping = new MembraneMapping( (Membrane) struct, vcBioModel.getSimulationContext(0), vcModelUnitSystem); membraneMapping.setGeometryClass(geometryClass);
 							if (geometryClass instanceof SubVolume) {
 								membraneMapping.getAreaPerUnitVolumeParameter().setExpression(new Expression(unitSize));
+								sbmlSymbolMapping.putInitial(compMapping, membraneMapping.getAreaPerUnitVolumeParameter());
 							} else if (geometryClass instanceof SurfaceClass) {
 								membraneMapping.getAreaPerUnitAreaParameter().setExpression(new Expression(unitSize));
+								sbmlSymbolMapping.putInitial(compMapping, membraneMapping.getAreaPerUnitAreaParameter());
 							}
 							structMappingsVector.add(membraneMapping);
 						}

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
@@ -427,6 +427,7 @@ public class SBMLImporter {
 						Expression sbmlDurationExpr = getExpressionFromFormula(event.getDelay().getMath(), lambdaFunctions, vcLogger);
 						Expression vcellDurationExpr = adjustExpression(sbmlModel, sbmlDurationExpr, triggerDelayParameter.getNameScope(), sbmlSymbolMapping, SymbolContext.RUNTIME);
 						triggerDelayParameter.setExpression(vcellDurationExpr);
+						sbmlSymbolMapping.putRuntime(event.getDelay(), triggerDelayParameter);
 
 						boolean bUseValsFromTriggerTime = true;
 						if (event.isSetUseValuesFromTriggerTime()) {
@@ -449,6 +450,7 @@ public class SBMLImporter {
 					if (sbmlTriggerExpr != null){
 						Expression vcellTriggerExpr = adjustExpression(sbmlModel, sbmlTriggerExpr, vcTriggerParameter.getNameScope(), sbmlSymbolMapping, SymbolContext.RUNTIME);
 						vcTriggerParameter.setExpression(vcellTriggerExpr);
+						sbmlSymbolMapping.putRuntime(event.getTrigger(), vcTriggerParameter);
 					}else{
 						vcLogger.sendMessage(VCLogger.Priority.HighPriority, VCLogger.ErrorType.SchemaValidation, "trigger expression not set for sbml Event "+event.getId());
 					}
@@ -3044,6 +3046,7 @@ public class SBMLImporter {
 							}
 							kineticsParameter.setExpression(exp);
 							kineticsParameter.setUnitDefinition(paramUnit);
+							sbmlSymbolMapping.putRuntime(param, kineticsParameter);
 							lpSet = true;
 						}
 						else { 
@@ -3569,6 +3572,12 @@ public class SBMLImporter {
 						
 						Expression subVolExpr = getExpressionFromFormula(analyticVol.getMath(), lambdaFunctions, vcLogger);
 						asv.setExpression(subVolExpr);
+
+						//
+						// can't add a mapping here because AnalyticSubVolume is not an EditableSymbolTableEntry - maybe some day.
+						//
+//						sbmlSymbolMapping.putRuntime(analyticVol, asv);
+
 					} catch (ExpressionException e) {
 						throw new SBMLImportException(
 								"Unable to set expression on subVolume '"
@@ -3926,6 +3935,7 @@ public class SBMLImporter {
 									sbmlSymbolMapping.putRuntime(sbmlBCondParam, vcellBCondParam);
 									if (sbmlBCondParam.isSetValue() && sbmlBCondParam.getValue() != 0.0) {
 										vcellBCondParam.setExpression(new Expression(sbmlBCondParam.getValue()));
+										sbmlSymbolMapping.putRuntime(sbmlBCondParam, vcellBCondParam);
 									}
 								} else {
 									logger.error("unexpected boundary condition parent type "+bCondn.getParent());

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -87,6 +87,7 @@ import cbit.util.xml.XmlUtil;
 import cbit.vcell.biomodel.BioModel;
 import cbit.vcell.biomodel.ModelUnitConverter;
 import cbit.vcell.clientdb.DocumentManager;
+import cbit.vcell.geometry.GeometryClass;
 import cbit.vcell.mapping.GeometryContext;
 import cbit.vcell.mapping.MathMapping;
 import cbit.vcell.mapping.MathSymbolMapping;
@@ -1219,12 +1220,12 @@ public class SEDMLExporter {
 		} else if (ste instanceof ModelParameter) {
 			// can only change parameter value. 
 			targetXpath = new XPathTarget(sbmlSupport.getXPathForGlobalParameter(ste.getName(), ParameterAttribute.value));
-		// TODO: add xpath for VolulePerUnitVolume and AreaPerUnitArea, see SBMLSupport
 			// use Ion's sample 3, with spatial app
 		}  else if (ste instanceof Structure || ste instanceof Structure.StructureSize || ste instanceof StructureMappingParameter) {
 			String compartmentId = ste.getName();
 			// can change compartment size or spatial dimension, but in vcell, we cannot change compartment dimension. 
 			String compartmentAttr = "";
+			String mappingId = "";
 			if (ste instanceof Structure.StructureSize) { 
 				compartmentId = ((StructureSize)ste).getStructure().getName();
 				compartmentAttr = ((StructureSize)ste).getName();
@@ -1237,6 +1238,9 @@ public class SEDMLExporter {
 					compartmentAttr = smp.getName();
 				} else if(role == StructureMapping.ROLE_AreaPerUnitArea || role == StructureMapping.ROLE_VolumePerUnitVolume) {
 					compartmentAttr = smp.getName();
+					Structure structure = smp.getStructure();
+					GeometryClass gc = smp.getSimulationContext().getGeometryContext().getStructureMapping(structure).getGeometryClass();
+					mappingId = TokenMangler.mangleToSName(gc.getName() + structure.getName());
 				}
 			}
 			if (compartmentAttr.length() < 1) {
@@ -1244,7 +1248,7 @@ public class SEDMLExporter {
 			} else if (compartmentAttr.equalsIgnoreCase("size")) {
 				targetXpath = new XPathTarget(sbmlSupport.getXPathForCompartment(compartmentId, CompartmentAttribute.size));
 			} else if(compartmentAttr.equalsIgnoreCase("AreaPerUnitArea") || compartmentAttr.equalsIgnoreCase("VolPerUnitVol")) {
-				targetXpath = new XPathTarget(sbmlSupport.getXPathForCompartmentMapping(compartmentId, CompartmentAttribute.unitSize));
+				targetXpath = new XPathTarget(sbmlSupport.getXPathForCompartmentMapping(compartmentId, mappingId, CompartmentAttribute.unitSize));
 			} else {
 				throw new RuntimeException("Unknown compartment attribute '" + compartmentAttr + "'; cannot get xpath target for compartment '" + compartmentId + "'.");
 			}

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
@@ -44,6 +44,7 @@ import org.jlibsedml.execution.ModelResolver;
 import org.jlibsedml.modelsupport.SBMLSupport;
 import org.jlibsedml.modelsupport.SUPPORTED_LANGUAGE;
 import org.jmathml.ASTNode;
+import org.sbml.jsbml.SBase;
 import org.vcell.sbml.vcell.SBMLImporter;
 import org.vcell.sbml.vcell.SBMLSymbolMapping;
 import org.vcell.sbml.vcell.SymbolContext;
@@ -374,15 +375,22 @@ public class SEDMLImporter {
 		MathSymbolMapping msm = (MathSymbolMapping) simContext.getMathDescription().getSourceSymbolMapping();
 		SBMLImporter sbmlImporter = importMap.get(simContext.getBioModel());
 		SBMLSymbolMapping sbmlMap = sbmlImporter.getSymbolMapping();
-		SymbolTableEntry ste =sbmlMap.getSte(sbmlMap.getMappedSBase(SBMLtargetID), SymbolContext.INITIAL);
+		SBase targetSBase = sbmlMap.getMappedSBase(SBMLtargetID);
+		if (targetSBase == null){
+			logger.error("couldn't find SBase with sid="+SBMLtargetID+" in SBMLSymbolMapping");
+			return null;
+		}
+		SymbolTableEntry ste =sbmlMap.getSte(targetSBase, SymbolContext.INITIAL);
 		Variable var = msm.getVariable(ste);
 		if (var instanceof Constant) {
 			constantName = var.getName();
 		}
 		if (constantName == null){
-			logger.warn("couldn't find target with sid="+SBMLtargetID+" in symbol mapping");
+			logger.error("couldn't find Constant target with sid="+SBMLtargetID+" in symbol mapping, var = "+var);
+			return null;
+		}else {
+			return constantName;
 		}
-		return constantName;
 	}
 
 	private void addRepeatedTasks(List<AbstractTask> ttt, HashMap<String, Simulation> vcSimulations)

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
@@ -501,7 +501,11 @@ public class SEDMLImporter {
 		}
 		// check whether all targets have addressable Constants on the Math side
 		for (Change change : changes) {
-			if (resolveConstant(refBM.getSimulationContext(0), sbmlSupport.getIdFromXPathIdentifer(change.getTargetXPath().toString())) == null) return false;
+			String sbmlID = sbmlSupport.getIdFromXPathIdentifer(change.getTargetXPath().toString());
+			if (resolveConstant(refBM.getSimulationContext(0), sbmlID) == null) {
+				logger.trace("could not map changeAttribute for ID "+sbmlID+" to a VCell Constant");
+				return false;
+			}
 		}
 		return true;
 	}

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
@@ -371,21 +371,17 @@ public class SEDMLImporter {
 		// finds name of math-side Constant corresponding to SBML entity, if there is one
 		// returns null if there isn't
 		String constantName = null;
-		MathMapping mathMapping = simContext.createNewMathMapping();
-		MathSymbolMapping msm;
-		try {
-			msm = mathMapping.getMathSymbolMapping();
-		} catch (MappingException | MathException | MatrixException | ExpressionException | ModelException e) {
-			// fail is equivalent with couldn't find
-			return null;
-		}
+		MathSymbolMapping msm = (MathSymbolMapping) simContext.getMathDescription().getSourceSymbolMapping();
 		SBMLImporter sbmlImporter = importMap.get(simContext.getBioModel());
 		SBMLSymbolMapping sbmlMap = sbmlImporter.getSymbolMapping();
 		SymbolTableEntry ste =sbmlMap.getSte(sbmlMap.getMappedSBase(SBMLtargetID), SymbolContext.INITIAL);
 		Variable var = msm.getVariable(ste);
 		if (var instanceof Constant) {
 			constantName = var.getName();
-		} 
+		}
+		if (constantName == null){
+			logger.warn("couldn't find target with sid="+SBMLtargetID+" in symbol mapping");
+		}
 		return constantName;
 	}
 

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
@@ -61,6 +61,7 @@ import cbit.vcell.mapping.SimulationContext.Application;
 import cbit.vcell.mapping.SimulationContext.MathMappingCallback;
 import cbit.vcell.mapping.SimulationContext.NetworkGenerationRequirements;
 import cbit.vcell.math.Constant;
+import cbit.vcell.math.MathDescription;
 import cbit.vcell.math.MathException;
 import cbit.vcell.math.Variable;
 import cbit.vcell.matrix.MatrixException;
@@ -372,7 +373,7 @@ public class SEDMLImporter {
 		// finds name of math-side Constant corresponding to SBML entity, if there is one
 		// returns null if there isn't
 		String constantName = null;
-		MathSymbolMapping msm = (MathSymbolMapping) simContext.getMathDescription().getSourceSymbolMapping();
+		MathSymbolMapping msm = (MathSymbolMapping)simContext.getMathDescription().getSourceSymbolMapping();
 		SBMLImporter sbmlImporter = importMap.get(simContext.getBioModel());
 		SBMLSymbolMapping sbmlMap = sbmlImporter.getSymbolMapping();
 		SBase targetSBase = sbmlMap.getMappedSBase(SBMLtargetID);
@@ -507,7 +508,7 @@ public class SEDMLImporter {
 		for (Change change : changes) {
 			String sbmlID = sbmlSupport.getIdFromXPathIdentifer(change.getTargetXPath().toString());
 			if (resolveConstant(refBM.getSimulationContext(0), sbmlID) == null) {
-				logger.trace("could not map changeAttribute for ID "+sbmlID+" to a VCell Constant");
+				logger.warn("could not map changeAttribute for ID "+sbmlID+" to a VCell Constant");
 				return false;
 			}
 		}
@@ -536,9 +537,11 @@ public class SEDMLImporter {
 				boolean bValidateSBML = false;
 				SBMLImporter sbmlImporter = new SBMLImporter(sbmlSource,transLogger,bValidateSBML);
 				bioModel = (BioModel)sbmlImporter.getBioModel();
-				bioModel.refreshDependencies();			
 				bioModel.setName(bioModelName);
 				bioModel.getSimulationContext(0).setName(mm.getName());
+				MathDescription math = bioModel.getSimulationContext(0).createNewMathMapping().getMathDescription();
+				bioModel.getSimulationContext(0).setMathDescription(math);
+				bioModel.refreshDependencies();			
 				docs.add(bioModel);
 				importMap.put(bioModel, sbmlImporter);
 			}


### PR DESCRIPTION
This PR fixes all known issues for round-tripping MathOverrides in simulations from NETWORK_DETERMINISTIC applications (non-spatial and spatial):

- primary changes to SEDML import and export
- includes cherry-picked commits from @jcschaff from branch map_symbol_unitsize

It also temporarily disables the attempts to import model changes as simulation overrides for stochastic applications, which present significant problems. For stochastic applications changes are being applied to the SBML prior to import.  This has a current limitation that compute changes (which become initial assignments) are lost.