### PR TITLE
348 simple invalid overrides

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/AbstractMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/AbstractMathMapping.java
@@ -547,6 +547,7 @@ public static final String MATH_FUNC_SUFFIX_SPECIES_INIT_CONC_UNIT_PREFIX = "_in
 static final String MATH_FUNC_SUFFIX_SPECIES_CONCENTRATION = "";
 public static final String MATH_VAR_SUFFIX_SPECIES_COUNT = "_Count";
 public static final String MATH_FUNC_SUFFIX_SPECIES_INIT_COUNT = "_initCount";
+	public static final String MATH_FUNC_SUFFIX_SPECIES_INIT_COUNT_template_replace = "_Count_initCount";
 static final String PARAMETER_PROBABLIITY_RATE_SUFFIX = "_probabilityRate";
 static final String PARAMETER_VELOCITY_X_SUFFIX = "_velocityX";
 static final String PARAMETER_VELOCITY_Y_SUFFIX = "_velocityY";

--- a/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
@@ -126,7 +126,8 @@ import cbit.vcell.units.VCUnitDefinition;
  * 		capacitances must not be overridden and must be constant (used as literals in KVL)
  */
 public class DiffEquMathMapping extends AbstractMathMapping {
-	private static final String MATH_FUNC_SUFFIX_EVENTASSIGN_OR_RATERULE_INIT = "_protocol_init";
+	protected static final String MATH_FUNC_SUFFIX_EVENTASSIGN_OR_RATERULE_INIT = "_protocol_init";
+	protected static final String MATH_FUNC_SUFFIX_EVENTASSIGN_OR_RATERULE_INIT_old = "_init";
 	private static final String MATH_FUNC_SUFFIX_RATERULE_RATE = "_rate";
 	private static final String MATH_FUNC_SUFFIX_ASSIGNMENTRULE = "_assign";
 	public static final int PARAMETER_ROLE_TOTALMASS = 0;

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -251,6 +251,11 @@ public class SimulationContext implements SimulationOwner, Versionable, Matchabl
 					DiffEquMathMapping.MATH_FUNC_SUFFIX_SPECIES_INIT_CONCENTRATION_umol_l_1));
 			builtin_replacements.add(new SymbolReplacementTemplate(DiffEquMathMapping.MATH_FUNC_SUFFIX_SPECIES_INIT_CONCENTRATION_umol_l_1,
 					DiffEquMathMapping.MATH_FUNC_SUFFIX_SPECIES_INIT_CONCENTRATION_uM));
+
+			// test for renamed initial condition constant (changed from _initCount to _Count_initCount)
+			builtin_replacements.add(new SymbolReplacementTemplate(DiffEquMathMapping.MATH_FUNC_SUFFIX_SPECIES_INIT_COUNT,
+					DiffEquMathMapping.MATH_FUNC_SUFFIX_SPECIES_INIT_COUNT_template_replace));
+
 		}
 
 		@Override

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -256,6 +256,10 @@ public class SimulationContext implements SimulationOwner, Versionable, Matchabl
 			builtin_replacements.add(new SymbolReplacementTemplate(DiffEquMathMapping.MATH_FUNC_SUFFIX_SPECIES_INIT_COUNT,
 					DiffEquMathMapping.MATH_FUNC_SUFFIX_SPECIES_INIT_COUNT_template_replace));
 
+			// test for renamed initial condition constant for a event assignment or rate rule init (changed from _init to _protocol_init)
+			builtin_replacements.add(new SymbolReplacementTemplate(DiffEquMathMapping.MATH_FUNC_SUFFIX_EVENTASSIGN_OR_RATERULE_INIT_old,
+					DiffEquMathMapping.MATH_FUNC_SUFFIX_EVENTASSIGN_OR_RATERULE_INIT));
+
 		}
 
 		@Override

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -335,11 +335,11 @@ public class SimulationContext implements SimulationOwner, Versionable, Matchabl
 			//
 			// if not found in the previous math symbol mapping, try to repair using suffix patterns.
 			//
-			if (currentMathSymbolMapping != null) {
-				for (SymbolReplacementTemplate replacementTemplate : builtin_replacements) {
+			for (SymbolReplacementTemplate replacementTemplate : builtin_replacements) {
+				if (name.endsWith(replacementTemplate.oldNameSuffix)) {
 					String repaired_name = name.replace(replacementTemplate.oldNameSuffix, replacementTemplate.newNameSuffix);
-					Variable mathVar = currentMathSymbolMapping.findVariableByName(repaired_name);
-					if (mathVar != null) {
+					Variable mathVar = mathDesc.getVariable(repaired_name);
+					if (mathVar instanceof Constant) {
 						logger.info("replaced math override name " + name + " with " + repaired_name + " with factor " + replacementTemplate.factor + " using template pattern");
 						return new SymbolReplacement(repaired_name, new Expression(replacementTemplate.factor));
 					}


### PR DESCRIPTION
see #348  

fix legacy math overrides based on pattern matching - does not require model refactorying or complex transformations.