### PR TITLE
Ion overrides

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/MathOverridesTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/MathOverridesTableModel.java
@@ -381,7 +381,7 @@ private void updateKeys(MathOverrides mathOverrides) {
 	if (mathOverrides != null) {
 		if (getEditable()) {
 			// show all
-			fieldKeys = mathOverrides.getAllConstantNames();
+			fieldKeys = mathOverrides.getFilteredConstantNames();
 		} else {
 			// summary, show only overriden ones
 			fieldKeys = mathOverrides.getOverridenConstantNames();

--- a/vcell-core/src/main/java/cbit/vcell/solver/MathOverrides.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/MathOverrides.java
@@ -909,4 +909,19 @@ public boolean isUnusedParameter(String name) {
 	}
 }
 
+
+public String[] getFilteredConstantNames() {
+	// TODO Jim to replace filtering logic
+	List<String> reservedConstants = Arrays.asList("KMOLE","_T_","_F_","F_nmol_","_N_pmol_","_PI_","_R_","_K_GHK","K_millivolts_per_volt","param_K_millivolts_per_volt");
+	List<String> allConstants = Arrays.asList(getAllConstantNames());
+	ArrayList<String> filteredConstants = new ArrayList<String>();
+	for (String constant : allConstants) {
+		if (reservedConstants.stream().anyMatch(constant::contains)) continue;
+		if (constant.startsWith("UnitFactor")) continue;
+		if (constant.startsWith("param__")) continue;
+		filteredConstants.add(constant);
+	}
+	return (String[])filteredConstants.toArray(new String[filteredConstants.size()]);
+}
+
 }

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
@@ -60,6 +60,8 @@ import cbit.vcell.mapping.SimulationContext;
 import cbit.vcell.mapping.SimulationContext.Application;
 import cbit.vcell.mapping.SimulationContext.MathMappingCallback;
 import cbit.vcell.mapping.SimulationContext.NetworkGenerationRequirements;
+import cbit.vcell.mapping.SpeciesContextSpec;
+import cbit.vcell.mapping.SpeciesContextSpec.SpeciesContextSpecParameter;
 import cbit.vcell.math.Constant;
 import cbit.vcell.math.MathDescription;
 import cbit.vcell.math.MathException;
@@ -254,17 +256,17 @@ public class SEDMLImporter {
 					}
 				}
 				if (matchingSimulationContext == null) {
-					if (!sedmlModel.getListOfChanges().isEmpty() && canTranslateToOverrides(bioModel, sedmlModel)) {
-						// for now we can't put overrides for different app type than original from SBML import
-						// if on initial check it looked like we can, we skipped the import with changes
-						// the referenced model has not been imported, this will bring it with changes applied
-						BioModel newBioModel = importModel(sedmlModel);
-						bmMap.put(sedmlModel.getId(), newBioModel);
-						bioModel = newBioModel;
-					}
+//					if (!sedmlModel.getListOfChanges().isEmpty() && canTranslateToOverrides(bioModel, sedmlModel)) {
+//						// for now we can't put overrides for different app type than original from SBML import
+//						// if on initial check it looked like we can, we skipped the import with changes
+//						// the referenced model has not been imported, this will bring it with changes applied
+//						BioModel newBioModel = importModel(sedmlModel);
+//						bmMap.put(sedmlModel.getId(), newBioModel);
+//						bioModel = newBioModel;
+//					}
 					matchingSimulationContext = SimulationContext.copySimulationContext(bioModel.getSimulationContext(0), sedmlOriginalModelName+"_"+existingSimulationContexts.length, bSpatial, appType);
 					bioModel.addSimulationContext(matchingSimulationContext);
-					bioModel.removeSimulationContext(bioModel.getSimulationContext(0));
+//					bioModel.removeSimulationContext(bioModel.getSimulationContext(0));
 					try {
 						matchingSimulationContext.setName(sedmlModel.getName());
 					} catch (Exception e) {
@@ -327,11 +329,12 @@ public class SEDMLImporter {
 					}
 				}
 			}
-			// purge unused biomodels
+			// purge unused biomodels and applications
 			for (BioModel doc : docs) {
-				if (doc.getSimulations() == null || doc.getSimulations().length == 0) {
-					docs.remove(doc);
+				for (int i = 0; i < doc.getSimulationContexts().length; i++) {
+					if (doc.getSimulationContext(i).getSimulations().length == 0) doc.removeSimulationContext(doc.getSimulationContext(i));
 				}
+				if (doc.getSimulations().length == 0) docs.remove(doc);
 			}
 			return docs;
 		} catch (Exception e) {
@@ -342,9 +345,18 @@ public class SEDMLImporter {
 	private void createOverrides(Simulation newSimulation, List<Change> changes) {
 		for (Change change : changes) {
 			String targetID = sbmlSupport.getIdFromXPathIdentifer(change.getTargetXPath().getTargetAsString());
-			String vcConstantName = resolveConstant(((SimulationContext)newSimulation.getSimulationOwner()), targetID);
+			SimulationContext importedSC = null; SimulationContext convertedSC = null;
+			SimulationContext currentSC = (SimulationContext)newSimulation.getSimulationOwner();
+			if (((SimulationContext)newSimulation.getSimulationOwner()).getApplicationType() == Application.NETWORK_STOCHASTIC) {
+				importedSC = currentSC.getBioModel().getSimulationContext(0);
+				convertedSC = (SimulationContext)newSimulation.getSimulationOwner();
+			} else {
+				importedSC = (SimulationContext)newSimulation.getSimulationOwner();
+				convertedSC = null;
+			}
+			String vcConstantName = resolveConstant(importedSC, convertedSC, targetID);
 			if (vcConstantName == null) {
-				logger.warn("target in change "+change+" could not be resolved to Constant, overrides not applied");
+				logger.error("target in change "+change+" could not be resolved to Constant, overrides not applied");
 				continue;
 			}
 			try {
@@ -368,11 +380,11 @@ public class SEDMLImporter {
 					System.out.println(vars);
 					for (org.jlibsedml.Variable var : vars) {
 						String sbmlID = sbmlSupport.getIdFromXPathIdentifer(var.getTarget());
-						String vcmlName = resolveConstant(((SimulationContext)newSimulation.getSimulationOwner()), sbmlID);
+						String vcmlName = resolveConstant(importedSC, convertedSC, sbmlID);
 						exp.substituteInPlace(new Expression(var.getId()), new Expression(vcmlName));
 					}
 				} else {
-					logger.warn("unsupported change "+change+" encountered, overrides not applied");
+					logger.error("unsupported change "+change+" encountered, overrides not applied");
 					continue;
 				}
 				Constant constant = new Constant(vcConstantName,exp);
@@ -384,12 +396,11 @@ public class SEDMLImporter {
 		}
 	}
 
-	private String resolveConstant(SimulationContext simContext, String SBMLtargetID) {
+	private String resolveConstant(SimulationContext importedSimContext, SimulationContext convertedSimContext, String SBMLtargetID) {
 		// finds name of math-side Constant corresponding to SBML entity, if there is one
 		// returns null if there isn't
-		String constantName = null;
-		MathSymbolMapping msm = (MathSymbolMapping)simContext.getMathDescription().getSourceSymbolMapping();
-		SBMLImporter sbmlImporter = importMap.get(simContext.getBioModel());
+		MathSymbolMapping msm = (MathSymbolMapping)importedSimContext.getMathDescription().getSourceSymbolMapping();
+		SBMLImporter sbmlImporter = importMap.get(importedSimContext.getBioModel());
 		SBMLSymbolMapping sbmlMap = sbmlImporter.getSymbolMapping();
 		SBase targetSBase = sbmlMap.getMappedSBase(SBMLtargetID);
 		if (targetSBase == null){
@@ -399,13 +410,28 @@ public class SEDMLImporter {
 		SymbolTableEntry ste =sbmlMap.getSte(targetSBase, SymbolContext.INITIAL);
 		Variable var = msm.getVariable(ste);
 		if (var instanceof Constant) {
-			constantName = var.getName();
-		}
-		if (constantName == null){
+			String constantName = var.getName();
+			// if simcontext was converted to stochastic then species init constants use different names
+			if (convertedSimContext != null && ste instanceof SpeciesContextSpecParameter) {
+				SpeciesContextSpecParameter scsp = (SpeciesContextSpecParameter)ste;
+				if (scsp.getRole() == SpeciesContextSpec.ROLE_InitialConcentration || scsp.getRole() == SpeciesContextSpec.ROLE_InitialCount) {
+					String spcName = scsp.getSpeciesContext().getName();
+					SpeciesContextSpec scs = null;
+					for (int i = 0; i < convertedSimContext.getReactionContext().getSpeciesContextSpecs().length; i++) {
+						scs = convertedSimContext.getReactionContext().getSpeciesContextSpecs()[i];
+						if (scs.getSpeciesContext().getName().equals(spcName)) {
+							break;
+						}
+					}
+					SpeciesContextSpecParameter convertedSCSP = scs.getInitialConditionParameter();
+					var = ((MathSymbolMapping)convertedSimContext.getMathDescription().getSourceSymbolMapping()).getVariable(convertedSCSP);
+					constantName = var.getName();
+				}
+			}
+			return constantName; 
+		} else {
 			logger.error("couldn't find Constant target with sid="+SBMLtargetID+" in symbol mapping, var = "+var);
 			return null;
-		}else {
-			return constantName;
 		}
 	}
 
@@ -429,6 +455,15 @@ public class SEDMLImporter {
 				rt = (RepeatedTask)selectedTask; // need to reset if we had a chain above
 				Task actualTask = (Task)referredTask;
 				Simulation simulation = vcSimulations.get(actualTask.getId());
+				SimulationContext importedSC = null; SimulationContext convertedSC = null;
+				SimulationContext currentSC = (SimulationContext)simulation.getSimulationOwner();
+				if (((SimulationContext)simulation.getSimulationOwner()).getApplicationType() == Application.NETWORK_STOCHASTIC) {
+					importedSC = currentSC.getBioModel().getSimulationContext(0);
+					convertedSC = (SimulationContext)simulation.getSimulationOwner();
+				} else {
+					importedSC = (SimulationContext)simulation.getSimulationOwner();
+					convertedSC = null;
+				}
 				List<SetValue> changes = rt.getChanges();
 				List<Change> functions = new ArrayList<Change>();
 				for (SetValue change : changes) {
@@ -440,8 +475,7 @@ public class SEDMLImporter {
 						ConstantArraySpec scanSpec = null;
 						String targetID = sbmlSupport
 								.getIdFromXPathIdentifer(change.getTargetXPath().getTargetAsString());
-						String constant = resolveConstant((SimulationContext) simulation.getSimulationOwner(),
-								targetID);
+						String constant = resolveConstant(importedSC, convertedSC, targetID);
 						if (range instanceof UniformRange) {
 							UniformRange ur = (UniformRange) range;
 							scanSpec = ConstantArraySpec.createIntervalSpec(constant,
@@ -522,7 +556,7 @@ public class SEDMLImporter {
 		// check whether all targets have addressable Constants on the Math side
 		for (Change change : changes) {
 			String sbmlID = sbmlSupport.getIdFromXPathIdentifer(change.getTargetXPath().toString());
-			if (resolveConstant(refBM.getSimulationContext(0), sbmlID) == null) {
+			if (resolveConstant(refBM.getSimulationContext(0), null, sbmlID) == null) {
 				logger.warn("could not map changeAttribute for ID "+sbmlID+" to a VCell Constant");
 				return false;
 			}


### PR DESCRIPTION
SEDMLImporter now properly handles all naming issues for Species initial concentrations used as targets or symbols in MathOverrides in simulations from stochastic applications.

Additional features:
- proper naming of simulations restored; should always roundtrip from VCell export and not create side effects with other SEDMLs
- name preserved on all types of Applications
- includes basic logic to merge multiple BioModels into one when Models are matchable (for future full roundtrip of BioModels with multiple applications)

Caveat: testing included many corner cases but not extensive.