### PR TITLE
FunctionalRange roundtrip symbolic parameter scans

### DIFF
--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -1003,6 +1003,7 @@ public class SEDMLExporter {
 				r = new UniformRange(rangeId, constantArraySpec.getMinValue().evaluateConstant(),
 						constantArraySpec.getMaxValue().evaluateConstant(), constantArraySpec.getNumValues(), type);
 				rt.addRange(r);
+				return r;
 			} else {
 				r = new UniformRange(rangeId, 1, 2, constantArraySpec.getNumValues(), type);
 				rt.addRange(r);
@@ -1028,19 +1029,20 @@ public class SEDMLExporter {
 				ASTNode math = Libsedml.parseFormulaString(func.infix());
 				fr.setMath(math);
 				rt.addRange(fr);
+				return fr;
 			}
 		} else {
 			// ----- Vector Range
+			// we do not preserve symbolic values... could be done via FunctionalRange using piecewise expression, but too cumbersome 
 			cbit.vcell.math.Constant[] cs = constantArraySpec.getConstants();
 			ArrayList<Double> values = new ArrayList<Double>();
 			for (int i = 0; i < cs.length; i++){
-				String value = cs[i].getExpression().infix();
-				values.add(Double.parseDouble(value));
+				values.add(new Double(cs[i].getExpression().evaluateConstant()));
 			}
 			r = new VectorRange(rangeId, values);
 			rt.addRange(r);
+			return r;
 		}
-		return r;
 	}
 
 	private void writeModelVCML(String savePath, String sBaseFileName, boolean bFromCLI) throws XmlParseException, IOException {

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -1033,7 +1033,9 @@ public class SEDMLExporter {
 			}
 		} else {
 			// ----- Vector Range
-			// we do not preserve symbolic values... could be done via FunctionalRange using piecewise expression, but too cumbersome 
+			// we do not preserve symbolic values...
+			// could be done via FunctionalRange using piecewise expression, but too cumbersome
+			// plus it can't be used yet anyway, since a List scan using symbols can't be saved to VCDB
 			cbit.vcell.math.Constant[] cs = constantArraySpec.getConstants();
 			ArrayList<Double> values = new ArrayList<Double>();
 			for (int i = 0; i < cs.length; i++){


### PR DESCRIPTION
Parameter Scan overrides using symbolic expressions are roundtripped to SEDML via FunctionalRange.
- Both linear and logarithmic interval scans are supported
- List scans are not supported (they flattened), but:
  - they can't be used in the application anyway because they can't be saved to database
  - they could be supported in the future (if the ability to save is there) via piecewise functions, but it would be extremely verbose
  - probably not worth it :)

Also has some import fixes related to reserved symbol parameters.
