### PR TITLE
Overriding min memory for Power users (we will add Kelvin to power users)

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/server/dispatcher/SimulationStateMachine.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/dispatcher/SimulationStateMachine.java
@@ -487,7 +487,7 @@ public class SimulationStateMachine {
 		KeyValue simID = simulationTask.getSimulationInfo().getSimulationVersion().getVersionKey();
 		SolverDescription solverDescription = simulationTask.getSimulation().getSolverTaskDescription().getSolverDescription();
 
-		MemLimitResults allowableMemMB = HtcProxy.getMemoryLimit(vcellUserid,simID,solverDescription, requiredMemMB);
+		MemLimitResults allowableMemMB = HtcProxy.getMemoryLimit(vcellUserid,simID,solverDescription, requiredMemMB, isPowerUser);
 		
 		final SimulationJobStatus newSimJobStatus;
 		if (requiredMemMB > allowableMemMB.getMemLimit()) {						

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/HtcProxy.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/HtcProxy.java
@@ -232,7 +232,8 @@ public abstract class HtcProxy {
 
 	public abstract String getSubmissionFileExtension();
 	public static class MemLimitResults {
-		private static final long FALLBACK_MEM_LIMIT_MB=4096;//MAX memory allowed if not set in limitFile, currently 4g
+		private static final long FALLBACK_MEM_LIMIT_MB=4096;		// MAX memory allowed if not set in limitFile, currently 4g
+		private static final long POWER_USER_MEMORY_FLOOR=10240; 	// MIN memory allowed if declared to be a power user, currently 10g
 		private long memLimit;
 		private String memLimitSource;
 		public MemLimitResults(long memLimit, String memLimitSource) {
@@ -246,7 +247,7 @@ public abstract class HtcProxy {
 		public String getMemLimitSource() {
 			return memLimitSource;
 		}
-		private static MemLimitResults getFallbackMemLimitMB(SolverDescription solverDescription,double estimatedMemSizeMB) {
+		private static MemLimitResults getFallbackMemLimitMB(SolverDescription solverDescription,double estimatedMemSizeMB, boolean isPowerUser) {
 			Long result = null;
 			String source = null;
 			try {
@@ -280,18 +281,17 @@ public abstract class HtcProxy {
 				result = (long)estimatedMemSizeMB;
 				source = "used Estimated";
 			}
-			// Temporary memory increase
-			if (result < 10240){
-				result = (long)10240;
-				source = "manual override";
+			if (isPowerUser && result < POWER_USER_MEMORY_FLOOR){
+				result = (long)POWER_USER_MEMORY_FLOOR;
+				source = "poweruser's memory override";
 			}
 
 			return new MemLimitResults(result, source);
 		}
 	}
 	public static final boolean bDebugMemLimit = false;
-	public static MemLimitResults getMemoryLimit(String vcellUserid,KeyValue simID,SolverDescription solverDescription,double estimatedMemSizeMB) {
-		return MemLimitResults.getFallbackMemLimitMB(solverDescription, estimatedMemSizeMB*1.5);
+	public static MemLimitResults getMemoryLimit(String vcellUserid, KeyValue simID, SolverDescription solverDescription ,double estimatedMemSizeMB, boolean isPowerUser) {
+		return MemLimitResults.getFallbackMemLimitMB(solverDescription, estimatedMemSizeMB*1.5, isPowerUser);
 //		boolean bUseEstimate = estimatedMemSizeMB >= MemLimitResults.getFallbackMemLimitMB(solverDescription);
 //		return new MemLimitResults((bUseEstimate?(long)estimatedMemSizeMB:MemLimitResults.getFallbackMemLimitMB(solverDescription)), (bUseEstimate?"used Estimated":"used FALLBACK_MEM_LIMIT"));
 //		//One of 5 limits are returned (ordered from highest to lowest priority):

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/HtcProxy.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/HtcProxy.java
@@ -232,7 +232,7 @@ public abstract class HtcProxy {
 
 	public abstract String getSubmissionFileExtension();
 	public static class MemLimitResults {
-		private static final long FALLBACK_MEM_LIMIT_MB=4096;//MAX memory allowed if not set in limitFile
+		private static final long FALLBACK_MEM_LIMIT_MB=4096;//MAX memory allowed if not set in limitFile, currently 4g
 		private long memLimit;
 		private String memLimitSource;
 		public MemLimitResults(long memLimit, String memLimitSource) {
@@ -280,6 +280,12 @@ public abstract class HtcProxy {
 				result = (long)estimatedMemSizeMB;
 				source = "used Estimated";
 			}
+			// Temporary memory increase
+			if (result < 10240){
+				result = (long)10240;
+				source = "manual override";
+			}
+
 			return new MemLimitResults(result, source);
 		}
 	}

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
@@ -459,7 +459,7 @@ public class SlurmProxy extends HtcProxy {
 		String vcellUserid = simTask.getUser().getName();
 		KeyValue simID = simTask.getSimulationInfo().getSimulationVersion().getVersionKey();
 		SolverDescription solverDescription = simTask.getSimulation().getSolverTaskDescription().getSolverDescription();
-		MemLimitResults memoryMBAllowed = HtcProxy.getMemoryLimit(vcellUserid,simID,solverDescription,memSizeMB);
+		MemLimitResults memoryMBAllowed = HtcProxy.getMemoryLimit(vcellUserid, simID, solverDescription, memSizeMB, simTask.isPowerUser());
 
 		LineStringBuilder slurmCommands = new LineStringBuilder();
 		slurmScriptInit(jobName, simTask.isPowerUser(), memoryMBAllowed, slurmCommands);


### PR DESCRIPTION
### Background
Kelvin has a model that demands more than 4gb of memory. We don't have a good analysis of why, but he's waiting on us for a fix. 

### Solution
The plan is by adding more memory for power user requests, we can simply make Kelvin a power user and quickly give him the memory he needs without also giving everyone else that memory.