### PR TITLE
Sbml importing of a param with the same name as a reserved symbol.

### DIFF
--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
@@ -1259,7 +1259,7 @@ public class SBMLImporter {
 	// returns true if reserved x,y,z symbols are used inappropriately - like in a non-spatial model
 	public static boolean isRestrictedXYZT(String name, BioModel vcBioModel, boolean bSpatial) {
 		if(bSpatial) {
-			return false;
+			return false;	// if spatial, xyzt are not restricted / reserved
 		}
 		ReservedSymbol rs = vcBioModel.getModel().getReservedSymbolByName(name);
 		if(rs == null) {

--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
@@ -858,6 +858,8 @@ public class SBMLImporter {
 							if(ExpressionUtils.functionallyEquivalent(new Expression(rsValue), new Expression(sbmlValue))) {
 								sbmlSymbolMapping.putRuntime(sbmlGlobalParam, rs);
 								continue;	// it's a reserved symbol, we have it already
+							} else {
+								vcParamName = ReservedParamPrefix + sbmlParamId;
 							}
 						} else if(!isSetRsValue && !isSetSbmlValue) {
 							continue;


### PR DESCRIPTION
But not functionally equivalent.
In which case we add the "param" prefix.