### PR TITLE
upon local/global math symbol conflicts, locals get "local_" prefix

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/AbstractStochMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/AbstractStochMathMapping.java
@@ -49,6 +49,7 @@ public abstract class AbstractStochMathMapping extends AbstractMathMapping {
 		refreshVariables();
 		
 		refreshLocalNameCount();
+		resolveMathSymbolConflicts();
 		refreshMathDescription();
 		reconcileWithOriginalModel();
 	}

--- a/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/DiffEquMathMapping.java
@@ -224,6 +224,7 @@ protected void refresh(MathMappingCallback callback) throws MappingException, Ex
 	}
 	refreshVariables();
 	refreshLocalNameCount();
+	resolveMathSymbolConflicts();
 	refreshMathDescription();		// we create math based on the transformed sim context
 	reconcileWithOriginalModel();	// we relate the symbols in the math to the symbols in the original sim context
 //	System.out.println("MathMapping.refresh End");

--- a/vcell-core/src/main/java/cbit/vcell/mapping/ParticleMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/ParticleMathMapping.java
@@ -1107,6 +1107,7 @@ protected void refresh(MathMappingCallback callback) throws MappingException, Ex
 	}
 	refreshVariables();
 	refreshLocalNameCount();
+	resolveMathSymbolConflicts();
 	refreshMathDescription();
 	combineHybrid();
 	reconcileWithOriginalModel();


### PR DESCRIPTION
#533

VCell has a global biological namespace for species and parameters and local namespaces for locally defined reaction parameters. 

normally, we mangle the local parameters by adding a suffix related to the reaction name (e.g. "_r0") to the local name (e.g. "J") which yields "J_r0" which is typically unique. 

On rare occasion, the mangled name conflicts with another Math Symbol Name.  Given that we have no unambiguous naming scheme which protects against generated math symbol conflicts (e.g. like using fully qualified names from biological symbols), we review the putative Math Symbol names assigned to each biological entity and look for naming conflicts. 

Upon conflict, we rename the locally defined entities (e.g. local reaction parameters) using the prefix "localN_" where N counts from 0 to M if M local entities share the same name. 
