### PR TITLE
new default SBML-compatible unit system nmol, l, dm2, dm

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/biomodel/ModelUnitConverter.java
+++ b/vcell-core/src/main/java/cbit/vcell/biomodel/ModelUnitConverter.java
@@ -22,13 +22,13 @@ public class ModelUnitConverter {
 	private final static Logger logger = LogManager.getLogger(ModelUnitConverter.class);
 
 	public static ModelUnitSystem createSbmlModelUnitSystem() {
-		final String substanceUnit = "uM.um3";
+		final String substanceUnit = "nmol";
 		String volumeSubstanceSymbol = substanceUnit;
 		String membraneSubstanceSymbol = substanceUnit;
 		String lumpedReactionSubstanceSymbol = substanceUnit;
-		String volumeSymbol = "um3";
-		String areaSymbol = "um2";
-		String lengthSymbol = "um";
+		String volumeSymbol = "l";
+		String areaSymbol = "dm2";
+		String lengthSymbol = "dm";
 		String timeSymbol = "s";
 		ModelUnitSystem mus = ModelUnitSystem.createVCModelUnitSystem(volumeSubstanceSymbol, membraneSubstanceSymbol, lumpedReactionSubstanceSymbol, volumeSymbol, areaSymbol, lengthSymbol, timeSymbol);
 		return mus;

--- a/vcell-core/src/test/java/cbit/vcell/biomodel/ModelUnitConverterTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/biomodel/ModelUnitConverterTest.java
@@ -13,6 +13,9 @@ import cbit.vcell.parser.ExpressionException;
 import cbit.vcell.solver.MathOverrides;
 import cbit.vcell.solver.Simulation;
 import cbit.vcell.solver.SimulationSymbolTable;
+import cbit.vcell.units.UnitSystemProvider;
+import cbit.vcell.units.VCUnitDefinition;
+import cbit.vcell.units.VCUnitSystem;
 import cbit.vcell.xml.XMLSource;
 import cbit.vcell.xml.XmlHelper;
 import cbit.vcell.xml.XmlParseException;
@@ -31,14 +34,15 @@ import java.util.Map;
 public class ModelUnitConverterTest {
 
     @Test
-    public void test_VCell_to_SBML_conversion() throws IOException, XmlParseException, ExpressionException, MatrixException, ModelException, MathException, MappingException {
+    public void test_VCell_to_SBML_conversion_uM_um3() throws IOException, XmlParseException, ExpressionException, MatrixException, ModelException, MathException, MappingException {
         BioModel bioModel_vcellUnits = getBioModelFromResource("MathOverrides_UnitSystem_vcell_units.vcml");
 
         BioModel expected_bioModel_sbmlUnts = getBioModelFromResource("MathOverrides_UnitSystem_sbml_units.vcml");
         expected_bioModel_sbmlUnts.refreshDependencies();
         MathDescription expectedMathDescription = expected_bioModel_sbmlUnts.getSimulationContext(0).createNewMathMapping().getMathDescription();
 
-        BioModel bioModel_sbmlUnits = ModelUnitConverter.createBioModelWithSBMLUnitSystem(bioModel_vcellUnits);
+        ModelUnitSystem modelUnitSystem = getModelUnitSystem_SBML_uM_um3();
+        BioModel bioModel_sbmlUnits = ModelUnitConverter.createBioModelWithNewUnitSystem(bioModel_vcellUnits, modelUnitSystem);
         MathDescription mathDescription = bioModel_sbmlUnits.getSimulationContext(0).getMathDescription();
 
         //
@@ -99,7 +103,90 @@ public class ModelUnitConverterTest {
     }
 
     @Test
-    public void test_VCell_to_SBML_conversion_same_name_overrides() throws IOException, XmlParseException, ExpressionException, MatrixException, ModelException, MathException, MappingException {
+    public void test_VCell_to_SBML_conversion_overrides_uM_um3() throws IOException, XmlParseException, ExpressionException, MatrixException, ModelException, MathException, MappingException {
+        BioModel bioModel_vcellUnits = getBioModelFromResource("BioModel_overrides_std_units.vcml");
+        {
+            Simulation sim = bioModel_vcellUnits.getSimulation(0);
+            MathOverrides mathOverrides = sim.getMathOverrides();
+
+            LinkedHashMap<String, OverrideInfo> expectedVCUnits = new LinkedHashMap<>();
+            expectedVCUnits.put("Kf_r0", new OverrideInfo("Kf_r0", "um2.s-1.molecules-1", new Expression(5.0), new Expression(21.0)));
+            expectedVCUnits.put("Kf_r1", new OverrideInfo("Kf_r1", "s-1", new Expression(3.0), new Expression(22.0)));
+            expectedVCUnits.put("Kr_r0", new OverrideInfo("Kr_r0", "s-1", new Expression(7.0), new Expression(23.0)));
+            expectedVCUnits.put("Kr_r1", new OverrideInfo("Kr_r1", "s-1", new Expression(8.0), new Expression(24.0)));
+            expectedVCUnits.put("s0_init_molecules_um_2", new OverrideInfo("s0_init_molecules_um_2", "molecules.um-2", new Expression(3.0), new Expression(11.0)));
+            expectedVCUnits.put("s1_init_molecules_um_2", new OverrideInfo("s1_init_molecules_um_2", "molecules.um-2", new Expression(4.0), new Expression(12.0)));
+            expectedVCUnits.put("s2_init_molecules_um_2", new OverrideInfo("s2_init_molecules_um_2", "molecules.um-2", new Expression(5.0), new Expression(13.0)));
+            expectedVCUnits.put("s3_init_uM", new OverrideInfo("s3_init_uM", "uM", new Expression(1.0), new Expression(14.0)));
+            expectedVCUnits.put("s4_init_uM", new OverrideInfo("s3_init_uM", "uM", new Expression(2.0), new Expression(15.0)));
+
+            MathOverrides expectedMathOverrides = new MathOverrides(sim);
+            for (Map.Entry<String, OverrideInfo> entry : expectedVCUnits.entrySet()) {
+                expectedMathOverrides.putConstant(new Constant(entry.getKey(), entry.getValue().overrideExp));
+            }
+            boolean equiv = expectedMathOverrides.compareEqual(mathOverrides);
+            if (!equiv) {
+                for (String c : expectedMathOverrides.getOverridenConstantNames()) {
+                    Constant constant = expectedMathOverrides.getConstant(c);
+                    System.out.println("expected: " + constant.getName() + "=" + constant.getExpression().infix());
+                }
+                for (String c : mathOverrides.getOverridenConstantNames()) {
+                    Constant constant = mathOverrides.getConstant(c);
+                    System.out.println("parsed: " + constant.getName() + "=" + constant.getExpression().infix());
+                }
+            }
+            Assert.assertTrue("expected math overrides to match", equiv);
+        }
+        ModelUnitSystem modelUnitSystem = getModelUnitSystem_SBML_uM_um3();
+        BioModel bioModel_sbmlUnits = ModelUnitConverter.createBioModelWithNewUnitSystem(bioModel_vcellUnits, modelUnitSystem);
+        {
+            Simulation sim = bioModel_sbmlUnits.getSimulation(0);
+            MathOverrides mathOverrides = sim.getMathOverrides();
+
+            LinkedHashMap<String, OverrideInfo> expectedVCUnits = new LinkedHashMap<>();
+            expectedVCUnits.put("Kf_r0", new OverrideInfo("Kf_r0", "um2.s-1.molecules-1", new Expression("5.0 / KMOLE"), new Expression("21.0 / KMOLE")));
+            expectedVCUnits.put("Kf_r1", new OverrideInfo("Kf_r1", "s-1", new Expression(3.0), new Expression(22.0)));
+            expectedVCUnits.put("Kr_r0", new OverrideInfo("Kr_r0", "s-1", new Expression(7.0), new Expression(23.0)));
+            expectedVCUnits.put("Kr_r1", new OverrideInfo("Kr_r1", "s-1", new Expression(8.0), new Expression(24.0)));
+            expectedVCUnits.put("s0_init_uM_um", new OverrideInfo("s0_init_uM_um", "uM", new Expression("3.0 * KMOLE"), new Expression("11.0 * KMOLE")));
+            expectedVCUnits.put("s1_init_uM_um", new OverrideInfo("s1_init_uM_um", "uM", new Expression("4.0 * KMOLE"), new Expression("12.0 * KMOLE")));
+            expectedVCUnits.put("s2_init_uM_um", new OverrideInfo("s2_init_uM_um", "uM", new Expression("5.0 * KMOLE"), new Expression("13.0 * KMOLE")));
+            expectedVCUnits.put("s3_init_uM", new OverrideInfo("s3_init_uM", "uM", new Expression(1.0), new Expression(14.0)));
+            expectedVCUnits.put("s4_init_uM", new OverrideInfo("s3_init_uM", "uM", new Expression(2.0), new Expression(15.0)));
+
+            MathOverrides expectedMathOverrides = new MathOverrides(sim);
+            for (Map.Entry<String, OverrideInfo> entry : expectedVCUnits.entrySet()) {
+                expectedMathOverrides.putConstant(new Constant(entry.getKey(), entry.getValue().overrideExp));
+            }
+            boolean equiv = expectedMathOverrides.compareEqual(mathOverrides);
+            if (!equiv) {
+                for (String c : expectedMathOverrides.getOverridenConstantNames()) {
+                    Constant constant = expectedMathOverrides.getConstant(c);
+                    System.out.println("expected: " + constant.getName() + "=" + constant.getExpression().infix());
+                }
+                for (String c : mathOverrides.getOverridenConstantNames()) {
+                    Constant constant = mathOverrides.getConstant(c);
+                    System.out.println("parsed: " + constant.getName() + "=" + constant.getExpression().infix());
+                }
+            }
+            Assert.assertTrue("expected math overrides to match", equiv);
+        }
+
+    }
+
+    private ModelUnitSystem getModelUnitSystem_SBML_uM_um3() {
+        VCUnitSystem tempUnitSystem = new VCUnitSystem() {};
+        VCUnitDefinition substanceUnit = tempUnitSystem.getInstance("uM.um3");
+        VCUnitDefinition volumeUnit = tempUnitSystem.getInstance("um3");
+        VCUnitDefinition areaUnit = tempUnitSystem.getInstance("um2");
+        VCUnitDefinition lengthUnit = tempUnitSystem.getInstance("um");
+        VCUnitDefinition timeUnit = tempUnitSystem.getInstance("s");
+        ModelUnitSystem modelUnitSystem = ModelUnitSystem.createSBMLUnitSystem(substanceUnit, volumeUnit, areaUnit, lengthUnit, timeUnit);
+        return modelUnitSystem;
+    }
+
+    @Test
+    public void test_VCell_to_SBML_conversion_overrides_default_SBML() throws IOException, XmlParseException, ExpressionException, MatrixException, ModelException, MathException, MappingException {
         BioModel bioModel_vcellUnits = getBioModelFromResource("BioModel_overrides_std_units.vcml");
         {
             Simulation sim = bioModel_vcellUnits.getSimulation(0);
@@ -139,15 +226,15 @@ public class ModelUnitConverterTest {
             MathOverrides mathOverrides = sim.getMathOverrides();
 
             LinkedHashMap<String, OverrideInfo> expectedVCUnits = new LinkedHashMap<>();
-            expectedVCUnits.put("Kf_r0", new OverrideInfo("Kf_r0", "um2.s-1.molecules-1", new Expression("5.0 / KMOLE"), new Expression("21.0 / KMOLE")));
+            expectedVCUnits.put("Kf_r0", new OverrideInfo("Kf_r0", "um2.s-1.molecules-1", new Expression("500.0 / KMOLE"), new Expression("2100.0 / KMOLE")));
             expectedVCUnits.put("Kf_r1", new OverrideInfo("Kf_r1", "s-1", new Expression(3.0), new Expression(22.0)));
             expectedVCUnits.put("Kr_r0", new OverrideInfo("Kr_r0", "s-1", new Expression(7.0), new Expression(23.0)));
             expectedVCUnits.put("Kr_r1", new OverrideInfo("Kr_r1", "s-1", new Expression(8.0), new Expression(24.0)));
-            expectedVCUnits.put("s0_init_uM_um", new OverrideInfo("s0_init_uM_um", "uM", new Expression("3.0 * KMOLE"), new Expression("11.0 * KMOLE")));
-            expectedVCUnits.put("s1_init_uM_um", new OverrideInfo("s1_init_uM_um", "uM", new Expression("4.0 * KMOLE"), new Expression("12.0 * KMOLE")));
-            expectedVCUnits.put("s2_init_uM_um", new OverrideInfo("s2_init_uM_um", "uM", new Expression("5.0 * KMOLE"), new Expression("13.0 * KMOLE")));
-            expectedVCUnits.put("s3_init_uM", new OverrideInfo("s3_init_uM", "uM", new Expression(1.0), new Expression(14.0)));
-            expectedVCUnits.put("s4_init_uM", new OverrideInfo("s3_init_uM", "uM", new Expression(2.0), new Expression(15.0)));
+            expectedVCUnits.put("s0_init_nmol_dm_2", new OverrideInfo("s0_init_nmol_dm_2", "nmol/l", new Expression("0.03 * KMOLE"), new Expression("0.11 * KMOLE")));
+            expectedVCUnits.put("s1_init_nmol_dm_2", new OverrideInfo("s1_init_nmol_dm_2", "nmol/l", new Expression("0.04 * KMOLE"), new Expression("0.12 * KMOLE")));
+            expectedVCUnits.put("s2_init_nmol_dm_2", new OverrideInfo("s2_init_nmol_dm_2", "nmol/l", new Expression("0.05 * KMOLE"), new Expression("0.13 * KMOLE")));
+            expectedVCUnits.put("s3_init_nmol_l_1", new OverrideInfo("s3_init_nmol_l_1", "nmol/l", new Expression(1000.0), new Expression(14000.0)));
+            expectedVCUnits.put("s4_init_nmol_l_1", new OverrideInfo("s4_init_nmol_l_1", "nmol/l", new Expression(2000.0), new Expression(15000.0)));
 
             MathOverrides expectedMathOverrides = new MathOverrides(sim);
             for (Map.Entry<String, OverrideInfo> entry : expectedVCUnits.entrySet()) {


### PR DESCRIPTION
see #362   New SBML-compatible model unit system - most SBML tools don't like a SBML substance unit of uM.um3 (which Ion pointed out is really 10^21 mol = zeptomol).

new SBML units for VCell export is familiar enough and well scaled.
substance = nmol
volume = l (litre)
area = dm2 (decimeters squared)
length = dm

volumetric concentration is in nM
surface densities are in nmol/dm^2 (where 1.0 nmol/dm^2 == 60000.0 molecules/um2)