### PR TITLE
accommodate single vcml or directory for validate

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -47,6 +47,11 @@ case "$rawCommand" in
     command="execute"
     shift
     ;;
+  "validate")
+    echo 'validate mode requested'
+    command="validate"
+    shift
+    ;;
   "version")
   echo 'version mode requested'
     command="version"

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/ValidateBatchCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/ValidateBatchCommand.java
@@ -12,12 +12,12 @@ import picocli.CommandLine.Option;
 import java.io.File;
 import java.util.concurrent.Callable;
 
-@Command(name = "validate-batch", description = "validate a directory of VCML files.")
+@Command(name = "validate", description = "validate either a directory or single VCML file.")
 public class ValidateBatchCommand implements Callable<Integer> {
 
     private final static Logger logger = LogManager.getLogger(ValidateBatchCommand.class);
 
-    @Option(names = { "-i", "--inputFilePath" }, description = "directory of .vcml files", required = true)
+    @Option(names = { "-i", "--inputFilePath" }, description = "directory of .vcml files or single .vcml file", required = true)
     private File inputFilePath;
 
     @Option(names = { "-o", "--outputFilePath" }, description = "full path to output directory", required = true)
@@ -27,11 +27,11 @@ public class ValidateBatchCommand implements Callable<Integer> {
     private boolean bDebug = false;
 
     // TODO: add forceLogFile option to command and pass down
-    
+
     public Integer call() {
         CLIRecorder cliLogger = null;
-        
-        Level logLevel = bDebug ? Level.DEBUG : logger.getLevel(); 
+
+        Level logLevel = bDebug ? Level.DEBUG : logger.getLevel();
         LoggerContext config = (LoggerContext)(LogManager.getContext(false));
         config.getConfiguration().getLoggerConfig(LogManager.getLogger("org.vcell").getName()).setLevel(logLevel);
         config.getConfiguration().getLoggerConfig(LogManager.getLogger("cbit").getName()).setLevel(logLevel);
@@ -42,14 +42,19 @@ public class ValidateBatchCommand implements Callable<Integer> {
             boolean bKeepFlushingLogs = true;
             cliLogger = new CLIRecorder(outputFilePath, bForceLogFiles, bKeepFlushingLogs);
             PropertyLoader.loadProperties();
-            if (!inputFilePath.exists() || !inputFilePath.isDirectory()){
-                throw new RuntimeException("inputFilePath '"+inputFilePath+"' should be a directory");
+            if (!inputFilePath.exists()){
+                throw new RuntimeException("inputFilePath '"+inputFilePath+"' should be a directory or single .vcml file");
             }
             if (!outputFilePath.exists() || !outputFilePath.isDirectory()){
                 throw new RuntimeException("outputFilePath '"+outputFilePath+"' should be a directory");
             }
-            logger.debug("Beginning batch import");
-            VcmlValidator.validateVcmlFiles(inputFilePath, outputFilePath, cliLogger, true);
+            if (inputFilePath.isDirectory()) {
+                logger.debug("Beginning batch validation");
+                VcmlValidator.validateVcmlFiles(inputFilePath, outputFilePath, cliLogger, true);
+            }else{
+                logger.debug("Beginning validation");
+                VcmlValidator.validateOneVcmlFile(inputFilePath, outputFilePath, true);
+            }
             return 0;
         } catch (Exception e) {
             e.printStackTrace(System.err);


### PR DESCRIPTION
needed to run on Slurm which submits one file per job.  see #572 