### PR TITLE
spatial apps with lumped reactions: SBML Export unsupported (math fails)

### DIFF
--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLExporter.java
@@ -2492,6 +2492,14 @@ public static void validateSimulationContextSupport(SimulationContext simulation
 	if (simulationContext.getMicroscopeMeasurement()!=null && simulationContext.getMicroscopeMeasurement().getFluorescentSpecies().size()>0){
 		throw new UnsupportedSbmlExportException("MicroscopyMeasurement '"+simulationContext.getMicroscopeMeasurement().getName()+"' defined involving convolution with kernel (point spread function), SBML Export is not supported");
 	}
+
+	// Check if this is a spatial deterministic application and the model contains lumped kinetics.
+	// VCell math has vcRegionVolume('cyt') functions, SBML round trip will use a constant size instead.
+	// The round trip validation will always fail.
+	Optional<ReactionStep> lumpedReaction = Arrays.stream(simulationContext.getModel().getReactionSteps()).filter(rs -> rs.getKinetics() instanceof LumpedKinetics).findFirst();
+	if (simulationContext.getGeometry().getDimension()>0 && simulationContext.getApplicationType()==Application.NETWORK_DETERMINISTIC && lumpedReaction.isPresent()){
+		throw new UnsupportedSbmlExportException("Lumped reaction '"+lumpedReaction.get().getName()+"' in spatial application, SBML Export is not supported");
+	}
 }
 
 /**


### PR DESCRIPTION
see #395 

skipping spatial applications with lumped reactions for now.

In the future, if we want to support these models for SBML Export we must:
1. verify that SBML Export and Import are implemented correctly (must be manual for now because Math is different)
2. find a way for round-trip math to correspond (VCell uses vcRegionVolume('cyt') function to make the reaction local and after SBML round-trip the generated math does not).  There is a way to map (for spatial SBML exports) to the domain sizes which correspond one-to-one with VCell regions ... then the math should round-trip accordingly.