### PR TITLE
Fixed issue where unix systems accidentally deleted needed files too soon.

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/run/ExecutionJob.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/ExecutionJob.java
@@ -142,6 +142,7 @@ public class ExecutionJob {
                 else logger.error("Processing of SedML has failed.\n" + stats.toString());
             }
             Hdf5Writer.writeHdf5(masterHdf5File, new File(this.outputDir));
+            
         } catch(PythonStreamException e){
             logger.error("Python-processing encountered fatal error. Execution is unable to properly continue.", e);
             throw e;

--- a/vcell-cli/src/main/java/org/vcell/cli/run/SedmlJob.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/SedmlJob.java
@@ -3,6 +3,7 @@ package org.vcell.cli.run;
 import cbit.vcell.resource.OperatingSystemInfo;
 import cbit.vcell.xml.ExternalDocInfo;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jlibsedml.*;
@@ -354,11 +355,11 @@ public class SedmlJob {
 
         for (File tempH5File : solverHandler.spatialResults.values()) {
             if (tempH5File == null) continue;
-            try {
-                Files.delete(tempH5File.toPath());
-            } catch (AccessDeniedException e) {
-                logger.error("Unable to delete intermediate file (due to JHDF suffering from JDK-4715154?).", e);
-            }
+            tempH5File.deleteOnExit();
+            if (!SystemUtils.IS_OS_WINDOWS) continue;
+            String message = "VCell can not delete intermediate file '%' on Windows OS " +
+                    "(this is due to the JHDF library suffering from JDK-4715154?).";
+            logger.warn(String.format(message, tempH5File.getName()));
         }
     }
 

--- a/vcell-cli/src/main/java/org/vcell/cli/run/SedmlJob.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/SedmlJob.java
@@ -357,7 +357,7 @@ public class SedmlJob {
             if (tempH5File == null) continue;
             tempH5File.deleteOnExit();
             if (!SystemUtils.IS_OS_WINDOWS) continue;
-            String message = "VCell can not delete intermediate file '%' on Windows OS " +
+            String message = "VCell can not delete intermediate file '%s' on Windows OS " +
                     "(this is due to the JHDF library suffering from JDK-4715154?).";
             logger.warn(String.format(message, tempH5File.getName()));
         }


### PR DESCRIPTION
An artifact of the old code was deleting the temporary spatial hdf5s used in CLI to store spatial results. This ended up being a bug that was largely silent on windows because of an existing JDK bug that does not properly delete files window's is holding onto like a Jack Russell terrier. However there were catastrophic effects on unix devices.

Call has been replaced with a `deleteOnExit` call, with a warning if the OS is windows that the operation will not succeed.

closes #876 by proxy, as this is the last step. 