### PR TITLE
fix simplifyJSCL(), introduce flattenSafe(), with tests.

### DIFF
--- a/vcell-core/src/test/java/cbit/vcell/biomodel/ModelCountAndConcentrationTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/biomodel/ModelCountAndConcentrationTest.java
@@ -48,7 +48,7 @@ public class ModelCountAndConcentrationTest {
         //
         Simulation expectedSim = expected_bioModel_stoch_init_count.getSimulation(0);
         Simulation sim = bioModel_stoch_init_concentration.getSimulation(0);
-        boolean overridesMatch = expectedSim.getMathOverrides().compareEquivalent(sim.getMathOverrides());
+        boolean overridesMatch = expectedSim.getMathOverrides().compareEqual(sim.getMathOverrides());
         Assert.assertTrue("expecting math overrides to be equivalent", overridesMatch);
     }
 
@@ -68,7 +68,7 @@ public class ModelCountAndConcentrationTest {
         //
         Simulation expectedSim = expected_bioModel_stoch_init_count.getSimulation(0);
         Simulation sim = bioModel_stoch_init_concentration.getSimulation(0);
-        boolean overridesMatch = expectedSim.getMathOverrides().compareEquivalent(sim.getMathOverrides());
+        boolean overridesMatch = expectedSim.getMathOverrides().compareEqual(sim.getMathOverrides());
         Assert.assertFalse("expecting math overrides to not be equivalent", overridesMatch);
     }
 
@@ -95,7 +95,7 @@ public class ModelCountAndConcentrationTest {
         //
         Simulation expectedSim = expected_bioModel_stoch_init_concentration.getSimulation(0);
         Simulation sim = bioModel_stoch_init_count.getSimulation(0);
-        boolean overridesMatch = expectedSim.getMathOverrides().compareEquivalent(sim.getMathOverrides());
+        boolean overridesMatch = expectedSim.getMathOverrides().compareEqual(sim.getMathOverrides());
         Assert.assertTrue("expecting math overrides to be equivalent", overridesMatch);
     }
 

--- a/vcell-math/src/main/java/cbit/vcell/parser/SimpleSymbolTable.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/SimpleSymbolTable.java
@@ -137,13 +137,13 @@ public class SimpleSymbolTable implements ScopedSymbolTable {
 		private int index = -1;
 		private NameScope nameScope = null;
 		private VCUnitDefinition vcUnitDefinition = null;
-		
-		private SimpleSymbolTableEntry(String argName, int argIndex, NameScope argNameScope){
+
+		public SimpleSymbolTableEntry(String argName, int argIndex, NameScope argNameScope){
 			this.name = argName;
 			this.index = argIndex;
 			this.nameScope = argNameScope;
 		}
-		private SimpleSymbolTableEntry(String argName, int argIndex, NameScope argNameScope, VCUnitDefinition unit){
+		public SimpleSymbolTableEntry(String argName, int argIndex, NameScope argNameScope, VCUnitDefinition unit){
 			this.name = argName;
 			this.index = argIndex;
 			this.nameScope = argNameScope;


### PR DESCRIPTION
see #376 

1.  Expression.simplifyJSCL() now avoids substitution of numerical values for constant symbols.
2. introduced Expression.flattenSafe() to flatten without substituting away constants (temporarily clears expression binding)
3. added good tests for bound and unbound expressions for Expression.simplifyJSCL(), .flatten(), .flattenSafe()