### PR TITLE
set vcell-sched init/max container size from 500/1000MB to 1000/2000MB

### DIFF
--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -121,9 +121,9 @@ services:
       replicas: 1
       resources:
         limits:
-          memory: 1000M
+          memory: 2000M
         reservations:
-          memory: 500M
+          memory: 1000M
       placement:
         constraints:
           - node.labels.zone == INTERNAL


### PR DESCRIPTION
see #859

to accommodate vcell-sched java heap space errors on server