### PR TITLE
389 mathgen var hash

### DIFF
--- a/vcell-core/src/main/java/cbit/util/xml/XmlRdfUtil.java
+++ b/vcell-core/src/main/java/cbit/util/xml/XmlRdfUtil.java
@@ -107,7 +107,7 @@ public class XmlRdfUtil {
    			ret += "\n\n";
    			ret += PubMet.EndRdf;
 
-   			System.out.println(ret);
+   			//System.out.println(ret);
    		} catch (RDFHandlerException e) {
 			logger.error("failed to create metadata");
 		}

--- a/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
@@ -490,7 +490,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 	while (enum1.hasMoreElements()){
 		SpeciesContextMapping scm = enum1.nextElement();
 		if (scm.getVariable() instanceof VolVariable){
-			if (!(mathDesc.getVariable(scm.getVariable().getName()) instanceof VolVariable)){
+			if (!(varHash.getVariable(scm.getVariable().getName()) instanceof VolVariable)){
 				varHash.addVariable(scm.getVariable());
 			}
 		}
@@ -707,7 +707,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 							// spatially resolved membrane, and must solve for potential .... 
 							//   make single MembraneRegionVariable for all resolved potentials
 							//
-							if (mathDesc.getVariable(Membrane.MEMBRANE_VOLTAGE_REGION_NAME)==null){
+							if (varHash.getVariable(Membrane.MEMBRANE_VOLTAGE_REGION_NAME)==null){
 								//varHash.addVariable(new MembraneRegionVariable(MembraneVoltage.MEMBRANE_VOLTAGE_REGION_NAME));
 								varHash.addVariable(new MembraneRegionVariable(getMathSymbol(membraneVoltage,geometryClass),domain));
 							}
@@ -1669,7 +1669,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 				if ((membraneMapping.getGeometryClass() instanceof SubVolume) && membraneMapping.getCalculateVoltage()){
 					MembraneElectricalDevice capacitiveDevice = potentialMapping.getCapacitiveDevice(membrane);
 					if (capacitiveDevice.getDependentVoltageExpression()==null){
-						VolVariable vVar = (VolVariable)mathDesc.getVariable(getMathSymbol(capacitiveDevice.getVoltageSymbol(),membraneMapping.getGeometryClass()));
+						VolVariable vVar = (VolVariable)varHash.getVariable(getMathSymbol(capacitiveDevice.getVoltageSymbol(),membraneMapping.getGeometryClass()));
 						Expression initExp = new Expression(getMathSymbol(capacitiveDevice.getMembraneMapping().getInitialVoltageParameter(),membraneMapping.getGeometryClass()));
 						subDomain.addEquation(new OdeEquation(vVar,initExp,getIdentifierSubstitutions(potentialMapping.getOdeRHS(capacitiveDevice,this), membrane.getMembraneVoltage().getUnitDefinition().divideBy(timeUnit),membraneMapping.getGeometryClass())));
 					}else{
@@ -1906,8 +1906,8 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 					if (numCapacitiveDevices!=1){
 						throw new MappingException("expecting 1 capacitive electrical device on graph edge for membrane "+membrane.getName()+", found '"+numCapacitiveDevices+"'");
 					}
-					if (mathDesc.getVariable(getMathSymbol(capacitiveDevice.getVoltageSymbol(),membraneMapping.getGeometryClass())) instanceof MembraneRegionVariable){
-						MembraneRegionVariable vVar = (MembraneRegionVariable)mathDesc.getVariable(getMathSymbol(capacitiveDevice.getVoltageSymbol(),membraneMapping.getGeometryClass()));
+					if (varHash.getVariable(getMathSymbol(capacitiveDevice.getVoltageSymbol(),membraneMapping.getGeometryClass())) instanceof MembraneRegionVariable){
+						MembraneRegionVariable vVar = (MembraneRegionVariable)varHash.getVariable(getMathSymbol(capacitiveDevice.getVoltageSymbol(),membraneMapping.getGeometryClass()));
 						Parameter initialVoltageParm = capacitiveDevice.getMembraneMapping().getInitialVoltageParameter();
 						Expression initExp = getIdentifierSubstitutions(initialVoltageParm.getExpression(),initialVoltageParm.getUnitDefinition(),capacitiveDevice.getMembraneMapping().getGeometryClass());
 						MembraneRegionEquation vEquation = new MembraneRegionEquation(vVar,initExp);

--- a/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
@@ -2072,7 +2072,9 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 	mathDesc.refreshDependencies();
 
 	if (!mathDesc.isValid()){
-		System.out.println(mathDesc.getVCML_database());
+		if (lg.isTraceEnabled()) {
+			lg.trace(mathDesc.getVCML_database());
+		}
 		throw new MappingException("generated an invalid mathDescription: "+mathDesc.getWarning());
 	}
 

--- a/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
@@ -1441,11 +1441,6 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 	}
 
 	//
-	// set Variables to MathDescription all at once with the order resolved by "VariableHash"
-	//
-	mathDesc.setAllVariables(varHash.getAlphabeticallyOrderedVariables());
-	
-	//
 	// geometry
 	//
 	if (simContext.getGeometryContext().getGeometry() != null){
@@ -2063,11 +2058,16 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 		if (fieldMathMappingParameters[i] instanceof UnitFactorParameter){
 			GeometryClass geometryClass = fieldMathMappingParameters[i].getGeometryClass();
 			Variable variable = newFunctionOrConstant(getMathSymbol(fieldMathMappingParameters[i],geometryClass),getIdentifierSubstitutions(fieldMathMappingParameters[i].getExpression(),fieldMathMappingParameters[i].getUnitDefinition(),geometryClass),fieldMathMappingParameters[i].getGeometryClass());
-			if (mathDesc.getVariable(variable.getName())==null){
-				mathDesc.addVariable(variable);
+			if (varHash.getVariable(variable.getName())==null){
+				varHash.addVariable(variable);
 			}
 		}
 	}
+
+	//
+	// set Variables to MathDescription all at once with the order resolved by "VariableHash"
+	//
+	mathDesc.setAllVariables(varHash.getAlphabeticallyOrderedVariables());
 
 	mathDesc.refreshDependencies();
 

--- a/vcell-core/src/main/java/cbit/vcell/mapping/ParticleMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/ParticleMathMapping.java
@@ -226,7 +226,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 	while (enum1.hasMoreElements()){
 		SpeciesContextMapping scm = enum1.nextElement();
 		if (scm.getVariable() instanceof ParticleVariable){
-			if (!(mathDesc.getVariable(scm.getVariable().getName()) instanceof ParticleVariable)){
+			if (!(varHash.getVariable(scm.getVariable().getName()) instanceof ParticleVariable)){
 				varHash.addVariable(scm.getVariable());
 			}
 		}
@@ -480,12 +480,6 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 	}
 
 	//
-	// set Variables to MathDescription all at once with the order resolved by "VariableHash"
-	//
-	mathDesc.setAllVariables(varHash.getAlphabeticallyOrderedVariables());
-	
-	
-	//
 	// geometry
 	//
 	if (getSimulationContext().getGeometryContext().getGeometry() != null){
@@ -703,7 +697,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 				SpeciesContextSpec scs = getSimulationContext().getReactionContext().getSpeciesContextSpec(sc);
 				GeometryClass scGeometryClass = getSimulationContext().getGeometryContext().getStructureMapping(sc.getStructure()).getGeometryClass();
 				String varName = getMathSymbol(sc, scGeometryClass);
-				Variable var = mathDesc.getVariable(varName);
+				Variable var = varHash.getVariable(varName);
 				if (var instanceof ParticleVariable)
 				{
 					ParticleVariable particle = (ParticleVariable)var;
@@ -806,7 +800,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 					SpeciesContextSpec scs = getSimulationContext().getReactionContext().getSpeciesContextSpec(sc);
 					GeometryClass scGeometryClass = getSimulationContext().getGeometryContext().getStructureMapping(sc.getStructure()).getGeometryClass();
 					String varName = getMathSymbol(sc, scGeometryClass);
-					Variable var = mathDesc.getVariable(varName);
+					Variable var = varHash.getVariable(varName);
 					if (var instanceof ParticleVariable){
 						ParticleVariable particle = (ParticleVariable)var;
 						reactantParticles.add(particle);
@@ -829,7 +823,7 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 					SpeciesContextSpec scs = getSimulationContext().getReactionContext().getSpeciesContextSpec(sc);
 					GeometryClass scGeometryClass = getSimulationContext().getGeometryContext().getStructureMapping(sc.getStructure()).getGeometryClass();
 					String varName = getMathSymbol(sc, scGeometryClass);
-					Variable var = mathDesc.getVariable(varName);
+					Variable var = varHash.getVariable(varName);
 					if (var instanceof ParticleVariable){
 						ParticleVariable particle = (ParticleVariable)var;
 						productParticles.add(particle);
@@ -965,12 +959,16 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 		if (fieldMathMappingParameters[i] instanceof UnitFactorParameter){
 			GeometryClass geometryClass = fieldMathMappingParameters[i].getGeometryClass();
 			Variable variable = newFunctionOrConstant(getMathSymbol(fieldMathMappingParameters[i],geometryClass),getIdentifierSubstitutions(fieldMathMappingParameters[i].getExpression(),fieldMathMappingParameters[i].getUnitDefinition(),geometryClass),fieldMathMappingParameters[i].getGeometryClass());
-			if (mathDesc.getVariable(variable.getName())==null){
-				variable.bind(mathDesc);
-				mathDesc.addVariable(variable);
+			if (varHash.getVariable(variable.getName())==null){
+				varHash.addVariable(variable);
 			}
 		}
 	}
+
+	//
+	// set Variables to MathDescription all at once with the order resolved by "VariableHash"
+	//
+	mathDesc.setAllVariables(varHash.getAlphabeticallyOrderedVariables());
 
 	mathDesc.refreshDependencies();
 

--- a/vcell-core/src/main/java/cbit/vcell/mapping/ParticleMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/ParticleMathMapping.java
@@ -973,15 +973,17 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 	mathDesc.refreshDependencies();
 
 	if (!mathDesc.isValid()){
-		lg.warn(mathDesc.getVCML_database());
+		if (lg.isTraceEnabled()) {
+			lg.trace(mathDesc.getVCML_database());
+		}
 		throw new MappingException("generated an invalid mathDescription: "+mathDesc.getWarning());
 	}
 
-	if (lg.isDebugEnabled()) {
-		System.out.println("]]]]]]]]]]]]]]]]]]]]]] VCML string begin ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
-		System.out.println(mathDesc.getVCML());
-		System.out.println("]]]]]]]]]]]]]]]]]]]]]] VCML string end ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
-	}
+//	if (lg.isTraceEnabled()) {
+//		System.out.println("]]]]]]]]]]]]]]]]]]]]]] VCML string begin ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
+//		System.out.println(mathDesc.getVCML());
+//		System.out.println("]]]]]]]]]]]]]]]]]]]]]] VCML string end ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
+//	}
 }
 
 /**
@@ -1299,13 +1301,15 @@ private void combineHybrid() throws MappingException, ExpressionException, Matri
 	mathDesc.refreshDependencies();
 
 	if (!mathDesc.isValid()){
-		System.out.println(mathDesc.getVCML_database());
+		if (lg.isTraceEnabled()) {
+			lg.trace(mathDesc.getVCML_database());
+		}
 		throw new MappingException("generated an invalid mathDescription: "+mathDesc.getWarning());
 	}
 
-	System.out.println("]]]]]]]]]]]]]]]]]]]]]] VCML string begin ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
-	System.out.println(mathDesc.getVCML());
-	System.out.println("]]]]]]]]]]]]]]]]]]]]]] VCML string end ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
+//	System.out.println("]]]]]]]]]]]]]]]]]]]]]] VCML string begin ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
+//	System.out.println(mathDesc.getVCML());
+//	System.out.println("]]]]]]]]]]]]]]]]]]]]]] VCML string end ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
 
 }
 

--- a/vcell-core/src/main/java/cbit/vcell/mapping/RulebasedMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/RulebasedMathMapping.java
@@ -437,7 +437,9 @@ protected RulebasedMathMapping(SimulationContext simContext, MathMappingCallback
 		mathDesc.refreshDependencies();
 
 		if (!mathDesc.isValid()){
-			System.out.println(mathDesc.getVCML_database());
+			if (lg.isTraceEnabled()) {
+				lg.trace(mathDesc.getVCML_database());
+			}
 			throw new MappingException("generated an invalid mathDescription: "+mathDesc.getWarning());
 		}
 	}

--- a/vcell-core/src/main/java/cbit/vcell/mapping/RulebasedMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/RulebasedMathMapping.java
@@ -393,11 +393,6 @@ protected RulebasedMathMapping(SimulationContext simContext, MathMappingCallback
 		}
 
 		//
-		// set Variables to MathDescription all at once with the order resolved by "VariableHash"
-		//
-		mathDesc.setAllVariables(varHash.getAlphabeticallyOrderedVariables());
-		
-		//
 		// set up particle initial conditions in subdomain
 		//
 		for (SpeciesContext sc : model.getSpeciesContexts()){
@@ -422,17 +417,22 @@ protected RulebasedMathMapping(SimulationContext simContext, MathMappingCallback
 		for (int i = 0; i < fieldMathMappingParameters.length; i++){
 			if (fieldMathMappingParameters[i] instanceof UnitFactorParameter){
 				Variable variable = newFunctionOrConstant(getMathSymbol(fieldMathMappingParameters[i],geometryClass),getIdentifierSubstitutions(fieldMathMappingParameters[i].getExpression(),fieldMathMappingParameters[i].getUnitDefinition(),geometryClass),fieldMathMappingParameters[i].getGeometryClass());
-				if (mathDesc.getVariable(variable.getName())==null){
-					mathDesc.addVariable(variable);
+				if (varHash.getVariable(variable.getName())==null){
+					varHash.addVariable(variable);
 				}
 			}
 			if (fieldMathMappingParameters[i] instanceof ObservableConcentrationParameter){
 				Variable variable = newFunctionOrConstant(getMathSymbol(fieldMathMappingParameters[i],geometryClass),getIdentifierSubstitutions(fieldMathMappingParameters[i].getExpression(),fieldMathMappingParameters[i].getUnitDefinition(),geometryClass),fieldMathMappingParameters[i].getGeometryClass());
-				if (mathDesc.getVariable(variable.getName())==null){
-					mathDesc.addVariable(variable);
+				if (varHash.getVariable(variable.getName())==null){
+					varHash.addVariable(variable);
 				}
 			}
 		}
+
+		//
+		// set Variables to MathDescription all at once with the order resolved by "VariableHash"
+		//
+		mathDesc.setAllVariables(varHash.getAlphabeticallyOrderedVariables());
 
 		mathDesc.refreshDependencies();
 

--- a/vcell-core/src/main/java/cbit/vcell/mapping/StochMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/StochMathMapping.java
@@ -544,7 +544,9 @@ private Expression getProbabilityRate(ReactionStep reactionStep, Expression rate
 		mathDesc.refreshDependencies();
 
 		if (!mathDesc.isValid()){
-			lg.error(mathDesc.getVCML_database());
+			if (lg.isTraceEnabled()) {
+				lg.trace(mathDesc.getVCML_database());
+			}
 			throw new MappingException("generated an invalid mathDescription: "+mathDesc.getWarning());
 		}
 	}

--- a/vcell-core/src/main/java/cbit/vcell/mapping/StochMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/StochMathMapping.java
@@ -499,7 +499,7 @@ private Expression getProbabilityRate(ReactionStep reactionStep, Expression rate
 			StructureMapping sm = simContext.getGeometryContext().getStructureMapping(speciesContextSpecs[i].getSpeciesContext().getStructure());
 			String varName = getMathSymbol(spCountParam, sm.getGeometryClass()); 
 
-			StochVolVariable var = (StochVolVariable)mathDesc.getVariable(varName);
+			StochVolVariable var = (StochVolVariable)varHash.getVariable(varName);
 			SpeciesContextSpec.SpeciesContextSpecParameter initParm = scSpecs[i].getInitialCountParameter();//stochastic use initial number of particles
 			//stochastic variables initial expression.
 			if (initParm!=null)

--- a/vcell-core/src/main/java/cbit/vcell/mapping/StochMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/StochMathMapping.java
@@ -490,11 +490,6 @@ private Expression getProbabilityRate(ReactionStep reactionStep, Expression rate
 		}
 
 		//
-		// set Variables to MathDescription all at once with the order resolved by "VariableHash"
-		//
-		mathDesc.setAllVariables(varHash.getAlphabeticallyOrderedVariables());
-		
-		//
 		// set up variable initial conditions in subDomain
 		//
 		SpeciesContextSpec scSpecs[] = simContext.getReactionContext().getSpeciesContextSpecs();
@@ -529,17 +524,22 @@ private Expression getProbabilityRate(ReactionStep reactionStep, Expression rate
 		for (int i = 0; i < fieldMathMappingParameters.length; i++){
 			if (fieldMathMappingParameters[i] instanceof UnitFactorParameter){
 				Variable variable = newFunctionOrConstant(getMathSymbol(fieldMathMappingParameters[i],geometryClass),getIdentifierSubstitutions(fieldMathMappingParameters[i].getExpression(),fieldMathMappingParameters[i].getUnitDefinition(),geometryClass),fieldMathMappingParameters[i].getGeometryClass());
-				if (mathDesc.getVariable(variable.getName())==null){
-					mathDesc.addVariable(variable);
+				if (varHash.getVariable(variable.getName())==null){
+					varHash.addVariable(variable);
 				}
 			}
 			if (fieldMathMappingParameters[i] instanceof ObservableCountParameter){
 				Variable variable = newFunctionOrConstant(getMathSymbol(fieldMathMappingParameters[i],geometryClass),getIdentifierSubstitutions(fieldMathMappingParameters[i].getExpression(),fieldMathMappingParameters[i].getUnitDefinition(),geometryClass),fieldMathMappingParameters[i].getGeometryClass());
-				if (mathDesc.getVariable(variable.getName())==null){
-					mathDesc.addVariable(variable);
+				if (varHash.getVariable(variable.getName())==null){
+					varHash.addVariable(variable);
 				}
 			}
 		}
+
+		//
+		// set Variables to MathDescription all at once with the order resolved by "VariableHash"
+		//
+		mathDesc.setAllVariables(varHash.getAlphabeticallyOrderedVariables());
 
 		mathDesc.refreshDependencies();
 


### PR DESCRIPTION
see #389 

During math generation, variables are collected in a VariableHash, and then topologically sorted and set on the MathDescription all at once. For some models, new unit conversion factors are added directly to the math rather than the VariableHash, and the topological sort fails to find all dependencies.

Solution is to wait until all variables are created and stored in VariableHash before any are added to the MathDescription.

This fixes some Omex round-trip errors.