### PR TITLE
Alpha Fix; swapped syntax and caught potentially empty Linking dir variable

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
@@ -647,7 +647,11 @@ public class SlurmProxy extends HtcProxy {
 
 //		lsb.write("(");
 		if (ec.getLdLibraryPath()!=null){
-			lsb.write("    export LD_LIBRARY_PATH="+ec.getLdLibraryPath().path+":$LD_LIBRARY_PATH");
+			lsb.write("if [ -z ${LD_LIBRARY_PATH+x} ]; then");
+			lsb.write("    export LD_LIBRARY_PATH=" + ec.getLdLibraryPath().path);
+			lsb.write("else");
+			lsb.write("    export LD_LIBRARY_PATH=" + ec.getLdLibraryPath().path + ":$LD_LIBRARY_PATH");
+			lsb.write("fi");
 		}
 		// lsb.write("singdevlooperr=\"Failed to mount squashfs image in (read only)\"");
 		// lsb.write("let c=0");
@@ -668,8 +672,8 @@ public class SlurmProxy extends HtcProxy {
 		// lsb.write("		 fi");
 		// lsb.write("		 echo retrying $c of 10...");
 		// lsb.write("    done");
-		lsb.write("      command=${cmd_prefix}" + cmd); // swap above with this line
-		lsb.write("      $(command)"); // swap above with this line
+		lsb.write("      command=\"${cmd_prefix}" + cmd + "\""); 
+		lsb.write("      $command"); 
 //		lsb.write(")");	// This line needs to stay
 		
 		lsb.write("stat=$?");


### PR DESCRIPTION
Bugs appear to have by caused by slight syntax error. Caught an additional bug regarding library path variables.

closes #545 