### PR TITLE
Override list intervals

### DIFF
--- a/vcell-api/src/main/java/org/vcell/rest/common/OverrideRepresentation.java
+++ b/vcell-api/src/main/java/org/vcell/rest/common/OverrideRepresentation.java
@@ -17,10 +17,10 @@ public class OverrideRepresentation {
 	public final String name;
 	public final String type;
 	public final String expression;
-	public final double[] values;
+	public final String[] values;
 	public final int cardinality;
 	
-	public OverrideRepresentation(String name, String type, int cardinality, double[] values, String expression) {
+	public OverrideRepresentation(String name, String type, int cardinality, String[] values, String expression) {
 		this.name = name;
 		this.type = type;
 		this.cardinality = cardinality;
@@ -38,7 +38,7 @@ public class OverrideRepresentation {
 			this.cardinality = 1;
 			if (element.getActualValue().isNumeric()){
 				this.type = OVERRIDE_TYPE_Single;
-				this.values = new double[] { element.getActualValue().evaluateConstant() };
+				this.values = new String[] { element.getActualValue().infix() };
 				this.expression = null;
 			}else{
 				this.type = OVERRIDE_TYPE_Variable;
@@ -58,9 +58,9 @@ public class OverrideRepresentation {
 			//
 			case ConstantArraySpec.TYPE_LIST:{
 				this.type = OVERRIDE_TYPE_List;
-				this.values = new double[this.cardinality];
+				this.values = new String[this.cardinality];
 				for (int i=0;i<cardinality;i++){
-					values[i] = arraySpec.getConstants()[i].getExpression().evaluateConstant();
+					values[i] = arraySpec.getConstants()[i].getExpression().infix();
 				}
 				break;
 			}
@@ -73,7 +73,7 @@ public class OverrideRepresentation {
 				}else{
 					this.type = OVERRIDE_TYPE_LinearInterval;
 				}
-				this.values = new double[] { arraySpec.getMinValue(), arraySpec.getMaxValue() };
+				this.values = new String[] { arraySpec.getMinValue().infix(), arraySpec.getMaxValue().infix() };
 				break;
 			}
 			default:{
@@ -129,8 +129,8 @@ public class OverrideRepresentation {
 		if (type.equals(OVERRIDE_TYPE_List)){
 			StringBuffer buffer = new StringBuffer();
 			buffer.append("[");
-			for (double val : values){
-				buffer.append(val+" ");
+			for (String val : values){
+				buffer.append("\""+val+"\", ");
 			}
 			buffer.append("]");
 		}
@@ -151,7 +151,7 @@ public class OverrideRepresentation {
 		return type;
 	}
 
-	public double[] getValues() {
+	public String[] getValues() {
 		return values;
 	}
 

--- a/vcell-api/src/main/java/org/vcell/rest/server/BiomodelSimulationSaveServerResource.java
+++ b/vcell-api/src/main/java/org/vcell/rest/server/BiomodelSimulationSaveServerResource.java
@@ -82,12 +82,12 @@ public class BiomodelSimulationSaveServerResource extends AbstractServerResource
 				String name = overrideObj.getString("name");
 				String type = overrideObj.getString("type");
 				int cardinality = overrideObj.getInt("cardinality");
-				double[] values = new double[0];
+				String[] values = new String[0];
 				if (overrideObj.has("values")){
 					JSONArray valuesArray = overrideObj.getJSONArray("values");
-					values = new double[valuesArray.length()];
+					values = new String[valuesArray.length()];
 					for (int j=0; j<valuesArray.length(); j++){
-						values[j] = valuesArray.getDouble(j);
+						values[j] = valuesArray.getString(j);
 					}
 				}
 				String expression = null;

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
@@ -566,11 +566,11 @@ public class VcmlOmexConverter {
 					try {
 						logger.trace(bos.toString(StandardCharsets.UTF_8.name()));
 					} catch (UnsupportedEncodingException e) {
-						logger.error(e);
+						logger.error("failed to write RDF to file during logging: "+e.getMessage(), e);
 					}
 				}
     		} catch (RDFHandlerException e) {
-    			logger.error(e);
+    			logger.error("error forming RDF: "+e.getMessage(), e);
 			}
     		return ret;
         }
@@ -584,7 +584,7 @@ public class VcmlOmexConverter {
     			ret = SesameRioUtil.writeRDFToString(graph, nsMap, RDFFormat.RDFXML);
     			SesameRioUtil.writeRDFToStream(System.out, graph, nsMap, RDFFormat.RDFXML);
     		} catch (RDFHandlerException e) {
-    			logger.error(e);
+    			logger.error("failed to write RDF to console: "+e.getMessage(), e);
 			}
     		return ret;
         }
@@ -615,7 +615,7 @@ public class VcmlOmexConverter {
 			ret = SesameRioUtil.writeRDFToString(graph, nsMap, RDFFormat.RDFXML);
 //			SesameRioUtil.writeRDFToStream(System.out, graph, nsMap, RDFFormat.RDFXML);
 		} catch (RDFHandlerException e) {
-			logger.error(e);
+			logger.error(e.getMessage(), e);
 		}
 		
 		String end = "\n\n" + ret.substring(ret.indexOf(PubMet.EndDescription0));

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/simulation/ParameterScanPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/simulation/ParameterScanPanel.java
@@ -42,7 +42,7 @@ public class ParameterScanPanel extends JPanel {
 	private JTextField ivjJTextFieldMin = null;
 	private JTextField ivjJTextFieldNumber = null;
 	private JTextField ivjJTextFieldValues = null;
-	private ConstantArraySpec fieldConstantArraySpec = ConstantArraySpec.createIntervalSpec("", 0, 0, 0, false);
+	private ConstantArraySpec fieldConstantArraySpec = ConstantArraySpec.createIntervalSpec("", "0", "0", 0, false);
 
 class IvjEventHandler implements java.beans.PropertyChangeListener {
 		public void propertyChange(java.beans.PropertyChangeEvent evt) {
@@ -75,8 +75,8 @@ public void applyValues() throws ExpressionException{
 	} else if (getJRadioButtonRange().isSelected()) {
 		setConstantArraySpec(ConstantArraySpec.createIntervalSpec(
 			getConstantArraySpec().getName(),
-			Double.parseDouble(getJTextFieldMin().getText()),
-			Double.parseDouble(getJTextFieldMax().getText()),
+			getJTextFieldMin().getText(),
+			getJTextFieldMax().getText(),
 			Integer.parseInt(getJTextFieldNumber().getText()),
 			getJCheckBoxLog().isSelected()
 			));
@@ -502,8 +502,8 @@ private void initFields(ConstantArraySpec spec) {
 		}
 		case ConstantArraySpec.TYPE_INTERVAL: {
 			getJRadioButtonRange().setSelected(true);
-			getJTextFieldMin().setText(""+spec.getMinValue());
-			getJTextFieldMax().setText(""+spec.getMaxValue());
+			getJTextFieldMin().setText(""+spec.getMinValue().infix());
+			getJTextFieldMax().setText(""+spec.getMaxValue().infix());
 			getJTextFieldNumber().setText(""+spec.getNumValues());
 			getJCheckBoxLog().setSelected(spec.isLogInterval());
 			break;

--- a/vcell-client/src/main/java/cbit/vcell/client/task/ClientTaskDispatcher.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/task/ClientTaskDispatcher.java
@@ -519,6 +519,7 @@ private static void dispatchFollowUp(Hashtable<String, Object> hash) {
  * @param exc java.lang.Exception
  */
 public static void recordException(Throwable exc, Hashtable<String, Object> hash) {
+	lg.error(exc.getMessage(), exc);
 	if (exc instanceof UserCancelException) {
 		hash.put(TASK_ABORTED_BY_USER, exc);
 	} else {

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/MathOverridesTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/MathOverridesTableModel.java
@@ -107,7 +107,7 @@ private void editScanValues(String name, int r) throws DivideByZeroException, Ex
 	if (getMathOverrides().isScan(name)) {
 		spec = getMathOverrides().getConstantArraySpec(name);
 	} else {
-		spec = ConstantArraySpec.createIntervalSpec(name, 0, getMathOverrides().getDefaultExpression(name).evaluateConstant(), 2, false);
+		spec = ConstantArraySpec.createIntervalSpec(name, "0", getMathOverrides().getDefaultExpression(name).infix(), 2, false);
 	}
 	panel.setConstantArraySpec(spec);
 	int confirm = DialogUtils.showComponentOKCancelDialog(ownerTable, panel, "Scan values for parameter '" + fieldKeys[r]);

--- a/vcell-core/src/main/java/cbit/vcell/biomodel/ModelUnitConverter.java
+++ b/vcell-core/src/main/java/cbit/vcell/biomodel/ModelUnitConverter.java
@@ -260,19 +260,11 @@ public class ModelUnitConverter {
 			power_of_KMOLE = power_of_KMOLE.multiplyBy(KMOLE_Unit);
 			if (practicallyDimensionlessUnit.multiplyBy(power_of_KMOLE).isCompatible(dimensionless)) {
 				double conversionScale = dimensionless.convertTo(1.0, practicallyDimensionlessUnit.multiplyBy(power_of_KMOLE));
-				try {
-					return Expression.mult(new Expression(conversionScale), Expression.power(new Expression(KMOLE, KMOLE.getNameScope()), -power));
-				} catch (ExpressionException e) {
-					throw new RuntimeException(e);
-				}
+				return Expression.mult(new Expression(conversionScale), Expression.power(new Expression(KMOLE, KMOLE.getNameScope()), -power));
 			}
 			if (practicallyDimensionlessUnit.divideBy(power_of_KMOLE).isCompatible(dimensionless)) {
 				double conversionScale = dimensionless.convertTo(1.0, practicallyDimensionlessUnit.divideBy(power_of_KMOLE));
-				try {
-					return Expression.mult(new Expression(conversionScale), Expression.power(new Expression(KMOLE, KMOLE.getNameScope()), power));
-				} catch (ExpressionException e) {
-					throw new RuntimeException(e);
-				}
+				return Expression.mult(new Expression(conversionScale), Expression.power(new Expression(KMOLE, KMOLE.getNameScope()), power));
 			}
 		}
 		throw new RuntimeException("unit " + practicallyDimensionlessUnit.getSymbol() + " is not practically dimensionless, even by using KMOLE");

--- a/vcell-core/src/main/java/cbit/vcell/mapping/AbstractMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/AbstractMathMapping.java
@@ -1051,7 +1051,7 @@ protected Expression getIdentifierSubstitutions(Expression origExp, VCUnitDefini
 				logger.error("exp='"+expStr+"' exception='"+e.getMessage()+"'", e);
 				localIssueList.add(new Issue(origExp, issueContext, IssueCategory.Units,"expected=["+((desiredExpUnitDef!=null)?(desiredExpUnitDef.getSymbol()):("null"))+"], exception="+e.getMessage(),Issue.SEVERITY_WARNING));
 			}catch (Exception e){
-				logger.error(e);
+				logger.error("error evaluating units for expression '"+origExp+": "+e.getMessage(), e);
 				localIssueList.add(new Issue(origExp, issueContext, IssueCategory.Units,"expected=["+((desiredExpUnitDef!=null)?(desiredExpUnitDef.getSymbol()):("null"))+"], exception="+e.getMessage(),Issue.SEVERITY_WARNING));
 			}
 			Expression newExp = new Expression(origExp);

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -926,8 +926,9 @@ public void refreshMathDescription(MathMappingCallback callback, NetworkGenerati
 		try {
 			setMathDescription(createNewMathMapping(callback, networkGenerationRequirements).getMathDescription());
 		} catch (Exception e) {
-			logger.error(e);
-			throw new RuntimeException("Application '"+getName()+"' has no generated Math, Failed to generate new Math: "+ e.getMessage());
+			String msg = "Application '"+getName()+"' has no generated Math, Failed to generate new Math: "+ e.getMessage();
+			logger.error(msg, e);
+			throw new RuntimeException(msg);
 		}
 	}
 }
@@ -2619,7 +2620,7 @@ public void refreshSpatialObjects() {
 				}
 			}
 		} catch (PropertyVetoException e) {
-			logger.error(e);
+			logger.error("failed to remove spatial objects: "+e.getMessage(), e);
 		}
 	}
 }

--- a/vcell-core/src/main/java/cbit/vcell/math/MathDescription.java
+++ b/vcell-core/src/main/java/cbit/vcell/math/MathDescription.java
@@ -807,7 +807,7 @@ private MathCompareResults compareEquivalentCanonicalMath(MathDescription newMat
 			return oldMathDesc.compareInvariantAttributes(newMathDesc,true);
 		}
 	}catch (Exception e){
-		logger.error(e);
+		logger.error("unexpected failure comparing math descriptions: "+e.getMessage(), e);
 		logMathTexts(this, newMathDesc, Decision.MathDifferent_FAILURE_UNKNOWN, "Failure comparing math: "+e.getMessage());
 		return new MathCompareResults(Decision.MathDifferent_FAILURE_UNKNOWN, "failed to compare math: "+e.getMessage());
 	}
@@ -891,17 +891,17 @@ private static boolean compareUpdate(Expression nExp, Expression oExp, Consumer<
 }
 
 private static void logMathTexts(MathDescription math1, MathDescription math2, Decision decision, String msg){
-	try {
-		if (logger.isTraceEnabled()) {
-			logger.trace("maths different: "+decision.name()+" details: "+msg
-					+"\n===================MATH 1==================\n"
-					+ math1.getVCML_database() + "\n"
-					+ "==================MATH 2====================\n"
-					+ math2.getVCML_database() + "\n"
-					+ "==================END MATHS=================");
+	if (logger.isTraceEnabled()) {
+		try {
+		logger.trace("maths different: "+decision.name()+" details: "+msg
+				+"\n===================MATH 1==================\n"
+				+ math1.getVCML_database() + "\n"
+				+ "==================MATH 2====================\n"
+				+ math2.getVCML_database() + "\n"
+				+ "==================END MATHS=================");
+		}catch (Exception e){
+			logger.error("error logging math description text: "+e.getMessage(), e);
 		}
-	}catch (Exception e){
-		logger.error(e);
 	}
 }
 

--- a/vcell-core/src/main/java/cbit/vcell/solver/ConstantArraySpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/ConstantArraySpec.java
@@ -76,6 +76,18 @@ public void applyFunctionToExpressions(Function<Expression, Expression> expressi
 	}
 }
 
+public void changeName(String newName) {
+	if (type == ConstantArraySpec.TYPE_LIST){
+		for (int i = 0; i < constants.length; i++){
+			constants[i] = new Constant(newName, constants[i].getExpression());
+		}
+	}
+	if (type == ConstantArraySpec.TYPE_INTERVAL){
+		for (int i = 0; i < constants.length; i++){
+			constants[i] = new Constant(newName, constants[i].getExpression());
+		}
+	}
+}
 
 /**
  * Checks for internal representation of objects, not keys from database

--- a/vcell-core/src/main/java/cbit/vcell/solver/ConstantArraySpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/ConstantArraySpec.java
@@ -12,6 +12,11 @@ package cbit.vcell.solver;
 import cbit.vcell.math.Constant;
 import cbit.vcell.math.VCML;
 import cbit.vcell.parser.Expression;
+import cbit.vcell.parser.ExpressionException;
+
+import java.util.ArrayList;
+import java.util.function.Function;
+
 /**
  * Insert the type's description here.
  * Creation date: (9/23/2005 1:25:30 PM)
@@ -23,8 +28,8 @@ public class ConstantArraySpec implements org.vcell.util.Matchable, java.io.Seri
 	private int type;
 	private int numValues;
 	private String name;
-	private double minValue;
-	private double maxValue;
+	private Expression minValue;
+	private Expression maxValue;
 	private boolean logInterval;
 	private Constant[] constants;
 
@@ -56,6 +61,21 @@ public static ConstantArraySpec clone(ConstantArraySpec spec) {
 	return clone;
 }
 
+public void applyFunctionToExpressions(Function<Expression, Expression> expressionFunction){
+	if (type == ConstantArraySpec.TYPE_LIST){
+		for (int i = 0; i < constants.length; i++){
+			constants[i] = new Constant(constants[i].getName(), expressionFunction.apply(constants[i].getExpression()));
+		}
+	}
+	if (type == ConstantArraySpec.TYPE_INTERVAL){
+		minValue = expressionFunction.apply(minValue);
+		maxValue = expressionFunction.apply(maxValue);
+		for (int i = 0; i < constants.length; i++){
+			constants[i] = new Constant(constants[i].getName(), expressionFunction.apply(constants[i].getExpression()));
+		}
+	}
+}
+
 
 /**
  * Checks for internal representation of objects, not keys from database
@@ -83,9 +103,15 @@ public boolean compareEqual(org.vcell.util.Matchable obj) {
  */
 public static ConstantArraySpec createFromString(String name, String description, int type) {
 	// parses toString() output to recreate object
-	java.util.StringTokenizer tokens = new java.util.StringTokenizer(description, ", ");
 	try {
 		if (type == TYPE_LIST) {
+			final String delimiter;
+			if (description.contains(";")){
+				delimiter = ";";
+			}else{
+				delimiter = ",";
+			}
+			java.util.StringTokenizer tokens = new java.util.StringTokenizer(description, delimiter);
 			String[] values = new String[tokens.countTokens()];
 			int i = 0;
 			while (tokens.hasMoreElements()) {
@@ -94,17 +120,26 @@ public static ConstantArraySpec createFromString(String name, String description
 			}
 			return createListSpec(name, values);
 		} else if (type == TYPE_INTERVAL) {
-			double minValue = Double.parseDouble(tokens.nextToken());
-			tokens.nextToken();
-			double maxValue = Double.parseDouble(tokens.nextToken());
-			String token = tokens.nextToken();
-			boolean logInterval = false;
-			if (token.equals("log")) {
-				logInterval = true;
-				token = tokens.nextToken();
+			int index_of_to = description.indexOf(" to ");
+			if (index_of_to == -1){
+				throw new RuntimeException("invalid format '"+description+"'");
 			}
+			String rest = description.substring(index_of_to+4);
+			boolean logInterval = false;
+			if (rest.contains("log,")){
+				logInterval = true;
+				rest = rest.replace("log,","");
+			}
+			int index_of_last_comma = rest.lastIndexOf(",");
+
+			String[] parts = description.replace(" to ",",").split(",");
+			String minValueExpStr = description.substring(0,index_of_to);
+			String maxValueExpStr = rest.substring(0, index_of_last_comma);
+			String rest2 = rest.substring(index_of_last_comma+1);
+			java.util.StringTokenizer tokens = new java.util.StringTokenizer(rest2, " ");
+			String token = tokens.nextToken();
 			int numValues = Integer.parseInt(token);
-			return createIntervalSpec(name, minValue, maxValue, numValues, logInterval);
+			return createIntervalSpec(name, minValueExpStr, maxValueExpStr, numValues, logInterval);
 		} else {
 			throw new RuntimeException("unknown type");
 		}
@@ -118,36 +153,55 @@ public static ConstantArraySpec createFromString(String name, String description
  * Insert the method's description here.
  * Creation date: (9/23/2005 1:47:17 PM)
  * @return cbit.vcell.solver.ConstantArraySpec
- * @param name java.lang.String
- * @param minValue double
- * @param maxValue double
+ * @param name String
+ * @param minValueExpStr String
+ * @param maxValueExpStr String
  * @param numValues int
  * @param logInterval boolean
  */
-public static ConstantArraySpec createIntervalSpec(String name, double minValue, double maxValue, int numValues, boolean logInterval) {
-	if (logInterval && (minValue * maxValue <= 0)) throw new RuntimeException("Min and Max values cannot be zero or have different signs for log interval");
+public static ConstantArraySpec createIntervalSpec(String name, String minValueExpStr, String maxValueExpStr, int numValues, boolean logInterval) {
+	Expression minValueExp = null;
+	Expression maxValueExp = null;
+	try {
+		minValueExp = new Expression(minValueExpStr);
+		maxValueExp = new Expression(maxValueExpStr);
+	} catch (ExpressionException e) {
+		throw new RuntimeException("failed to parse expressions '"+minValueExpStr+"' and '"+maxValueExpStr+"': "+e.getMessage(), e);
+	}
+	try {
+		double minValue = minValueExp.evaluateConstant();
+		double maxValue = maxValueExp.evaluateConstant();
+		if (logInterval && (minValue * maxValue <= 0)) throw new RuntimeException("Min and Max values cannot be zero or have different signs for log interval");
+	} catch (ExpressionException e){
+	}
 	ConstantArraySpec spec = new ConstantArraySpec();
 	spec.type = TYPE_INTERVAL;
 	spec.name = name;
-	spec.minValue = minValue;
-	spec.maxValue = maxValue;
+	spec.minValue = minValueExp;
+	spec.maxValue = maxValueExp;
 	spec.numValues = numValues;
 	spec.logInterval = logInterval;
 	spec.constants = new Constant[numValues];
 	if (logInterval) {
 		for (int i = 0; i < numValues; i++){
-			spec.constants[i] = new Constant(name, new cbit.vcell.parser.Expression(minValue * Math.pow(maxValue/minValue, ((double)i)/(numValues - 1))));
+			spec.constants[i] = new Constant(name, Expression.mult(
+					minValueExp,
+					Expression.power(Expression.div(maxValueExp, minValueExp),
+							((double)i)/(numValues - 1))));
 		}
 	} else {
 		for (int i = 0; i < numValues; i++){
-			spec.constants[i] = new Constant(name, new cbit.vcell.parser.Expression(minValue + (maxValue - minValue) * ((double)i)/(numValues - 1)));
+			spec.constants[i] = new Constant(name, Expression.add(
+					minValueExp,
+					Expression.mult(Expression.add(maxValueExp, Expression.negate(minValueExp)),
+							new Expression(((double)i)/(numValues - 1)))));
 		}
 	}
 	return spec;
 }
 
 
-/**
+	/**
  * Insert the method's description here.
  * Creation date: (9/23/2005 1:33:00 PM)
  * @return cbit.vcell.solver.ConstantArraySpec
@@ -181,7 +235,7 @@ public Constant[] getConstants() {
  * Creation date: (9/23/2005 2:21:53 PM)
  * @return double
  */
-public double getMaxValue() {
+public Expression getMaxValue() {
 	return maxValue;
 }
 
@@ -191,7 +245,7 @@ public double getMaxValue() {
  * Creation date: (9/23/2005 2:21:53 PM)
  * @return double
  */
-public double getMinValue() {
+public Expression getMinValue() {
 	return minValue;
 }
 
@@ -257,13 +311,13 @@ public String toString() {
 			cbit.vcell.math.Constant[] cs = getConstants();
 			String list = "";
 			for (int i = 0; i < cs.length; i++){
-				list += cs[i].getExpression().infix() + ", ";
+				list += cs[i].getExpression().infix() + "; ";
 			}
 			list = list.substring(0, list.length() - 2);
 			return list;
 		} 
 		case TYPE_INTERVAL: {
-			String interval = minValue + " to " + maxValue + ", ";
+			String interval = minValue.infix() + " to " + maxValue.infix() + ", ";
 			if (logInterval) interval += "log, ";
 			interval += numValues + " values";
 			return interval;
@@ -273,4 +327,5 @@ public String toString() {
 		}
 	}
 }
+
 }

--- a/vcell-core/src/main/java/cbit/vcell/solver/MathOverrides.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/MathOverrides.java
@@ -22,6 +22,7 @@ import org.vcell.util.IssueContext.ContextType;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Constant expressions that override those specified in the MathDescription
@@ -122,6 +123,12 @@ public class MathOverrides implements Matchable, java.io.Serializable {
 			}
 		}
 
+		public void changeName(String newName) {
+			this.name = newName;
+			if (this.spec!=null){
+				this.spec.changeName(newName);
+			}
+		}
 	}
 
 /**
@@ -200,7 +207,12 @@ public boolean compareEqual(Matchable obj) {
 	if (!(obj instanceof MathOverrides)){
 		return false;
 	}
-	boolean returnValue = Compare.isEqual(toVector(getOverridesHash().elements()),toVector(((MathOverrides)obj).getOverridesHash().elements()));
+	List<Element> elements = Collections.list(getOverridesHash().elements());
+	List<Element> otherElements = Collections.list(((MathOverrides)obj).getOverridesHash().elements());
+	// sort elements by name of overridden constant
+	elements.sort((el1,el2) -> el1.name.compareTo(el2.name));
+	otherElements.sort((el1,el2) -> el1.name.compareTo(el2.name));
+	boolean returnValue = Compare.isEqual(elements, otherElements);
 	return returnValue;
 }
 
@@ -792,6 +804,7 @@ void updateFromMathDescription() {
 							return substitutedExp;
 						};
 						element.applyFunctionToExpressions(scaleExpressionsByUnitFactor);
+						element.changeName(replacement.newName);
 						overridesHash.put(replacement.newName, element);
 						removeConstant(name);
 					}

--- a/vcell-core/src/main/java/cbit/vcell/xml/XmlHelper.java
+++ b/vcell-core/src/main/java/cbit/vcell/xml/XmlHelper.java
@@ -1065,7 +1065,7 @@ public class XmlHelper {
 
 			xml = stringWriter.toString();
 		} catch (Exception e) {
-			logger.error(e);
+			logger.error("unexpected exception updating attribute "+xpathExpression+" to "+newValue+": "+e.getMessage(), e);
 		}
 		return xml;
 	}
@@ -1129,7 +1129,7 @@ public class XmlHelper {
 
 			xml = stringWriter.toString();
 		} catch (Exception e) 	{
-			logger.error(e);
+			logger.error("error while updating XML attribute: "+e.getMessage(), e);
 		}
 		return xml;
 	}

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -585,8 +585,8 @@ public class SEDMLExporter {
 									if(constantArraySpec.getType() == ConstantArraySpec.TYPE_INTERVAL) {
 										// ------ Uniform Range
 										UniformType type = constantArraySpec.isLogInterval() ? UniformType.LOG : UniformType.LINEAR;
-										r = new UniformRange(rangeId, constantArraySpec.getMinValue(), 
-												constantArraySpec.getMaxValue(), constantArraySpec.getNumValues(), type);
+										r = new UniformRange(rangeId, constantArraySpec.getMinValue().evaluateConstant(),
+												constantArraySpec.getMaxValue().evaluateConstant(), constantArraySpec.getNumValues(), type);
 										rt.addRange(r);
 									} else {
 										// ----- Vector Range
@@ -656,8 +656,8 @@ public class SEDMLExporter {
 									if(constantArraySpec.getType() == ConstantArraySpec.TYPE_INTERVAL) {
 										// ------ Uniform Range
 										UniformType type = constantArraySpec.isLogInterval() ? UniformType.LOG : UniformType.LINEAR;
-										r = new UniformRange(rangeId, constantArraySpec.getMinValue(), 
-												constantArraySpec.getMaxValue(), constantArraySpec.getNumValues(), type);
+										r = new UniformRange(rangeId, constantArraySpec.getMinValue().evaluateConstant(),
+												constantArraySpec.getMaxValue().evaluateConstant(), constantArraySpec.getNumValues(), type);
 										rt.addRange(r);
 									} else {
 										// ----- Vector Range

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
@@ -542,7 +542,7 @@ public class SEDMLImporter {
 						if (range instanceof UniformRange) {
 							UniformRange ur = (UniformRange) range;
 							scanSpec = ConstantArraySpec.createIntervalSpec(constant,
-									Math.min(ur.getStart(), ur.getEnd()), Math.max(ur.getStart(), ur.getEnd()),
+									""+Math.min(ur.getStart(), ur.getEnd()), ""+Math.max(ur.getStart(), ur.getEnd()),
 									ur.getNumberOfPoints(), ur.getType().equals(UniformType.LOG));
 						} else if (range instanceof VectorRange) {
 							VectorRange vr = (VectorRange) range;

--- a/vcell-core/src/test/java/cbit/vcell/solver/MathOverridesTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/solver/MathOverridesTest.java
@@ -1,0 +1,88 @@
+package cbit.vcell.solver;
+
+import cbit.vcell.parser.ExpressionException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MathOverridesTest {
+
+    @Test
+    public void test_constantArraySpec_interval_simple_linear(){
+        ConstantArraySpec expected = ConstantArraySpec.createIntervalSpec(
+                "name",
+                "4",
+                "8",
+                3, false);
+
+        String description = "4 to 8, 3 values";
+        ConstantArraySpec cas = ConstantArraySpec.createFromString("name", description, ConstantArraySpec.TYPE_INTERVAL);
+        Assert.assertEquals(expected.toString(), cas.toString());
+    }
+
+    @Test
+    public void test_constantArraySpec_interval_complex_linear(){
+        ConstantArraySpec expected = ConstantArraySpec.createIntervalSpec(
+                "name",
+                "(KMOLE * (1.0 * pow(KMOLE,1.0)))",
+                "((2.0 * KMOLE) * (1.0 * pow(KMOLE,1.0)))",
+                2, false);
+
+        String description = "(KMOLE * (1.0 * pow(KMOLE,1.0))) to ((2.0 * KMOLE) * (1.0 * pow(KMOLE,1.0))), 2 values";
+        ConstantArraySpec cas = ConstantArraySpec.createFromString("name", description, ConstantArraySpec.TYPE_INTERVAL);
+        Assert.assertEquals(expected.toString(), cas.toString());
+    }
+
+    @Test
+    public void test_constantArraySpec_interval_simple_log(){
+        ConstantArraySpec expected = ConstantArraySpec.createIntervalSpec(
+                "name",
+                "4",
+                "8",
+                3, true);
+
+        String description = "4 to 8, log, 3 values";
+        ConstantArraySpec cas = ConstantArraySpec.createFromString("name", description, ConstantArraySpec.TYPE_INTERVAL);
+        Assert.assertEquals(expected.toString(), cas.toString());
+    }
+
+    @Test
+    public void test_constantArraySpec_interval_complex_log(){
+        ConstantArraySpec expected = ConstantArraySpec.createIntervalSpec(
+                "name",
+                "(KMOLE * (1.0 * pow(KMOLE,1.0)))",
+                "((2.0 * KMOLE) * (1.0 * pow(KMOLE,1.0)))",
+                2, true);
+
+        String description = "(KMOLE * (1.0 * pow(KMOLE,1.0))) to ((2.0 * KMOLE) * (1.0 * pow(KMOLE,1.0))), log, 2 values";
+        ConstantArraySpec cas = ConstantArraySpec.createFromString("name", description, ConstantArraySpec.TYPE_INTERVAL);
+        Assert.assertEquals(expected.toString(), cas.toString());
+    }
+
+
+    @Test
+    public void test_constantArraySpec_list_simple_linear() throws ExpressionException {
+        ConstantArraySpec expected = ConstantArraySpec.createListSpec("name",
+                new String[] {
+                        "4",
+                        "6",
+                        "8" });
+
+        String description = "4, 6, 8";
+        ConstantArraySpec cas = ConstantArraySpec.createFromString("name", description, ConstantArraySpec.TYPE_LIST);
+        Assert.assertEquals(expected.toString(), cas.toString());
+    }
+
+    @Test
+    public void test_constantArraySpec_list_complex_linear() throws ExpressionException {
+        ConstantArraySpec expected = ConstantArraySpec.createListSpec("name",
+                new String[] {
+                    "(KMOLE * (1.0 * pow(KMOLE,1.0)))",
+                    "((2.0 * KMOLE) * (1.0 * pow(KMOLE,1.0)))",
+                    "((3.0 * KMOLE) * (1.0 * pow(KMOLE,1.0)))"});
+
+        String description = "(KMOLE * (1.0 * pow(KMOLE,1.0))); ((2.0 * KMOLE) * (1.0 * pow(KMOLE,1.0))); ((3.0 * KMOLE) * (1.0 * pow(KMOLE,1.0)))";
+        ConstantArraySpec cas = ConstantArraySpec.createFromString("name", description, ConstantArraySpec.TYPE_LIST);
+        Assert.assertEquals(expected.toString(), cas.toString());
+    }
+
+ }

--- a/vcell-math/src/main/java/cbit/vcell/parser/ASTFloatNode.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/ASTFloatNode.java
@@ -123,7 +123,7 @@ public Node flatten() throws ExpressionException {
 			}else{
 				return value.toString();
 			}
-		  } else if (lang == LANGUAGE_UNITS) {
+		  } else if (lang == LANGUAGE_UNITS || lang == LANGUAGE_JSCL) {
 			  if (value == value.intValue()) {
 				  return Integer.toString(value.intValue());
 			  } else {

--- a/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
@@ -634,7 +634,7 @@ public int hashCode() {
  * @param expression Expression
  * @exception java.lang.Exception The exception description.
  */
-public static Expression invert(Expression expression) throws ExpressionException {
+public static Expression invert(Expression expression)  {
 	Expression exp = new Expression();
 	ASTInvertTermNode invertNode = new ASTInvertTermNode();
 	
@@ -827,7 +827,7 @@ public static Expression power(Expression expression1, Expression expression2) t
 	return function(FunctionType.POW, expression1, expression2);
 }
 
-public static Expression power(Expression expression1, double exponent) throws ExpressionException {
+public static Expression power(Expression expression1, double exponent) {
 	return function(FunctionType.POW, expression1, new Expression(exponent));
 }
 

--- a/vcell-math/src/test/java/cbit/vcell/parser/ExpressionFlattenTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/ExpressionFlattenTest.java
@@ -28,7 +28,7 @@ public class ExpressionFlattenTest {
                 {new Expression("KMOLE/KMOLE"),
                         new Expression("1.0")},
                 {new Expression("KMOLE/KMOLE*KMOLE/KMOLE"),
-                        new Expression("KMOLE/KMOLE")},
+                        new Expression("1.0")},
                 {new Expression("KMOLE/KMOLE*KMOLE/KMOLE2"),
                         new Expression("KMOLE/KMOLE2")},
                 {new Expression("KMOLE*pow(KMOLE,-1)"),
@@ -38,9 +38,7 @@ public class ExpressionFlattenTest {
                 {new Expression("5/KMOLE*KMOLE"),
                         new Expression("5.0")},
                 {new Expression("5*KMOLE*pow(KMOLE,-2)"),
-                        new Expression("5*KMOLE*pow(KMOLE,-2)")},
-                {new Expression("- (SCAfoldchange * KMOLE * pow(KMOLE,-1.0) * ERDensity_ER_SM * Jmax2_IP3R_flux * (1.0 - (Ca_spine / Ca_ER)) * pow((KMOLE * pow(KMOLE,-1.0) * h_ER_SM * IP3_spine * Ca_spine / (IP3_spine + dIP3_IP3R_flux) / (Ca_spine + Kact_IP3R_flux)),3.0))"),
-                 new Expression("- (SCAfoldchange                           * ERDensity_ER_SM * Jmax2_IP3R_flux * (1.0 - (Ca_spine / Ca_ER)) * pow((                          h_ER_SM * IP3_spine * Ca_spine / (IP3_spine + dIP3_IP3R_flux) / (Ca_spine + Kact_IP3R_flux)),3.0))")},
+                        new Expression("5.0 / KMOLE")},
         });
     }
 

--- a/vcell-math/src/test/java/cbit/vcell/parser/ExpressionUtilsJSCLFlattenTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/ExpressionUtilsJSCLFlattenTest.java
@@ -44,7 +44,7 @@ public class ExpressionUtilsJSCLFlattenTest {
                         new Expression("5.0")},
 
                 {new Expression("(5.0 * KMOLE * ((1.0 / KMOLE) ^ 2.0))"),
-                        new Expression("(5.0 * KMOLE * ((1.0 / KMOLE) ^ 2.0))")},
+                        new Expression("(5.0 / KMOLE)")},
 
                 {new Expression("(10.0 * pow(KMOLE,-1.0) * Size_c0)"),
                         new Expression("((10.0 * Size_c0) / KMOLE)")},
@@ -67,11 +67,8 @@ public class ExpressionUtilsJSCLFlattenTest {
                 {new Expression("(((2.0 * KMOLE) * (1.0 * pow(KMOLE,1.0))) * (1.0 * pow(KMOLE, - 1.0)))"),
                         new Expression("2.0*KMOLE")},
 
-                {new Expression("1.0"),
-                        new Expression("1.0")},
-
-                {new Expression("- (SCAfoldchange * KMOLE * pow(KMOLE,-1.0) * ERDensity_ER_SM * Jmax2_IP3R_flux * (1.0 - (Ca_spine / Ca_ER)) * pow((KMOLE * pow(KMOLE,-1.0) * h_ER_SM * IP3_spine * Ca_spine / (IP3_spine + dIP3_IP3R_flux) / (Ca_spine + Kact_IP3R_flux)),3.0))"),
-                 new Expression("( - (ERDensity_ER_SM * Jmax2_IP3R_flux * SCAfoldchange * (((Ca_spine * IP3_spine * h_ER_SM) / ((Ca_spine + Kact_IP3R_flux) * (IP3_spine + dIP3_IP3R_flux))) ^ 3.0) * (Ca_ER - Ca_spine)) / Ca_ER)")},
+                {new Expression("((KMOLE ^ 2.0) / KMOLE)"),
+                        new Expression("KMOLE")},
         });
     }
 

--- a/vcell-math/src/test/java/cbit/vcell/parser/ExpressionUtilsJSCLFlattenTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/ExpressionUtilsJSCLFlattenTest.java
@@ -61,11 +61,11 @@ public class ExpressionUtilsJSCLFlattenTest {
                 {new Expression("(((50.0 * Size_c0) + (KMOLE * s1_Count_init_uM / (KMOLE / Size_c0))) / Size_c0)"),
                         new Expression("(50.0 + s1_Count_init_uM)")},
 
-                {new Expression("1.0"),
-                        new Expression("1.0")},
+                {new Expression("((KMOLE * (1.0 * pow(KMOLE,1.0))) * (1.0 * pow(KMOLE, - 1.0)))"),
+                        new Expression("KMOLE")},
 
-                {new Expression("1.0"),
-                        new Expression("1.0")},
+                {new Expression("(((2.0 * KMOLE) * (1.0 * pow(KMOLE,1.0))) * (1.0 * pow(KMOLE, - 1.0)))"),
+                        new Expression("2.0*KMOLE")},
 
                 {new Expression("1.0"),
                         new Expression("1.0")},


### PR DESCRIPTION
Fix MathOverride Lists and Intervals (ranges) which don't handle

- unit system changes (which need KMOLE or equivalent)
- and model transformations when changing initial concentrations <-> initial counts for stochastic applications (which need compartment size symbols and sometimes KMOLE).  

Both of these situations arise in SBML/SEDML processing.  

This work generalized MathOverride Lists and Intervals to take expressions rather than doubles, allowing incorporation of KMOLE and compartment size symbols.  Expression simplification for canceling such factors was improved significantly.

All Math Overrides now transform correctly.

List/Interval editors could be more friendly (with autocomplete for available symbols), but this is not essential now.