### PR TITLE
For rules select group by molecules button, for the rest select the ungrouped button

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/graph/gui/ReactionCartoonEditorPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/graph/gui/ReactionCartoonEditorPanel.java
@@ -893,9 +893,14 @@ public class ReactionCartoonEditorPanel extends JPanel implements ActionListener
 		reactionCartoonMolecule.setModel(model);
 		reactionCartoonRule.setModel(model);
 		refreshButtons();
-		if(getModel() != null) {	// TODO: when rules are present, select button "grouped by molecule"
-			getGroupMoleculeButton().setSelected(true);	// select by default the grouped by molecule button
-			setViewMode("groupmolecule");				// show by default the groupmolecule view
+		if(getModel() != null) {
+			if(!getModel().getRbmModelContainer().getReactionRuleList().isEmpty()) {
+				getGroupMoleculeButton().setSelected(true);	// select by default the grouped by molecule button
+				setViewMode("groupmolecule");				// show by default the groupmolecule view
+			} else {
+				getUngroupButton().setSelected(true);		// select by default the ungrouped by molecule button
+				setViewMode("ungroup");						// show by default the ungrouped view
+			}
 		}
 	}
 	public void selectedObjectsChanged() {


### PR DESCRIPTION
For plain models with no rules we show the "full" layout (ReactionCartoonFull) because the "molecule" layout (ReactionCartoonMolecule) is populated by shapes initialized by the random numbers generator.
However, for rule based models we'll continue to show the "molecule" layout by default, and show both layout buttons.

This fixes issue #533