### PR TITLE
Added temp fieldSimulationVersion to Simulation constructors

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/solver/Simulation.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/Simulation.java
@@ -181,6 +181,17 @@ public Simulation(MathDescription mathDescription, SimulationOwner simulationOwn
 	this( );
 	addVetoableChangeListener(this);
 
+	// Give temporary fieldSimulationVersion (needed for linuxSharedLibs())
+	fieldSimulationVersion = SimulationVersion.createTempSimulationVersion();
+	
+	fieldName = fieldSimulationVersion.getName();
+	fieldDescription = fieldSimulationVersion.getAnnot();
+	if (fieldSimulationVersion.getParentSimulationReference()!=null){
+		fieldSimulationIdentifier = null;
+	}else{
+		fieldSimulationIdentifier = createSimulationID(fieldSimulationVersion.getVersionKey());
+	}
+
 	try {
 		setMathDescription(mathDescription);
 	} catch (java.beans.PropertyVetoException e) {


### PR DESCRIPTION
The nullPointerException being caused in recent versions comes down to a change from using TempSimulation to Simulation, and failing to assign a version; On linux systems, a value from this null field would be queried, and subsequently vcell would crash.