### PR TITLE
fix NPE when unmapped compartments exported as SBML

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/math/BoundaryConditionType.java
+++ b/vcell-core/src/main/java/cbit/vcell/math/BoundaryConditionType.java
@@ -114,7 +114,7 @@ public boolean equals(Object obj) {
  * @param bcString java.lang.String
  */
 public static BoundaryConditionType fromString(String bcString) {
-	if (bcString==null){
+	if (bcString==null || bcString.length()==0){
 		return null;
 	}
 	return new BoundaryConditionType(bcString);

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
@@ -311,18 +311,22 @@ private void addCompartments() throws XMLStreamException, SbmlException {
 		StructureMapping vcStructMapping = getSelectedSimContext().getGeometryContext().getStructureMapping(vcStructures[i]);
 		try {
 			if (vcStructMapping.getSizeParameter().getExpression() != null) {
-				if(vcSelectedSimContext.getGeometry() != null && vcSelectedSimContext.getGeometry().getDimension() == 0) {
+				if(vcSelectedSimContext.getGeometry().getDimension() == 0) {
 					sbmlCompartment.setSize(vcStructMapping.getSizeParameter().getExpression().evaluateConstant());
 				} else {
-					Expression sizeRatio = vcStructMapping.getUnitSizeParameter().getExpression();
 					GeometryClass srcGeometryClass = vcStructMapping.getGeometryClass();
-					GeometricRegion[] srcGeometricRegions = vcSelectedSimContext.getGeometry().getGeometrySurfaceDescription().getGeometricRegions(srcGeometryClass);
-					if (srcGeometricRegions != null) {
-						double size = 0;
-						for (GeometricRegion srcGeometricRegion : srcGeometricRegions) {
-							size += srcGeometricRegion.getSize();
+					if (srcGeometryClass!=null) {
+						Expression sizeRatio = vcStructMapping.getUnitSizeParameter().getExpression();
+						GeometricRegion[] srcGeometricRegions = vcSelectedSimContext.getGeometry().getGeometrySurfaceDescription().getGeometricRegions(srcGeometryClass);
+						if (srcGeometricRegions != null) {
+							double size = 0;
+							for (GeometricRegion srcGeometricRegion : srcGeometricRegions) {
+								size += srcGeometricRegion.getSize();
+							}
+							sbmlCompartment.setSize(Expression.mult(new Expression(sizeRatio), new Expression(size)).evaluateConstant());
 						}
-						sbmlCompartment.setSize(Expression.mult(new Expression(sizeRatio), new Expression(size)).evaluateConstant());
+					}else{
+						sbmlCompartment.setSize(vcStructMapping.getSizeParameter().getExpression().evaluateConstant());
 					}
 				}
 			}


### PR DESCRIPTION
exporting Spatial SBML from VCell failed with a NullPointerException when there were unmapped compartments (eg. Features and/or Membranes which were not mapped to geometric domains.

Changes were made to tolerate incompletely mapped vcell structures (e.g. compartments).