### PR TITLE
fixed Not serializable exception in Simulation editor

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/math/MathDescription.java
+++ b/vcell-core/src/main/java/cbit/vcell/math/MathDescription.java
@@ -73,7 +73,7 @@ public class MathDescription implements Versionable, Matchable, SymbolTable, Ser
 		this.sourceSymbolMapping = sourceSymbolMapping;
 	}
 
-	private SourceSymbolMapping sourceSymbolMapping;
+	private transient SourceSymbolMapping sourceSymbolMapping;
 	private final static Logger logger = LogManager.getLogger(MathDescription.class);
 
 	public static final TreeMap<Long,TreeSet<String>> originalHasLowPrecisionConstants = new TreeMap<>();


### PR DESCRIPTION
SourceSymbolMapping field in MathDescription was not transient, and MathSymbolMapping is not serializable (lots of assorted objects reachable by MathSymbolMapping).

field is now transient.