### PR TITLE
Import copasi omex

### DIFF
--- a/vcell-core/src/main/java/org/jlibsedml/Libsedml.java
+++ b/vcell-core/src/main/java/org/jlibsedml/Libsedml.java
@@ -149,7 +149,8 @@ public class Libsedml {
         return SEDMLTags.SEDML_L1V1_NS.equalsIgnoreCase(doc.getRootElement()
                 .getNamespaceURI()) || SEDMLTags.SEDML_L1V2_NS.equalsIgnoreCase(doc.getRootElement()
                         .getNamespaceURI()) || SEDMLTags.SEDML_L1V3_NS.equalsIgnoreCase(doc.getRootElement()
-                                .getNamespaceURI());
+                                .getNamespaceURI()) || SEDMLTags.SEDML_L1V4_NS.equalsIgnoreCase(doc.getRootElement()
+                                		.getNamespaceURI());
 
     }
 
@@ -329,7 +330,7 @@ public class Libsedml {
             }
             return new ArchiveComponents(contents, docs);
         } catch (Exception e) {
-            throw new XMLException("Error reading archive", e);
+            throw new XMLException("Error reading archive: " + e.getMessage());
         } finally {
             try {
                 zis.close();

--- a/vcell-core/src/main/java/org/jlibsedml/SEDMLReader.java
+++ b/vcell-core/src/main/java/org/jlibsedml/SEDMLReader.java
@@ -25,7 +25,6 @@ class SEDMLReader {
 
 	Namespace sedNS = null;
 	Logger   log = LoggerFactory.getLogger(SEDMLReader.class);
-
 	Model getModel(Element modelElement) throws DataConversionException {
 		Model m = new Model(modelElement.getAttributeValue(SEDMLTags.MODEL_ATTR_ID),
 		        modelElement.getAttributeValue(SEDMLTags.MODEL_ATTR_NAME),
@@ -207,12 +206,19 @@ class SEDMLReader {
 			}
 		}
 		if (simElement.getName().equals(SEDMLTags.SIM_UTC)) {
+			int numberOf;
+			if (simElement.getAttributeValue(SEDMLTags.UTCA_POINTS_NUM) != null) {
+				// deprecated in version 4
+				numberOf = Integer.parseInt(simElement.getAttributeValue(SEDMLTags.UTCA_POINTS_NUM));
+			} else {
+				numberOf = Integer.parseInt(simElement.getAttributeValue(SEDMLTags.UTCA_STEPS_NUM));
+			}
             s = new UniformTimeCourse(simElement.getAttributeValue(SEDMLTags.SIM_ATTR_ID), 
                     simElement.getAttributeValue(SEDMLTags.SIM_ATTR_NAME), 
                     Double.parseDouble(simElement.getAttributeValue(SEDMLTags.UTCA_INIT_T)), 
                     Double.parseDouble(simElement.getAttributeValue(SEDMLTags.UTCA_OUT_START_T)),
                     Double.parseDouble(simElement.getAttributeValue(SEDMLTags.UTCA_OUT_END_T)),
-                    Integer.parseInt(simElement.getAttributeValue(SEDMLTags.UTCA_POINTS_NUM)), alg);
+                    numberOf, alg);
 		} else if(simElement.getName().equals(SEDMLTags.SIM_OS)) {
             s = new OneStep(simElement.getAttributeValue(SEDMLTags.SIM_ATTR_ID), 
                     simElement.getAttributeValue(SEDMLTags.SIM_ATTR_NAME), alg,

--- a/vcell-core/src/main/java/org/jlibsedml/SEDMLTags.java
+++ b/vcell-core/src/main/java/org/jlibsedml/SEDMLTags.java
@@ -10,6 +10,7 @@ public class SEDMLTags {
 	public static final String SEDML_L1V1_NS = "http://sed-ml.org/";
 	public static final String SEDML_L1V2_NS = "http://sed-ml.org/sed-ml/level1/version2";
 	public static final String SEDML_L1V3_NS = "http://sed-ml.org/sed-ml/level1/version3";
+	public static final String SEDML_L1V4_NS = "http://sed-ml.org/sed-ml/level1/version4";
 	public static final String SBML_NS = "http://www.sbml.org/sbml/level2";
 	public static final String SBML_NS_L2V4 = "http://www.sbml.org/sbml/level2/version4";
 	public static final String MATHML_NS = "http://www.w3.org/1998/Math/MathML";
@@ -80,6 +81,7 @@ public class SEDMLTags {
     public static final String UTCA_OUT_START_T			= "outputStartTime";
     public static final String UTCA_OUT_END_T			= "outputEndTime";
     public static final String UTCA_POINTS_NUM			= "numberOfPoints";
+    public static final String UTCA_STEPS_NUM			= "numberOfSteps";
     
     // one step attributes
     public static final String OS_STEP                  = "step";

--- a/vcell-core/src/main/java/org/jlibsedml/SedML.java
+++ b/vcell-core/src/main/java/org/jlibsedml/SedML.java
@@ -126,10 +126,10 @@ public final class SedML extends SEDBase {
             throw new IllegalArgumentException(MessageFormat.format(
                     "Invalid level {0}, valid level is {1}", aLevel, "1"));
         }
-        if (aVersion < 1 || aVersion > 3) {
+        if (aVersion < 1 || aVersion > 4) {
             throw new IllegalArgumentException(MessageFormat.format(
                     "Invalid version {0}, valid versions are {1}", aVersion,
-                    "1,2,3"));
+                    "1,2,3,4"));
         }
         this.level = aLevel;
         this.version = aVersion;

--- a/vcell-core/src/main/java/org/jlibsedml/XMLException.java
+++ b/vcell-core/src/main/java/org/jlibsedml/XMLException.java
@@ -28,7 +28,7 @@ public class XMLException extends Exception{
 	}
 
 	public XMLException(String string) {
-		// TODO Auto-generated constructor stub
+		super(string);
 	}
 
 	

--- a/vcell-core/src/main/java/org/jlibsedml/execution/ArchiveModelResolver.java
+++ b/vcell-core/src/main/java/org/jlibsedml/execution/ArchiveModelResolver.java
@@ -1,6 +1,9 @@
 package org.jlibsedml.execution;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.FileSystems;
 import java.util.List;
 
 import org.jlibsedml.ArchiveComponents;
@@ -8,20 +11,35 @@ import org.jlibsedml.IModelContent;
 
 public class ArchiveModelResolver implements IModelResolver {
   private ArchiveComponents ac;
+  private String sedmlPath = "";
     public ArchiveModelResolver(ArchiveComponents ac) {
         this.ac=ac;
     }
     public String getModelXMLFor(URI modelURI) {
-        String rc=null;
         List<IModelContent> children = ac.getModelFiles();
+    	String modelStr = modelURI.toString();
+    	// try direct match first
         for (IModelContent imc: children) {
             String modelElementStr = imc.getName();
-            String modelStr = modelURI.toString();
             if(modelElementStr.equals(modelStr)){
-                rc = imc.getContents();
+                return imc.getContents();
             }
         }
-        return rc;
+        // try relative path to sedml
+        File sedLocation = new File(sedmlPath);
+        String modelLocation = new File(sedLocation, modelStr).toString();
+		modelStr = FileSystems.getDefault().getPath(modelLocation).normalize().toString();
+        for (IModelContent imc: children) {
+            String modelElementStr = FileSystems.getDefault().getPath(imc.getName()).normalize().toString();
+            if(modelElementStr.equals(modelStr)){
+                return imc.getContents();
+            }
+        }
+        // couldn't resolve
+        return null;
     }
+	public void setSedmlPath(String sedmlPath) {
+		this.sedmlPath = sedmlPath;
+	}
 
 }


### PR DESCRIPTION
This fixes a number of bugs and issues uncovered when trying to import in GUI an OMEX file produced by COPASI:
- all errors on import are silently dropped
- SEDML L1V4 not recognized as valid version
- relative URIs for model references are not resolved (GUI only - they were handled properly in CLI)
- deprecated attribute in UniformTimeCourse Simulation
This also fixes a coincidentally discovered bug of not recognizing XML files as SEDML unless specific file extension is being used (XML content type should never be assumed based on file extension, but handled exclusively via XML tags) 