### PR TITLE
skip SBML Export of MicroscopyMeasurements (convolutions) - part of math

### DIFF
--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
@@ -2487,6 +2487,11 @@ public static void validateSimulationContextSupport(SimulationContext simulation
 			throw new UnsupportedSbmlExportException("Species '"+scs.getDisplayName()+"' has FieldData as initial condition, SBML Export is not supported");
 		}
 	}
+
+	// Check if there is a microscopy protocol defined (e.g. convolution)
+	if (simulationContext.getMicroscopeMeasurement()!=null){
+		throw new UnsupportedSbmlExportException("MicroscopyMeasurement '"+simulationContext.getMicroscopeMeasurement().getName()+"' defined involving convolution with kernel (point spread function), SBML Export is not supported");
+	}
 }
 
 /**

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
@@ -2489,7 +2489,7 @@ public static void validateSimulationContextSupport(SimulationContext simulation
 	}
 
 	// Check if there is a microscopy protocol defined (e.g. convolution)
-	if (simulationContext.getMicroscopeMeasurement()!=null){
+	if (simulationContext.getMicroscopeMeasurement()!=null && simulationContext.getMicroscopeMeasurement().getFluorescentSpecies().size()>0){
 		throw new UnsupportedSbmlExportException("MicroscopyMeasurement '"+simulationContext.getMicroscopeMeasurement().getName()+"' defined involving convolution with kernel (point spread function), SBML Export is not supported");
 	}
 }


### PR DESCRIPTION
see #393 

MicroscopyMeasurements (e.g. convolution of spatial solution with microscope's point spread function to simulate microscopy image) is implemented in VCell as part of the MathDescription (post-processing step).

This makes any such model fail math comparison in SBML round trip.

Later, we can accommodate this situation by stripping away the MicroscopyMeasurement from the Application before exporting to SBML.