### PR TITLE
SEDML export refactoring, first pass - SBML format

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/sbml/ModelCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/sbml/ModelCommand.java
@@ -5,9 +5,11 @@ import cbit.vcell.biomodel.BioModel;
 import cbit.vcell.mapping.SimulationContext;
 import cbit.vcell.xml.XMLSource;
 import cbit.vcell.xml.XmlHelper;
-import org.vcell.cli.vcml.ModelFormat;
+
 import org.vcell.sbml.vcell.SBMLExporter;
 import org.vcell.sbml.vcell.SBMLImporter;
+import org.vcell.sedml.ModelFormat;
+
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/ExportOmexBatchCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/ExportOmexBatchCommand.java
@@ -3,6 +3,7 @@ package org.vcell.cli.vcml;
 import cbit.vcell.resource.PropertyLoader;
 
 import org.vcell.cli.CLILocalLogFileManager;
+import org.vcell.sedml.ModelFormat;
 import org.vcell.util.DataAccessException;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/ExportOmexCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/ExportOmexCommand.java
@@ -1,6 +1,8 @@
 package org.vcell.cli.vcml;
 
 import cbit.vcell.resource.PropertyLoader;
+
+import org.vcell.sedml.ModelFormat;
 import org.vcell.util.DataAccessException;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/ModelFormat.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/ModelFormat.java
@@ -1,5 +1,0 @@
-package org.vcell.cli.vcml;
-
-public enum ModelFormat {
-    SBML, VCML;
-}

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
@@ -48,6 +48,7 @@ import org.sbpax.schemas.util.DefaultNameSpaces;
 import org.sbpax.schemas.util.OntUtil;
 import org.sbpax.util.SesameRioUtil;
 import org.vcell.cli.*;
+import org.vcell.sedml.ModelFormat;
 import org.vcell.sedml.PubMet;
 import org.vcell.sedml.SEDMLExporter;
 import org.vcell.util.DataAccessException;
@@ -388,7 +389,7 @@ public class VcmlOmexConverter {
         
         SEDMLExporter sedmlExporter = new SEDMLExporter(bioModel, sedmlLevel, sedmlVersion, simsToExport);
         SEDMLDocument sedmlDocument = sedmlExporter.getSEDMLFile0(outputDir, vcmlName,
-				modelFormat.equals(ModelFormat.VCML), modelFormat.equals(ModelFormat.SBML), true, bValidate);
+				modelFormat, true, bValidate);
         SedML sedmlModel = sedmlDocument.getSedMLModel();
         if(sedmlModel.getModels().size() == 0) {
             File dir = new File(outputDir);

--- a/vcell-client/src/main/java/org/vcell/util/gui/exporter/OmexExtensionFilter.java
+++ b/vcell-client/src/main/java/org/vcell/util/gui/exporter/OmexExtensionFilter.java
@@ -22,6 +22,7 @@ import org.openrdf.rio.RDFHandlerException;
 import org.sbpax.impl.HashGraph;
 import org.sbpax.schemas.util.DefaultNameSpaces;
 import org.sbpax.util.SesameRioUtil;
+import org.vcell.sedml.ModelFormat;
 import org.vcell.sedml.PubMet;
 import org.vcell.sedml.SEDMLExporter;
 import org.vcell.util.FileUtils;
@@ -55,6 +56,7 @@ public class OmexExtensionFilter extends SedmlExtensionFilter {
 		SEDMLExporter sedmlExporter = null;
 		if (bioModel != null) {
 			
+			ModelFormat modelFormat = ModelFormat.SBML;
 			Object[] options = {"VCML","SBML"};
 			int choice = JOptionPane.showOptionDialog(null,	// parent component
 					"VCML or SBML?",			// message,
@@ -63,13 +65,12 @@ public class OmexExtensionFilter extends SedmlExtensionFilter {
 					JOptionPane.QUESTION_MESSAGE,	// messageType
 					null,						// Icon
 					options,
-					"VCML");					// initialValue 
-			boolean bForceVCML = choice == 0 ? true : false;
-			boolean bForceSBML = choice == 1 ? true : false;
+					"SBML");					// initialValue 
+			if (choice == 0) modelFormat = ModelFormat.VCML;
 			
 			sedmlExporter = new SEDMLExporter(bioModel, sedmlLevel, sedmlVersion, null);
 			boolean bRoundTripSBMLValidation = true;
-			resultString = sedmlExporter.getSEDMLFile(sPath, sFile, bForceVCML, bForceSBML, false, bRoundTripSBMLValidation);
+			resultString = sedmlExporter.getSEDMLFile(sPath, sFile, modelFormat, false, bRoundTripSBMLValidation);
 
 			// convert biomodel to vcml and save to file.
 			String vcmlString = XmlHelper.bioModelToXML(bioModel);

--- a/vcell-client/src/main/java/org/vcell/util/gui/exporter/SedmlExtensionFilter.java
+++ b/vcell-client/src/main/java/org/vcell/util/gui/exporter/SedmlExtensionFilter.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import javax.swing.JOptionPane;
 
+import org.vcell.sedml.ModelFormat;
 import org.vcell.sedml.SEDMLExporter;
 import org.vcell.util.FileUtils;
 
@@ -37,6 +38,7 @@ public class SedmlExtensionFilter extends SelectorExtensionFilter {
 		
 		SEDMLExporter sedmlExporter = null;
 		if (bioModel != null) {
+			ModelFormat modelFormat = ModelFormat.SBML;
 			Object[] options = {"VCML","SBML"};
 			int choice = JOptionPane.showOptionDialog(null,	// parent component
 					"VCML or SBML?",			// message,
@@ -45,13 +47,12 @@ public class SedmlExtensionFilter extends SelectorExtensionFilter {
 					JOptionPane.QUESTION_MESSAGE,	// messageType
 					null,						// Icon
 					options,
-					"VCML");					// initialValue 
-			boolean bForceVCML = choice == 0 ? true : false;
-			boolean bForceSBML = choice == 1 ? true : false;
+					"SBML");					// initialValue 
+			if (choice == 0) modelFormat = ModelFormat.VCML;
 
 			sedmlExporter = new SEDMLExporter(bioModel, sedmlLevel, sedmlVersion, null);
 			boolean bRoundTripSBMLValidation = true;
-			resultString = sedmlExporter.getSEDMLFile(sPath, sFile, bForceVCML, bForceSBML, false, bRoundTripSBMLValidation);
+			resultString = sedmlExporter.getSEDMLFile(sPath, sFile, modelFormat, false, bRoundTripSBMLValidation);
 		} else {
 			throw new RuntimeException("unsupported Document Type " + Objects.requireNonNull(bioModel).getClass().getName() + " for SedML export");
 		}

--- a/vcell-core/src/main/java/org/vcell/sedml/ModelFormat.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/ModelFormat.java
@@ -1,0 +1,5 @@
+package org.vcell.sedml;
+
+public enum ModelFormat {
+    SBML, VCML, SBML_VCML;
+}

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -83,12 +83,15 @@ import org.vcell.util.document.BioModelChildSummary.MathType;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import com.google.common.base.CaseFormat;
+
 import cbit.util.xml.XmlUtil;
 import cbit.vcell.biomodel.BioModel;
 import cbit.vcell.biomodel.ModelUnitConverter;
 import cbit.vcell.clientdb.DocumentManager;
 import cbit.vcell.geometry.GeometryClass;
 import cbit.vcell.mapping.GeometryContext;
+import cbit.vcell.mapping.MappingException;
 import cbit.vcell.mapping.MathMapping;
 import cbit.vcell.mapping.MathSymbolMapping;
 import cbit.vcell.mapping.SimulationContext;
@@ -99,12 +102,15 @@ import cbit.vcell.mapping.SimulationContext.Application;
 import cbit.vcell.mapping.StructureMapping.StructureMappingParameter;
 import cbit.vcell.math.Constant;
 import cbit.vcell.math.Function;
+import cbit.vcell.math.MathException;
 import cbit.vcell.math.MathUtilities;
+import cbit.vcell.matrix.MatrixException;
 import cbit.vcell.model.Kinetics.KineticsParameter;
 import cbit.vcell.model.Membrane;
 import cbit.vcell.model.Model.ModelParameter;
 import cbit.vcell.model.Model.ReservedSymbol;
 import cbit.vcell.model.Model.ReservedSymbolRole;
+import cbit.vcell.model.ModelException;
 import cbit.vcell.model.ModelProcess;
 import cbit.vcell.model.ModelQuantity;
 import cbit.vcell.model.ModelUnitSystem;
@@ -112,7 +118,9 @@ import cbit.vcell.model.ProxyParameter;
 import cbit.vcell.model.SpeciesContext;
 import cbit.vcell.model.Structure;
 import cbit.vcell.model.Structure.StructureSize;
+import cbit.vcell.parser.DivideByZeroException;
 import cbit.vcell.parser.Expression;
+import cbit.vcell.parser.ExpressionBindingException;
 import cbit.vcell.parser.ExpressionException;
 import cbit.vcell.parser.SymbolTableEntry;
 import cbit.vcell.parser.VariableSymbolTable;
@@ -153,6 +161,9 @@ public class SEDMLExporter {
 	private static String DATAGENERATOR_TIME_NAME = "time";
 	private static String DATAGENERATOR_TIME_SYMBOL = "t";
 	
+	private String sbmlLanguageURN = SUPPORTED_LANGUAGE.SBML_GENERIC.getURN();
+	private String vcmlLanguageURN = SUPPORTED_LANGUAGE.VCELL_GENERIC.getURN();
+	
 	public SEDMLExporter(BioModel argBiomodel, int argLevel, int argVersion, List<Simulation> argSimsToExport) {
 		super();
 		this.vcBioModel = argBiomodel;
@@ -161,8 +172,8 @@ public class SEDMLExporter {
 		this.simsToExport = argSimsToExport;
 	}
 
-	public SEDMLDocument getSEDMLFile0(String sPath, String sBaseFileName, boolean bForceVCML, boolean bForceSBML, 
-				boolean bFromOmex, boolean bRoundTripSBMLValidation) {
+	public SEDMLDocument getSEDMLFile0(String sPath, String sBaseFileName, ModelFormat modelFormat, 
+				boolean bFromCLI, boolean bRoundTripSBMLValidation) {
 
 		// Create an SEDMLDocument and create the SEDMLModel from the document, so that other details can be added to it in translateBioModel()
 		SEDMLDocument sedmlDocument = new SEDMLDocument(this.sedmlLevel, this.sedmlVersion);
@@ -197,835 +208,90 @@ public class SEDMLExporter {
 		sedmlModel.setAdditionalNamespaces(nsList);
 
 		
-		translateBioModelToSedML(sPath, sBaseFileName, bForceVCML, bForceSBML, bFromOmex, bRoundTripSBMLValidation);
+		translateBioModelToSedML(sPath, sBaseFileName, modelFormat, bFromCLI, bRoundTripSBMLValidation);
 		
 		int models = sedmlModel.getModels().size();
 		int tasks = sedmlModel.getTasks().size();
 		int sims = sedmlModel.getSimulations().size();
 		return sedmlDocument;
 	}
-	public String getSEDMLFile(String sPath, String sBaseFileName, boolean bForceVCML, boolean bForceSBML, boolean bFromOmex, boolean bRoundTripSBMLValidation) {
-		SEDMLDocument doc = getSEDMLFile0(sPath, sBaseFileName, bForceVCML, bForceSBML, bFromOmex, bRoundTripSBMLValidation);
+	public String getSEDMLFile(String sPath, String sBaseFileName, ModelFormat modelFormat, boolean bFromCLI, boolean bRoundTripSBMLValidation) {
+		SEDMLDocument doc = getSEDMLFile0(sPath, sBaseFileName, modelFormat, bFromCLI, bRoundTripSBMLValidation);
 		return doc.writeDocumentToString();
 	}
 
 
-	private void translateBioModelToSedML(String savePath, String sBaseFileName, boolean bForceVCML, boolean bForceSBML,
-				boolean bFromOmex, boolean bRoundTripSBMLValidation) {		// true if invoked for omex export, false if for sedml
+	private void translateBioModelToSedML(String savePath, String sBaseFileName, ModelFormat modelFormat,
+				boolean bFromCLI, boolean bRoundTripSBMLValidation) {		// true if invoked for omex export, false if for sedml
 		sbmlFilePathStrAbsoluteList.clear();
-		// models
 		try {
 			SimulationContext[] simContexts = vcBioModel.getSimulationContexts();
-			cbit.vcell.model.Model vcModel = vcBioModel.getModel();
-			String sbmlLanguageURN = SUPPORTED_LANGUAGE.SBML_GENERIC.getURN();	// "urn:sedml:language:sbml";
-			String vcmlLanguageURN = SUPPORTED_LANGUAGE.VCELL_GENERIC.getURN();	// "urn:sedml:language:vcml";
-			String bioModelName = vcBioModel.getName();
-			String bioModelID = TokenMangler.mangleToSName(bioModelName);
-			//String usrHomeDirPath = ResourceUtil.getUserHomeDir().getAbsolutePath();
-			SBMLSupport sbmlSupport = new SBMLSupport();		// to get Xpath string for variables.
 			int simContextCnt = 0;	// for model count, task subcount
-			boolean bSpeciesAddedAsDataGens = false;
 			String sedmlNotesStr = "";
 
 			for (SimulationContext simContext : simContexts) {
-
-				// Export the application itself to SBML, with default overrides
-				String sbmlString = null;
-				int level = 3;
-				int version = 1;
-				boolean isSpatial = simContext.getGeometry().getDimension() > 0 ? true : false;
-				Map<Pair <String, String>, String> l2gMap = null;		// local to global translation map
-
-				boolean sbmlExportFailed = false;
-				if(!bForceVCML) {	// we try to save to SBML
+				if (modelFormat == ModelFormat.SBML_VCML) {
+					// TODO
+					throw new RuntimeException("Hybrid SBML_VCML export not yet implemented");
+				}
+				
+				if (modelFormat == ModelFormat.SBML) {
+					boolean sbmlExportFailed = false;
+					// Export the application itself to SBML, with default values (overrides will become model changes or repeated tasks)
+					String sbmlString = null;
+					boolean isSpatial = simContext.getGeometry().getDimension() > 0 ? true : false;
+					Map<Pair <String, String>, String> l2gMap = null;		// local to global translation map
+	
 					try {
 						Pair <String, Map<Pair <String, String>, String>> pair = XmlHelper.exportSBMLwithMap(vcBioModel, 3, 2, 0, isSpatial, simContext, null, bRoundTripSBMLValidation);
 						sbmlString = pair.one;
 						l2gMap = pair.two;
 					} catch (Exception e) {
-						String msg = "Export failed: for simContext '"+simContext.getName()+"': " + e.getMessage();
+						String msg = "SBML export failed for simContext '"+simContext.getName()+"': " + e.getMessage();
 						logger.error(msg, e);
-						throw new RuntimeException(msg, e);
+						sbmlExportFailed = true;
 					}
-				} else {	// we want to force VCML, we act as if saving to SBML failed
-					sbmlExportFailed = true;
-				}
 
-				// applications that don't produce a proper sbml (for example NFSim or Smoldyn) are 
-				// marked as failed, even if exporting to sbml didn't throw any exception
-				if (simContext.getGeometry().getDimension() > 0 && simContext.getApplicationType() == Application.NETWORK_STOCHASTIC) {
-					sbmlExportFailed = true;
-				} else if(simContext.getApplicationType() == Application.RULE_BASED_STOCHASTIC) {
-					sbmlExportFailed = true;
-				}
-
-				String simContextName = simContext.getName();
-				String filePathStrAbsolute = null;
-				String filePathStrRelative = null;
-				String urn = null;
-				String simContextId = null;
-				
-				if(bForceSBML == true && sbmlExportFailed == true) {
-					continue;		// exclude this sim if sbml export failed and we are in sbml-only mode
-				}
-				
-				if(sbmlExportFailed) {
-					//						filePathStrAbsolute = Paths.get(savePath, bioModelName + ".vcml").toString();
-					filePathStrAbsolute = Paths.get(savePath, sBaseFileName + ".vcml").toString();
-					//						filePathStrRelative = bioModelName + ".vcml";
-					filePathStrRelative = sBaseFileName + ".vcml";
-					if(!bFromOmex) {	// the vcml file is managed elsewhere when called for omex
-						String vcmlString = XmlHelper.bioModelToXML(vcBioModel);
-						XmlUtil.writeXMLStringToFile(vcmlString, filePathStrAbsolute, true);
-						sbmlFilePathStrAbsoluteList.add(filePathStrRelative);
+					// applications that are not compatible with SBML are marked as failed 
+					if (simContext.getGeometry().getDimension() > 0 && simContext.getApplicationType() == Application.NETWORK_STOCHASTIC) {
+						logger.error("SimContext '"+simContext.getName()+"' is not compatible with SBML export");
+						sbmlExportFailed = true;
+					} else if(simContext.getApplicationType() == Application.RULE_BASED_STOCHASTIC) {
+						logger.error("SimContext '"+simContext.getName()+"' is not compatible with SBML export");
+						sbmlExportFailed = true;
 					}
-					urn = vcmlLanguageURN;
-					sedmlModel.addModel(new Model(bioModelID, bioModelName, urn, filePathStrRelative));
-				} else {
-					//						filePathStrAbsolute = Paths.get(savePath, bioModelName + "_" + TokenMangler.mangleToSName(simContextName) + ".xml").toString();
-					filePathStrAbsolute = Paths.get(savePath, sBaseFileName + "_" + TokenMangler.mangleToSName(simContextName) + ".xml").toString();
-					//						filePathStrRelative = bioModelName + "_" +  TokenMangler.mangleToSName(simContextName) + ".xml";
-					filePathStrRelative = sBaseFileName + "_" +  TokenMangler.mangleToSName(simContextName) + ".xml";
-					XmlUtil.writeXMLStringToFile(sbmlString, filePathStrAbsolute, true);
-					urn = sbmlLanguageURN;
-					sbmlFilePathStrAbsoluteList.add(filePathStrRelative);
-					simContextId = TokenMangler.mangleToSName(simContextName);
-					sedmlModel.addModel(new Model(simContextId, simContextName, urn, filePathStrRelative));
-				}
-
-				MathMapping mathMapping = simContext.createNewMathMapping();
-				MathSymbolMapping mathSymbolMapping = mathMapping.getMathSymbolMapping();
-
-				// -------
-				// create sedml objects (simulation, task, datagenerators, report, plot) for each simulation in simcontext 
-				// -------
-				
-
-				int simCount = 0;
-//				String taskRef = null;
-				int overrideCount = 0;
-				for (Simulation vcSimulation : simContext.getSimulations()) {
-					// if we have a hash containing a subset of simulations to export
-					// skip simulations not present in hash
-					if (simsToExport != null && !simsToExport.contains(vcSimulation)) continue;
-
-					// 1 -------> check compatibility
-					// if simContext is non-spatial stochastic, check if sim is histogram; if so, skip it, it can't be encoded in sedml 1.x
-					SolverTaskDescription simTaskDesc = vcSimulation.getSolverTaskDescription();
-					if (simContext.getGeometry().getDimension() == 0 && simContext.isStoch()) {
-						long numOfTrials = simTaskDesc.getStochOpt().getNumOfTrials();
-						if (numOfTrials > 1) {
-							String msg = "\n\t" + simContextName + " ( " + vcSimulation.getName() + " ) : export of non-spatial stochastic simulation with histogram option to SEDML not supported at this time.";
-							sedmlNotesStr += msg;
+					
+					if (!sbmlExportFailed) {
+						writeModelSBML(savePath, sBaseFileName, sbmlString, simContext);
+						exportSimulationsSBML(simContextCnt, simContext, sbmlString, l2gMap);
+					} else {
+						if (bFromCLI) {
 							continue;
-						}
-					}
-					
-					// 2 ------->
-					// create Algorithm and sedmlSimulation (UniformtimeCourse)
-					SolverDescription vcSolverDesc = simTaskDesc.getSolverDescription();
-					String kiSAOIdStr = vcSolverDesc.getKisao();
-					Algorithm sedmlAlgorithm = new Algorithm(kiSAOIdStr);
-					TimeBounds vcSimTimeBounds = simTaskDesc.getTimeBounds();
-					double startingTime = vcSimTimeBounds.getStartingTime();
-					String simName = vcSimulation.getName();
-					UniformTimeCourse utcSim = new UniformTimeCourse(TokenMangler.mangleToSName(simName), simName, startingTime, startingTime, 
-							vcSimTimeBounds.getEndingTime(), (int) simTaskDesc.getExpectedNumTimePoints(), sedmlAlgorithm);
-
-					boolean enableAbsoluteErrorTolerance;		// --------- deal with error tolerance
-					boolean enableRelativeErrorTolerance;
-					if (vcSolverDesc.isSemiImplicitPdeSolver() || vcSolverDesc.isChomboSolver()) {
-						enableAbsoluteErrorTolerance = false;
-						enableRelativeErrorTolerance = true;
-					} else if (vcSolverDesc.hasErrorTolerance()) {
-						enableAbsoluteErrorTolerance = true;
-						enableRelativeErrorTolerance = true;
-					} else {
-						enableAbsoluteErrorTolerance = false;
-						enableRelativeErrorTolerance = false;
-					}	
-					if(enableAbsoluteErrorTolerance) {
-						ErrorTolerance et = simTaskDesc.getErrorTolerance();
-						String kisaoStr = ErrorTolerance.ErrorToleranceDescription.Absolute.getKisao();
-						AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, et.getAbsoluteErrorTolerance()+"");
-						sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
-					}
-					if(enableRelativeErrorTolerance) {
-						ErrorTolerance et = simTaskDesc.getErrorTolerance();
-						String kisaoStr = ErrorTolerance.ErrorToleranceDescription.Relative.getKisao();
-						AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, et.getRelativeErrorTolerance()+"");
-						sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
-					}
-
-					boolean enableDefaultTimeStep;		// ---------- deal with time step (code adapted from TimeSpecPanel.refresh()
-					boolean enableMinTimeStep;
-					boolean enableMaxTimeStep;
-					if (vcSolverDesc.compareEqual(SolverDescription.StochGibson)) { // stochastic time
-						enableDefaultTimeStep = false;
-						enableMinTimeStep = false;
-						enableMaxTimeStep = false;
-					} else if(vcSolverDesc.compareEqual(SolverDescription.NFSim)) {
-						enableDefaultTimeStep = false;
-						enableMinTimeStep = false;
-						enableMaxTimeStep = false;
-					} else {
-						// fixed time step solvers and non spatial stochastic solvers only show default time step.
-						if (!vcSolverDesc.hasVariableTimestep() || vcSolverDesc.isNonSpatialStochasticSolver()) {
-							enableDefaultTimeStep = true;
-							enableMinTimeStep = false;
-							enableMaxTimeStep = false;
 						} else {
-							// variable time step solvers shows min and max, but sundials solvers don't show min
-							enableDefaultTimeStep = false;
-							enableMinTimeStep = true;
-							enableMaxTimeStep = true;			
-							if (vcSolverDesc.hasSundialsTimeStepping()) {
-								enableMinTimeStep = false;
-							}
+							throw new Exception ("SimContext '"+simContext.getName()+"' is not compatible with SBML export");
 						}
-					}
-					TimeStep ts = simTaskDesc.getTimeStep();
-					if(enableDefaultTimeStep) {
-						String kisaoStr = TimeStep.TimeStepDescription.Default.getKisao();
-						AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, ts.getDefaultTimeStep()+"");
-						sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
-					}
-					if(enableMinTimeStep) {
-						String kisaoStr = TimeStep.TimeStepDescription.Minimum.getKisao();
-						AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, ts.getMinimumTimeStep()+"");
-						sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
-					}
-					if(enableMaxTimeStep) {
-						String kisaoStr = TimeStep.TimeStepDescription.Maximum.getKisao();
-						AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, ts.getMaximumTimeStep()+"");
-						sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
-					}
+					}			
+				}
 
-					if(simTaskDesc.getSimulation().getMathDescription().isNonSpatialStoch()) {	// ------- deal with seed
-						NonspatialStochSimOptions nssso = simTaskDesc.getStochOpt();
-						if(nssso.isUseCustomSeed()) {
-							String kisaoStr = SolverDescription.AlgorithmParameterDescription.Seed.getKisao();	// 488
-							AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, nssso.getCustomSeed()+"");
-							sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
-						}
-					} else {
-						;	// (... isRuleBased(), isSpatial(), isMovingMembrane(), isSpatialHybrid() ...
-					}
+				if (modelFormat == ModelFormat.VCML) {
+					writeModelVCML(savePath, sBaseFileName, bFromCLI);
+					exportSimulationsVCML(simContextCnt, simContext);
+				}
 
-					if(vcSolverDesc == SolverDescription.HybridEuler || 						// -------- deal with hybrid solvers (non-spatial)
-							vcSolverDesc == SolverDescription.HybridMilAdaptive ||
-							vcSolverDesc == SolverDescription.HybridMilstein) {
-						NonspatialStochHybridOptions nssho = simTaskDesc.getStochHybridOpt();
-
-						String kisaoStr = SolverDescription.AlgorithmParameterDescription.Epsilon.getKisao();
-						AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, nssho.getEpsilon()+"");
-						sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
-
-						kisaoStr = SolverDescription.AlgorithmParameterDescription.Lambda.getKisao();
-						sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, nssho.getLambda()+"");
-						sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
-
-						kisaoStr = SolverDescription.AlgorithmParameterDescription.MSRTolerance.getKisao();
-						sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, nssho.getMSRTolerance()+"");
-						sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
-					}
-					if(vcSolverDesc == SolverDescription.HybridMilAdaptive) {					// --------- one more param for hybrid-adaptive
-						NonspatialStochHybridOptions nssho = simTaskDesc.getStochHybridOpt();
-
-						String kisaoStr = SolverDescription.AlgorithmParameterDescription.SDETolerance.getKisao();
-						AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, nssho.getSDETolerance()+"");
-						sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
-					}
-
-					// TODO: consider adding notes for the algorithm parameters, to provide human-readable description of kisao terms
-					//						sedmlAlgorithm.addNote(createNotesElement(algorithmNotesStr));
-					// TODO: even better, AlgorithmParameter in sed-ml should also have a human readable "name" field
-
-					// add a note to utcSim to indicate actual solver name
-					String simNotesStr = "Actual Solver Name : '" + vcSolverDesc.getDisplayLabel() + "'.";  
-					utcSim.addNote(createNotesElement(simNotesStr));
-					sedmlModel.addSimulation(utcSim);
-
-					// 3 ------->
-					// create Tasks
-					Set<String> dataGeneratorTasksSet = new LinkedHashSet<>();	// tasks not referenced as subtasks by any other (repeated) task; only these will have data generators
-					MathOverrides mathOverrides = new MathOverrides(vcSimulation, vcSimulation.getMathOverrides());
-					if((sbmlExportFailed == false) && mathOverrides != null && mathOverrides.hasOverrides()) {
-						String[] overridenConstantNames = mathOverrides.getOverridenConstantNames();
-						String[] scannedConstantsNames = mathOverrides.getScannedConstantNames();
-						HashMap<String, String> scannedParamHash = new HashMap<String, String>();
-						HashMap<String, String> unscannedParamHash = new HashMap<String, String>();
-						
-						VariableSymbolTable varST = new VariableSymbolTable();
-						String[] constantNames = mathOverrides.getAllConstantNames();
-						final HashMap<String, Expression> substitutedConstants = new HashMap<>();
-						{
-							final ArrayList<Constant> overrides = new ArrayList<>();
-							for (String constantName : constantNames) {
-								overrides.add(new Constant(constantName, new Expression(mathOverrides.getActualExpression(constantName, 0))));
-							}
-							for (Constant override : overrides) {
-								 varST.addVar(override);
-							}
-							for (Constant override : overrides) {
-								 override.bind(varST);
-							}
-							for (Constant override : overrides) {
-								 Expression flattened = MathUtilities.substituteFunctions(override.getExpression(), varST, true);
-								 substitutedConstants.put(override.getName(), new Expression(flattened));
-							}
-						}
-						
-						// need to check for "leftover" overrides from parameter renaming or other model editing
-						HashMap<String, String> missingParamHash = new HashMap<String, String>();
-						for (String name : scannedConstantsNames) {
-							if (!mathOverrides.isUnusedParameter(name)) {
-								scannedParamHash.put(name, name);
-							} else {
-								missingParamHash.put(name, name);
-							}
-						}
-						for (String name : overridenConstantNames) {
-							if (!scannedParamHash.containsKey(name)) {
-								if (!mathOverrides.isUnusedParameter(name)) {
-									unscannedParamHash.put(name, name);
-								} else {
-									missingParamHash.put(name, name);
-								}
-							}
-						}
-						if (!missingParamHash.isEmpty()) {
-							for (String missingParamName : missingParamHash.values()) {
-								logger.error("WARNING: there is an override entry for non-existent parameter "+missingParamName);
-							}
-						}
-
-						if (!unscannedParamHash.isEmpty() && scannedParamHash.isEmpty()) {
-							// only parameters with simple overrides (numeric/expression) no scans
-							// create new model with change for each parameter that has override; add simple task
-							String overriddenSimContextId = simContextId + "_" + overrideCount;
-							String overriddenSimContextName = simContextName + " modified";
-							Model sedModel = new Model(overriddenSimContextId, overriddenSimContextName, sbmlLanguageURN, "#"+simContextId);
-							overrideCount++;
-
-							int variableCount = 0;
-							for (String unscannedParamName : unscannedParamHash.values()) {
-								SymbolTableEntry ste = getSymbolTableEntryForModelEntity(mathSymbolMapping, unscannedParamName);
-								if(ste == null) {
-									throw new RuntimeException("failed to retrieve vcell parameter from unscanned SEDML parameter " + unscannedParamName + " using mathSymbolMapping.");
-								}
-								Expression unscannedParamExpr = mathOverrides.getActualExpression(unscannedParamName, 0);
-								if(unscannedParamExpr.isNumeric()) {
-									// if expression is numeric, add ChangeAttribute to model created above
-									XPathTarget targetXpath = getTargetAttributeXPath(ste, l2gMap);
-									ChangeAttribute changeAttribute = new ChangeAttribute(targetXpath, unscannedParamExpr.infix());
-									sedModel.addChange(changeAttribute);
-								} else {
-									
-									Map<String, XPathTarget> symbolToTargetMap = new LinkedHashMap<>();
-									// create setValue for unscannedParamName (which contains a scanned param in its expression)
-									String[] symbols = unscannedParamExpr.getSymbols();
-									for(String symbol : symbols) {
-										SymbolTableEntry entry = getSymbolTableEntryForModelEntity(mathSymbolMapping, symbol);
-										XPathTarget target = getTargetAttributeXPath(entry, l2gMap);
-										symbolToTargetMap.put(symbol, target);
-									}
-
-									// non-numeric expression : add 'computeChange' to modified model
-									XPathTarget targetXpath = getTargetAttributeXPath(ste, l2gMap);
-									ComputeChange computeChange = new ComputeChange(targetXpath);
-									
-									Expression expr = new Expression(unscannedParamExpr);
-									String[] exprSymbols = expr.getSymbols();
-									for (String symbol : exprSymbols) {
-										String varName = overriddenSimContextId + "_" + symbol + "_" + variableCount;
-										Variable sedmlVar = new Variable(varName, varName, overriddenSimContextId, symbolToTargetMap.get(symbol).toString());
-										expr.substituteInPlace(new Expression(symbol), new Expression(varName));
-										computeChange.addVariable(sedmlVar);
-										variableCount++;
-									}
-									ASTNode math = Libsedml.parseFormulaString(expr.infix());
-									computeChange.setMath(math);
-									sedModel.addChange(computeChange);
-								}
-							}
-							sedmlModel.addModel(sedModel);
-
-							String taskId = "tsk_" + simContextCnt + "_" + simCount;
-							Task sedmlTask = new Task(taskId, vcSimulation.getName(), sedModel.getId(), utcSim.getId());
-							dataGeneratorTasksSet.add(sedmlTask.getId());
-							sedmlModel.addTask(sedmlTask);
-//							taskRef = taskId;		// to be used later to add dataGenerators : one set of DGs per model (simContext).
-							
-						} else if (!scannedParamHash.isEmpty() && unscannedParamHash.isEmpty()) {
-							// only parameters with scans
-							String taskId = "tsk_" + simContextCnt + "_" + simCount;
-							String ownerTaskId = taskId;
-							Task sedmlTask = new Task(taskId, vcSimulation.getName(), simContextId, utcSim.getId());
-							dataGeneratorTasksSet.add(sedmlTask.getId());
-							sedmlModel.addTask(sedmlTask);
-
-							int repeatedTaskIndex = 0;
-							for (String scannedConstName : scannedConstantsNames) {
-								String repeatedTaskId = "repTsk_" + simContextCnt + "_" + simCount + "_" + repeatedTaskIndex;
-								String rangeId = "range_" + simContextCnt + "_" + simCount + "_" + scannedConstName;
-//								if(repeatedTaskIndex == 0) {
-//									taskRef = repeatedTaskId;
-//								}
-								RepeatedTask rt = new RepeatedTask(repeatedTaskId, repeatedTaskId, true, rangeId);
-								dataGeneratorTasksSet.add(rt.getId());
-								SubTask subTask = new SubTask("0", ownerTaskId);
-								dataGeneratorTasksSet.remove(ownerTaskId);
-								rt.addSubtask(subTask);
-								ConstantArraySpec constantArraySpec = mathOverrides.getConstantArraySpec(scannedConstName);
-								// list of Ranges, if sim is parameter scan.
-								if(constantArraySpec != null) {
-									Range r = null;
-									//										System.out.println("     " + constantArraySpec.toString());
-									if(constantArraySpec.getType() == ConstantArraySpec.TYPE_INTERVAL) {
-										// ------ Uniform Range
-										UniformType type = constantArraySpec.isLogInterval() ? UniformType.LOG : UniformType.LINEAR;
-										r = new UniformRange(rangeId, constantArraySpec.getMinValue().evaluateConstant(),
-												constantArraySpec.getMaxValue().evaluateConstant(), constantArraySpec.getNumValues(), type);
-										rt.addRange(r);
-									} else {
-										// ----- Vector Range
-										cbit.vcell.math.Constant[] cs = constantArraySpec.getConstants();
-										ArrayList<Double> values = new ArrayList<Double>();
-										for (int i = 0; i < cs.length; i++){
-											String value = cs[i].getExpression().infix();
-											values.add(Double.parseDouble(value));
-										}
-										r = new VectorRange(rangeId, values);
-										rt.addRange(r);
-									}
-
-									// list of Changes
-									SymbolTableEntry ste = getSymbolTableEntryForModelEntity(mathSymbolMapping, scannedConstName);
-									XPathTarget target = getTargetAttributeXPath(ste, l2gMap);
-									//ASTNode math1 = new ASTCi(r.getId());		// was scannedConstName
-									ASTNode math1 = Libsedml.parseFormulaString(r.getId());		// here the math is always the range id expression
-									SetValue setValue = new SetValue(target, r.getId(), simContextId);
-									setValue.setMath(math1);
-									rt.addChange(setValue);
-								} else {
-									throw new RuntimeException("No scan ranges found for scanned parameter : '" + scannedConstName + "'.");
-								}
-								ownerTaskId = repeatedTaskId;
-								repeatedTaskIndex++;
-								
-								sedmlModel.addTask(rt);
-							}
-
-						} else {
-							// both scanned and simple parameters : create new model with change for each simple override; add RepeatedTask
-							Map<String, RepeatedTask> rangeToRepeatedTaskHash = new LinkedHashMap<> ();
-							List<RepeatedTask> repeatedTasksList = new ArrayList<> ();
-							
-							// create new model with change for each unscanned parameter that has override
-							String overriddenSimContextId = simContextId + "_" + overrideCount;
-							String overriddenSimContextName = simContextName + " modified";
-							Model sedModel = new Model(overriddenSimContextId, overriddenSimContextName, sbmlLanguageURN, "#"+simContextId);
-							overrideCount++;
-
-							String taskId = "tsk_" + simContextCnt + "_" + simCount;
-							String ownerTaskId = taskId;
-							Task sedmlTask = new Task(taskId, vcSimulation.getName(), overriddenSimContextId, utcSim.getId());
-							dataGeneratorTasksSet.add(sedmlTask.getId());
-							sedmlModel.addTask(sedmlTask);
-
-							// scanned parameters
-							int repeatedTaskIndex = 0;
-							int variableCount = 0;
-							for (String scannedConstName : scannedConstantsNames) {
-								String repeatedTaskId = "repTsk_" + simContextCnt + "_" + simCount + "_" + repeatedTaskIndex;
-								String rangeId = "range_" + simContextCnt + "_" + simCount + "_" + scannedConstName;
-//								if(repeatedTaskIndex == 0) {
-//									taskRef = repeatedTaskId;
-//								}
-								RepeatedTask rt = new RepeatedTask(repeatedTaskId, repeatedTaskId, true, rangeId);
-								dataGeneratorTasksSet.add(rt.getId());
-								SubTask subTask = new SubTask("0", ownerTaskId);
-								dataGeneratorTasksSet.remove(ownerTaskId);
-								rt.addSubtask(subTask);
-								ConstantArraySpec constantArraySpec = mathOverrides.getConstantArraySpec(scannedConstName);
-								// list of Ranges, if sim is parameter scan.
-								if(constantArraySpec != null) {
-									Range r = null;
-									//										System.out.println("     " + constantArraySpec.toString());
-									if(constantArraySpec.getType() == ConstantArraySpec.TYPE_INTERVAL) {
-										// ------ Uniform Range
-										UniformType type = constantArraySpec.isLogInterval() ? UniformType.LOG : UniformType.LINEAR;
-										r = new UniformRange(rangeId, constantArraySpec.getMinValue().evaluateConstant(),
-												constantArraySpec.getMaxValue().evaluateConstant(), constantArraySpec.getNumValues(), type);
-										rt.addRange(r);
-									} else {
-										// ----- Vector Range
-										cbit.vcell.math.Constant[] cs = constantArraySpec.getConstants();
-										ArrayList<Double> values = new ArrayList<Double>();
-										for (int i = 0; i < cs.length; i++){
-											String value = cs[i].getExpression().infix();
-											values.add(Double.parseDouble(value));
-										}
-										r = new VectorRange(rangeId, values);
-										rt.addRange(r);
-									}
-
-									// use scannedParamHash to store rangeId for that param, since it might be needed if unscanned param has a scanned param in expr.
-									if (scannedParamHash.get(scannedConstName).equals(scannedConstName)) {
-										// the hash was originally populated as <scannedParamName, scannedParamName>. Replace 'value' with rangeId for scannedParam
-										scannedParamHash.put(scannedConstName, r.getId());
-										rangeToRepeatedTaskHash.put(r.getId(), rt);		// we'll need the right repeated task for this range later on, in the unscanned loop
-									}
-
-									// list of Changes
-									SymbolTableEntry ste = getSymbolTableEntryForModelEntity(mathSymbolMapping, scannedConstName);
-									XPathTarget target = getTargetAttributeXPath(ste, l2gMap);
-									// TODO: math needs to refer to the parameter id, not name
-									ASTNode math1 = Libsedml.parseFormulaString(r.getId());		// here the math is always the range id expression
-									SetValue setValue = new SetValue(target, r.getId(), overriddenSimContextId);
-									setValue.setMath(math1);
-									rt.addChange(setValue);
-								} else {
-									throw new RuntimeException("No scan ranges found for scanned parameter : '" + scannedConstName + "'.");
-								}
-								ownerTaskId = repeatedTaskId;
-								repeatedTaskIndex++;
-								
-								repeatedTasksList.add(rt);
-							}
-
-							// for unscanned parameter overrides
-							for (String unscannedParamName : unscannedParamHash.values()) {
-								SymbolTableEntry ste = getSymbolTableEntryForModelEntity(mathSymbolMapping, unscannedParamName);
-								if(ste == null) {
-									throw new RuntimeException("failed to retrieve vcell parameter from unscanned SEDML parameter " + unscannedParamName + " using mathSymbolMapping.");
-								}
-								Expression unscannedParamExpr = mathOverrides.getActualExpression(unscannedParamName, 0);
-								if(unscannedParamExpr.isNumeric()) {
-									// if expression is numeric, add ChangeAttribute to model created above
-									XPathTarget targetXpath = getTargetAttributeXPath(ste, l2gMap);
-									ChangeAttribute changeAttribute = new ChangeAttribute(targetXpath, unscannedParamExpr.infix());
-									sedModel.addChange(changeAttribute);
-								} else {
-									// check for any scanned parameter in unscanned parameter expression
-									String[] exprSymbols = unscannedParamExpr.getSymbols();
-									boolean bHasScannedParameter = false;
-									List<String> scannedParamNameInUnscannedParamExpList = new ArrayList<> ();
-									for (String symbol : exprSymbols) {
-										if (scannedParamHash.get(symbol) != null) {
-											bHasScannedParameter = true;
-											scannedParamNameInUnscannedParamExpList.add(new String(symbol));
-										}
-									}
-									// (scanned parameter in expr) ? (add setValue for unscanned param in repeatedTask) : (add computeChange to modifiedModel)
-									Map<String, XPathTarget> symbolToTargetMap = new LinkedHashMap<>();
-									String[] symbols = unscannedParamExpr.getSymbols();
-									for(String symbol : symbols) {
-										SymbolTableEntry entry = getSymbolTableEntryForModelEntity(mathSymbolMapping, symbol);
-										XPathTarget target = getTargetAttributeXPath(entry, l2gMap);
-										symbolToTargetMap.put(symbol, target);
-									}
-									if (bHasScannedParameter) {
-										// create setValue for unscannedParamName (which contains a scanned param in its expression)
-										SymbolTableEntry entry = getSymbolTableEntryForModelEntity(mathSymbolMapping, unscannedParamName);
-										XPathTarget target = getTargetAttributeXPath(entry, l2gMap);
-										Set<String> rangeIdSet = new HashSet<>();
-										for(String scannedParamNameInUnscannedParamExp : scannedParamNameInUnscannedParamExpList) {
-											String rangeId = scannedParamHash.get(scannedParamNameInUnscannedParamExp);
-											rangeIdSet.add(rangeId);	// all the ranges referred in the scannedParamNameInUnscannedParamExpList
-										}
-										for(String rangeId : rangeIdSet) {
-											SetValue setValue = new SetValue(target, rangeId, overriddenSimContextId);	// @TODO: we have no range??
-											Expression expr = new Expression(unscannedParamExpr);
-											for(String symbol : symbols) {
-												String symbolName = rangeId + "_" + symbol + "_" + variableCount;
-												Variable sedmlVar = new Variable(symbolName, symbolName, overriddenSimContextId, symbolToTargetMap.get(symbol).toString());	// sbmlSupport.getXPathForSpecies(symbol));
-												setValue.addVariable(sedmlVar);
-												expr.substituteInPlace(new Expression(symbol), new Expression(symbolName));
-												variableCount++;
-											}
-											ASTNode math = Libsedml.parseFormulaString(expr.infix());
-											setValue.setMath(math);
-											RepeatedTask rtRecovered = rangeToRepeatedTaskHash.get(rangeId);
-											rtRecovered.addChange(setValue);
-										}
-									} else {
-										// non-numeric expression : add 'computeChange' to modified model
-										XPathTarget targetXpath = getTargetAttributeXPath(ste, l2gMap);
-										ComputeChange computeChange = new ComputeChange(targetXpath);
-										Expression expr = new Expression(unscannedParamExpr);
-										for (String symbol : exprSymbols) {
-											String varName = overriddenSimContextId + "_" + symbol + "_" + variableCount;
-											Variable sedmlVar = new Variable(varName, varName, overriddenSimContextId, symbolToTargetMap.get(symbol).toString());
-											expr.substituteInPlace(new Expression(symbol), new Expression(varName));
-											computeChange.addVariable(sedmlVar);
-											variableCount++;
-										}
-										ASTNode math = Libsedml.parseFormulaString(expr.infix());
-										computeChange.setMath(math);
-										sedModel.addChange(computeChange);
-									}
-								}
-							}
-							sedmlModel.addModel(sedModel);
-							for(RepeatedTask rt : repeatedTasksList) {
-								sedmlModel.addTask(rt);
-							}
-						}
-					} else {						// no math overrides, add basic task.
-						String taskId = "tsk_" + simContextCnt + "_" + simCount;
-						
-						// temporary workaround
-						// TODO better fix
-						simContextId = sbmlExportFailed? bioModelID : simContextId;
-						
-						Task sedmlTask = new Task(taskId, vcSimulation.getName(), simContextId, utcSim.getId());
-						dataGeneratorTasksSet.add(sedmlTask.getId());
-						sedmlModel.addTask(sedmlTask);
-//						taskRef = taskId;		// to be used later to add dataGenerators : one set of DGs per model (simContext).
-					}
-					
-					// 4 ------->
-					// Create DataGenerators
-
-					List<DataGenerator> dataGeneratorsOfSim = new ArrayList<> ();					
-					Map<String, DataGenerator> timeDataGeneratorMap = new LinkedHashMap<>();
-					for(String taskRef : dataGeneratorTasksSet) {
-						// add one DataGenerator for 'time'
-						String timeDataGenPrefix = DATAGENERATOR_TIME_NAME + "_" + taskRef;
-						DataGenerator timeDataGen = sedmlModel.getDataGeneratorWithId(timeDataGenPrefix);
-						org.jlibsedml.Variable timeVar = new org.jlibsedml.Variable(DATAGENERATOR_TIME_SYMBOL + "_" + taskRef, DATAGENERATOR_TIME_SYMBOL, taskRef, VariableSymbol.TIME);
-						ASTNode math = Libsedml.parseFormulaString(DATAGENERATOR_TIME_SYMBOL + "_" + taskRef);
-						timeDataGen = new DataGenerator(timeDataGenPrefix, timeDataGenPrefix, math);
-						timeDataGen.addVariable(timeVar);
-						sedmlModel.addDataGenerator(timeDataGen);
-						dataGeneratorsOfSim.add(timeDataGen);
-						timeDataGeneratorMap.put(taskRef, timeDataGen);
-	
-						// add dataGenerators for species
-						// get species list from SBML model.
-						//		        		Map<String, String> name2IdMap = new LinkedHashMap<> ();
-						String dataGenIdPrefix = "dataGen_" + taskRef;
-						if(sbmlExportFailed) {		// we try vcml export
-							for(SpeciesContext sc : vcModel.getSpeciesContexts()) {
-								String varName = sc.getName();
-								String varId = varName + "_" + taskRef;
-								//								name2IdMap.put(varName, varId);
-								ASTNode varMath = Libsedml.parseFormulaString(varId);
-								String dataGenId = dataGenIdPrefix + "_" + TokenMangler.mangleToSName(varName);
-								DataGenerator dataGen = new DataGenerator(dataGenId, dataGenId, varMath);
-								org.jlibsedml.Variable variable = new org.jlibsedml.Variable(varId, varName, taskRef, XmlHelper.getXPathForSpecies(varName));
-								dataGen.addVariable(variable);
-								sedmlModel.addDataGenerator(dataGen);
-								dataGeneratorsOfSim.add(dataGen);
-							}
-						} else {
-							String[] varNamesList = SimSpec.fromSBML(sbmlString).getVarsList();
-							for (String varName : varNamesList) {
-								String varId = varName + "_" + taskRef;
-								//								name2IdMap.put(varName, varId);
-								org.jlibsedml.Variable sedmlVar = new org.jlibsedml.Variable(varId, varName, taskRef, sbmlSupport.getXPathForSpecies(varName));
-								ASTNode varMath = Libsedml.parseFormulaString(varId);
-								String dataGenId = dataGenIdPrefix + "_" + TokenMangler.mangleToSName(varName);			//"dataGen_" + varCount; - old code
-								DataGenerator dataGen = new DataGenerator(dataGenId, dataGenId, varMath);
-								dataGen.addVariable(sedmlVar);
-								sedmlModel.addDataGenerator(dataGen);
-								dataGeneratorsOfSim.add(dataGen);
-							}
-						}
-	
-						// add DataGenerators for output functions here
-						ArrayList<AnnotatedFunction> outputFunctions = simContext.getOutputFunctionContext().getOutputFunctionsList();
-						for (AnnotatedFunction annotatedFunction : outputFunctions) {
-							//							Expression originalFunctionExpression = annotatedFunction.getExpression();
-							//							Expression modifiedFunctionExpr = new Expression(annotatedFunction.getExpression());
-							//							System.out.println("Before: " + originalFunctionExpression);
-							//							String[] symbols = modifiedFunctionExpr.getSymbols();
-							//							for(String symbol : symbols) {
-							//								String id = name2IdMap.get(symbol);
-							//								if(id == null) {
-							//									System.err.println("Could not find id for " + symbol);
-							//								} else {
-							//									modifiedFunctionExpr.substituteInPlace(new Expression(symbol), new Expression(id));
-							//								}
-							//							}
-							//							System.out.println("After:  " + modifiedFunctionExpr);
-							//							ASTNode funcMath = Libsedml.parseFormulaString(modifiedFunctionExpr.infix());
-							String dataGenId = dataGenIdPrefix + "_" + TokenMangler.mangleToSName(annotatedFunction.getName());		//"dataGen_" + varCount; - old code
-							String varId = TokenMangler.mangleToSName(annotatedFunction.getName()) + taskRef;
-	
-							if(sbmlExportFailed) {		// VCML
-								Expression exp = new Expression(varId);
-								ASTNode funcMath = Libsedml.parseFormulaString(exp.infix());
-								DataGenerator dataGen = new DataGenerator(dataGenId, dataGenId, funcMath);
-								org.jlibsedml.Variable sedmlVar = new org.jlibsedml.Variable(varId, annotatedFunction.getName(), taskRef, 
-										XmlHelper.getXPathForOutputFunction(simContextName, annotatedFunction.getName()));
-								dataGen.addVariable(sedmlVar);
-								sedmlModel.addDataGenerator(dataGen);
-								dataGeneratorsOfSim.add(dataGen);
-							} else {					// SBML
-	
-							}
-	
-	
-	
-	
-							//							String[] functionSymbols = originalFunctionExpression.getSymbols();
-							//							for (String symbol : functionSymbols) {
-							//								String symbolName = TokenMangler.mangleToSName(symbol);
-							//								// try to get symbol from model, if null, try simContext.mathDesc
-							//								SymbolTableEntry ste = vcModel.getEntry(symbol);
-							//								if (ste == null) {
-							//									ste = simContext.getMathDescription().getEntry(symbol);
-							//								}
-							//								if (ste instanceof SpeciesContext || ste instanceof Structure || ste instanceof ModelParameter) {
-							//									XPathTarget targetXPath = getTargetXPath(ste, l2gMap);
-							//									if(sbmlExportFailed) {		// VCML
-							//										if(ste instanceof SpeciesContext) {
-							////											String varId = symbolName + "_" + taskRef;
-							////											org.jlibsedml.Variable sedmlVar = new org.jlibsedml.Variable(varId, symbolName, taskRef, XmlHelper.getXPathForSpecies(symbolName));
-							////											dataGen.addVariable(sedmlVar);
-							//										} else {
-							//											System.err.println("Not a species");
-							//										}
-							//									} else {					// SBML
-							////										String varId = symbolName + "_" + taskRef;
-							////										org.jlibsedml.Variable sedmlVar = new org.jlibsedml.Variable(varId, symbolName, taskRef, targetXPath.getTargetAsString());
-							////										dataGen.addVariable(sedmlVar);
-							//									}
-							//								} else {
-							//									double value = 0.0;
-							//									if (ste instanceof Function) {
-							//										try {
-							//											value = ste.getExpression().evaluateConstant();
-							//										} catch (Exception e) {
-							//											e.printStackTrace(System.out);
-							//											throw new RuntimeException("Unable to evaluate function '" + ste.getName() + "' for output function '" + annotatedFunction.getName() + "'.", e);
-							//										}
-							//									} else {
-							//										value = ste.getConstantValue();
-							//									}
-							//									Parameter sedmlParameter = new Parameter(symbolName, symbolName, value);
-							//									dataGen.addParameter(sedmlParameter);
-							//								}
-							//							}
-						}
-					}
-
-					// 5 ------->
-					// create Report and Plot
-
-					for(String taskRef : dataGeneratorTasksSet) {
-						// add output to sedml Model : 1 plot2d for each non-spatial simulation with all vars (species/output functions) vs time (1 curve per var)
-						// ignoring output for spatial deterministic (spatial stochastic is not exported to SEDML) and non-spatial stochastic applications with histogram
-						if (!(simContext.getGeometry().getDimension() > 0)) {
-							String plot2dId = "plot2d_" + TokenMangler.mangleToSName(vcSimulation.getName());
-							String reportId = "report_" + TokenMangler.mangleToSName(vcSimulation.getName());
-							//								String reportId = "__plot__" + plot2dId;
-							String plotName = simContextName + "_" + simName + "_plot";
-							Plot2D sedmlPlot2d = new Plot2D(plot2dId, plotName);
-							Report sedmlReport = new Report(reportId, plotName);
-	
-							sedmlPlot2d.addNote(createNotesElement("Plot of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
-							sedmlReport.addNote(createNotesElement("Report of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
-							DataGenerator dgtime = sedmlModel.getDataGeneratorWithId(DATAGENERATOR_TIME_NAME + "_" + taskRef);
-							String xDataRef = dgtime.getId();
-							String xDatasetXId = "__data_set__" + plot2dId + dgtime.getId();
-							DataSet dataSet = new DataSet(xDatasetXId, DATAGENERATOR_TIME_NAME, xDataRef, xDataRef);	// id, name, label, data generator reference
-							sedmlReport.addDataSet(dataSet);
-	
-							// add a curve for each dataGenerator in SEDML model
-							int curveCnt = 0;
-							// String id, String name, ASTNode math
-							for (DataGenerator dg : dataGeneratorsOfSim) {
-								// no curve for time, since time is xDateReference
-								if (dg.getId().equals(xDataRef)) {
-									continue;
-								}
-								String curveId = "curve_" + plot2dId + "_" + dg.getName();
-								String datasetYId = "__data_set__" + plot2dId + dg.getName();
-								Curve curve = new Curve(curveId, dg.getName(), false, false, xDataRef, dg.getId());
-								sedmlPlot2d.addCurve(curve);
-								//									// id, name, label, dataRef
-								//									// dataset id    <- unique id
-								//									// dataset name  <- data generator name
-								//									// dataset label <- dataset id
-								DataSet yDataSet = new DataSet(datasetYId, dg.getName(), dg.getId(), dg.getId());
-								sedmlReport.addDataSet(yDataSet);
-								curveCnt++;
-							}
-							sedmlModel.addOutput(sedmlPlot2d);
-							sedmlModel.addOutput(sedmlReport);
-						} else {		// spatial deterministic
-							if(simContext.getApplicationType().equals(Application.NETWORK_DETERMINISTIC)) {	// we ignore spatial stochastic (Smoldyn)
-								if(bForceVCML) {
-									String reportId = "_report_" + TokenMangler.mangleToSName(vcSimulation.getName());
-									Report sedmlReport = new Report(reportId, simContext.getName() + "plots");
-									String xDataRef = sedmlModel.getDataGeneratorWithId(DATAGENERATOR_TIME_NAME + "_" + taskRef).getId();
-									String xDatasetXId = "datasetX_" + DATAGENERATOR_TIME_NAME + "_" +timeDataGeneratorMap.get(taskRef).getId();
-									DataSet dataSetTime = new DataSet(xDatasetXId, xDataRef, xDatasetXId, xDataRef);
-									sedmlReport.addDataSet(dataSetTime);
-									int surfaceCnt = 0;
-									for (DataGenerator dg : dataGeneratorsOfSim) {
-										if (dg.getId().equals(xDataRef)) {
-											continue;
-										}
-										//										String datasetYId = "datasetY_" + surfaceCnt;
-										String datasetYId = "__data_set__" + surfaceCnt + "_" + dg.getName();
-										DataSet yDataSet = new DataSet(datasetYId, dg.getName(), datasetYId, dg.getId());
-										sedmlReport.addDataSet(yDataSet);
-	
-										surfaceCnt++;
-									}
-									sedmlModel.addOutput(sedmlReport);
-								} else {	// spatial deterministic SBML
-									// TODO: add surfaces to the plots
-									String plot3dId = "plot3d_" + TokenMangler.mangleToSName(vcSimulation.getName());
-									String reportId = "report_" + TokenMangler.mangleToSName(vcSimulation.getName());
-									String plotName = simContext.getName() + "plots";
-									Plot3D sedmlPlot3d = new Plot3D(plot3dId, plotName);
-									Report sedmlReport = new Report(reportId, plotName);
-	
-									sedmlPlot3d.addNote(createNotesElement("Plot of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
-									sedmlReport.addNote(createNotesElement("Report of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
-									DataGenerator dgtime = sedmlModel.getDataGeneratorWithId(DATAGENERATOR_TIME_NAME + "_" + taskRef);
-									String xDataRef = dgtime.getId();
-									String xDatasetXId = "__data_set__" + plot3dId + dgtime.getId();
-									DataSet dataSet = new DataSet(xDatasetXId, DATAGENERATOR_TIME_NAME, xDataRef, xDataRef);	// id, name, label, data generator reference
-									sedmlReport.addDataSet(dataSet);
-	
-									// add a curve for each dataGenerator in SEDML model
-									int curveCnt = 0;
-									// String id, String name, ASTNode math
-									for (DataGenerator dg : dataGeneratorsOfSim) {
-										// no curve for time, since time is xDateReference
-										if (dg.getId().equals(xDataRef)) {
-											continue;
-										}
-										String curveId = "curve_" + plot3dId + "_" + dg.getName();
-										String datasetYId = "__data_set__" + plot3dId + dg.getName();
-	
-										DataSet yDataSet = new DataSet(datasetYId, dg.getName(), dg.getId(), dg.getId());
-										sedmlReport.addDataSet(yDataSet);
-										curveCnt++;
-									}
-									sedmlModel.addOutput(sedmlReport);
-								}
-							}
-						}
-					}
-					simCount++;
-				} // end - for 'sims'
+				// if sedmlNotesStr is not null, there were some Simulations that could not be exported to SEDML (eg., spatial stochastic). Create a notes element and add it to sedml Model.
+	        	if (sedmlNotesStr.length() > 0) {
+		        	sedmlNotesStr = "\n\tThe following Simulations in the VCell model were not exported to SEDML : " + sedmlNotesStr;
+	        		logger.error(sedmlNotesStr);
+		        	if (bFromCLI) {
+		        		continue;
+		        	} else {
+		        		throw new Exception(sedmlNotesStr);
+		        	}
+	        	}
 				simContextCnt++;
-			}	// end - for 'simContexts'
+			}
 			
-        	// if sedmlNotesStr is not null, there were some applications that could not be exported to SEDML (eg., spatial stochastic). Create a notes element and add it to sedml Model.
-        	if (sedmlNotesStr.length() > 0) {
-	        	sedmlNotesStr = "\n\tThe following applications in the VCell model were not exported to VCell : " + sedmlNotesStr;
-	        	sedmlModel.addNote(createNotesElement(sedmlNotesStr));
-        	}
-        	if(sedmlModel.getModels() != null && sedmlModel.getModels().size() > 0) {
+       	if(sedmlModel.getModels() != null && sedmlModel.getModels().size() > 0) {
         		logger.trace("Number of models in the sedml is " + sedmlModel.getModels().size());
         	}
 	
@@ -1033,6 +299,783 @@ public class SEDMLExporter {
 		} catch (Exception e) {
 			throw new RuntimeException("Error adding model to SEDML document : " + e.getMessage(), e);
 		}
+	}
+
+	private String exportSimulationsVCML(int simContextCnt, SimulationContext simContext) {
+		// TODO
+		// extracted below snippets related to VCML format from old code before refactoring
+		
+//		if(sbmlExportFailed) {		// we try vcml export
+//			for(SpeciesContext sc : vcModel.getSpeciesContexts()) {
+//				String varName = sc.getName();
+//				String varId = varName + "_" + taskRef;
+//				//								name2IdMap.put(varName, varId);
+//				ASTNode varMath = Libsedml.parseFormulaString(varId);
+//				String dataGenId = dataGenIdPrefix + "_" + TokenMangler.mangleToSName(varName);
+//				DataGenerator dataGen = new DataGenerator(dataGenId, dataGenId, varMath);
+//				org.jlibsedml.Variable variable = new org.jlibsedml.Variable(varId, varName, taskRef, XmlHelper.getXPathForSpecies(varName));
+//				dataGen.addVariable(variable);
+//				sedmlModel.addDataGenerator(dataGen);
+//				dataGeneratorsOfSim.add(dataGen);
+//			}
+//		}		
+
+//		if(sbmlExportFailed) {		// VCML
+//			Expression exp = new Expression(varId);
+//			ASTNode funcMath = Libsedml.parseFormulaString(exp.infix());
+//			DataGenerator dataGen = new DataGenerator(dataGenId, dataGenId, funcMath);
+//			org.jlibsedml.Variable sedmlVar = new org.jlibsedml.Variable(varId, annotatedFunction.getName(), taskRef, 
+//					XmlHelper.getXPathForOutputFunction(simContextName, annotatedFunction.getName()));
+//			dataGen.addVariable(sedmlVar);
+//			sedmlModel.addDataGenerator(dataGen);
+//			dataGeneratorsOfSim.add(dataGen);
+//		} else {					// SBML
+//
+//		}
+	
+//		if(bForceVCML) {
+//			String reportId = "_report_" + TokenMangler.mangleToSName(vcSimulation.getName());
+//			Report sedmlReport = new Report(reportId, simContext.getName() + "plots");
+//			String xDataRef = sedmlModel.getDataGeneratorWithId(DATAGENERATOR_TIME_NAME + "_" + taskRef).getId();
+//			String xDatasetXId = "datasetX_" + DATAGENERATOR_TIME_NAME + "_" +timeDataGeneratorMap.get(taskRef).getId();
+//			DataSet dataSetTime = new DataSet(xDatasetXId, xDataRef, xDatasetXId, xDataRef);
+//			sedmlReport.addDataSet(dataSetTime);
+//			int surfaceCnt = 0;
+//			for (DataGenerator dg : dataGeneratorsOfSim) {
+//				if (dg.getId().equals(xDataRef)) {
+//					continue;
+//				}
+//				//										String datasetYId = "datasetY_" + surfaceCnt;
+//				String datasetYId = "__data_set__" + surfaceCnt + "_" + dg.getName();
+//				DataSet yDataSet = new DataSet(datasetYId, dg.getName(), datasetYId, dg.getId());
+//				sedmlReport.addDataSet(yDataSet);
+//
+//				surfaceCnt++;
+//			}
+//			sedmlModel.addOutput(sedmlReport);
+//		} else {	// spatial deterministic SBML
+		
+		// add DataGenerators for output functions here
+//		ArrayList<AnnotatedFunction> outputFunctions = simContext.getOutputFunctionContext().getOutputFunctionsList();
+//		for (AnnotatedFunction annotatedFunction : outputFunctions) {
+//					Expression originalFunctionExpression = annotatedFunction.getExpression();
+//					Expression modifiedFunctionExpr = new Expression(annotatedFunction.getExpression());
+//					System.out.println("Before: " + originalFunctionExpression);
+//					String[] symbols = modifiedFunctionExpr.getSymbols();
+//					for(String symbol : symbols) {
+//						String id = name2IdMap.get(symbol);
+//						if(id == null) {
+//							System.err.println("Could not find id for " + symbol);
+//						} else {
+//							modifiedFunctionExpr.substituteInPlace(new Expression(symbol), new Expression(id));
+//						}
+//					}
+//					System.out.println("After:  " + modifiedFunctionExpr);
+//					ASTNode funcMath = Libsedml.parseFormulaString(modifiedFunctionExpr.infix());
+//			String dataGenId = dataGenIdPrefix + "_" + TokenMangler.mangleToSName(annotatedFunction.getName());		//"dataGen_" + varCount; - old code
+//			String varId = TokenMangler.mangleToSName(annotatedFunction.getName()) + taskRef;
+//					String[] functionSymbols = originalFunctionExpression.getSymbols();
+//					for (String symbol : functionSymbols) {
+//						String symbolName = TokenMangler.mangleToSName(symbol);
+//						// try to get symbol from model, if null, try simContext.mathDesc
+//						SymbolTableEntry ste = vcModel.getEntry(symbol);
+//						if (ste == null) {
+//							ste = simContext.getMathDescription().getEntry(symbol);
+//						}
+//						if (ste instanceof SpeciesContext || ste instanceof Structure || ste instanceof ModelParameter) {
+//							XPathTarget targetXPath = getTargetXPath(ste, l2gMap);
+//							if(sbmlExportFailed) {		// VCML
+//								if(ste instanceof SpeciesContext) {
+////									String varId = symbolName + "_" + taskRef;
+////									org.jlibsedml.Variable sedmlVar = new org.jlibsedml.Variable(varId, symbolName, taskRef, XmlHelper.getXPathForSpecies(symbolName));
+////									dataGen.addVariable(sedmlVar);
+//								} else {
+//									System.err.println("Not a species");
+//								}
+//							} else {					// SBML
+////								String varId = symbolName + "_" + taskRef;
+////								org.jlibsedml.Variable sedmlVar = new org.jlibsedml.Variable(varId, symbolName, taskRef, targetXPath.getTargetAsString());
+////								dataGen.addVariable(sedmlVar);
+//							}
+//						} else {
+//							double value = 0.0;
+//							if (ste instanceof Function) {
+//								try {
+//									value = ste.getExpression().evaluateConstant();
+//								} catch (Exception e) {
+//									e.printStackTrace(System.out);
+//									throw new RuntimeException("Unable to evaluate function '" + ste.getName() + "' for output function '" + annotatedFunction.getName() + "'.", e);
+//								}
+//							} else {
+//								value = ste.getConstantValue();
+//							}
+//							Parameter sedmlParameter = new Parameter(symbolName, symbolName, value);
+//							dataGen.addParameter(sedmlParameter);
+//						}
+//					}
+		if (true) throw new RuntimeException("VCML export not finished");
+		return "";
+	}
+	
+	private String exportSimulationsSBML(int simContextCnt, SimulationContext simContext,
+			String sbmlString, Map<Pair<String, String>, String> l2gMap)
+			throws ExpressionBindingException, ExpressionException, DivideByZeroException, IOException, SbmlException, MappingException, MathException, MatrixException, ModelException {
+		// -------
+		// create sedml objects (simulation, task, datagenerators, report, plot) for each simulation in simcontext 
+		// -------	
+		String simContextName = simContext.getName();
+		String simContextId = TokenMangler.mangleToSName(simContextName);
+		simCount = 0;
+		overrideCount = 0;
+		String sedmlNotesStr = "";
+		MathMapping mathMapping = simContext.createNewMathMapping();
+		MathSymbolMapping mathSymbolMapping = mathMapping.getMathSymbolMapping();
+		for (Simulation vcSimulation : simContext.getSimulations()) {
+			// if we have a hash containing a subset of simulations to export
+			// skip simulations not present in hash
+			if (simsToExport != null && !simsToExport.contains(vcSimulation)) continue;
+
+			// 1 -------> check compatibility
+			// if simContext is non-spatial stochastic, check if sim is histogram; if so, skip it, it can't be encoded in sedml 1.x
+			SolverTaskDescription simTaskDesc = vcSimulation.getSolverTaskDescription();
+			if (simContext.getGeometry().getDimension() == 0 && simContext.isStoch()) {
+				long numOfTrials = simTaskDesc.getStochOpt().getNumOfTrials();
+				if (numOfTrials > 1) {
+					String msg = "\n\t" + simContextName + " ( " + vcSimulation.getName() + " ) : export of non-spatial stochastic simulation with histogram option to SEDML not supported at this time.";
+					sedmlNotesStr += msg;
+					continue;
+				}
+			}
+			
+			// 2 ------->
+			// create sedmlSimulation (UniformTimeCourse) with specs and algorithm parameters
+			UniformTimeCourse utcSim = createSEDMLsim(simTaskDesc);
+
+			// 3 ------->
+			// create Tasks
+			Set<String> dataGeneratorTasksSet = new LinkedHashSet<>();	// tasks not referenced as subtasks by any other (repeated) task; only these will have data generators
+			MathOverrides mathOverrides = new MathOverrides(vcSimulation, vcSimulation.getMathOverrides()); // need to clone so we can manipulate expressions
+			createSEDMLtasks(simContextCnt, l2gMap, simContextName, simContextId, mathSymbolMapping,
+					vcSimulation, utcSim, dataGeneratorTasksSet, mathOverrides);
+			
+			// 4 ------->
+			// Create DataGenerators
+
+			List<DataGenerator> dataGeneratorsOfSim = createSEDMLdatagens(sbmlString, dataGeneratorTasksSet);
+
+			// 5 ------->
+			// create Report and Plot
+
+			for(String taskRef : dataGeneratorTasksSet) {
+				createSEDMLoutputs(simContext, vcSimulation, dataGeneratorsOfSim, taskRef);
+			}
+			simCount++;
+		} // end - for 'sims'
+		return sedmlNotesStr;
+	}
+
+	private void createSEDMLoutputs(SimulationContext simContext, Simulation vcSimulation,
+			List<DataGenerator> dataGeneratorsOfSim, String taskRef) {
+		// add output to sedml Model : 1 plot2d for each non-spatial simulation with all vars (species/output functions) vs time (1 curve per var)
+		// ignoring output for spatial deterministic (spatial stochastic is not exported to SEDML) and non-spatial stochastic applications with histogram
+		if (!(simContext.getGeometry().getDimension() > 0)) {
+			String plot2dId = "plot2d_" + TokenMangler.mangleToSName(vcSimulation.getName());
+			String reportId = "report_" + TokenMangler.mangleToSName(vcSimulation.getName());
+			//								String reportId = "__plot__" + plot2dId;
+			String plotName = simContext.getName() + "_" + vcSimulation.getName() + "_plot";
+			Plot2D sedmlPlot2d = new Plot2D(plot2dId, plotName);
+			Report sedmlReport = new Report(reportId, plotName);
+
+			sedmlPlot2d.addNote(createNotesElement("Plot of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
+			sedmlReport.addNote(createNotesElement("Report of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
+			DataGenerator dgtime = sedmlModel.getDataGeneratorWithId(DATAGENERATOR_TIME_NAME + "_" + taskRef);
+			String xDataRef = dgtime.getId();
+			String xDatasetXId = "__data_set__" + plot2dId + dgtime.getId();
+			DataSet dataSet = new DataSet(xDatasetXId, DATAGENERATOR_TIME_NAME, xDataRef, xDataRef);	// id, name, label, data generator reference
+			sedmlReport.addDataSet(dataSet);
+
+			// add a curve for each dataGenerator in SEDML model
+			int curveCnt = 0;
+			// String id, String name, ASTNode math
+			for (DataGenerator dg : dataGeneratorsOfSim) {
+				// no curve for time, since time is xDateReference
+				if (dg.getId().equals(xDataRef)) {
+					continue;
+				}
+				String curveId = "curve_" + plot2dId + "_" + dg.getName();
+				String datasetYId = "__data_set__" + plot2dId + dg.getName();
+				Curve curve = new Curve(curveId, dg.getName(), false, false, xDataRef, dg.getId());
+				sedmlPlot2d.addCurve(curve);
+				//									// id, name, label, dataRef
+				//									// dataset id    <- unique id
+				//									// dataset name  <- data generator name
+				//									// dataset label <- dataset id
+				DataSet yDataSet = new DataSet(datasetYId, dg.getName(), dg.getId(), dg.getId());
+				sedmlReport.addDataSet(yDataSet);
+				curveCnt++;
+			}
+			sedmlModel.addOutput(sedmlPlot2d);
+			sedmlModel.addOutput(sedmlReport);
+		} else {		// spatial deterministic
+			if(simContext.getApplicationType().equals(Application.NETWORK_DETERMINISTIC)) {	// we ignore spatial stochastic (Smoldyn)
+				// TODO: add curves/surfaces to the plots
+				String plot3dId = "plot3d_" + TokenMangler.mangleToSName(vcSimulation.getName());
+				String reportId = "report_" + TokenMangler.mangleToSName(vcSimulation.getName());
+				String plotName = simContext.getName() + "plots";
+				Plot3D sedmlPlot3d = new Plot3D(plot3dId, plotName);
+				Report sedmlReport = new Report(reportId, plotName);
+
+				sedmlPlot3d.addNote(createNotesElement("Plot of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
+				sedmlReport.addNote(createNotesElement("Report of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
+				DataGenerator dgtime = sedmlModel.getDataGeneratorWithId(DATAGENERATOR_TIME_NAME + "_" + taskRef);
+				String xDataRef = dgtime.getId();
+				String xDatasetXId = "__data_set__" + plot3dId + dgtime.getId();
+				DataSet dataSet = new DataSet(xDatasetXId, DATAGENERATOR_TIME_NAME, xDataRef, xDataRef);	// id, name, label, data generator reference
+				sedmlReport.addDataSet(dataSet);
+
+				// add a curve for each dataGenerator in SEDML model
+				int curveCnt = 0;
+				// String id, String name, ASTNode math
+				for (DataGenerator dg : dataGeneratorsOfSim) {
+					// no curve for time, since time is xDateReference
+					if (dg.getId().equals(xDataRef)) {
+						continue;
+					}
+					String curveId = "curve_" + plot3dId + "_" + dg.getName();
+					String datasetYId = "__data_set__" + plot3dId + dg.getName();
+
+					DataSet yDataSet = new DataSet(datasetYId, dg.getName(), dg.getId(), dg.getId());
+					sedmlReport.addDataSet(yDataSet);
+					curveCnt++;
+				}
+				sedmlModel.addOutput(sedmlReport);
+			}
+		}
+	}
+
+	private List<DataGenerator> createSEDMLdatagens(String sbmlString, Set<String> dataGeneratorTasksSet)
+			throws IOException, SbmlException {
+		List<DataGenerator> dataGeneratorsOfSim = new ArrayList<> ();					
+		for(String taskRef : dataGeneratorTasksSet) {
+			// add one DataGenerator for 'time'
+			String timeDataGenPrefix = DATAGENERATOR_TIME_NAME + "_" + taskRef;
+			DataGenerator timeDataGen = sedmlModel.getDataGeneratorWithId(timeDataGenPrefix);
+			org.jlibsedml.Variable timeVar = new org.jlibsedml.Variable(DATAGENERATOR_TIME_SYMBOL + "_" + taskRef, DATAGENERATOR_TIME_SYMBOL, taskRef, VariableSymbol.TIME);
+			ASTNode math = Libsedml.parseFormulaString(DATAGENERATOR_TIME_SYMBOL + "_" + taskRef);
+			timeDataGen = new DataGenerator(timeDataGenPrefix, timeDataGenPrefix, math);
+			timeDataGen.addVariable(timeVar);
+			sedmlModel.addDataGenerator(timeDataGen);
+			dataGeneratorsOfSim.add(timeDataGen);
+
+			// add dataGenerators for species
+			// get species list from SBML model.
+			//		        		Map<String, String> name2IdMap = new LinkedHashMap<> ();
+			String dataGenIdPrefix = "dataGen_" + taskRef;
+
+			String[] varNamesList = SimSpec.fromSBML(sbmlString).getVarsList();
+			for (String varName : varNamesList) {
+				String varId = varName + "_" + taskRef;
+				//								name2IdMap.put(varName, varId);
+				org.jlibsedml.Variable sedmlVar = new org.jlibsedml.Variable(varId, varName, taskRef, sbmlSupport.getXPathForSpecies(varName));
+				ASTNode varMath = Libsedml.parseFormulaString(varId);
+				String dataGenId = dataGenIdPrefix + "_" + TokenMangler.mangleToSName(varName);			//"dataGen_" + varCount; - old code
+				DataGenerator dataGen = new DataGenerator(dataGenId, dataGenId, varMath);
+				dataGen.addVariable(sedmlVar);
+				sedmlModel.addDataGenerator(dataGen);
+				dataGeneratorsOfSim.add(dataGen);
+			}
+		}
+		return dataGeneratorsOfSim;
+	}
+
+	private UniformTimeCourse createSEDMLsim(SolverTaskDescription simTaskDesc) {
+		SolverDescription vcSolverDesc = simTaskDesc.getSolverDescription();
+		String kiSAOIdStr = vcSolverDesc.getKisao();
+		Algorithm sedmlAlgorithm = new Algorithm(kiSAOIdStr);
+		TimeBounds vcSimTimeBounds = simTaskDesc.getTimeBounds();
+		double startingTime = vcSimTimeBounds.getStartingTime();
+		String simName = simTaskDesc.getSimulation().getName();
+		UniformTimeCourse utcSim = new UniformTimeCourse(TokenMangler.mangleToSName(simName), simName, startingTime, startingTime, 
+				vcSimTimeBounds.getEndingTime(), (int) simTaskDesc.getExpectedNumTimePoints(), sedmlAlgorithm);
+
+		boolean enableAbsoluteErrorTolerance;		// --------- deal with error tolerance
+		boolean enableRelativeErrorTolerance;
+		if (vcSolverDesc.isSemiImplicitPdeSolver() || vcSolverDesc.isChomboSolver()) {
+			enableAbsoluteErrorTolerance = false;
+			enableRelativeErrorTolerance = true;
+		} else if (vcSolverDesc.hasErrorTolerance()) {
+			enableAbsoluteErrorTolerance = true;
+			enableRelativeErrorTolerance = true;
+		} else {
+			enableAbsoluteErrorTolerance = false;
+			enableRelativeErrorTolerance = false;
+		}	
+		if(enableAbsoluteErrorTolerance) {
+			ErrorTolerance et = simTaskDesc.getErrorTolerance();
+			String kisaoStr = ErrorTolerance.ErrorToleranceDescription.Absolute.getKisao();
+			AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, et.getAbsoluteErrorTolerance()+"");
+			sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
+		}
+		if(enableRelativeErrorTolerance) {
+			ErrorTolerance et = simTaskDesc.getErrorTolerance();
+			String kisaoStr = ErrorTolerance.ErrorToleranceDescription.Relative.getKisao();
+			AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, et.getRelativeErrorTolerance()+"");
+			sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
+		}
+
+		boolean enableDefaultTimeStep;		// ---------- deal with time step (code adapted from TimeSpecPanel.refresh()
+		boolean enableMinTimeStep;
+		boolean enableMaxTimeStep;
+		if (vcSolverDesc.compareEqual(SolverDescription.StochGibson)) { // stochastic time
+			enableDefaultTimeStep = false;
+			enableMinTimeStep = false;
+			enableMaxTimeStep = false;
+		} else if(vcSolverDesc.compareEqual(SolverDescription.NFSim)) {
+			enableDefaultTimeStep = false;
+			enableMinTimeStep = false;
+			enableMaxTimeStep = false;
+		} else {
+			// fixed time step solvers and non spatial stochastic solvers only show default time step.
+			if (!vcSolverDesc.hasVariableTimestep() || vcSolverDesc.isNonSpatialStochasticSolver()) {
+				enableDefaultTimeStep = true;
+				enableMinTimeStep = false;
+				enableMaxTimeStep = false;
+			} else {
+				// variable time step solvers shows min and max, but sundials solvers don't show min
+				enableDefaultTimeStep = false;
+				enableMinTimeStep = true;
+				enableMaxTimeStep = true;			
+				if (vcSolverDesc.hasSundialsTimeStepping()) {
+					enableMinTimeStep = false;
+				}
+			}
+		}
+		TimeStep ts = simTaskDesc.getTimeStep();
+		if(enableDefaultTimeStep) {
+			String kisaoStr = TimeStep.TimeStepDescription.Default.getKisao();
+			AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, ts.getDefaultTimeStep()+"");
+			sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
+		}
+		if(enableMinTimeStep) {
+			String kisaoStr = TimeStep.TimeStepDescription.Minimum.getKisao();
+			AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, ts.getMinimumTimeStep()+"");
+			sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
+		}
+		if(enableMaxTimeStep) {
+			String kisaoStr = TimeStep.TimeStepDescription.Maximum.getKisao();
+			AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, ts.getMaximumTimeStep()+"");
+			sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
+		}
+
+		if(simTaskDesc.getSimulation().getMathDescription().isNonSpatialStoch()) {	// ------- deal with seed
+			NonspatialStochSimOptions nssso = simTaskDesc.getStochOpt();
+			if(nssso.isUseCustomSeed()) {
+				String kisaoStr = SolverDescription.AlgorithmParameterDescription.Seed.getKisao();	// 488
+				AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, nssso.getCustomSeed()+"");
+				sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
+			}
+		} else {
+			;	// (... isRuleBased(), isSpatial(), isMovingMembrane(), isSpatialHybrid() ...
+		}
+
+		if(vcSolverDesc == SolverDescription.HybridEuler || 						// -------- deal with hybrid solvers (non-spatial)
+				vcSolverDesc == SolverDescription.HybridMilAdaptive ||
+				vcSolverDesc == SolverDescription.HybridMilstein) {
+			NonspatialStochHybridOptions nssho = simTaskDesc.getStochHybridOpt();
+
+			String kisaoStr = SolverDescription.AlgorithmParameterDescription.Epsilon.getKisao();
+			AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, nssho.getEpsilon()+"");
+			sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
+
+			kisaoStr = SolverDescription.AlgorithmParameterDescription.Lambda.getKisao();
+			sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, nssho.getLambda()+"");
+			sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
+
+			kisaoStr = SolverDescription.AlgorithmParameterDescription.MSRTolerance.getKisao();
+			sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, nssho.getMSRTolerance()+"");
+			sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
+		}
+		if(vcSolverDesc == SolverDescription.HybridMilAdaptive) {					// --------- one more param for hybrid-adaptive
+			NonspatialStochHybridOptions nssho = simTaskDesc.getStochHybridOpt();
+
+			String kisaoStr = SolverDescription.AlgorithmParameterDescription.SDETolerance.getKisao();
+			AlgorithmParameter sedmlAlgorithmParameter = new AlgorithmParameter(kisaoStr, nssho.getSDETolerance()+"");
+			sedmlAlgorithm.addAlgorithmParameter(sedmlAlgorithmParameter);
+		}
+
+		// TODO: consider adding notes for the algorithm parameters, to provide human-readable description of kisao terms
+		//						sedmlAlgorithm.addNote(createNotesElement(algorithmNotesStr));
+		// TODO: even better, AlgorithmParameter in sed-ml should also have a human readable "name" field
+
+		// add a note to utcSim to indicate actual solver name
+		String simNotesStr = "Actual Solver Name : '" + vcSolverDesc.getDisplayLabel() + "'.";  
+		utcSim.addNote(createNotesElement(simNotesStr));
+		sedmlModel.addSimulation(utcSim);
+		return utcSim;
+	}
+	
+	private void createSEDMLtasks(int simContextCnt, Map<Pair<String, String>, String> l2gMap, String simContextName,
+			String simContextId, MathSymbolMapping mathSymbolMapping, Simulation vcSimulation, UniformTimeCourse utcSim,
+			Set<String> dataGeneratorTasksSet, MathOverrides mathOverrides)
+			throws ExpressionBindingException, ExpressionException, DivideByZeroException {
+		if(mathOverrides != null && mathOverrides.hasOverrides()) {
+			String[] overridenConstantNames = mathOverrides.getOverridenConstantNames();
+			String[] scannedConstantsNames = mathOverrides.getScannedConstantNames();
+			HashMap<String, String> scannedParamHash = new HashMap<String, String>();
+			HashMap<String, String> unscannedParamHash = new HashMap<String, String>();
+			
+			VariableSymbolTable varST = new VariableSymbolTable();
+			String[] constantNames = mathOverrides.getAllConstantNames();
+			final HashMap<String, Expression> substitutedConstants = new HashMap<>();
+			{
+				final ArrayList<Constant> overrides = new ArrayList<>();
+				for (String constantName : constantNames) {
+					overrides.add(new Constant(constantName, new Expression(mathOverrides.getActualExpression(constantName, 0))));
+				}
+				for (Constant override : overrides) {
+					 varST.addVar(override);
+				}
+				for (Constant override : overrides) {
+					 override.bind(varST);
+				}
+				for (Constant override : overrides) {
+					 Expression flattened = MathUtilities.substituteFunctions(override.getExpression(), varST, true);
+					 substitutedConstants.put(override.getName(), new Expression(flattened));
+				}
+			}
+			
+			// need to check for "leftover" overrides from parameter renaming or other model editing
+			HashMap<String, String> missingParamHash = new HashMap<String, String>();
+			for (String name : scannedConstantsNames) {
+				if (!mathOverrides.isUnusedParameter(name)) {
+					scannedParamHash.put(name, name);
+				} else {
+					missingParamHash.put(name, name);
+				}
+			}
+			for (String name : overridenConstantNames) {
+				if (!scannedParamHash.containsKey(name)) {
+					if (!mathOverrides.isUnusedParameter(name)) {
+						unscannedParamHash.put(name, name);
+					} else {
+						missingParamHash.put(name, name);
+					}
+				}
+			}
+			if (!missingParamHash.isEmpty()) {
+				for (String missingParamName : missingParamHash.values()) {
+					logger.error("WARNING: there is an override entry for non-existent parameter "+missingParamName);
+				}
+			}
+
+			if (!unscannedParamHash.isEmpty() && scannedParamHash.isEmpty()) {
+				// only parameters with simple overrides (numeric/expression) no scans
+				// create new model with change for each parameter that has override; add simple task
+				String overriddenSimContextId = simContextId + "_" + overrideCount;
+				String overriddenSimContextName = simContextName + " modified";
+				Model sedModel = new Model(overriddenSimContextId, overriddenSimContextName, sbmlLanguageURN, "#"+simContextId);
+				overrideCount++;
+
+				int variableCount = 0;
+				for (String unscannedParamName : unscannedParamHash.values()) {
+					SymbolTableEntry ste = getSymbolTableEntryForModelEntity(mathSymbolMapping, unscannedParamName);
+					if(ste == null) {
+						throw new RuntimeException("failed to retrieve vcell parameter from unscanned SEDML parameter " + unscannedParamName + " using mathSymbolMapping.");
+					}
+					Expression unscannedParamExpr = mathOverrides.getActualExpression(unscannedParamName, 0);
+					if(unscannedParamExpr.isNumeric()) {
+						// if expression is numeric, add ChangeAttribute to model created above
+						XPathTarget targetXpath = getTargetAttributeXPath(ste, l2gMap);
+						ChangeAttribute changeAttribute = new ChangeAttribute(targetXpath, unscannedParamExpr.infix());
+						sedModel.addChange(changeAttribute);
+					} else {
+						
+						Map<String, XPathTarget> symbolToTargetMap = new LinkedHashMap<>();
+						// create setValue for unscannedParamName (which contains a scanned param in its expression)
+						String[] symbols = unscannedParamExpr.getSymbols();
+						for(String symbol : symbols) {
+							SymbolTableEntry entry = getSymbolTableEntryForModelEntity(mathSymbolMapping, symbol);
+							XPathTarget target = getTargetAttributeXPath(entry, l2gMap);
+							symbolToTargetMap.put(symbol, target);
+						}
+
+						// non-numeric expression : add 'computeChange' to modified model
+						XPathTarget targetXpath = getTargetAttributeXPath(ste, l2gMap);
+						ComputeChange computeChange = new ComputeChange(targetXpath);
+						
+						Expression expr = new Expression(unscannedParamExpr);
+						String[] exprSymbols = expr.getSymbols();
+						for (String symbol : exprSymbols) {
+							String varName = overriddenSimContextId + "_" + symbol + "_" + variableCount;
+							Variable sedmlVar = new Variable(varName, varName, overriddenSimContextId, symbolToTargetMap.get(symbol).toString());
+							expr.substituteInPlace(new Expression(symbol), new Expression(varName));
+							computeChange.addVariable(sedmlVar);
+							variableCount++;
+						}
+						ASTNode math = Libsedml.parseFormulaString(expr.infix());
+						computeChange.setMath(math);
+						sedModel.addChange(computeChange);
+					}
+				}
+				sedmlModel.addModel(sedModel);
+
+				String taskId = "tsk_" + simContextCnt + "_" + simCount;
+				Task sedmlTask = new Task(taskId, vcSimulation.getName(), sedModel.getId(), utcSim.getId());
+				dataGeneratorTasksSet.add(sedmlTask.getId());
+				sedmlModel.addTask(sedmlTask);
+//							taskRef = taskId;		// to be used later to add dataGenerators : one set of DGs per model (simContext).
+				
+			} else if (!scannedParamHash.isEmpty() && unscannedParamHash.isEmpty()) {
+				// only parameters with scans
+				String taskId = "tsk_" + simContextCnt + "_" + simCount;
+				String ownerTaskId = taskId;
+				Task sedmlTask = new Task(taskId, vcSimulation.getName(), simContextId, utcSim.getId());
+				dataGeneratorTasksSet.add(sedmlTask.getId());
+				sedmlModel.addTask(sedmlTask);
+
+				int repeatedTaskIndex = 0;
+				for (String scannedConstName : scannedConstantsNames) {
+					String repeatedTaskId = "repTsk_" + simContextCnt + "_" + simCount + "_" + repeatedTaskIndex;
+					String rangeId = "range_" + simContextCnt + "_" + simCount + "_" + scannedConstName;
+//								if(repeatedTaskIndex == 0) {
+//									taskRef = repeatedTaskId;
+//								}
+					RepeatedTask rt = new RepeatedTask(repeatedTaskId, repeatedTaskId, true, rangeId);
+					dataGeneratorTasksSet.add(rt.getId());
+					SubTask subTask = new SubTask("0", ownerTaskId);
+					dataGeneratorTasksSet.remove(ownerTaskId);
+					rt.addSubtask(subTask);
+					ConstantArraySpec constantArraySpec = mathOverrides.getConstantArraySpec(scannedConstName);
+					// list of Ranges, if sim is parameter scan.
+					if(constantArraySpec != null) {
+						Range r = null;
+						//										System.out.println("     " + constantArraySpec.toString());
+						if(constantArraySpec.getType() == ConstantArraySpec.TYPE_INTERVAL) {
+							// ------ Uniform Range
+							UniformType type = constantArraySpec.isLogInterval() ? UniformType.LOG : UniformType.LINEAR;
+							r = new UniformRange(rangeId, constantArraySpec.getMinValue().evaluateConstant(),
+									constantArraySpec.getMaxValue().evaluateConstant(), constantArraySpec.getNumValues(), type);
+							rt.addRange(r);
+						} else {
+							// ----- Vector Range
+							cbit.vcell.math.Constant[] cs = constantArraySpec.getConstants();
+							ArrayList<Double> values = new ArrayList<Double>();
+							for (int i = 0; i < cs.length; i++){
+								String value = cs[i].getExpression().infix();
+								values.add(Double.parseDouble(value));
+							}
+							r = new VectorRange(rangeId, values);
+							rt.addRange(r);
+						}
+
+						// list of Changes
+						SymbolTableEntry ste = getSymbolTableEntryForModelEntity(mathSymbolMapping, scannedConstName);
+						XPathTarget target = getTargetAttributeXPath(ste, l2gMap);
+						//ASTNode math1 = new ASTCi(r.getId());		// was scannedConstName
+						ASTNode math1 = Libsedml.parseFormulaString(r.getId());		// here the math is always the range id expression
+						SetValue setValue = new SetValue(target, r.getId(), simContextId);
+						setValue.setMath(math1);
+						rt.addChange(setValue);
+					} else {
+						throw new RuntimeException("No scan ranges found for scanned parameter : '" + scannedConstName + "'.");
+					}
+					ownerTaskId = repeatedTaskId;
+					repeatedTaskIndex++;
+					
+					sedmlModel.addTask(rt);
+				}
+
+			} else {
+				// both scanned and simple parameters : create new model with change for each simple override; add RepeatedTask
+				Map<String, RepeatedTask> rangeToRepeatedTaskHash = new LinkedHashMap<> ();
+				List<RepeatedTask> repeatedTasksList = new ArrayList<> ();
+				
+				// create new model with change for each unscanned parameter that has override
+				String overriddenSimContextId = simContextId + "_" + overrideCount;
+				String overriddenSimContextName = simContextName + " modified";
+				Model sedModel = new Model(overriddenSimContextId, overriddenSimContextName, sbmlLanguageURN, "#"+simContextId);
+				overrideCount++;
+
+				String taskId = "tsk_" + simContextCnt + "_" + simCount;
+				String ownerTaskId = taskId;
+				Task sedmlTask = new Task(taskId, vcSimulation.getName(), overriddenSimContextId, utcSim.getId());
+				dataGeneratorTasksSet.add(sedmlTask.getId());
+				sedmlModel.addTask(sedmlTask);
+
+				// scanned parameters
+				int repeatedTaskIndex = 0;
+				int variableCount = 0;
+				for (String scannedConstName : scannedConstantsNames) {
+					String repeatedTaskId = "repTsk_" + simContextCnt + "_" + simCount + "_" + repeatedTaskIndex;
+					String rangeId = "range_" + simContextCnt + "_" + simCount + "_" + scannedConstName;
+//								if(repeatedTaskIndex == 0) {
+//									taskRef = repeatedTaskId;
+//								}
+					RepeatedTask rt = new RepeatedTask(repeatedTaskId, repeatedTaskId, true, rangeId);
+					dataGeneratorTasksSet.add(rt.getId());
+					SubTask subTask = new SubTask("0", ownerTaskId);
+					dataGeneratorTasksSet.remove(ownerTaskId);
+					rt.addSubtask(subTask);
+					ConstantArraySpec constantArraySpec = mathOverrides.getConstantArraySpec(scannedConstName);
+					// list of Ranges, if sim is parameter scan.
+					if(constantArraySpec != null) {
+						Range r = null;
+						//										System.out.println("     " + constantArraySpec.toString());
+						if(constantArraySpec.getType() == ConstantArraySpec.TYPE_INTERVAL) {
+							// ------ Uniform Range
+							UniformType type = constantArraySpec.isLogInterval() ? UniformType.LOG : UniformType.LINEAR;
+							r = new UniformRange(rangeId, constantArraySpec.getMinValue().evaluateConstant(),
+									constantArraySpec.getMaxValue().evaluateConstant(), constantArraySpec.getNumValues(), type);
+							rt.addRange(r);
+						} else {
+							// ----- Vector Range
+							cbit.vcell.math.Constant[] cs = constantArraySpec.getConstants();
+							ArrayList<Double> values = new ArrayList<Double>();
+							for (int i = 0; i < cs.length; i++){
+								String value = cs[i].getExpression().infix();
+								values.add(Double.parseDouble(value));
+							}
+							r = new VectorRange(rangeId, values);
+							rt.addRange(r);
+						}
+
+						// use scannedParamHash to store rangeId for that param, since it might be needed if unscanned param has a scanned param in expr.
+						if (scannedParamHash.get(scannedConstName).equals(scannedConstName)) {
+							// the hash was originally populated as <scannedParamName, scannedParamName>. Replace 'value' with rangeId for scannedParam
+							scannedParamHash.put(scannedConstName, r.getId());
+							rangeToRepeatedTaskHash.put(r.getId(), rt);		// we'll need the right repeated task for this range later on, in the unscanned loop
+						}
+
+						// list of Changes
+						SymbolTableEntry ste = getSymbolTableEntryForModelEntity(mathSymbolMapping, scannedConstName);
+						XPathTarget target = getTargetAttributeXPath(ste, l2gMap);
+						// TODO: math needs to refer to the parameter id, not name
+						ASTNode math1 = Libsedml.parseFormulaString(r.getId());		// here the math is always the range id expression
+						SetValue setValue = new SetValue(target, r.getId(), overriddenSimContextId);
+						setValue.setMath(math1);
+						rt.addChange(setValue);
+					} else {
+						throw new RuntimeException("No scan ranges found for scanned parameter : '" + scannedConstName + "'.");
+					}
+					ownerTaskId = repeatedTaskId;
+					repeatedTaskIndex++;
+					
+					repeatedTasksList.add(rt);
+				}
+
+				// for unscanned parameter overrides
+				for (String unscannedParamName : unscannedParamHash.values()) {
+					SymbolTableEntry ste = getSymbolTableEntryForModelEntity(mathSymbolMapping, unscannedParamName);
+					if(ste == null) {
+						throw new RuntimeException("failed to retrieve vcell parameter from unscanned SEDML parameter " + unscannedParamName + " using mathSymbolMapping.");
+					}
+					Expression unscannedParamExpr = mathOverrides.getActualExpression(unscannedParamName, 0);
+					if(unscannedParamExpr.isNumeric()) {
+						// if expression is numeric, add ChangeAttribute to model created above
+						XPathTarget targetXpath = getTargetAttributeXPath(ste, l2gMap);
+						ChangeAttribute changeAttribute = new ChangeAttribute(targetXpath, unscannedParamExpr.infix());
+						sedModel.addChange(changeAttribute);
+					} else {
+						// check for any scanned parameter in unscanned parameter expression
+						String[] exprSymbols = unscannedParamExpr.getSymbols();
+						boolean bHasScannedParameter = false;
+						List<String> scannedParamNameInUnscannedParamExpList = new ArrayList<> ();
+						for (String symbol : exprSymbols) {
+							if (scannedParamHash.get(symbol) != null) {
+								bHasScannedParameter = true;
+								scannedParamNameInUnscannedParamExpList.add(new String(symbol));
+							}
+						}
+						// (scanned parameter in expr) ? (add setValue for unscanned param in repeatedTask) : (add computeChange to modifiedModel)
+						Map<String, XPathTarget> symbolToTargetMap = new LinkedHashMap<>();
+						String[] symbols = unscannedParamExpr.getSymbols();
+						for(String symbol : symbols) {
+							SymbolTableEntry entry = getSymbolTableEntryForModelEntity(mathSymbolMapping, symbol);
+							XPathTarget target = getTargetAttributeXPath(entry, l2gMap);
+							symbolToTargetMap.put(symbol, target);
+						}
+						if (bHasScannedParameter) {
+							// create setValue for unscannedParamName (which contains a scanned param in its expression)
+							SymbolTableEntry entry = getSymbolTableEntryForModelEntity(mathSymbolMapping, unscannedParamName);
+							XPathTarget target = getTargetAttributeXPath(entry, l2gMap);
+							Set<String> rangeIdSet = new HashSet<>();
+							for(String scannedParamNameInUnscannedParamExp : scannedParamNameInUnscannedParamExpList) {
+								String rangeId = scannedParamHash.get(scannedParamNameInUnscannedParamExp);
+								rangeIdSet.add(rangeId);	// all the ranges referred in the scannedParamNameInUnscannedParamExpList
+							}
+							for(String rangeId : rangeIdSet) {
+								SetValue setValue = new SetValue(target, rangeId, overriddenSimContextId);	// @TODO: we have no range??
+								Expression expr = new Expression(unscannedParamExpr);
+								for(String symbol : symbols) {
+									String symbolName = rangeId + "_" + symbol + "_" + variableCount;
+									Variable sedmlVar = new Variable(symbolName, symbolName, overriddenSimContextId, symbolToTargetMap.get(symbol).toString());	// sbmlSupport.getXPathForSpecies(symbol));
+									setValue.addVariable(sedmlVar);
+									expr.substituteInPlace(new Expression(symbol), new Expression(symbolName));
+									variableCount++;
+								}
+								ASTNode math = Libsedml.parseFormulaString(expr.infix());
+								setValue.setMath(math);
+								RepeatedTask rtRecovered = rangeToRepeatedTaskHash.get(rangeId);
+								rtRecovered.addChange(setValue);
+							}
+						} else {
+							// non-numeric expression : add 'computeChange' to modified model
+							XPathTarget targetXpath = getTargetAttributeXPath(ste, l2gMap);
+							ComputeChange computeChange = new ComputeChange(targetXpath);
+							Expression expr = new Expression(unscannedParamExpr);
+							for (String symbol : exprSymbols) {
+								String varName = overriddenSimContextId + "_" + symbol + "_" + variableCount;
+								Variable sedmlVar = new Variable(varName, varName, overriddenSimContextId, symbolToTargetMap.get(symbol).toString());
+								expr.substituteInPlace(new Expression(symbol), new Expression(varName));
+								computeChange.addVariable(sedmlVar);
+								variableCount++;
+							}
+							ASTNode math = Libsedml.parseFormulaString(expr.infix());
+							computeChange.setMath(math);
+							sedModel.addChange(computeChange);
+						}
+					}
+				}
+				sedmlModel.addModel(sedModel);
+				for(RepeatedTask rt : repeatedTasksList) {
+					sedmlModel.addTask(rt);
+				}
+			}
+		} else {						// no math overrides, add basic task.
+			String taskId = "tsk_" + simContextCnt + "_" + simCount;
+			Task sedmlTask = new Task(taskId, vcSimulation.getName(), simContextId, utcSim.getId());
+			dataGeneratorTasksSet.add(sedmlTask.getId());
+			sedmlModel.addTask(sedmlTask);
+//						taskRef = taskId;		// to be used later to add dataGenerators : one set of DGs per model (simContext).
+		}
+	}
+
+	private void writeModelVCML(String savePath, String sBaseFileName, boolean bFromCLI) throws XmlParseException, IOException {
+		String filePathStrAbsolute;
+		String filePathStrRelative;
+		//						filePathStrAbsolute = Paths.get(savePath, bioModelName + ".vcml").toString();
+		filePathStrAbsolute = Paths.get(savePath, sBaseFileName + ".vcml").toString();
+		//						filePathStrRelative = bioModelName + ".vcml";
+		filePathStrRelative = sBaseFileName + ".vcml";
+		if(!bFromCLI) {	// the vcml file is managed elsewhere when called for omex
+			String vcmlString = XmlHelper.bioModelToXML(vcBioModel);
+			XmlUtil.writeXMLStringToFile(vcmlString, filePathStrAbsolute, true);
+			sbmlFilePathStrAbsoluteList.add(filePathStrRelative);
+		}
+		String bioModelName = vcBioModel.getName();
+		sedmlModel.addModel(new Model(TokenMangler.mangleToSName(bioModelName), bioModelName, vcmlLanguageURN, filePathStrRelative));
+	}
+
+	private void writeModelSBML(String savePath, String sBaseFileName, String sbmlString, SimulationContext simContext) throws IOException {
+		String simContextName = simContext.getName();
+		String simContextId = TokenMangler.mangleToSName(simContextName);
+		//						filePathStrAbsolute = Paths.get(savePath, bioModelName + "_" + TokenMangler.mangleToSName(simContextName) + ".xml").toString();
+		String filePathStrAbsolute = Paths.get(savePath, sBaseFileName + "_" + simContextId + ".xml").toString();
+		//						filePathStrRelative = bioModelName + "_" +  TokenMangler.mangleToSName(simContextName) + ".xml";
+		String filePathStrRelative = sBaseFileName + "_" +  simContextId + ".xml";
+		XmlUtil.writeXMLStringToFile(sbmlString, filePathStrAbsolute, true);
+		sbmlFilePathStrAbsoluteList.add(filePathStrRelative);
+		sedmlModel.addModel(new Model(simContextId, simContextName, sbmlLanguageURN, filePathStrRelative));
 	}
 
 	private double getReservedSymbolValue(SymbolTableEntry ste) {
@@ -1478,6 +1521,12 @@ public class SEDMLExporter {
 	// we know exactly which files we need to archive: those in sbmlFilePathStrAbsoluteList
 	// each file is deleted after being added to archive
 	private final int BUFFER = 2048;
+
+	private int simCount;
+
+	private int overrideCount;
+
+	private SBMLSupport sbmlSupport = new SBMLSupport();
 	public boolean createZipArchive(String srcFolder, String sFileName) {
 		try {
 			BufferedInputStream origin = null;


### PR DESCRIPTION
**First**, implementing new contract for SEDML/OMEX export, based on ModelFormat choice coming from GUI or CLI:
- GUI: formats mutually exclusive
- GUI: if anything fails the operation is aborted, error pops up with information on failure
- CLI: hybrid format allowable, but must be specified, by adding another entry to ModelFormat Enumeration (to be used in the future with corresponding new option in ExportOmexCommand)
- CLI: if any Application or Simulation fails, failure is logged and the processing continues if more Applications/Simulations

In the future CLI convert should use the same structured logging as CLI execute so that we have all tasks and their exceptions in json/yml for automated parsing and reporting.

**Second**, breaking down SEDMLExporter translation monster-method into individual methods dealing with SEDML model, simulation, task, and output components.

**Third**, various cleanup here and there, including defaulting to SBML in popup and improving messaging.

**Finally**, the VCML and hybrid SBML_VCML options are just stubbed out, will write fresh later.