### PR TITLE
323 fix override templates

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
@@ -84,7 +84,7 @@ public class VcmlOmexConverter {
 		}
 		Predicate<Simulation> simulationExportFilter = simulation -> true;
 		BioModelInfo bioModelInfo = null;
-		boolean isCreated = vcmlToOmexConversion(input.getAbsolutePath(), bioModelInfo, null, outputDir.getAbsolutePath(),
+		boolean isCreated = vcmlToOmexConversion(input.getAbsolutePath(), bioModelInfo, outputDir.getAbsolutePath(), outputDir.getAbsolutePath(),
 				simulationExportFilter, modelFormat, bForceLogFiles, bValidateOmex);
 		if (isCreated) {
 			logger.info("Combine archive created for `" + input + "`");

--- a/vcell-core/src/main/java/cbit/vcell/mapping/MathSymbolMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/MathSymbolMapping.java
@@ -10,8 +10,7 @@
 
 package cbit.vcell.mapping;
 
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.*;
 
 import cbit.vcell.math.*;
 import org.vcell.util.BeanUtils;
@@ -28,9 +27,9 @@ import cbit.vcell.parser.SymbolTableEntry;
  * @author: Jim Schaff
  */
 public class MathSymbolMapping implements SourceSymbolMapping {
-	private java.util.HashMap<SymbolTableEntry, String> biologicalToMathSymbolNameHash = new java.util.HashMap<SymbolTableEntry, String>();
-	private java.util.HashMap<SymbolTableEntry, Variable> biologicalToMathHash = new java.util.HashMap<SymbolTableEntry, Variable>();
-	private java.util.HashMap<Variable, SymbolTableEntry[]> mathToBiologicalHash = new java.util.HashMap<Variable, SymbolTableEntry[]>();
+	private TreeMap<SymbolTableEntry, String> biologicalToMathSymbolNameHash = new TreeMap<SymbolTableEntry, String>();
+	private TreeMap<SymbolTableEntry, Variable> biologicalToMathHash = new TreeMap<SymbolTableEntry, Variable>();
+	private TreeMap<Variable, SymbolTableEntry[]> mathToBiologicalHash = new TreeMap<Variable, SymbolTableEntry[]>();
 
 /**
  * MathSymbolMapping constructor comment.

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -231,7 +231,7 @@ public class SimulationContext implements SimulationOwner, Versionable, Matchabl
 		private final List<SymbolReplacementTemplate> builtin_replacements = new ArrayList<>();
 		private final IdentifiableProvider bioIdentifiableProvider = new BioModel(null);
 
-		void SimulationContextOverridesResolver() {
+		SimulationContextOverridesResolver() {
 			// test for renamed initial condition constant (changed from _init to _init_uM)
 			builtin_replacements.add(new SymbolReplacementTemplate(DiffEquMathMapping.MATH_FUNC_SUFFIX_SPECIES_INIT_CONCENTRATION_old,
 					DiffEquMathMapping.MATH_FUNC_SUFFIX_SPECIES_INIT_CONCENTRATION_uM));

--- a/vcell-core/src/main/java/cbit/vcell/math/Variable.java
+++ b/vcell-core/src/main/java/cbit/vcell/math/Variable.java
@@ -241,7 +241,7 @@ public void setIndex(int symbolTableIndex) {
  * @return java.lang.String
  */
 public String toString() {
-	return getClass().getName().substring(getClass().getName().lastIndexOf('.')+1)+" <"+getQualifiedName()+">";
+	return getClass().getSimpleName()+" <"+getQualifiedName()+">";
 }
 public Domain getDomain() {
 	return this.domain;

--- a/vcell-core/src/main/java/cbit/vcell/solver/MathOverrides.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/MathOverrides.java
@@ -896,7 +896,7 @@ private void verifyExpression(Constant value, boolean checkScan) throws Expressi
 			//
 			Variable variable = mathDescription.getVariable(symbols[i]);
 			if (!(variable != null && variable instanceof Constant)){
-				throw new ExpressionBindingException("identifier " + symbols[i] + " is not a constant. " +
+				throw new ExpressionBindingException("identifier " + symbols[i] + " is of type '"+variable.getClass().getSimpleName()+"'. " +
 						"Parameter overrides should only refer to constants.");
 			}
 			if (checkScan && isScan(symbols[i])) {

--- a/vcell-math/src/main/java/cbit/vcell/parser/ASTFloatNode.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/ASTFloatNode.java
@@ -131,9 +131,17 @@ public Node flatten() throws ExpressionException {
 			  }
 		  } else if (lang == LANGUAGE_JSCL) {
 			  if (value == value.intValue() && Math.abs(value) <= 2) {
-				  return Integer.toString(value.intValue());
+				  if (value >= 0) {
+					  return Integer.toString(value.intValue());
+				  }else{
+					  return "("+ value.intValue() +")";
+				  }
 			  } else {
-				  return value.toString();
+				  if (value >= 0) {
+					  return value.toString();
+				  }else{
+					  return "("+ value +")";
+				  }
 			  }
 		  } else {
 		      return value.toString();

--- a/vcell-math/src/main/java/cbit/vcell/parser/ExpressionUtils.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/ExpressionUtils.java
@@ -211,15 +211,18 @@ private static SimpleNode createTerminalNode(java.util.Random random, boolean bI
 }
 
 public static Expression simplifyUsingJSCL(Expression exp) throws ExpressionException {
-	return simplifyUsingJSCL(exp, 100);
+	return simplifyUsingJSCL(exp, 200);
 }
 
 public static Expression simplifyUsingJSCL(Expression exp, int maxExpLength) throws ExpressionException {
 	long startTime = System.currentTimeMillis();
 	jscl.math.Expression jsclExpression = null;
 	String jsclExpressionString = exp.infix_JSCL();
-	if (jsclExpressionString.replace("underscore","_").length()>100){
+	if (jsclExpressionString.replace("underscore","_").length()>maxExpLength){
 		throw new ExpressionException("large expression, abort JSCL simplification");
+	}
+	if (jsclExpressionString.contains("<") || jsclExpressionString.contains(">")){
+		throw new ExpressionException("JSCL cannot parse inequalities, cannot parse \""+jsclExpressionString+"\"");
 	}
 	try {
 		jsclExpression = jscl.math.Expression.valueOf(jsclExpressionString);
@@ -231,7 +234,7 @@ public static Expression simplifyUsingJSCL(Expression exp, int maxExpLength) thr
 	String expandStr = expand.toString();
 	Generic simplify = expand.simplify();
 	String simplifyStr = simplify.toString();
-	if (simplifyStr.replace("underscore","_").length()>100){
+	if (simplifyStr.replace("underscore","_").length()>maxExpLength){
 		throw new ExpressionException("large expression, abort JSCL simplification");
 	}
 	jscl.math.Generic jsclSolution = simplify.factorize();
@@ -249,7 +252,7 @@ public static Expression simplifyUsingJSCL(Expression exp, int maxExpLength) thr
 	Generic expand1 = jsclExpression.expand();
 	Generic simplify1 = expand1.simplify();
 	String simplifyStr1 = simplify.toString();
-	if (simplifyStr1.replace("underscore","_").length()>100){
+	if (simplifyStr1.replace("underscore","_").length()>maxExpLength){
 		throw new ExpressionException("large expression, abort JSCL simplification");
 	}
 	jsclSolution = simplify1.factorize();

--- a/vcell-math/src/main/java/cbit/vcell/parser/SymbolTableEntry.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/SymbolTableEntry.java
@@ -20,7 +20,7 @@ import cbit.vcell.units.VCUnitDefinition;
  * or a <code>ReactionParticipant</code>
  * <p>
  */
-public interface SymbolTableEntry {
+public interface SymbolTableEntry extends Comparable<SymbolTableEntry> {
 
 /**
  * This method was created in VisualAge.
@@ -64,4 +64,15 @@ VCUnitDefinition getUnitDefinition();
  * @exception java.lang.Exception The exception description.
  */
 public boolean isConstant() throws ExpressionException;
+
+	@Override
+	default int compareTo(SymbolTableEntry o) {
+		int classCompareTo = getClass().getSimpleName().compareTo(o.getClass().getSimpleName());
+		if (classCompareTo != 0){
+			return classCompareTo;
+		}
+		String thisName = (getNameScope()!=null) ? (getNameScope().getAbsoluteScopePrefix()+"."+getName()) : getName();
+		String otherName = (o.getNameScope()!=null) ? (o.getNameScope().getAbsoluteScopePrefix()+"."+o.getName()) : o.getName();
+		return thisName.compareTo(otherName);
+	}
 }


### PR DESCRIPTION
see #323 

fixed math override fixes which used hard-coded string templates for suffixes.  This was broken because of a syntax issue - the templates were never populated (see SimulationContext changes).
Also, sorting Variables and Bio SymbolTableEntries in the MathSymbolMapping maps makes debugging easier by sorting by Type and fully qualified identifier names.  By side effect, it may have corrected some models (where some Variables or Bio Symbols didn't behave properly as map keys (e.g. duplicate instances or bad .equals()/.hashCode() implementations).