### PR TITLE
limit expression size for JSCL simplify, fail to exp.flatten(), log t>1s

### DIFF
--- a/vcell-math/src/main/java/cbit/vcell/parser/ASTFloatNode.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/ASTFloatNode.java
@@ -112,19 +112,25 @@ public Node flatten() throws ExpressionException {
   {
 	  if (value==null){
 		  return "null";
-	  }else if (value.doubleValue()==0.0){
+	  }else if (value ==0.0){
 		  return "0.0";
 	  }else{
 		  if (lang == LANGUAGE_ECLiPSe){
-			if (value.doubleValue() == Double.POSITIVE_INFINITY){
+			if (value == Double.POSITIVE_INFINITY){
 				return "1.0Inf";
-			}else if (value.doubleValue() == Double.NEGATIVE_INFINITY){
+			}else if (value == Double.NEGATIVE_INFINITY){
 				return "-1.0Inf";
 			}else{
 				return value.toString();
 			}
-		  } else if (lang == LANGUAGE_UNITS || lang == LANGUAGE_JSCL) {
+		  } else if (lang == LANGUAGE_UNITS) {
 			  if (value == value.intValue()) {
+				  return Integer.toString(value.intValue());
+			  } else {
+				  return value.toString();
+			  }
+		  } else if (lang == LANGUAGE_JSCL) {
+			  if (value == value.intValue() && Math.abs(value) <= 2) {
 				  return Integer.toString(value.intValue());
 			  } else {
 				  return value.toString();

--- a/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
@@ -346,7 +346,7 @@ flattenCount++;////////////////////////
 		try {
 			safeExp = ExpressionUtils.simplifyUsingJSCL(safeExp);
 		}catch (Exception e) {
-			logger.warn("simplify with JSCL failed on expression '"+safeExp.infix()+"': "+e.getMessage(),e);
+			logger.warn("simplify with JSCL failed on expression '"+safeExp.infix()+"': "+e.getMessage());
 		}
 		if (bindings.size()>0) {
 			safeExp.bindExpression(symbolTable);

--- a/vcell-math/src/test/java/cbit/vcell/parser/ExpressionUtilsJSCLFlattenTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/ExpressionUtilsJSCLFlattenTest.java
@@ -1,6 +1,5 @@
 package cbit.vcell.parser;
 
-import jscl.text.ParseException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,69 +13,106 @@ public class ExpressionUtilsJSCLFlattenTest {
 
     private Expression expectedFlattenedExpression;
     private Expression origExpression;
+    private Boolean tooBig;
 
-    public ExpressionUtilsJSCLFlattenTest(Expression origExpression, Expression expectedFlattenedExpression) {
+    public ExpressionUtilsJSCLFlattenTest(Expression origExpression, Expression expectedFlattenedExpression, Boolean tooBig) {
         this.expectedFlattenedExpression = expectedFlattenedExpression;
         this.origExpression = origExpression;
+        this.tooBig = tooBig;
     }
 
 
 
     @Parameterized.Parameters
-    public static Collection<Expression[]> testCases() throws ExpressionException {
-        return Arrays.asList(new Expression[][]{
+    public static Collection<Object[]> testCases() throws ExpressionException {
+        return Arrays.asList(new Object[][]{
                 {new Expression("KMOLE/KMOLE"),
-                        new Expression("1.0")},
+                        new Expression("1.0"),
+                        Boolean.FALSE},
 
                 {new Expression("KMOLE/KMOLE*KMOLE/KMOLE"),
-                        new Expression("1.0")},
+                        new Expression("1.0"),
+                        Boolean.FALSE},
 
                 {new Expression("KMOLE/KMOLE*KMOLE/KMOLE2"),
-                        new Expression("KMOLE/KMOLE2")},
+                        new Expression("KMOLE/KMOLE2"),
+                        Boolean.FALSE},
 
                 {new Expression("KMOLE*pow(KMOLE,-1)"),
-                        new Expression("1.0")},
+                        new Expression("1.0"),
+                        Boolean.FALSE},
 
                 {new Expression("5*KMOLE*pow(KMOLE,-1)"),
-                        new Expression("5.0")},
+                        new Expression("5.0"),
+                        Boolean.FALSE},
 
                 {new Expression("5/KMOLE*KMOLE"),
-                        new Expression("5.0")},
+                        new Expression("5.0"),
+                        Boolean.FALSE},
 
                 {new Expression("(5.0 * KMOLE * ((1.0 / KMOLE) ^ 2.0))"),
-                        new Expression("(5.0 / KMOLE)")},
+                        new Expression("(5.0 / KMOLE)"),
+                        Boolean.FALSE},
 
                 {new Expression("(10.0 * pow(KMOLE,-1.0) * Size_c0)"),
-                        new Expression("((10.0 * Size_c0) / KMOLE)")},
+                        new Expression("((10.0 * Size_c0) / KMOLE)"),
+                        Boolean.FALSE},
 
                 {new Expression("(50.0 + (s1_Count_initCount / (pow(KMOLE,-1.0) * Size_c0)))"),
-                        new Expression("(((50.0 * Size_c0) + (KMOLE * s1_Count_initCount)) / Size_c0)")},
+                        new Expression("(((50.0 * Size_c0) + (KMOLE * s1_Count_initCount)) / Size_c0)"),
+                        Boolean.FALSE},
 
                 {new Expression("(10.0 * Size_c0 / KMOLE)"),
-                        new Expression("((10.0 * Size_c0) / KMOLE)")},
+                        new Expression("((10.0 * Size_c0) / KMOLE)"),
+                        Boolean.FALSE},
 
                 {new Expression("(50.0 + (s1_Count_initCount / (pow(KMOLE,-1.0) * Size_c0)))"),
-                        new Expression("(((50.0 * Size_c0) + (KMOLE * s1_Count_initCount)) / Size_c0)")},
+                        new Expression("(((50.0 * Size_c0) + (KMOLE * s1_Count_initCount)) / Size_c0)"),
+                        Boolean.FALSE},
 
                 {new Expression("(((50.0 * Size_c0) + (KMOLE * s1_Count_init_uM / (KMOLE / Size_c0))) / Size_c0)"),
-                        new Expression("(50.0 + s1_Count_init_uM)")},
+                        new Expression("(50.0 + s1_Count_init_uM)"),
+                        Boolean.FALSE},
 
                 {new Expression("((KMOLE * (1.0 * pow(KMOLE,1.0))) * (1.0 * pow(KMOLE, - 1.0)))"),
-                        new Expression("KMOLE")},
+                        new Expression("KMOLE"),
+                        Boolean.FALSE},
 
                 {new Expression("(((2.0 * KMOLE) * (1.0 * pow(KMOLE,1.0))) * (1.0 * pow(KMOLE, - 1.0)))"),
-                        new Expression("2.0*KMOLE")},
+                        new Expression("2.0*KMOLE"),
+                        Boolean.FALSE},
 
                 {new Expression("((KMOLE ^ 2.0) / KMOLE)"),
-                        new Expression("KMOLE")},
+                        new Expression("KMOLE"),
+                        Boolean.FALSE},
+
+                {new Expression(       "(((V32 / ((k32 ^ 3.0) + (Ca_nM ^ 3.0))) + b32) * ((Vm32 * (Ca_nM ^ 7.0) / ((km32 ^ 7.0) + (Ca_nM ^ 7.0))) + bm32))"),
+                        new Expression("((V32 + (b32 * (Ca_nM ^ 3.0)) + (b32 * (k32 ^ 3.0))) * ((Vm32 * (Ca_nM ^ 7.0)) + (bm32 * (Ca_nM ^ 7.0)) + (bm32 * (km32 ^ 7.0))) / (((Ca_nM ^ 3.0) + (k32 ^ 3.0)) * ((Ca_nM ^ 7.0) + (km32 ^ 7.0))))"),
+                        Boolean.TRUE},
+
+                {new Expression(       "(((V32 / ((k32 ^ 2.0) + (Ca_nM ^ 2.0))) + b32) * ((Vm32 * (Ca_nM ^ 7.0) / ((km32 ^ 7.0) + (Ca_nM ^ 7.0))) + bm32))"),
+                        new Expression("((V32 + ((Ca_nM ^ 2.0) * b32) + (b32 * (k32 ^ 2.0))) * ((Vm32 * (Ca_nM ^ 7.0)) + (bm32 * (Ca_nM ^ 7.0)) + (bm32 * (km32 ^ 7.0))) / (((Ca_nM ^ 2.0) + (k32 ^ 2.0)) * ((Ca_nM ^ 7.0) + (km32 ^ 7.0))))"),
+                        Boolean.TRUE},
+
+                {new Expression("((kf * (1.0 - BrF) * PointedD_Cyt * BarbedD_Cyt / L) - (((k1 * L) + (k2 * (L ^ 2.0) * N)) * N * FAD_Cyt / (FAD_Cyt + FAT_Cyt + FADPi_Cyt)))"),
+                        new Expression("1.0"),
+                        Boolean.TRUE},
         });
     }
 
     @Test
-    public void simplifySymbolFactorTest() throws ExpressionException, ParseException {
-        Expression flattenedExp = ExpressionUtils.simplifyUsingJSCL(origExpression);
-        Assert.assertTrue("expected='"+expectedFlattenedExpression.infix()+"', actual='"+flattenedExp.infix()+"'", expectedFlattenedExpression.compareEqual(flattenedExp));
-    }
+    public void simplifySymbolFactorTest_small() throws ExpressionException {
+        try {
+            Expression flattenedExp = ExpressionUtils.simplifyUsingJSCL(origExpression);
+            Assert.assertTrue("expected='" + expectedFlattenedExpression.infix() + "', actual='" + flattenedExp.infix() + "'", expectedFlattenedExpression.compareEqual(flattenedExp));
+        } catch (ExpressionException e){
+            if (tooBig){
+                return;
+            }else{
+                throw e;
+            }
+        }
+   }
 
 }
 


### PR DESCRIPTION
see Issue #316 