### PR TITLE
fix NPE when calling SBMLDocument.printErrors() when no errors.

### DIFF
--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/MathModel_SBMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/MathModel_SBMLExporter.java
@@ -253,7 +253,9 @@ public static String getSBMLString(cbit.vcell.mathmodel.MathModel mathModel, lon
 
 	// Error check - use libSBML's document.printError to print to outputstream
 	System.out.println("\n\nSBML Export Error Report");
-	sbmlDocument.printErrors(System.out);
+	if (sbmlDocument.getErrorCount()>0) {
+		sbmlDocument.printErrors(System.out);
+	}
 
 	return sbmlStr;
 }


### PR DESCRIPTION
see #608 

Fixes failure in parameter estimation when trying to print SBMLDocument Errors (but there are no SBML Errors - list is null).