### PR TITLE
smarter override filter (not used in editor) and safer iter.remove()

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -348,6 +348,38 @@ public class SimulationContext implements SimulationOwner, Versionable, Matchabl
 			return null;
 		}
 
+		/**
+		 * @return set of constant names belonging to physical constants and unit conversions
+		 *         or 'null' if it cannot fulfill request (e.g. MathSymbolMapping is missing)
+		 */
+		@Override
+		public Set<String> getNonOverridableConstantNames() {
+			MathSymbolMapping mathSymbolMapping = (MathSymbolMapping) mathDesc.getSourceSymbolMapping();
+			if (mathSymbolMapping == null){
+				return null;
+			}
+			List<Constant> constants = Collections.list(mathDesc.getConstants());
+			Set<String> nonOverridableConstantNames = new LinkedHashSet<>();
+			for (Constant c : constants){
+				SymbolTableEntry[] stes = mathSymbolMapping.getBiologicalSymbol(c);
+				if (stes != null && stes.length > 0){
+					SymbolTableEntry bioSTE = stes[0];
+					if (bioSTE instanceof ReservedSymbol){
+						ReservedSymbol reservedSymbol = (ReservedSymbol)bioSTE;
+						if (reservedSymbol.getRole() != ReservedSymbolRole.TEMPERATURE) {
+							nonOverridableConstantNames.add(c.getName());
+						}
+					} else if (bioSTE instanceof AbstractMathMapping.MathMappingParameter){
+						AbstractMathMapping.MathMappingParameter mmParam = (AbstractMathMapping.MathMappingParameter) bioSTE;
+						if (mmParam.getRole() == AbstractMathMapping.PARAMETER_ROLE_UNITFACTOR){
+							nonOverridableConstantNames.add(c.getName());
+						}
+					}
+				}
+			}
+			return nonOverridableConstantNames;
+		}
+
 	}
 
 		public class SimulationContextParameter extends Parameter implements ExpressionContainer {

--- a/vcell-core/src/main/java/cbit/vcell/solver/MathOverrides.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/MathOverrides.java
@@ -949,8 +949,26 @@ public boolean isUnusedParameter(String name) {
 
 
 public String[] getFilteredConstantNames() {
-	// TODO Jim to replace filtering logic
-	List<String> reservedConstants = Arrays.asList("KMOLE","_T_","_F_","F_nmol_","_N_pmol_","_PI_","_R_","_K_GHK","K_millivolts_per_volt","param_K_millivolts_per_volt");
+	//
+	// try to ask SimulationContext for Constants which map to unit conversions and physical constants (exclude these).
+	//
+	SimulationOwner simulationOwner = simulation.getSimulationOwner();
+	//
+	// MathModels don't provide MathOverrides resolvers, and in context of Simulation editor, cloned Simulation doesn't have an owner (transient field)
+	//
+	if (simulationOwner != null && simulationOwner.getMathOverridesResolver() != null) {
+		Set<String> nonOverridableConstantNames = simulationOwner.getMathOverridesResolver().getNonOverridableConstantNames();
+		if (nonOverridableConstantNames!=null) { // returns null if MathSymbolMapping is missing from MathDescription.
+			List<String> allConstants = Arrays.asList(getAllConstantNames());
+			allConstants.removeAll(nonOverridableConstantNames);
+			return allConstants.toArray(new String[0]);
+		}
+	}
+
+	//
+	// Simulation owner cannot provide intelligent choices (MathModel or MathSymbolMapping is missing)
+	//
+	List<String> reservedConstants = Arrays.asList("KMOLE", "_T_", "_F_", "F_nmol_", "_N_pmol_", "_PI_", "_R_", "_K_GHK", "K_millivolts_per_volt", "param_K_millivolts_per_volt");
 	List<String> allConstants = Arrays.asList(getAllConstantNames());
 	ArrayList<String> filteredConstants = new ArrayList<String>();
 	for (String constant : allConstants) {
@@ -959,7 +977,7 @@ public String[] getFilteredConstantNames() {
 		if (constant.startsWith("param__")) continue;
 		filteredConstants.add(constant);
 	}
-	return (String[])filteredConstants.toArray(new String[filteredConstants.size()]);
+	return filteredConstants.toArray(new String[filteredConstants.size()]);
 }
 
 }

--- a/vcell-core/src/main/java/cbit/vcell/solver/MathOverridesResolver.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/MathOverridesResolver.java
@@ -5,9 +5,10 @@ import cbit.vcell.parser.Expression;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public interface MathOverridesResolver {
-    
+
     class SymbolReplacement {
         public final String newName;
         public final Expression factor;
@@ -27,4 +28,11 @@ public interface MathOverridesResolver {
     }
 
     SymbolReplacement getSymbolReplacement(String name);
+
+    /**
+     * @return set of constant names belonging to physical constants and unit conversions
+     *         or 'null' if it cannot fulfill request (e.g. MathSymbolMapping is missing)
+     */
+    Set<String> getNonOverridableConstantNames();
+
 }

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
@@ -4,10 +4,7 @@ package org.vcell.sedml;
 import java.beans.PropertyVetoException;
 import java.io.*;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import cbit.vcell.parser.ExpressionMathMLParser;
 import cbit.vcell.parser.SymbolTableEntry;
@@ -327,11 +324,16 @@ public class SEDMLImporter {
 				}
 			}
 			// purge unused biomodels and applications
-			for (BioModel doc : docs) {
+			Iterator<BioModel> docIter = docs.iterator();
+			while (docIter.hasNext()) {
+				BioModel doc = docIter.next();
 				for (int i = 0; i < doc.getSimulationContexts().length; i++) {
-					if (doc.getSimulationContext(i).getSimulations().length == 0) doc.removeSimulationContext(doc.getSimulationContext(i));
+					if (doc.getSimulationContext(i).getSimulations().length == 0) {
+						doc.removeSimulationContext(doc.getSimulationContext(i));
+						i--;
+					}
 				}
-				if (doc.getSimulations().length == 0) docs.remove(doc);
+				if (doc.getSimulations().length == 0) docIter.remove();
 			}
 			// finally try to consolidate SimContexts into fewer (posibly just one) BioModels
 			// unlikely to happen from SEDMLs not originating from VCell, but very useful for roundtripping if so
@@ -352,9 +354,7 @@ public class SEDMLImporter {
 			BioModel strippedBM = null;
 			try {
 				strippedBM = XmlHelper.cloneBioModel(bm);
-				for (Simulation sim : strippedBM.getSimulations()) {
-					strippedBM.removeSimulation(sim);
-				}
+				strippedBM.setSimulations(new Simulation[0]);
 				strippedBM.removeSimulationContext(strippedBM.getSimulationContext(0));
 			} catch (XmlParseException | PropertyVetoException e) {
 				// TODO Auto-generated catch block


### PR DESCRIPTION
minor updates to Ion's work on MathOverrides (to filter unwanted MathOverrides which are distracting to the users).

- replaced hard-coded symbol names for KMOLE, Unit Factors, etc (which are not reasonably overridable) with code which refers to MathSymbolMapping to associate with reservedSymbols (e.g. KMOLE) and some MathMappingParameter (e.g. Unit factors).
- At the moment, the Simulation editor panel clones the Simulation making the above improvement impossible (the code is there, but it opts out because the information is marked as 'transient').
- The code is to be merged anyway, the logic is sound and will be invoked anywhere the Simulation is not cloned.