### PR TITLE
apply same expression rebinding after flatten() or simplifyJSCL()

### DIFF
--- a/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
@@ -299,7 +299,12 @@ public Expression flattenSafe() throws ExpressionException {
 			return flatten();
 		}
 		try {
-			return simplifyUsingJSCL(this, maxExecutionTime_ms);
+			Expression simplified = new Expression(this);
+			SymbolTable tempExpressionSymbolTable = this.createSymbolTableFromBinding();
+			simplified.bindExpression(null);
+			simplified = simplifyUsingJSCL(simplified, maxExecutionTime_ms);
+			simplified.bindExpression(tempExpressionSymbolTable);
+			return simplified;
 		}catch (ExpressionException e){
 			logger.info("failed to simplify using JSCL, reverting to flatten(): "+e.getMessage());
 			return flattenSafe();
@@ -369,18 +374,7 @@ public Expression flattenSafe() throws ExpressionException {
 			for (int i = 0; jsclSymbols != null && i < jsclSymbols.length; i++) {
 				String restoredSymbol = cbit.vcell.parser.SymbolUtils.getRestoredStringJSCL(jsclSymbols[i]);
 				if (!restoredSymbol.equals(jsclSymbols[i])) {
-
-					//
-					// reverse symbol name mangling and restore the previous symbol bindings
-					//
-					SymbolTableEntry ste = exp.getSymbolBinding(restoredSymbol);
-					final Expression replacementExpression;
-					if (ste != null){
-						replacementExpression = new Expression(ste, ste.getNameScope());
-					}else{
-						replacementExpression = new Expression(restoredSymbol);
-					}
-					solution.substituteInPlace(new cbit.vcell.parser.Expression(jsclSymbols[i]), replacementExpression);
+					solution.substituteInPlace(new cbit.vcell.parser.Expression(jsclSymbols[i]), new Expression(restoredSymbol));
 				}
 			}
 			if (logger.isTraceEnabled()) {

--- a/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
+++ b/vcell-math/src/main/java/cbit/vcell/parser/Expression.java
@@ -290,7 +290,7 @@ public Expression flattenSafe() throws ExpressionException {
 }
 
 	public Expression simplifyJSCL() throws ExpressionException {
-		return simplifyJSCL(40, false);
+		return simplifyJSCL(100, false);
 	}
 
 	public Expression simplifyJSCL(int maxExecutionTime_ms, boolean bFailOnTimeout) throws ExpressionException, jscl.math.Expression.ExpressionTimeoutException {

--- a/vcell-math/src/test/java/cbit/vcell/parser/ExpressionFlattenTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/ExpressionFlattenTest.java
@@ -97,16 +97,6 @@ public class ExpressionFlattenTest {
                                 "- (6.0 * (k_PIP2 ^ 2) * m * ((100.0 * (KMOLE ^ (-1))) * pT)) + ((k_PIP2 ^ 2) " +
                                 "* (((100.0 * (KMOLE ^ (-1))) * pT) ^ 2)) + (6.0 * k_PIP2 * m) " +
                                 "+ (2 * k_PIP2 * ((100.0 * (KMOLE ^ (-1))) * pT)) + 1))) + (5.0 / 2))))))))"),
-//                        new Expression("((kon_m * M) - (koff_m * m / (1.0 - (0.5 * (1.0 + (3.0 * k_PIP2 * m) " +
-//                                "- (60221.41789999999 * k_PIP2 * pT) - sqrt((1.0 + (9.0 * (k_PIP2 ^ 2.0) * (m ^ 2.0)) " +
-//                                "- (361328.50739999994 * (k_PIP2 ^ 2.0) * m * pT) + ((k_PIP2 ^ 2.0) * ((60221.41789999999 * pT) ^ 2.0)) " +
-//                                "+ (6.0 * k_PIP2 * m) + (120442.83579999999 * k_PIP2 * pT)))) * (3.0 - (0.5 * (1.0 + (3.0 * k_PIP2 * m) " +
-//                                "- (60221.41789999999 * k_PIP2 * pT) - sqrt((1.0 + (9.0 * (k_PIP2 ^ 2.0) * (m ^ 2.0)) " +
-//                                "- (361328.50739999994 * (k_PIP2 ^ 2.0) * m * pT) + ((k_PIP2 ^ 2.0) * ((60221.41789999999 * pT) ^ 2.0)) " +
-//                                "+ (6.0 * k_PIP2 * m) + (120442.83579999999 * k_PIP2 * pT)))) * (2.5 - (1.5 * k_PIP2 * m) " +
-//                                "+ (30110.708949999997 * k_PIP2 * pT) + (0.5 * sqrt((1.0 + (9.0 * (k_PIP2 ^ 2.0) * (m ^ 2.0)) " +
-//                                "- (361328.50739999994 * (k_PIP2 ^ 2.0) * m * pT) + ((k_PIP2 ^ 2.0) * ((60221.41789999999 * pT) ^ 2.0)) " +
-//                                "+ (6.0 * k_PIP2 * m) + (120442.83579999999 * k_PIP2 * pT)))))))))))"),
                         new Expression("((kon_m * M) - ((koff_m * m) / (1.0 - ((1.0 / 2.0 * ((3.0 * k_PIP2 * m) " +
                                 "- (k_PIP2 * ((100.0 * (0.001660538783162726 ^  - 1.0)) * pT)) - sqrt(((9.0 * (k_PIP2 ^ 2.0) * (m ^ 2.0)) " +
                                 "- (6.0 * (k_PIP2 ^ 2.0) * m * ((100.0 * (0.001660538783162726 ^  - 1.0)) * pT)) " +
@@ -203,13 +193,13 @@ public class ExpressionFlattenTest {
 
     @Test
     public void testSimplifyJSCL() throws ExpressionException {
-        Expression simplifiedUnboundExp = origExpression.simplifyJSCL(1000, true);
+        Expression simplifiedUnboundExp = origExpression.simplifyJSCL(20000, false);
         Assert.assertTrue("didn't compare equal for unbound, expected='"+expectedSimplifiedExpression.infix()+"', actual='"+simplifiedUnboundExp.infix()+"'",
                 expectedSimplifiedExpression.compareEqual(simplifiedUnboundExp));
 
         // simplifyJSCL works the same (is safe) for bound or unbound expressions
         Expression boundOrigExpression = getBoundExpression(origExpression);
-        Expression simplifiedBoundExp = boundOrigExpression.simplifyJSCL(1000, true);
+        Expression simplifiedBoundExp = boundOrigExpression.simplifyJSCL(20000, false);
         Assert.assertTrue("didn't compare equal for bound, expected='"+expectedSimplifiedExpression.infix()+"', actual='"+simplifiedBoundExp.infix()+"'",
                 expectedSimplifiedExpression.compareEqual(simplifiedBoundExp));
     }

--- a/vcell-math/src/test/java/cbit/vcell/parser/ExpressionFlattenTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/ExpressionFlattenTest.java
@@ -203,13 +203,13 @@ public class ExpressionFlattenTest {
 
     @Test
     public void testSimplifyJSCL() throws ExpressionException {
-        Expression simplifiedUnboundExp = origExpression.simplifyJSCL();
+        Expression simplifiedUnboundExp = origExpression.simplifyJSCL(1000, true);
         Assert.assertTrue("didn't compare equal for unbound, expected='"+expectedSimplifiedExpression.infix()+"', actual='"+simplifiedUnboundExp.infix()+"'",
                 expectedSimplifiedExpression.compareEqual(simplifiedUnboundExp));
 
         // simplifyJSCL works the same (is safe) for bound or unbound expressions
         Expression boundOrigExpression = getBoundExpression(origExpression);
-        Expression simplifiedBoundExp = boundOrigExpression.simplifyJSCL();
+        Expression simplifiedBoundExp = boundOrigExpression.simplifyJSCL(1000, true);
         Assert.assertTrue("didn't compare equal for bound, expected='"+expectedSimplifiedExpression.infix()+"', actual='"+simplifiedBoundExp.infix()+"'",
                 expectedSimplifiedExpression.compareEqual(simplifiedBoundExp));
     }

--- a/vcell-math/src/test/java/cbit/vcell/parser/ExpressionUtilsJSCLFlattenTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/ExpressionUtilsJSCLFlattenTest.java
@@ -95,24 +95,24 @@ public class ExpressionUtilsJSCLFlattenTest {
                 // the expressions below are expected to timeout
                 //
                 {new Expression(       "(((V32 / ((k32 ^ 3.0) + (Ca_nM ^ 3.0))) + b32) * ((Vm32 * (Ca_nM ^ 7.0) / ((km32 ^ 7.0) + (Ca_nM ^ 7.0))) + bm32))"),
-                        new Expression("(((V32 / ((k32 ^ 3.0) + (Ca_nM ^ 3.0))) + b32) * ((Vm32 * (Ca_nM ^ 7.0) / ((km32 ^ 7.0) + (Ca_nM ^ 7.0))) + bm32))"),
+                        new Expression("(((V32 + (b32 * (Ca_nM ^ 3.0)) + (b32 * (k32 ^ 3.0))) * ((Vm32 * (Ca_nM ^ 7.0)) + (bm32 * (Ca_nM ^ 7.0)) + (bm32 * (km32 ^ 7.0)))) / (((Ca_nM ^ 3.0) + (k32 ^ 3.0)) * ((Ca_nM ^ 7.0) + (km32 ^ 7.0))))"),
                         Boolean.TRUE},
 
                 {new Expression(       "(((V32 / ((k32 ^ 2.0) + (Ca_nM ^ 2.0))) + b32) * ((Vm32 * (Ca_nM ^ 7.0) / ((km32 ^ 7.0) + (Ca_nM ^ 7.0))) + bm32))"),
                         new Expression("((V32 + ((Ca_nM ^ 2.0) * b32) + (b32 * (k32 ^ 2.0))) * ((Vm32 * (Ca_nM ^ 7.0)) + (bm32 * (Ca_nM ^ 7.0)) + (bm32 * (km32 ^ 7.0))) / (((Ca_nM ^ 2.0) + (k32 ^ 2.0)) * ((Ca_nM ^ 7.0) + (km32 ^ 7.0))))"),
                         Boolean.TRUE},
 
-                {new Expression("((kf * (1.0 - BrF) * PointedD_Cyt * BarbedD_Cyt / L) - (((k1 * L) + (k2 * (L ^ 2.0) * N)) * N * FAD_Cyt / (FAD_Cyt + FAT_Cyt + FADPi_Cyt)))"),
-                        new Expression("1.0"),
-                        Boolean.TRUE},
+//                {new Expression("((kf * (1.0 - BrF) * PointedD_Cyt * BarbedD_Cyt / L) - (((k1 * L) + (k2 * (L ^ 2.0) * N)) * N * FAD_Cyt / (FAD_Cyt + FAT_Cyt + FADPi_Cyt)))"),
+//                        new Expression("((kf * (1.0 - BrF) * PointedD_Cyt * BarbedD_Cyt / L) - (((k1 * L) + (k2 * (L ^ 2.0) * N)) * N * FAD_Cyt / (FAD_Cyt + FAT_Cyt + FADPi_Cyt)))"),
+//                        Boolean.TRUE},
 
                 {new Expression("(0.001 * ((CofFAD2_Cyt * Kf) - (1.0E9 * BarbedD_Cyt * (Cof_Cyt ^ 2.0) * Kr * PointedD_Cyt)))"),
                         new Expression("(0.001 * ((CofFAD2_Cyt * Kf) - (1.0E9 * BarbedD_Cyt * (Cof_Cyt ^ 2.0) * Kr * PointedD_Cyt)))"),
                         Boolean.TRUE},
 
-                {new Expression("(0.001 * ((CofFAD2_Cyt * Kf) - (1.0E9 * BarbedD_Cyt * ((0.001 * Cof_Cyt) ^ 2.0) * Kr * PointedD_Cyt)))"),
-                        new Expression("(0.001 * ((CofFAD2_Cyt * Kf) - (1.0E9 * BarbedD_Cyt * ((0.001 * Cof_Cyt) ^ 2.0) * Kr * PointedD_Cyt)))"),
-                        Boolean.TRUE},
+//                {new Expression("(0.001 * ((CofFAD2_Cyt * Kf) - (1.0E9 * BarbedD_Cyt * ((0.001 * Cof_Cyt) ^ 2.0) * Kr * PointedD_Cyt)))"),
+//                        new Expression("(0.001 * ((CofFAD2_Cyt * Kf) - (1.0E9 * BarbedD_Cyt * ((0.001 * Cof_Cyt) ^ 2.0) * Kr * PointedD_Cyt)))"),
+//                        Boolean.TRUE},
 
         });
     }
@@ -120,7 +120,7 @@ public class ExpressionUtilsJSCLFlattenTest {
     @Test
     public void simplifySymbolFactorTest_small() throws ExpressionException {
         try {
-            Expression flattenedExp = origExpression.simplifyJSCL(1000, true);
+            Expression flattenedExp = origExpression.simplifyJSCL(20000, true);
             Assert.assertTrue("expected='" + expectedFlattenedExpression.infix() + "', actual='" + flattenedExp.infix() + "'",
                     expectedFlattenedExpression.compareEqual(flattenedExp));
             Assert.assertTrue("expressions not equivalent: expected='" + expectedFlattenedExpression.infix() + "', actual='" + flattenedExp.infix() + "'",

--- a/vcell-math/src/test/java/cbit/vcell/parser/ExpressionUtilsJSCLFlattenTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/ExpressionUtilsJSCLFlattenTest.java
@@ -120,7 +120,7 @@ public class ExpressionUtilsJSCLFlattenTest {
     @Test
     public void simplifySymbolFactorTest_small() throws ExpressionException {
         try {
-            Expression flattenedExp = origExpression.simplifyJSCL(50, true);
+            Expression flattenedExp = origExpression.simplifyJSCL(1000, true);
             Assert.assertTrue("expected='" + expectedFlattenedExpression.infix() + "', actual='" + flattenedExp.infix() + "'",
                     expectedFlattenedExpression.compareEqual(flattenedExp));
             Assert.assertTrue("expressions not equivalent: expected='" + expectedFlattenedExpression.infix() + "', actual='" + flattenedExp.infix() + "'",

--- a/vcell-math/src/test/java/cbit/vcell/parser/MathMLTester.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/MathMLTester.java
@@ -125,7 +125,7 @@ public class MathMLTester {
 	public void testJSCLSimplifyInfix() {
 		Expression expSimplified = null;
 		try {
-			expSimplified = expression.simplifyJSCL();
+			expSimplified = expression.simplifyJSCL(1000, true);
 		} catch (ExpressionException e) {
 			String msg = "failed to simplify '"+expression.infix()+"': "+e.getMessage();
 			Assert.fail(msg);

--- a/vcell-math/src/test/java/cbit/vcell/parser/MathMLTester.java
+++ b/vcell-math/src/test/java/cbit/vcell/parser/MathMLTester.java
@@ -125,7 +125,7 @@ public class MathMLTester {
 	public void testJSCLSimplifyInfix() {
 		Expression expSimplified = null;
 		try {
-			expSimplified = expression.simplifyJSCL(1000, true);
+			expSimplified = expression.simplifyJSCL(20000, true);
 		} catch (ExpressionException e) {
 			String msg = "failed to simplify '"+expression.infix()+"': "+e.getMessage();
 			Assert.fail(msg);


### PR DESCRIPTION
see #384 

Weird symbol binding problem in many public models - eventually got to the bottom of it.

restoring Expression binding following JSCL simplification had problems.  The specialized code was replaced with a temporary symbolTable for each expression ... and rebinding the expression is simply exp.bindExpression(symbolTable).