### PR TITLE
347 biomodel update all

### DIFF
--- a/vcell-admin/src/main/java/org/vcell/stochtest/StochtestRunService.java
+++ b/vcell-admin/src/main/java/org/vcell/stochtest/StochtestRunService.java
@@ -156,27 +156,8 @@ public class StochtestRunService {
 		    	   	}
 		    		bioModel.addSimulationContext(simContext);
 		    	}
-		    	
-		    	MathMappingCallback mathMappingCallback = new MathMappingCallback() {
-					
-					@Override
-					public void setProgressFraction(float fractionDone) {
-					}
-					
-					@Override
-					public void setMessage(String message) {
-					}
-					
-					@Override
-					public boolean isInterrupted() {
-						return false;
-					}
-				};
-				
-				MathMapping mathMapping = simContext.createNewMathMapping(mathMappingCallback, NetworkGenerationRequirements.ComputeFullStandardTimeout);
-				MathDescription mathDesc = mathMapping.getMathDescription(mathMappingCallback);
-				simContext.setMathDescription(mathDesc);
-				
+		    	simContext.updateAll(false);
+
 				if (simContext.isInsufficientIterations()){
 					networkGenProbs = "insufficientIterations";
 				} else if (simContext.isInsufficientMaxMolecules()){

--- a/vcell-admin/src/test/java/org/vcell/sbml/SbmlVcmlConverter.java
+++ b/vcell-admin/src/test/java/org/vcell/sbml/SbmlVcmlConverter.java
@@ -123,10 +123,8 @@ public static void main(String[] args) {
 				if (!bSimulate) {
 					return;
 				}
-				// Generate math for lone simContext
-				SimulationContext simContext = (SimulationContext)bioModel.getSimulationContext(0);  
-				MathDescription mathDesc = simContext.createNewMathMapping().getMathDescription();
-				simContext.setMathDescription(mathDesc);
+				bioModel.updateAll(); // generate math
+				SimulationContext simContext = (SimulationContext)bioModel.getSimulationContext(0);
 
 				// Create basic simulation, with IDA solver (set in solve method) and other defaults, and end time 'Te'
 				org.vcell.util.document.SimulationVersion simVersion = new org.vcell.util.document.SimulationVersion(

--- a/vcell-admin/src/test/java/org/vcell/sbml/SbmlVcmlConverter.java
+++ b/vcell-admin/src/test/java/org/vcell/sbml/SbmlVcmlConverter.java
@@ -123,7 +123,7 @@ public static void main(String[] args) {
 				if (!bSimulate) {
 					return;
 				}
-				bioModel.updateAll(); // generate math
+				bioModel.updateAll(true); // generate math
 				SimulationContext simContext = (SimulationContext)bioModel.getSimulationContext(0);
 
 				// Create basic simulation, with IDA solver (set in solve method) and other defaults, and end time 'Te'

--- a/vcell-admin/src/test/java/org/vcell/sbml/test/VCellSBMLSolver.java
+++ b/vcell-admin/src/test/java/org/vcell/sbml/test/VCellSBMLSolver.java
@@ -130,9 +130,9 @@ public class VCellSBMLSolver implements SBMLSolver {
 			//
 		    // select only Application, generate math, and create a single Simulation.
 			//
+			bioModel.updateAll();
 		    SimulationContext simContext = bioModel.getSimulationContext(0);
-		    MathMapping mathMapping = simContext.createNewMathMapping();
-		    MathDescription mathDesc = mathMapping.getMathDescription();
+		    MathDescription mathDesc = simContext.getMathDescription();
 		    String vcml = mathDesc.getVCML();
 		    try (PrintWriter pw = new PrintWriter("vcmlTrace.txt")) {
 		    	pw.println(vcml);
@@ -416,9 +416,9 @@ public class VCellSBMLSolver implements SBMLSolver {
 			//
 		    // select only Application, generate math, and create a single Simulation.
 			//
+			bioModel.updateAll();
 		    SimulationContext simContext = bioModel.getSimulationContext(0);
-		    MathMapping mathMapping = simContext.createNewMathMapping();
-		    MathDescription mathDesc = mathMapping.getMathDescription();
+		    MathDescription mathDesc = simContext.getMathDescription();
 		    simContext.setMathDescription(mathDesc);
 		    SimulationVersion simVersion =
 		        new SimulationVersion(

--- a/vcell-admin/src/test/java/org/vcell/sbml/test/VCellSBMLSolver.java
+++ b/vcell-admin/src/test/java/org/vcell/sbml/test/VCellSBMLSolver.java
@@ -130,7 +130,7 @@ public class VCellSBMLSolver implements SBMLSolver {
 			//
 		    // select only Application, generate math, and create a single Simulation.
 			//
-			bioModel.updateAll();
+			bioModel.updateAll(false);
 		    SimulationContext simContext = bioModel.getSimulationContext(0);
 		    MathDescription mathDesc = simContext.getMathDescription();
 		    String vcml = mathDesc.getVCML();
@@ -416,7 +416,7 @@ public class VCellSBMLSolver implements SBMLSolver {
 			//
 		    // select only Application, generate math, and create a single Simulation.
 			//
-			bioModel.updateAll();
+			bioModel.updateAll(false);
 		    SimulationContext simContext = bioModel.getSimulationContext(0);
 		    MathDescription mathDesc = simContext.getMathDescription();
 		    simContext.setMathDescription(mathDesc);

--- a/vcell-api/src/main/java/org/vcell/rest/common/SimulationRepresentation.java
+++ b/vcell-api/src/main/java/org/vcell/rest/common/SimulationRepresentation.java
@@ -11,6 +11,7 @@ import cbit.vcell.mapping.SimulationContext;
 import cbit.vcell.math.Constant;
 import cbit.vcell.math.MathDescription;
 import cbit.vcell.math.MathException;
+import cbit.vcell.math.MathSymbolTable;
 import cbit.vcell.matrix.MatrixException;
 import cbit.vcell.model.Model.ReservedSymbol;
 import cbit.vcell.model.ModelException;
@@ -129,11 +130,11 @@ public class SimulationRepresentation {
 			return null;
 		}
 		MathDescription mathDesc = simContext.getMathDescription(); // initialize to old mathDescription in case error generating math
-		MathMapping mathMapping = simContext.createNewMathMapping();
 		MathSymbolMapping mathSymbolMapping = null;
 		try {
-			mathDesc = mathMapping.getMathDescription();
-			mathSymbolMapping = mathMapping.getMathSymbolMapping();
+			simContext.updateAll(true);
+			mathDesc = simContext.getMathDescription();
+			mathSymbolMapping = (MathSymbolMapping) simContext.getMathDescription().getSourceSymbolMapping();
 		} catch (Exception e1) {
 			System.err.println(e1.getMessage());
 		}

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
@@ -298,25 +298,8 @@ public class VcmlOmexConverter {
 				try {
 					//check if all structure sizes are specified
 					scArray[i].checkValidity();
-					//
-					// compute Geometric Regions if necessary
-					//
-					cbit.vcell.geometry.surface.GeometrySurfaceDescription geoSurfaceDescription = scArray[i].getGeometry().getGeometrySurfaceDescription();
-					if (geoSurfaceDescription!=null && geoSurfaceDescription.getGeometricRegions()==null){
-						cbit.vcell.geometry.surface.GeometrySurfaceUtils.updateGeometricRegions(geoSurfaceDescription);
-					}
-					if (scArray[i].getModel() != bioModel.getModel()) {
-						throw new Exception("The BioModel's physiology doesn't match that for Application '"+scArray[i].getName()+"'");
-					}
-					//
-					// create new MathDescription
-					//
-					MathDescription math = scArray[i].createNewMathMapping().getMathDescription();
-					//
-					// load MathDescription into SimulationContext
-					// (BioModel is responsible for propagating this to all applicable Simulations).
-					//
-					scArray[i].setMathDescription(math);
+					scArray[i].updateAll(true);
+
 				} catch(Exception e) {
 					String msg = "failed to export SimulationContext "+scArray[i].getName()+": "+e.getMessage();
 					logger.error(msg, e);

--- a/vcell-client/src/main/java/cbit/vcell/client/ClientRequestManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ClientRequestManager.java
@@ -1082,19 +1082,7 @@ public class ClientRequestManager
 			@Override
 			public void run(Hashtable<String, Object> hashTable) throws Exception {
 
-				MathMappingCallback dummyCallback = new MathMappingCallback() {
-					public void setProgressFraction(float percentDone) {
-					}
-
-					public void setMessage(String message) {
-					}
-
-					public boolean isInterrupted() {
-						return false;
-					}
-				};
-				MathMapping transformedMathMapping = simContext.createNewMathMapping(dummyCallback,
-						NetworkGenerationRequirements.ComputeFullStandardTimeout);
+				MathMapping transformedMathMapping = simContext.createNewMathMapping();
 
 				BioModel newBioModel = new BioModel(null);
 				SimulationContext transformedSimContext = transformedMathMapping
@@ -1149,29 +1137,12 @@ public class ClientRequestManager
 			@Override
 			public void run(Hashtable<String, Object> hashTable) throws Exception {
 
-				MathMappingCallback dummyCallback = new MathMappingCallback() {
-					public void setProgressFraction(float percentDone) {
-					}
-
-					public void setMessage(String message) {
-					}
-
-					public boolean isInterrupted() {
-						return false;
-					}
-				};
-				MathMapping transformedMathMapping = simContext.createNewMathMapping(dummyCallback,
-						NetworkGenerationRequirements.ComputeFullStandardTimeout);
-//			simContext.setMathDescription(transformedMathMapping.getMathDescription());
+				MathMapping transformedMathMapping = simContext.createNewMathMapping();
 
 				BioModel newBioModel = new BioModel(null);
 				SimulationContext transformedSimContext = transformedMathMapping
 						.getTransformation().transformedSimContext;
 				Model model = transformedSimContext.getModel();
-
-//			for(ReactionStep rs : model.getReactionSteps()) {
-//				model.removeReactionStep(rs);
-//			}
 
 				newBioModel.setModel(model);
 
@@ -3875,34 +3846,16 @@ public class ClientRequestManager
 					BioModel bioModel = (BioModel) doc;
 					SimulationContext simulationContext = bioModel.getSimulationContext(0);
 					simulationContext.setName(BMDB_DEFAULT_APPLICATION);
-					MathMappingCallback callback = new MathMappingCallback() {
-						@Override
-						public void setProgressFraction(float fractionDone) {
-						}
-
-						@Override
-						public void setMessage(String message) {
-						}
-
-						@Override
-						public boolean isInterrupted() {
-							return false;
-						}
-					};
-					MathMapping mathMapping = simulationContext.createNewMathMapping(callback,
-							NetworkGenerationRequirements.ComputeFullNoTimeout);
-					MathDescription mathDesc = null;
 					try {
-						mathDesc = mathMapping.getMathDescription(callback);
-						simulationContext.setMathDescription(mathDesc);
+						simulationContext.updateAll(false);
+						MathDescription mathDesc = simulationContext.getMathDescription();
 
 						Simulation sim = new Simulation(mathDesc);
 						sim.setName(simulationContext.getBioModel().getFreeSimulationName());
 						simulationContext.addSimulation(sim);
 						bioModel.refreshDependencies();
 
-					} catch (MappingException | MathException | MatrixException | ExpressionException
-							| ModelException e1) {
+					} catch (MappingException e1) {
 						e1.printStackTrace();
 					}
 					hashTable.put("doc", doc);

--- a/vcell-client/src/main/java/cbit/vcell/client/TestingFrameworkWindowManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/TestingFrameworkWindowManager.java
@@ -367,31 +367,10 @@ public String addTestCases(final TestSuiteInfoNew tsInfo, final TestCaseNew[] te
 									}
 								}
 							}
+							bioModel.updateAll(true);
 							SimulationContext[] simContexts = bioModel.getSimulationContexts();
 							for (int j = 0; j < simContexts.length; j++){
 								simContexts[j].clearVersion();
-								GeometrySurfaceDescription gsd = simContexts[j].getGeometry().getGeometrySurfaceDescription();
-								if(gsd != null){
-									GeometricRegion[] grArr = gsd.getGeometricRegions();
-									if(grArr == null){
-										gsd.updateAll();
-									}
-								}
-								MathMapping mathMapping = simContexts[j].createNewMathMapping();
-
-								// for older models that do not have absolute compartment sizes set, but have relative sizes (SVR/VF); or if there is only one compartment with size not set,
-								// compute absolute compartment sizes using relative sizes and assuming a default value of '1' for one of the compartments.
-								// Otherwise, the math generation will fail, since for the relaxed topology (VCell 5.3 and later) absolute compartment sizes are required.
-								GeometryContext gc = simContexts[j].getGeometryContext();
-								if (simContexts[j].getGeometry().getDimension() == 0 &&
-										((gc.isAllSizeSpecifiedNull() && !gc.isAllVolFracAndSurfVolSpecifiedNull()) || (gc.getModel().getStructures().length == 1 && gc.isAllSizeSpecifiedNull())) ) {
-									// choose the first structure in model and set its size to '1'.
-									Structure struct = simContexts[j].getModel().getStructure(0);
-									double structSize = 1.0;
-									StructureSizeSolver.updateAbsoluteStructureSizes(simContexts[j], struct, structSize, struct.getStructureSize().getUnitDefinition());
-								}
-
-								simContexts[j].setMathDescription(mathMapping.getMathDescription());
 							}
 							Simulation[] sims = bioModel.getSimulations();
 							String[] simNames = new String[sims.length];

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/simulation/OutputFunctionsListTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/simulation/OutputFunctionsListTableModel.java
@@ -211,18 +211,10 @@ public void propertyChange(java.beans.PropertyChangeEvent evt) {
 		AsynchClientTask task0 = new AsynchClientTask("Renaming Functions", AsynchClientTask.TASKTYPE_NONSWING_BLOCKING, false, false) {
 			@Override
 			public void run(Hashtable<String, Object> hashTable) throws Exception {
-				MathMappingCallback callback = new MathMappingCallback() {
-					@Override
-					public void setProgressFraction(float fractionDone) { }
-					@Override
-					public void setMessage(String message) { }
-					@Override
-					public boolean isInterrupted() { return false; }
-				};
-				MathMapping mathMapping = simulationContext.createNewMathMapping(callback, NetworkGenerationRequirements.ComputeFullNoTimeout);
+				MathMapping mathMapping = simulationContext.createNewMathMapping();
 				MathDescription mathDesc = null;
 				try {
-					mathDesc = mathMapping.getMathDescription(callback);
+					mathDesc = mathMapping.getMathDescription();
 				} catch (MappingException | MathException | MatrixException | ExpressionException | ModelException e1) {
 					e1.printStackTrace();
 				}

--- a/vcell-core/src/main/java/cbit/vcell/biomodel/BioModel.java
+++ b/vcell-core/src/main/java/cbit/vcell/biomodel/BioModel.java
@@ -17,7 +17,11 @@ import java.beans.VetoableChangeSupport;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import cbit.vcell.mapping.StructureMapping;
+import cbit.vcell.mapping.*;
+import cbit.vcell.math.MathException;
+import cbit.vcell.matrix.MatrixException;
+import cbit.vcell.model.*;
+import cbit.vcell.parser.ExpressionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vcell.model.rbm.MolecularType;
@@ -47,21 +51,8 @@ import cbit.vcell.biomodel.meta.IdentifiableProvider;
 import cbit.vcell.biomodel.meta.VCID;
 import cbit.vcell.biomodel.meta.VCMetaData;
 import cbit.vcell.geometry.Geometry;
-import cbit.vcell.mapping.ReactionSpec;
-import cbit.vcell.mapping.SimulationContext;
-import cbit.vcell.mapping.SpeciesContextSpec;
 import cbit.vcell.math.MathDescription;
-import cbit.vcell.model.BioModelEntityObject;
-import cbit.vcell.model.Model;
 import cbit.vcell.model.Model.RbmModelContainer;
-import cbit.vcell.model.ModelUnitSystem;
-import cbit.vcell.model.RbmObservable;
-import cbit.vcell.model.ReactionRule;
-import cbit.vcell.model.ReactionStep;
-import cbit.vcell.model.Species;
-import cbit.vcell.model.SpeciesContext;
-import cbit.vcell.model.Structure;
-import cbit.vcell.model.VCellSbmlName;
 import cbit.vcell.parser.NameScope;
 import cbit.vcell.parser.SymbolTableEntry;
 import cbit.vcell.solver.Simulation;
@@ -1391,4 +1382,10 @@ public String getDisplayType() {
 	return typeName;
 }
 
+public void updateAll(boolean bForceUpgrade) throws MappingException {
+	refreshDependencies();
+	for (SimulationContext simulationContext : getSimulationContexts()){
+		simulationContext.updateAll(bForceUpgrade);
+	}
+}
 }

--- a/vcell-core/src/main/java/cbit/vcell/modelopt/ModelOptimizationMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/modelopt/ModelOptimizationMapping.java
@@ -111,12 +111,6 @@ public void applySolutionToMathOverrides(Simulation simulation, OptimizationResu
 }
 
 
-/**
- * Insert the method's description here.
- * Creation date: (8/22/2005 9:26:52 AM)
- * @return cbit.vcell.opt.OptimizationSpec
- * @param modelOptimizationSpec cbit.vcell.modelopt.ModelOptimizationSpec
- */
 MathSymbolMapping computeOptimizationSpec() throws MathException, MappingException {
 
 	if (getModelOptimizationSpec().getReferenceData()==null){
@@ -264,42 +258,21 @@ MathSymbolMapping computeOptimizationSpec() throws MathException, MappingExcepti
 }
 
 
-/**
- * Insert the method's description here.
- * Creation date: (8/25/2005 10:32:23 AM)
- * @return cbit.vcell.modelopt.ModelOptimizationSpec
- */
 public ModelOptimizationSpec getModelOptimizationSpec() {
 	return modelOptimizationSpec;
 }
 
 
-/**
- * Insert the method's description here.
- * Creation date: (8/22/2005 9:26:52 AM)
- * @return cbit.vcell.opt.OptimizationSpec
- * @param modelOptimizationSpec cbit.vcell.modelopt.ModelOptimizationSpec
- */
 public OptimizationSpec getOptimizationSpec() {
 	return optimizationSpec;
 }
 
 
-/**
- * Insert the method's description here.
- * Creation date: (8/25/2005 10:26:34 AM)
- * @return cbit.vcell.modelopt.ParameterMapping[]
- */
 public ParameterMapping[] getParameterMappings() {
 	return parameterMappings;
 }
 
 
-/**
- * Gets the constraintData property (cbit.vcell.opt.ConstraintData) value.
- * @return The constraintData property value.
- * @see #setConstraintData
- */
 private ReferenceData getRemappedReferenceData(MathMapping mathMapping) throws MappingException {
 	if (modelOptimizationSpec.getReferenceData()==null){
 		return null;

--- a/vcell-core/src/main/java/cbit/vcell/modelopt/ModelOptimizationSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/modelopt/ModelOptimizationSpec.java
@@ -509,12 +509,6 @@ public void removeUncoupledParameters() {
 }
 
 
-/**
- * Insert the method's description here.
- * Creation date: (5/5/2006 5:18:19 PM)
- * @return cbit.vcell.modelopt.ParameterMappingSpec
- * @param parameter cbit.vcell.model.Parameter
- */
 public ParameterMappingSpec getParameterMappingSpec(String parameterName) {
 	for (int i = 0;fieldParameterMappingSpecs!=null && i < fieldParameterMappingSpecs.length; i++){
 		if (fieldParameterMappingSpecs[i].getModelParameter().getName().equals(parameterName)){
@@ -543,11 +537,6 @@ private ParameterMappingSpec getParameterMappingSpecByCompareEqual(Parameter par
 	return null;
 }
 
-/**
- * Gets the parameterMapping property (cbit.vcell.modelopt.ParameterMapping[]) value.
- * @return The parameterMapping property value.
- * @see #setParameterMapping
- */
 public ParameterMappingSpec[] getParameterMappingSpecs() {
 	return fieldParameterMappingSpecs;
 }
@@ -564,11 +553,6 @@ protected java.beans.PropertyChangeSupport getPropertyChange() {
 }
 
 
-/**
- * Gets the constraintData property (cbit.vcell.opt.ConstraintData) value.
- * @return The constraintData property value.
- * @see #setConstraintData
- */
 public ReferenceData getReferenceData() {
 	return fieldReferenceData;
 }
@@ -599,11 +583,6 @@ public ReferenceDataMappingSpec[] getReferenceDataMappingSpecs() {
 }
 
 
-/**
- * Gets the simulationContext property (cbit.vcell.mapping.SimulationContext) value.
- * @return The simulationContext property value.
- * @see #setSimulationContext
- */
 public SimulationContext getSimulationContext() {
 	return parameterEstimationTask.getSimulationContext();
 }
@@ -789,12 +768,6 @@ public synchronized void removeVetoableChangeListener(java.lang.String propertyN
 }
 
 
-/**
- * Sets the parameterMapping property (cbit.vcell.modelopt.ParameterMapping[]) value.
- * @param parameterMapping The new value for the property.
- * @exception java.beans.PropertyVetoException The exception description.
- * @see #getParameterMapping
- */
 public void setParameterMappingSpecs(ParameterMappingSpec[] parameterMappingSpecs) throws java.beans.PropertyVetoException {
 	ParameterMappingSpec[] oldValue = fieldParameterMappingSpecs;
 	fireVetoableChange("parameterMappingSpecs", oldValue, parameterMappingSpecs);
@@ -803,11 +776,6 @@ public void setParameterMappingSpecs(ParameterMappingSpec[] parameterMappingSpec
 }
 
 
-/**
- * Sets the constraintData property (cbit.vcell.opt.ConstraintData) value.
- * @param constraintData The new value for the property.
- * @see #getConstraintData
- */
 public void setReferenceData(ReferenceData referenceData) {
 	ReferenceData oldValue = fieldReferenceData;
 	fieldReferenceData = referenceData;
@@ -818,11 +786,6 @@ public void setReferenceData(ReferenceData referenceData) {
 }
 
 
-/**
- * Sets the referenceDataMappingSpecs property (cbit.vcell.modelopt.ReferenceDataMappingSpec[]) value.
- * @param referenceDataMappingSpecs The new value for the property.
- * @see #getReferenceDataMappingSpecs
- */
 private void setReferenceDataMappingSpecs(ReferenceDataMappingSpec[] referenceDataMappingSpecs) {
 	ReferenceDataMappingSpec[] oldValue = fieldReferenceDataMappingSpecs;
 	fieldReferenceDataMappingSpecs = referenceDataMappingSpecs;

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
@@ -1658,6 +1658,7 @@ private void roundTripValidation() throws SBMLValidationException {
 				Files.write(Paths.get(outputDir, "orig_vcml.xml"), XmlHelper.bioModelToXML(bioModel, false).getBytes(StandardCharsets.UTF_8));
 			}
 			if (reread_BioModel_sbml_units != null) {
+				reread_BioModel_sbml_units.updateAll(false);
 				Files.write(Paths.get(outputDir, "reread_vcml_sbml_units.xml"), XmlHelper.bioModelToXML(reread_BioModel_sbml_units, false).getBytes(StandardCharsets.UTF_8));
 			}
 			if (reread_BioModel_vcell_units != null) {

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
@@ -1581,9 +1581,7 @@ private void roundTripValidation() throws SBMLValidationException {
 		bioModel.refreshDependencies();
 		// for cloned biomodel/simcontext, force no mass conservation and regenerate math for later comparison.
 		bioModel.getSimulationContext(0).setUsingMassConservationModelReduction(false);
-		MathMapping mathMapping = bioModel.getSimulationContext(0).createNewMathMapping();
-		bioModel.getSimulationContext(0).setMathDescription(mathMapping.getMathDescription());
-
+		bioModel.getSimulationContext(0).updateAll(false);
 
 		//
 		// reimport the recently exported SBML model as a BioModel (still with SBML units)
@@ -1634,9 +1632,7 @@ private void roundTripValidation() throws SBMLValidationException {
 				SimulationContext newSimulationContext = SimulationContext.copySimulationContext(simulationContextToReplace, simContextName, bSpatial_original, applicationType_original);
 				newSimulationContext.getGeometry().precomputeAll(new GeometryThumbnailImageFactoryAWT());
 				reread_BioModel_vcell_units.setSimulationContexts(new SimulationContext[] { newSimulationContext });
-				reread_BioModel_vcell_units.refreshDependencies();
-				MathMapping newMathMapping = newSimulationContext.createNewMathMapping();
-				newSimulationContext.setMathDescription(newMathMapping.getMathDescription());
+				reread_BioModel_vcell_units.updateAll(false);
 			}
 
 			MathDescription origMathDescription = bioModel.getSimulationContext(0).getMathDescription();

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLImporter.java
@@ -731,9 +731,7 @@ public class SEDMLImporter {
 				bioModel = (BioModel)sbmlImporter.getBioModel();
 				bioModel.setName(bioModelName);
 				bioModel.getSimulationContext(0).setName(mm.getName());
-				MathDescription math = bioModel.getSimulationContext(0).createNewMathMapping().getMathDescription();
-				bioModel.getSimulationContext(0).setMathDescription(math);
-				bioModel.refreshDependencies();			
+				bioModel.updateAll(false);
 				docs.add(bioModel);
 				importMap.put(bioModel, sbmlImporter);
 			}

--- a/vcell-core/src/test/java/cbit/vcell/biomodel/BioModelTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/biomodel/BioModelTest.java
@@ -42,9 +42,8 @@ public static BioModel getExample() throws Exception {
 	bioModel.getModel().setName("physiology_"+Integer.toHexString(((new Random()).nextInt())));
 	SimulationContext sc2 = new SimulationContext(bioModel.getModel(),new Geometry("0-D Geometry_"+Integer.toHexString(((new Random()).nextInt())),0));
 	sc2.setName("simContext2_"+Integer.toHexString(((new Random()).nextInt())));
-	sc1.setMathDescription(sc1.createNewMathMapping().getMathDescription());
-	sc2.setMathDescription(sc2.createNewMathMapping().getMathDescription());
 	bioModel.setSimulationContexts(new SimulationContext[] { sc1, sc2 });
+	bioModel.updateAll(false);
 
 	//
 	// add simulations (must be after 
@@ -108,7 +107,7 @@ public static BioModel getExampleWithImage() throws Exception {
 	bioModel.setSimulationContexts(new SimulationContext[] { /*sc1,*/ sc2 });
 	sc2.setName("simContext2_"+Integer.toHexString(((new Random()).nextInt())));
 //	sc1.setMathDescription(sc1.createNewMathMapping().getMathDescription());
-	sc2.setMathDescription(sc2.createNewMathMapping().getMathDescription());
+	bioModel.updateAll(false);
 
 	//
 	// add simulations (must be after 

--- a/vcell-core/src/test/java/cbit/vcell/biomodel/ModelCountAndConcentrationTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/biomodel/ModelCountAndConcentrationTest.java
@@ -30,8 +30,8 @@ public class ModelCountAndConcentrationTest {
         BioModel bioModel_stoch_init_concentration = getBioModelFromResource("ExportScanTest2_stoch_concentration.vcml");
 
         BioModel expected_bioModel_stoch_init_count = getBioModelFromResource("ExportScanTest2_stoch_count.vcml");
-        expected_bioModel_stoch_init_count.refreshDependencies();
-        MathDescription expectedMathDescription = expected_bioModel_stoch_init_count.getSimulationContext(0).createNewMathMapping().getMathDescription();
+        expected_bioModel_stoch_init_count.updateAll(false);
+        MathDescription expectedMathDescription = expected_bioModel_stoch_init_count.getSimulationContext(0).getMathDescription();
 
         SimulationContext stoch_app = bioModel_stoch_init_concentration.getSimulationContext("stoch app");
         stoch_app.setUsingConcentration(false, true);
@@ -57,8 +57,8 @@ public class ModelCountAndConcentrationTest {
         BioModel bioModel_stoch_init_concentration = getBioModelFromResource("ExportScanTest2_stoch_concentration.vcml");
 
         BioModel expected_bioModel_stoch_init_count = getBioModelFromResource("ExportScanTest2_stoch_count.vcml");
-        expected_bioModel_stoch_init_count.refreshDependencies();
-        MathDescription expectedMathDescription = expected_bioModel_stoch_init_count.getSimulationContext(0).createNewMathMapping().getMathDescription();
+        expected_bioModel_stoch_init_count.updateAll(false);
+        MathDescription expectedMathDescription = expected_bioModel_stoch_init_count.getSimulationContext(0).getMathDescription();
 
         SimulationContext stoch_app = bioModel_stoch_init_concentration.getSimulationContext("stoch app");
         stoch_app.setUsingConcentration(false, false);
@@ -77,8 +77,8 @@ public class ModelCountAndConcentrationTest {
         BioModel bioModel_stoch_init_count = getBioModelFromResource("ExportScanTest2_stoch_count.vcml");
 
         BioModel expected_bioModel_stoch_init_concentration = getBioModelFromResource("ExportScanTest2_stoch_concentration.vcml");
-        expected_bioModel_stoch_init_concentration.refreshDependencies();
-        MathDescription expectedMathDescription = expected_bioModel_stoch_init_concentration.getSimulationContext(0).createNewMathMapping().getMathDescription();
+        expected_bioModel_stoch_init_concentration.updateAll(false);
+        MathDescription expectedMathDescription = expected_bioModel_stoch_init_concentration.getSimulationContext(0).getMathDescription();
 
         SimulationContext stoch_app = bioModel_stoch_init_count.getSimulationContext("stoch app");
         stoch_app.setUsingConcentration(true, true);
@@ -104,8 +104,7 @@ public class ModelCountAndConcentrationTest {
         BioModel bioModel_stoch_init_count = getBioModelFromResource("ExportScanTest2_stoch_count.vcml");
 
         BioModel expected_bioModel_stoch_init_concentration = getBioModelFromResource("ExportScanTest2_stoch_concentration.vcml");
-        expected_bioModel_stoch_init_concentration.refreshDependencies();
-        MathDescription expectedMathDescription = expected_bioModel_stoch_init_concentration.getSimulationContext(0).createNewMathMapping().getMathDescription();
+        expected_bioModel_stoch_init_concentration.updateAll(false);
 
         SimulationContext stoch_app = bioModel_stoch_init_count.getSimulationContext("stoch app");
         stoch_app.setUsingConcentration(true, false);

--- a/vcell-server/src/test/java/cbit/vcell/mapping/MathGenerationHashVisitor.java
+++ b/vcell-server/src/test/java/cbit/vcell/mapping/MathGenerationHashVisitor.java
@@ -23,6 +23,7 @@ public class MathGenerationHashVisitor implements VCDatabaseVisitor {
 
 	private static PrintStream mathGenHashStream = null;
 
+	@Override
 	public boolean filterBioModel(BioModelInfo bioModelInfo) {
 		if (bioModelInfo.getVersion().getOwner().getName().equals("schaff")){
 			return true;
@@ -30,6 +31,7 @@ public class MathGenerationHashVisitor implements VCDatabaseVisitor {
 		return false;
 	}
 
+	@Override
 	public void visitBioModel(BioModel bioModel, PrintStream logFilePrintStream) {
 		try {
 			logFilePrintStream.println(bioModel.getVersion().getName()+"  "+bioModel.getVersion().getDate()+"  "+bioModel.getVersion().getVersionKey());
@@ -80,17 +82,21 @@ public class MathGenerationHashVisitor implements VCDatabaseVisitor {
 	    return result;
 	}
 
+	@Override
 	public boolean filterGeometry(GeometryInfo geometryInfo) {
 		return false;
 	}
 
+	@Override
 	public void visitGeometry(Geometry geometry, PrintStream logFilePrintStream) {
 	}
 
+	@Override
 	public boolean filterMathModel(MathModelInfo mathModelInfo) {
 		return false;
 	}
 
+	@Override
 	public void visitMathModel(MathModel mathModel, PrintStream logFilePrintStream) {
 	}
 


### PR DESCRIPTION
see #347 

limited simplification SimulationContext update steps - introduced BioModel.updateAll(boolean bForceUpdate) and SimulationContext.updateAll(boolean bForceUpdate).  This limited the exposure to SimulationContext.createNewMathMapping() by maybe 10-20%.  

It turns out that the majority of independent invocations of SimulationContext.createNewMathMapping() related to

1.  Swing/non-Swing threading
2. required access to the most current MathSymbolMapping
3. Customization of the process (e.g. VirtualFrap generates math and then adds to it).