### PR TITLE
Error message on trying to run sim (and database constraint bug)

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/solver/Simulation.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/Simulation.java
@@ -180,17 +180,6 @@ public Simulation(MathDescription mathDescription, SimulationOwner simulationOwn
 	this( );
 	addVetoableChangeListener(this);
 
-	// Give temporary fieldSimulationVersion (needed for linuxSharedLibs())
-	fieldSimulationVersion = SimulationVersion.createTempSimulationVersion();
-	
-	fieldName = fieldSimulationVersion.getName();
-	fieldDescription = fieldSimulationVersion.getAnnot();
-	if (fieldSimulationVersion.getParentSimulationReference()!=null){
-		fieldSimulationIdentifier = null;
-	}else{
-		fieldSimulationIdentifier = createSimulationID(fieldSimulationVersion.getVersionKey());
-	}
-
 	try {
 		setMathDescription(mathDescription);
 	} catch (java.beans.PropertyVetoException e) {


### PR DESCRIPTION
see Issue #816.

This fix should fix the "simulation not found" server-side errors as well as the SQL Constraint errors sometimes found in database service.

The solution was not roll back the addition of a random simulation key which was introduced in PR #445 - will reopen #445 to find a more surgical solution to local computation with field data.
