### PR TITLE
admin CLI 'test-load-models' compares db tables and xml cache

### DIFF
--- a/vcell-admin/pom.xml
+++ b/vcell-admin/pom.xml
@@ -130,7 +130,12 @@
 		    <artifactId>jackson-databind</artifactId>
 		    <version>2.13.4.1</version>
 		</dependency>
- 	</dependencies>
+		<dependency>
+			<groupId>info.picocli</groupId>
+			<artifactId>picocli</artifactId>
+			<version>4.6.3</version>
+		</dependency>
+	</dependencies>
 	
 	<build>
         <plugins>

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/AdminCLI.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/AdminCLI.java
@@ -1,0 +1,43 @@
+package org.vcell.admin.cli;
+
+import cbit.vcell.mongodb.VCMongoMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.vcell.admin.cli.mathverifier.LoadModelsCommand;
+import org.vcell.util.document.KeyValue;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+
+@Command(name = "AdminCLI", subcommands = {
+        LoadModelsCommand.class,
+        CommandLine.HelpCommand.class
+})
+public class AdminCLI {
+
+    private final static Logger logger = LogManager.getLogger(AdminCLI.class);
+
+    public static void main(String[] args) {
+        int exitCode = -1;
+        try{
+            if (logger.isDebugEnabled()) logger.debug("!!!DEBUG Mode Active!!!");
+            VCMongoMessage.enabled = false;
+            CommandLine commandLine = new CommandLine(new AdminCLI());
+            commandLine.registerConverter(KeyValue.class, new KeyValueTypeConverter());
+            exitCode = commandLine.execute(args);
+        } catch (Throwable t){
+            t.printStackTrace();
+            logger.fatal("VCell encountered a serious error: " + t.getMessage(), t);
+        } finally {
+             System.exit(exitCode);
+        }
+    }
+
+    static class KeyValueTypeConverter implements CommandLine.ITypeConverter<KeyValue> {
+        @Override
+        public KeyValue convert(String value) throws Exception {
+            return new KeyValue(value);
+        }
+    }
+
+}

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/mathverifier/LoadModelsCommand.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/mathverifier/LoadModelsCommand.java
@@ -1,0 +1,70 @@
+package org.vcell.admin.cli.mathverifier;
+
+import cbit.vcell.modeldb.MathVerifier;
+import cbit.vcell.resource.PropertyLoader;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.vcell.admin.cli.CLIDatabaseService;
+import org.vcell.util.Compare;
+import org.vcell.util.document.KeyValue;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+
+@Command(name = "test-load-models", description = "test the loading biomodels/mathmodels from db tables and cached XML")
+public class LoadModelsCommand implements Callable<Integer> {
+
+    private final static Logger logger = LogManager.getLogger(LoadModelsCommand.class);
+
+    @Option(names = { "-u", "--userids" }, required = false, description = "vcell user ids (separated by commas) - defaults to all")
+    private String[] userids = null;
+
+    @Option(names = {  "--biomodel-keys" }, split=",", required = false, description = "biomodel key(s) to scan")
+    private ArrayList<KeyValue> biomodelkeys = new ArrayList<>();
+
+    @Option(names = { "--mathmodel-keys" }, split=",", required = false, description = "mathmodel key(s) to scan")
+    private ArrayList<KeyValue> mathmodelkeys = new ArrayList<>();
+
+    @Option(names = { "-v", "--software-version" }, required = true, description = "vcell software version")
+    private String softwareVersion = null;
+
+    @Option(names = { "--update-database" }, defaultValue = "false", required = false, description = "update database - use with caution")
+    private boolean bUpdateDatabase = false;
+
+    @Option(names = {"-d", "--debug"}, description = "full application debug mode")
+    private boolean bDebug = false;
+
+    public Integer call() {
+        Level logLevel = bDebug ? Level.DEBUG : logger.getLevel(); 
+        
+        LoggerContext config = (LoggerContext)(LogManager.getContext(false));
+        config.getConfiguration().getLoggerConfig(LogManager.getLogger("org.vcell").getName()).setLevel(logLevel);
+        config.getConfiguration().getLoggerConfig(LogManager.getLogger("cbit").getName()).setLevel(logLevel);
+        config.updateLoggers();
+
+        try {
+            PropertyLoader.loadProperties();
+            try (CLIDatabaseService cliDatabaseService = new CLIDatabaseService()) {
+                MathVerifier mathVerifier = cliDatabaseService.getMathVerifier();
+                Compare.CompareLogger compareLogger = new Compare.CompareLogger() {
+                    @Override
+                    public void compareFailed() {
+                        logger.warn("comparison failed");
+                    }
+                };
+
+                mathVerifier.runLoadTest(userids, biomodelkeys.toArray(new KeyValue[0]), mathmodelkeys.toArray(new KeyValue[0]), softwareVersion, bUpdateDatabase, compareLogger);
+            } catch (RuntimeException e) {
+                e.printStackTrace(System.err);
+            }
+            return 0;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+}

--- a/vcell-cli/pom.xml
+++ b/vcell-cli/pom.xml
@@ -97,7 +97,8 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.17.1</version>
-        </dependency>        <dependency>
+        </dependency>
+        <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
             <version>4.6.3</version>

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/ExportOmexBatchCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/ExportOmexBatchCommand.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 
+import org.vcell.admin.cli.CLIDatabaseService;
 import org.vcell.cli.CLIRecorder;
 import org.vcell.sedml.ModelFormat;
 import org.vcell.util.DataAccessException;

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/VcmlOmexConverter.java
@@ -4,30 +4,12 @@ import cbit.util.xml.VCLogger;
 import cbit.util.xml.VCLoggerException;
 import cbit.util.xml.XmlRdfUtil;
 import cbit.util.xml.XmlUtil;
-import cbit.util.xml.VCLogger.ErrorType;
-import cbit.util.xml.VCLogger.Priority;
 import cbit.vcell.biomodel.BioModel;
-import cbit.vcell.biomodel.ModelUnitConverter;
-import cbit.vcell.field.FieldFunctionArguments;
-import cbit.vcell.field.FieldUtilities;
 import cbit.vcell.mapping.MappingException;
-import cbit.vcell.mapping.MathMappingCallbackTaskAdapter;
 import cbit.vcell.mapping.SimulationContext;
-import cbit.vcell.mapping.SimulationContext.MathMappingCallback;
-import cbit.vcell.mapping.SimulationContext.NetworkGenerationRequirements;
-import cbit.vcell.math.Constant;
-import cbit.vcell.math.MathCompareResults;
-import cbit.vcell.math.MathDescription;
-import cbit.vcell.math.SubDomain;
-import cbit.vcell.math.Variable;
-import cbit.vcell.parser.Expression;
 import cbit.vcell.resource.NativeLib;
-import cbit.vcell.resource.OperatingSystemInfo;
-import cbit.vcell.resource.ResourceUtil;
 import cbit.vcell.server.SimulationJobStatusPersistent;
-import cbit.vcell.solver.MathOverrides;
 import cbit.vcell.solver.Simulation;
-import cbit.vcell.solver.SimulationSymbolTable;
 import cbit.vcell.solver.SolverDescription;
 //import cbit.vcell.util.NativeLoader;
 import cbit.vcell.xml.XMLSource;
@@ -36,7 +18,6 @@ import cbit.vcell.xml.XmlParseException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.jlibsedml.SEDMLDocument;
-import org.jlibsedml.SedML;
 import org.openrdf.model.Graph;
 import org.openrdf.model.Literal;
 import org.openrdf.model.URI;
@@ -47,13 +28,11 @@ import org.openrdf.rio.RDFHandlerException;
 import org.sbml.libcombine.CombineArchive;
 import org.sbml.libcombine.KnownFormats;
 import org.sbpax.impl.HashGraph;
-import org.sbpax.schemas.BioPAX3;
 import org.sbpax.schemas.util.DefaultNameSpaces;
 import org.sbpax.schemas.util.OntUtil;
 import org.sbpax.util.SesameRioUtil;
+import org.vcell.admin.cli.CLIDatabaseService;
 import org.vcell.cli.*;
-import org.vcell.sbml.vcell.SBMLImportException;
-import org.vcell.sbml.vcell.SBMLImporter;
 import org.vcell.sedml.ModelFormat;
 import org.vcell.sedml.PubMet;
 import org.vcell.sedml.SEDMLExporter;
@@ -63,9 +42,7 @@ import org.vcell.util.document.*;
 import java.beans.PropertyVetoException;
 import java.io.*;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.sql.SQLException;
@@ -112,7 +89,7 @@ public class VcmlOmexConverter {
 									File input,
 									File outputDir,
 									ModelFormat modelFormat,
-									CLIRecorder cliLogger, 
+									CLIRecorder cliLogger,
 									boolean bHasDataOnly,
 									boolean bMakeLogsOnly,
 									boolean bNonSpatialOnly,

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/MathVerifier.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/MathVerifier.java
@@ -15,10 +15,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Vector;
+import java.util.*;
 
 import javax.swing.JFrame;
 
@@ -71,7 +68,7 @@ import cbit.vcell.xml.XmlParseException;
  * @author: Jim Schaff
  */
 public class MathVerifier {
-	public static final Logger lg = LogManager.getLogger(DbDriver.class);
+	private static final Logger lg = LogManager.getLogger(DbDriver.class);
 
 	//
 	// list of files to discard ???
@@ -87,8 +84,6 @@ public class MathVerifier {
 	private DatabaseServerImpl dbServerImpl = null;
 	private KeyFactory keyFactory = null;
 	private cbit.vcell.modeldb.MathDescriptionDbDriver mathDescDbDriver = null;
-	private java.util.HashSet skipHash = new java.util.HashSet(); // holds KeyValues of BioModels to skip
-	private String testFlag;
 	private Timestamp timeStamp;
 
 /**
@@ -167,9 +162,9 @@ public static class LoadModelsStatTable extends Table{
 	
 }
 
-public static final String MV_DEFAULT = "MV_DEFAULT";
-public static final String MV_LOAD_XML = "MV_LOAD_XML";
-
+enum ScanMode {
+	DEFAULT, LOAD_XML
+}
 public static MathVerifier createMathVerifier(
 		String dbHostName,String dbName,String dbSchemaUser,String dbPassword) throws Exception{
 	
@@ -250,15 +245,17 @@ public static void main(String[] args) {
         
 	try {
     	MathVerifier mathVerifier = MathVerifier.createMathVerifier(host, db, dbSchemaUser, dbPassword);
-        if(testFlag.equals(MV_LOAD_XML)){
+        if(testFlag.equals(ScanMode.LOAD_XML.name())){
         	Compare.CompareLogger compareLogger = null;
         	if(bCompareLoggerException){
         		compareLogger = Compare.DEFAULT_COMPARE_LOGGER;
         	}
-        	mathVerifier.runLoadTest((user == null?null:new String[] {user}), bioMathKeyArr,softwareVersion,bUpdateDatabase,compareLogger);
-        }else if(testFlag.equals(MV_DEFAULT)){
+        	mathVerifier.runLoadTest((user == null?null:new String[] {user}), bioMathKeyArr, bioMathKeyArr,softwareVersion,bUpdateDatabase,compareLogger);
+        }else if(testFlag.equals(ScanMode.DEFAULT.name())){
         	mathVerifier.runMathTest((user == null?null:new String[] {user}),bioMathKeyArr,bUpdateDatabase);
-        }
+        }else{
+			throw new RuntimeException("unsupported test flag: "+testFlag);
+		}
 	} catch (Throwable e) {
 	    e.printStackTrace(System.out);
 	}
@@ -288,30 +285,34 @@ private void closeAllConnections(){
 
 }
 
-public void runLoadTest(String[] scanUserids,KeyValue[] bioAndMathModelKeys,String softwareVersion,boolean bUpdateDatabase,Compare.CompareLogger compareLogger) throws Exception{
+public void runLoadTest(String[] scanUserids,KeyValue[] bioModelKeys,KeyValue[] mathModelKeys,String softwareVersion,boolean bUpdateDatabase,Compare.CompareLogger compareLogger) throws Exception{
 	Compare.logger = compareLogger;
-	this.testFlag = MathVerifier.MV_LOAD_XML;
 	this.timeStamp = new Timestamp(System.currentTimeMillis());
 	User[] scanUsers = createUsersFromUserids(scanUserids);
     try{
     	if(bUpdateDatabase){
-    		MathVerifier.initLoadModelsStatTable(softwareVersion,(scanUserids==null?null:scanUsers),bioAndMathModelKeys,this.timeStamp,this.conFactory,this.keyFactory);
+			List<KeyValue> keyValues = new ArrayList<>();
+			if (bioModelKeys!=null) keyValues.addAll(Arrays.asList(bioModelKeys));
+			if (mathModelKeys!=null) keyValues.addAll(Arrays.asList(mathModelKeys));
+    		MathVerifier.initLoadModelsStatTable(softwareVersion,(scanUserids==null?null:scanUsers),keyValues.toArray(new KeyValue[0]),this.timeStamp,this.conFactory,this.keyFactory);
     	}
-    	this.scan(scanUsers, bUpdateDatabase, bioAndMathModelKeys);
+		this.scanBioModels(scanUsers, bUpdateDatabase, bioModelKeys, ScanMode.LOAD_XML);
+		this.scanMathModels(scanUsers, bUpdateDatabase, mathModelKeys);
     }finally{
     	closeAllConnections();
     }
 
 }
-public void runMathTest(String[] scanUserids,KeyValue[] bioAndMathModelKeys,boolean bUpdateDatabase) throws Exception{
-	this.testFlag = MathVerifier.MV_DEFAULT;
+
+public void runMathTest(String[] scanUserids,KeyValue[] mathModelKeys,boolean bUpdateDatabase) throws Exception{
 	User[] scanUsers = createUsersFromUserids(scanUserids);
     try{
-    	this.scan(scanUsers, bUpdateDatabase, bioAndMathModelKeys);
+    	this.scanMathModels(scanUsers, bUpdateDatabase, mathModelKeys);
     }finally{
     	closeAllConnections();
     }
 }
+
 private static void initLoadModelsStatTable(String softwareVersion,User[] users,KeyValue[] bioAndMathModelKeys,Timestamp timestamp,
 		ConnectionFactory conFactory,KeyFactory keyFactory) throws Exception{
 	java.sql.Connection con = null;
@@ -415,7 +416,7 @@ private static void initLoadModelsStatTable(String softwareVersion,User[] users,
 					"'"+timestamp.toString()+"'"+
 					",NULL,"+
 					"'"+TokenMangler.getSQLEscapedString(softwareVersion, LoadModelsStatTable.SOFTWARE_VERS_SIZE)+"'"+
-					",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL)");
+					",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL)");
 			DbDriver.updateCleanSQL(con, sql.toString());
 
 		}
@@ -880,11 +881,7 @@ public MathGenerationResults testMathGeneration(KeyValue simContextKey) throws S
 	}
 }
 
-/**
- * Insert the method's description here.
- * Creation date: (2/2/01 3:40:29 PM)
- */
-public void scan(User users[], boolean bUpdateDatabase, KeyValue[] bioAndMathModelKeys) throws MathException, MappingException, SQLException, DataAccessException, ModelException, ExpressionException {
+	public void scanBioModels(User users[], boolean bUpdateDatabase, KeyValue[] bioModelKeys, ScanMode testFlag) throws MathException, MappingException, SQLException, DataAccessException, ModelException, ExpressionException {
 //	java.util.Calendar calendar = java.util.GregorianCalendar.getInstance();
 ////	calendar.set(2002,java.util.Calendar.MAY,7+1);
 //	calendar.set(2002,java.util.Calendar.JULY,1);
@@ -892,114 +889,137 @@ public void scan(User users[], boolean bUpdateDatabase, KeyValue[] bioAndMathMod
 ////	calendar.set(2001,java.util.Calendar.JUNE,13+1);
 //	calendar.set(2002,java.util.Calendar.JANUARY,1);
 //	final java.util.Date totalVolumeCorrectionFixDate = calendar.getTime();
-	
-	KeyValue[] sortedBioAndMathModelKeys = null;
-	if(bioAndMathModelKeys != null){
-		sortedBioAndMathModelKeys = bioAndMathModelKeys.clone();
-		Arrays.sort(sortedBioAndMathModelKeys,keyValueCpmparator);
-	}
-	for (int i=0;i<users.length;i++){
-		User user = users[i];
-		BioModelInfo[] bioModelInfos0 = dbServerImpl.getBioModelInfos(user,false);
-		MathModelInfo[] mathModelInfos0 = dbServerImpl.getMathModelInfos(user,false);
-		if (lg.isTraceEnabled()) lg.trace("Testing user '"+user+"'");
 
-		Vector<VCDocumentInfo> userBioAndMathModelInfoV =
-			new Vector<VCDocumentInfo>();
-		userBioAndMathModelInfoV.addAll(Arrays.asList(bioModelInfos0));
-		userBioAndMathModelInfoV.addAll(Arrays.asList(mathModelInfos0));
-			
-		//
-		// for each bioModel, load BioModelMetaData (to get list of keys for simulations and simContexts
-		//
-		for (int j = 0; j < userBioAndMathModelInfoV.size(); j++){
+		KeyValue[] sortedBioModelKeys = null;
+		if(bioModelKeys != null){
+			sortedBioModelKeys = bioModelKeys.clone();
+			Arrays.sort(sortedBioModelKeys,keyValueCpmparator);
+		}
+		for (User user : users){
+			BioModelInfo[] bioModelInfos = dbServerImpl.getBioModelInfos(user,false);
+			if (lg.isTraceEnabled()) lg.trace("Testing user '"+user+"'");
+
 			//
-			// if certain Bio or Math models are requested, then filter all else out
+			// for each bioModel, load BioModelMetaData (to get list of keys for simulations and simContexts
 			//
-			VCDocumentInfo documentInfo = userBioAndMathModelInfoV.elementAt(j);
-			KeyValue versionKey = documentInfo.getVersion().getVersionKey();
-			if (sortedBioAndMathModelKeys != null){
-				int srch = Arrays.binarySearch(sortedBioAndMathModelKeys, versionKey,keyValueCpmparator);
-				if (srch < 0){
+			for (BioModelInfo bioModelInfo : bioModelInfos){
+				//
+				// if certain Bio or Math models are requested, then filter all else out
+				//
+				KeyValue versionKey = bioModelInfo.getVersion().getVersionKey();
+				if (sortedBioModelKeys != null){
+					int srch = Arrays.binarySearch(sortedBioModelKeys, versionKey,keyValueCpmparator);
+					if (srch < 0){
+						continue;
+					}
+				}
+
+				try {
+					//
+					// read in the BioModel and MathModel from the database
+					//
+					BioModel bioModelFromDBCache = null;
+					BigString bioModelXMLFromDBCache = null;
+					try{
+						long startTime = System.currentTimeMillis();
+						bioModelXMLFromDBCache =
+									new BigString(dbServerImpl.getServerDocumentManager().getBioModelXML(
+											new QueryHashtable(), user, versionKey, false));
+						bioModelFromDBCache = XmlHelper.XMLToBioModel(new XMLSource(bioModelXMLFromDBCache.toString()));
+						if(bUpdateDatabase && testFlag == ScanMode.LOAD_XML){
+							updateLoadModelsStatTable_LoadTest(System.currentTimeMillis()-startTime,
+									versionKey, null);
+						}
+					}catch(Exception e){
+						lg.error(e.getMessage(),e);
+						if (bUpdateDatabase && testFlag == ScanMode.LOAD_XML){
+							updateLoadModelsStatTable_LoadTest(0, versionKey, e);
+						}
+					}
+
+					if (testFlag == ScanMode.LOAD_XML){
+						//
+						// OPERATION = LOADTEST
+						//
+						if (bioModelXMLFromDBCache != null){
+							testDocumentLoad(bUpdateDatabase, user, bioModelInfo, bioModelFromDBCache);
+						}
+
+					}else if (testFlag == ScanMode.DEFAULT){
+						//
+						// OPERATION = DEFAULT (check math generation)
+						//
+						checkMathForBioModel(bioModelXMLFromDBCache, bioModelFromDBCache, user, bUpdateDatabase);
+					}
+
+				}catch (Throwable e){
+					lg.error(e.getMessage(),e); // exception in whole BioModel
+					// can't update anything in database, since we don't know what simcontexts are involved
+				}
+			}
+		}
+	}
+
+	public void scanMathModels(User users[], boolean bUpdateDatabase, KeyValue[] mathModelKeys) throws MathException, MappingException, SQLException, DataAccessException, ModelException, ExpressionException {
+
+		KeyValue[] sortedMathModelKeys = null;
+		if(mathModelKeys != null){
+			sortedMathModelKeys = mathModelKeys.clone();
+			Arrays.sort(sortedMathModelKeys,keyValueCpmparator);
+		}
+		for (User user : users){
+			MathModelInfo[] mathModelInfos = dbServerImpl.getMathModelInfos(user,false);
+			if (lg.isTraceEnabled()) lg.trace("Testing user '"+user+"'");
+
+			//
+			// for each bioModel, load BioModelMetaData (to get list of keys for simulations and simContexts
+			//
+			for (MathModelInfo mathModelInfo : mathModelInfos){
+				//
+				// if certain Bio or Math models are requested, then filter all else out
+				//
+				KeyValue versionKey = mathModelInfo.getVersion().getVersionKey();
+				if (sortedMathModelKeys != null && Arrays.binarySearch(sortedMathModelKeys, versionKey,keyValueCpmparator) < 0) {
 					continue;
 				}
-			}
 
-			if (!(documentInfo instanceof BioModelInfo)){
-				continue;
-			}
-//			BioModelInfo bioModelInfo = (BioModelInfo)documentInfo;
-//			VCellSoftwareVersion softwareVersion = bioModelInfo.getSoftwareVersion();
-//			if (softwareVersion.getVersionString().equals("4.8") && (softwareVersion.getSite().equals(VCellSite.BETA) || softwareVersion.getSite().equals(VCellSite.RELEASE))){
-//				// process this one.
-//			}else{
-//				continue;
-//			}
-			//
-			// filter out any bioModelKeys present in the "SkipList"
-			//
-			if (skipHash.contains(versionKey)){
-				System.out.println("skipping "+
-					(documentInfo instanceof BioModelInfo?"BioModel":"MathModel")+
-					" with key '"+versionKey+"'");
-				continue;
-			}
+				try {
+					//
+					// read in the BioModel and MathModel from the database
+					//
+					MathModel mathModelFromDBCache = null;
+					BigString mathModelXMLFromDBCache = null;
+					try{
+						long startTime = System.currentTimeMillis();
+						mathModelXMLFromDBCache =
+								new BigString(dbServerImpl.getServerDocumentManager().getMathModelXML(
+										new QueryHashtable(), user, versionKey, false));
+						mathModelFromDBCache = XmlHelper.XMLToMathModel(new XMLSource(mathModelXMLFromDBCache.toString()));
+						if(bUpdateDatabase){
+							updateLoadModelsStatTable_LoadTest(System.currentTimeMillis()-startTime,
+									versionKey, null);
+						}
+					}catch(Exception e){
+						lg.error(e.getMessage(),e);
+						if (bUpdateDatabase){
+							updateLoadModelsStatTable_LoadTest(0, versionKey, e);
+						}
+					}
 
-			try {
-				//
-				// read in the BioModel and MathModel from the database
-				//
-				VCDocument vcDocumentFromDBCache = null;
-				BigString vcDocumentXMLFromDBCache = null;
-				try{
-					long startTime = System.currentTimeMillis();
-					if(documentInfo instanceof BioModelInfo){
-						vcDocumentXMLFromDBCache =
-							new BigString(dbServerImpl.getServerDocumentManager().getBioModelXML(
-								new QueryHashtable(), user, versionKey, false));
-						vcDocumentFromDBCache = XmlHelper.XMLToBioModel(new XMLSource(vcDocumentXMLFromDBCache.toString()));
-					}else{
-						vcDocumentXMLFromDBCache =
-							new BigString(dbServerImpl.getServerDocumentManager().getMathModelXML(
-								new QueryHashtable(), user, versionKey, false));						
-						vcDocumentFromDBCache = XmlHelper.XMLToMathModel(new XMLSource(vcDocumentXMLFromDBCache.toString()));
+					//
+					// OPERATION = LOADTEST (there is no math generation for math models)
+					//
+					if (mathModelXMLFromDBCache != null){
+						testDocumentLoad(bUpdateDatabase, user, mathModelInfo, mathModelFromDBCache);
 					}
-					if(bUpdateDatabase && testFlag.equals(MathVerifier.MV_LOAD_XML)){
-						updateLoadModelsStatTable_LoadTest(System.currentTimeMillis()-startTime,
-							versionKey, null);
-					}
-				}catch(Exception e){
-					lg.error(e.getMessage(),e);
-					if (bUpdateDatabase && testFlag.equals(MathVerifier.MV_LOAD_XML)){
-						updateLoadModelsStatTable_LoadTest(0, versionKey, e);
-					}
+
+				}catch (Throwable e){
+					lg.error(e.getMessage(),e); // exception in whole BioModel
+					// can't update anything in database, since we don't know what simcontexts are involved
 				}
-				
-				if (testFlag.equals(MathVerifier.MV_LOAD_XML)){
-					//
-					// OPERATION = LOADTEST
-					//
-					if (vcDocumentXMLFromDBCache != null){
-						testDocumentLoad(bUpdateDatabase, user, documentInfo, vcDocumentFromDBCache);
-					}
-					
-				}else if (testFlag.equals(MathVerifier.MV_DEFAULT)){
-					//
-					// OPERATION = DEFAULT (check math generation)
-					//
-					if (vcDocumentFromDBCache instanceof BioModel){
-						BioModel bioModel = (BioModel)vcDocumentFromDBCache;
-						checkMathForBioModel(vcDocumentXMLFromDBCache, bioModel, user, bUpdateDatabase);
-					}
-				}
-				
-			}catch (Throwable e){
-	            lg.error(e.getMessage(),e); // exception in whole BioModel
-	            // can't update anything in database, since we don't know what simcontexts are involved
 			}
-		}	
+		}
 	}
-}
 
 private void testDocumentLoad(boolean bUpdateDatabase, User user, VCDocumentInfo documentInfo, VCDocument vcDocumentFromDBCache) {
 	KeyValue versionKey = documentInfo.getVersion().getVersionKey();
@@ -1661,18 +1681,5 @@ public void scanSimContexts(boolean bUpdateDatabase, KeyValue[] simContextKeys) 
         }
     }
 }
-
-
-/**
- * Insert the method's description here.
- * Creation date: (6/7/2004 12:01:12 PM)
- * @param simContexts KeyValue[]
- */
-public void setSkipList(KeyValue[] simContextKeys) {
-	for (int i = 0; i < simContextKeys.length; i++){
-		skipHash.add(simContextKeys[i]);
-	}
-}
-
 
 }


### PR DESCRIPTION
#585 
new java-based admin CLI in vcell-admin module.
- added command to use MathVerifier capabilities to load and compare models and newly generated XML with models retrieved directly from db tables and from the database's XML cache. 