### PR TITLE
VCell_Rel 7.4 patch - fix NPE when calling SBMLDocument.printErrors() when no errors.

### DIFF
--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/MathModel_SBMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/MathModel_SBMLExporter.java
@@ -271,7 +271,9 @@ public static String getSBMLString(cbit.vcell.mathmodel.MathModel mathModel, lon
 
 	// Error check - use libSBML's document.printError to print to outputstream
 	System.out.println("\n\nSBML Export Error Report");
-	sbmlDocument.printErrors(System.out);
+	if (sbmlDocument.getErrorCount()>0) {
+		sbmlDocument.printErrors(System.out);
+	}
 
 	return sbmlStr;
 }


### PR DESCRIPTION
see #608

hot patch for VCell_Rel (currently version 7.4.34)