### PR TITLE
Fixed exception throwing, fixed vcell cli log creation option, and fixed variable passing

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteCommand.java
@@ -67,7 +67,6 @@ public class ExecuteCommand implements Callable<Integer> {
     public Integer call() {
         CLIRecorder cliLogger = null;
         try {
-            cliLogger = new CLIRecorder(outputFilePath); // CLILogger will throw an execption if our output dir isn't valid.
 
             Level logLevel = logger.getLevel();
             if (!bQuiet && bDebug) {
@@ -75,6 +74,10 @@ public class ExecuteCommand implements Callable<Integer> {
             } else if (bQuiet) {
                 logLevel = Level.OFF;
             }
+
+            // CLILogger will throw an exception if our output dir isn't valid.
+            boolean shouldFlush = this.bKeepFlushingLogs || (this.bForceLogFiles && this.bDebug);
+            cliLogger = new CLIRecorder(this.outputFilePath, this.bForceLogFiles, shouldFlush);
             
             LoggerContext config = (LoggerContext)(LogManager.getContext(false));
             config.getConfiguration().getLoggerConfig(LogManager.getLogger("org.vcell").getName()).setLevel(logLevel);
@@ -122,7 +125,8 @@ public class ExecuteCommand implements Callable<Integer> {
             }
 
             
-            CLIPythonManager.getInstance().closePythonProcess(); // WARNING: Python will need reinstantiation after this is called
+            CLIPythonManager.getInstance().closePythonProcess();
+            // WARNING: Python needs re-instantiation once the above line is called!
             return 0;
         } catch (Exception e) { ///TODO: Break apart into specific exceptions to maximize logging.
             org.apache.logging.log4j.LogManager.getLogger(this.getClass()).error(e.getMessage(), e);

--- a/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteImpl.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteImpl.java
@@ -76,15 +76,6 @@ public class ExecuteImpl {
                 logger.info("Execution finished with no failures");
                 return;
             }
-            // We had failures.
-            StringBuilder failedFileString = new StringBuilder();
-            for (String f : failedFiles){
-                failedFileString.append(String.format("\t- %s\n", f));
-            }
-            String errString = "Execution finished, but the following file(s) failed:\n" + failedFileString;
-            logger.error(errString);
-            throw new ExecutionException(errString);
-
         } catch (Exception e) {
             StringBuilder failedFileString = new StringBuilder();
             logger.fatal("Fatal error caught executing batch mode (ending execution)", e);
@@ -95,6 +86,14 @@ public class ExecuteImpl {
 
             throw new RuntimeException("Fatal error caught executing batch mode", e);
         }
+
+        // We had failures.
+        StringBuilder failedFileString = new StringBuilder();
+        for (String f : failedFiles){
+            failedFileString.append(String.format("\t- %s\n", f));
+        }
+        String errString = "Execution finished, but the following file(s) failed:\n" + failedFileString;
+        logger.error(errString);
     }
 
     private static void runSingleExecOmex(File inputFile, File outputDir, CLIRecordable cliLogger, boolean bKeepTempFiles,
@@ -199,10 +198,11 @@ public class ExecuteImpl {
             boolean bKeepTempFiles, boolean bExactMatchOnly, boolean bEncapsulateOutput, boolean bSmallMeshOverride,
             boolean bCoerceToDistributed)
             throws ExecutionException, PythonStreamException, IOException, InterruptedException, HDF5Exception {
-        ExecutionJob requestedExecution = new ExecutionJob(inputFile, rootOutputDir, cliRecorder, 
+
+        ExecutionJob requestedExecution = new ExecutionJob(inputFile, rootOutputDir, cliRecorder, bCoerceToDistributed,
             bKeepTempFiles, bExactMatchOnly, bEncapsulateOutput, bSmallMeshOverride);
         requestedExecution.preprocessArchive();
-        requestedExecution.executeArchive(bCoerceToDistributed);
+        requestedExecution.executeArchive();
         requestedExecution.postProcessessArchive();
     }
 

--- a/vcell-cli/src/main/java/org/vcell/cli/run/ExecutionJob.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/ExecutionJob.java
@@ -27,7 +27,7 @@ public class ExecutionJob {
     private final static Logger logger = LogManager.getLogger(ExecutionJob.class);
 
     private long startTime, endTime; 
-    private boolean bExactMatchOnly, bSmallMeshOverride, bKeepTempFiles;
+    private boolean bCoerceToDistributed, bExactMatchOnly, bSmallMeshOverride, bKeepTempFiles;
     private StringBuilder logOmexMessage;
     private String inputFilePath, bioModelBaseName, outputBaseDir, outputDir;
     private boolean anySedmlDocumentHasSucceeded = false;    // set to true if at least one sedml document run is successful
@@ -51,7 +51,7 @@ public class ExecutionJob {
      * @param bEncapsulateOutput whether to provide a sub-folder for outputs (needed for batch jobs)
      * @param bSmallMeshOverride whether to use small meshes or standard meshes.
      */
-    public ExecutionJob(File inputFile, File rootOutputDir, CLIRecordable cliRecorder,
+    public ExecutionJob(File inputFile, File rootOutputDir, CLIRecordable cliRecorder, boolean bCoerceToDistributed,
             boolean bKeepTempFiles, boolean bExactMatchOnly, boolean bEncapsulateOutput, boolean bSmallMeshOverride){
         this();
         this.inputFile = inputFile;
@@ -61,6 +61,7 @@ public class ExecutionJob {
         this.bioModelBaseName = FileUtils.getBaseName(inputFile.getName()); // input file without the path
         this.outputBaseDir = rootOutputDir.getAbsolutePath();
         this.outputDir = bEncapsulateOutput ? Paths.get(outputBaseDir, bioModelBaseName).toString() : outputBaseDir;
+        this.bCoerceToDistributed = bCoerceToDistributed;
         this.bKeepTempFiles = bKeepTempFiles;
         this.bExactMatchOnly = bExactMatchOnly;
         this.bSmallMeshOverride = bSmallMeshOverride;
@@ -122,21 +123,22 @@ public class ExecutionJob {
      * @throws IOException if there are system I/O issues
      * @throws ExecutionException if an execution specfic error occurs
      */
-    public void executeArchive(boolean bCoerceToDistributed) throws HDF5Exception, PythonStreamException, ExecutionException {
+    public void executeArchive() throws HDF5Exception, PythonStreamException, ExecutionException {
         try {
             Hdf5DataContainer masterHdf5File = new Hdf5DataContainer();
             this.queueAllSedml();
 
             for (String sedmlLocation : this.sedmlLocations){
-                SedmlJob job = new SedmlJob(sedmlLocation, this.omexHandler, this.inputFile, new File(this.outputBaseDir), this.outputDir, this.sedmlPath2d3d.toString(), 
-                    this.cliRecorder, this.bKeepTempFiles, this.bExactMatchOnly, this.bSmallMeshOverride, this.logOmexMessage);
+                SedmlJob job = new SedmlJob(sedmlLocation, this.omexHandler, this.inputFile, new File(this.outputBaseDir),
+                        this.outputDir, this.sedmlPath2d3d.toString(), this.cliRecorder, this.bCoerceToDistributed,
+                        this.bKeepTempFiles, this.bExactMatchOnly, this.bSmallMeshOverride, this.logOmexMessage);
                 if (!job.preProcessDoc()){
                     SedmlStatistics stats = job.getDocStatistics(); // Must process document first
                     logger.error("Statistics of failed SedML:\n" + stats.toString());
                     this.anySedmlDocumentHasFailed = true;
                 }
                 SedmlStatistics stats = job.getDocStatistics();
-                boolean hasSucceeded = job.simulateSedml(masterHdf5File, bCoerceToDistributed);
+                boolean hasSucceeded = job.simulateSedml(masterHdf5File);
                 this.anySedmlDocumentHasSucceeded |= hasSucceeded;
                 this.anySedmlDocumentHasFailed &= hasSucceeded;
                 if (hasSucceeded) logger.info("Processing of SedML succeeded.\n" + stats.toString());


### PR DESCRIPTION
1) An exception was thrown to indicicate models had failed, but instead caused VCell to believe it had fatally crashed.
2) vcell batch mode improperly disregarded a flag telling it to force vcell log files. Additional features to keep flushing the logs were included.
3) "bCoerceToDistributed" was passed down from start to end as a local variable, but had no impact on most functions it passed through. It's now passed to constructers only and saved as a constant instance variable (similar to the other boolean runtime options, like bKeepLogFiles)