### PR TITLE
Fixed renamed reaction parameters revert to predefined names on save.

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
@@ -450,6 +450,7 @@ java.io.Serializable, IssueSource, Relatable
 			super.firePropertyChange(PROPERTYNAME_NAME, oldValue, name);
 		}
 		private void replaceNameLocal(String name) {
+			// used rather than setName() to avoid unnecessary propogation of an alternate name during parsing.
 			fieldParameterName = name;
 		}
 		
@@ -1158,6 +1159,8 @@ private ArrayList<KineticsParameter> getKineticsParametersFromTokens(String kine
 			
 			//
 			// find out if expression refers to another parameter declaration (expression of type "paramName;").
+			//
+			//     e.g. CurrentDensity I2;
 			//
 			String[] symbols = exp.getSymbols();
 			boolean bIsSingleId = false;

--- a/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
@@ -1224,6 +1224,16 @@ private ArrayList<KineticsParameter> getKineticsParametersFromTokens(String kine
 		ForwardRate K1;
 		ReverseRate K2;
 	} 
+	 ... or ...
+	Kinetics MassActionKinetics {
+		ForwardRate 'Kf_PIP2_PLC'
+		ReverseRate 'Kr_PIP2_PLC'
+		Parameter Kf_PIP2_PLC kf_PIP2PLC;
+		Parameter Kr_PIP2_PLC kr_PIP2PLC;
+		Parameter kf_PIP2PLC 200.0;
+		Parameter kr_PIP2PLC (Kd_PIP2PLC * kf_PIP2PLC);
+		Parameter Kd_PIP2PLC 2.0;
+	}
 	 */
 	for (String origSymbol : symbolRenamings.keySet()){
 		String newSymbol = symbolRenamings.get(origSymbol);

--- a/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
@@ -449,7 +449,10 @@ java.io.Serializable, IssueSource, Relatable
 			}
 			super.firePropertyChange(PROPERTYNAME_NAME, oldValue, name);
 		}
-
+		private void replaceNameLocal(String name) {
+			fieldParameterName = name;
+		}
+		
 		public boolean isDescriptionEditable() {
 			return false;
 		}
@@ -1129,14 +1132,14 @@ private ArrayList<KineticsParameter> getKineticsParametersFromTokens(String kine
 		}
 
 		String nextTokenAfterRole = tokens.nextToken();
-		if (nextTokenAfterRole.endsWith("'") && nextTokenAfterRole.startsWith("'")){
+		if (nextTokenAfterRole.endsWith(";")){
 			//
 			// if requiredIdentifier name is present (delimited by single quotes)
 			// use it as the user-supplied name for that required parameter
 			//
 			//     e.g. CurrentDensity 'currentDensity'
 			//
-			String parmName = nextTokenAfterRole.substring(1,nextTokenAfterRole.length()-1);
+			String parmName = nextTokenAfterRole.substring(0,nextTokenAfterRole.length()-1);
 			if (!parameterForRole.getName().equals(parmName)){
 				symbolRenamings.put(parameterForRole.getName(),parmName);
 			}
@@ -1219,7 +1222,7 @@ private ArrayList<KineticsParameter> getKineticsParametersFromTokens(String kine
 		}
 		for (KineticsParameter kp : localParameters){
 			if (kp.getName().equals(origSymbol)){
-				kp.setName(newSymbol);
+				kp.replaceNameLocal(newSymbol);
 				if (newParam != null && kp.getExpression().isZero()){
 					kp.setExpression(new Expression(newParam.getExpression()));
 				}

--- a/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
@@ -1247,7 +1247,7 @@ private ArrayList<KineticsParameter> getKineticsParametersFromTokens(String kine
 	// merge parameters with same name (one is UserDefined, the other is Reserved role)
 	//
 	boolean bDirty = true;
-	while (bDirty){
+	while (bDirty) {
 		bDirty = false;
 		for (KineticsParameter kp1 : localParameters){
 			KineticsParameter kp_withSameName = null;

--- a/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
@@ -1132,14 +1132,14 @@ private ArrayList<KineticsParameter> getKineticsParametersFromTokens(String kine
 		}
 
 		String nextTokenAfterRole = tokens.nextToken();
-		if (nextTokenAfterRole.endsWith(";")){
+		if (nextTokenAfterRole.endsWith("'") && nextTokenAfterRole.startsWith("'")){
 			//
 			// if requiredIdentifier name is present (delimited by single quotes)
 			// use it as the user-supplied name for that required parameter
 			//
 			//     e.g. CurrentDensity 'currentDensity'
 			//
-			String parmName = nextTokenAfterRole.substring(0,nextTokenAfterRole.length()-1);
+			String parmName = nextTokenAfterRole.substring(1,nextTokenAfterRole.length()-1);
 			if (!parameterForRole.getName().equals(parmName)){
 				symbolRenamings.put(parameterForRole.getName(),parmName);
 			}

--- a/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/Kinetics.java
@@ -1209,9 +1209,19 @@ private ArrayList<KineticsParameter> getKineticsParametersFromTokens(String kine
 		}
 	}
 	
-	//
-	// rename reserved parameter names and update expressions to reflect new names
-	//
+	/*
+	 * rename reserved parameter names and update expressions to reflect new names
+	 * typical renaming example of kinetics_vcmlStr, Kf, Kr renamed to K1, K2
+	 * 
+	 Kinetics MassActionKinetics { 
+		Parameter J ((K1 * s0) - (K2 * s1)); [uM.s-1]
+		Parameter K1 (g0 / g1); [s-1]
+		Parameter K2 (g1 / g0); [s-1]
+		Rate J;
+		ForwardRate K1;
+		ReverseRate K2;
+	} 
+	 */
 	for (String origSymbol : symbolRenamings.keySet()){
 		String newSymbol = symbolRenamings.get(origSymbol);
 		KineticsParameter newParam = null;


### PR DESCRIPTION
Addressing issue #333