### PR TITLE
cache and simplify MathOverride resolver - major speedup

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -231,7 +231,6 @@ public class SimulationContext implements SimulationOwner, Versionable, Matchabl
 
 	public class SimulationContextOverridesResolver implements MathOverridesResolver {
 		private final List<SymbolReplacementTemplate> builtin_replacements = new ArrayList<>();
-		private final IdentifiableProvider bioIdentifiableProvider = new BioModel(null);
 
 		SimulationContextOverridesResolver() {
 			// test for renamed initial condition constant (changed from _init to _init_uM)
@@ -281,7 +280,7 @@ public class SimulationContext implements SimulationOwner, Versionable, Matchabl
 							VCUnitDefinition previousUnit = ste.getUnitDefinition();
 							if (ste instanceof Identifiable) {
 								Identifiable prevIdentifiableObject = (Identifiable) ste;
-								VCID previousVCID = bioIdentifiableProvider.getVCID(prevIdentifiableObject);
+								VCID previousVCID = bioModel.getVCID(prevIdentifiableObject);
 								Identifiable newIdentifiableObject = bioModel.getIdentifiableObject(previousVCID);
 								if (newIdentifiableObject instanceof SymbolTableEntry) {
 									SymbolTableEntry newBioSte = (SymbolTableEntry) newIdentifiableObject;
@@ -502,6 +501,7 @@ public class SimulationContext implements SimulationOwner, Versionable, Matchabl
 	public static final int NUM_ROLES		= 1;
 	public static final String RoleDesc = "user defined";
 
+	private transient SimulationContextOverridesResolver simulationContextOverridesResolver;
 	private Version version = null;
 	private GeometryContext geoContext = null;
 	private ReactionContext reactionContext = null;
@@ -1638,7 +1638,10 @@ public OutputFunctionContext getOutputFunctionContext() {
 
 	@Override
 	public MathOverridesResolver getMathOverridesResolver() {
-		return new SimulationContextOverridesResolver();
+		if (this.simulationContextOverridesResolver == null){
+			this.simulationContextOverridesResolver = new SimulationContextOverridesResolver();
+		}
+		return this.simulationContextOverridesResolver;
 	}
 
 	/**

--- a/vcell-core/src/main/java/cbit/vcell/solver/MathOverrides.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/MathOverrides.java
@@ -861,7 +861,9 @@ void updateFromMathDescription() {
 				}
 				renamedMap.put(name, replacement);
 			}else{
-				logger.error("didn't find a replacement for math override symbol " + name);
+				if (!mathDescriptionHash.contains(name)) {
+					logger.error("didn't find a replacement for math override symbol " + name);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
see #378 

major performance improvement when exporting very large biomodels to omex **_(saves 10s of seconds)_**, avoid instantiating SimulationContextOverridesResolver for every symbol request - and avoid instantiation of empty BioModel in constructor.  

[VisualVM](https://visualvm.github.io/download.html) (free Java profiling tool) was very helpful and very easy to use to diagnose this problem.