### PR TITLE
bad struct mapping exp binding: fixed bad generated math sizes exps

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -3790,7 +3790,7 @@ public void updateAll(boolean bForceUpgrade) throws MappingException {
 				// choose the first structure in model and set its size to '1'.
 				Structure struct = getModel().getStructure(0);
 				double structSize = 1.0;
-				StructureSizeSolver.updateAbsoluteStructureSizes(this, struct, structSize, struct.getStructureSize().getUnitDefinition());
+				StructureSizeSolver.updateAbsoluteStructureSizes_symbolic(this, struct, structSize, struct.getStructureSize().getUnitDefinition());
 			}
 		}
 

--- a/vcell-core/src/main/java/cbit/vcell/mapping/StructureMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/StructureMapping.java
@@ -234,7 +234,7 @@ public abstract class StructureMapping implements Matchable, ScopedSymbolTable, 
 		public void setExpression(Expression expression) throws ExpressionBindingException {
 			if (expression!=null){
 				expression = new Expression(expression);
-				expression.bindExpression(StructureMapping.this);
+				expression.bindExpression(getSimulationContext());
 			}
 			Expression oldValue = fieldParameterExpression;
 			fieldParameterExpression = expression;

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/StructureSizeSolver.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/StructureSizeSolver.java
@@ -14,7 +14,6 @@ import java.util.Enumeration;
 import java.util.List;
 
 import cbit.vcell.matrix.MatrixException;
-import cbit.vcell.parser.ExpressionBindingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vcell.util.TokenMangler;
@@ -82,15 +81,6 @@ public class StructureSizeSolver {
 			return null;
 		}
 
-		public SolverParameter get(StructureMappingParameter param){
-			for (SolverParameter solverParameter : solverParameters){
-				if (solverParameter.parameter == param){
-					return solverParameter;
-				}
-			}
-			return null;
-		}
-		
 		public String getName(StructureMappingParameter param){
 			for (SolverParameter solverParameter : solverParameters){
 				if (solverParameter.parameter == param){


### PR DESCRIPTION
#593 

subtle bug in expression binding caused math generation expression problem - not obvious - required very careful testing.