### PR TITLE
replace altool with notarytool in Macos installer notarization

### DIFF
--- a/.github/workflows/site_deploy.yml
+++ b/.github/workflows/site_deploy.yml
@@ -115,13 +115,17 @@ jobs:
         set +e
         cd installers
         export MAC_INSTALLER=`ls *dmg`
-        xcrun altool --notarize-app --primary-bundle-id "edu.uchc.vcell.alpha" -u "${{ secrets.MACID }}" -p "${{ secrets.MACPW }}" --file $MAC_INSTALLER > altool_output
-        cat altool_output | grep UUID | cut -d " " -f3 > UUID
+        xcrun notarytool submit --output-format normal --no-progress --no-wait --team-id "${{ secrets.MACTEAMID }}" --apple-id "${{ secrets.MACID }}" --password "${{ secrets.MACPW }}" $MAC_INSTALLER > submit_output
+        echo "output returned by notarytool submit:"
+        cat submit_output
+        cat submit_output | grep UUID | cut -d " " -f3 > UUID
         for minutes in {1..5}
         do
           sleep 60
-          xcrun altool --notarization-info `cat UUID` -u "${{ secrets.MACID }}" -p "${{ secrets.MACPW }}" > status
-          grep -q success status
+          xcrun notarytool info --output-format normal --no-progress --team-id "${{ secrets.MACTEAMID }}" --apple-id "${{ secrets.MACID }}" --password "${{ secrets.MACPW }}" `cat UUID` > info_output
+          echo "output returned by notarytool info:"
+          cat info_output
+          grep -q success info_output
           if [[ $? == 0 ]]; then
             echo "notarized succesfully"
             break
@@ -129,7 +133,7 @@ jobs:
             echo "wait another minute and check again"
           fi
         done
-        grep -q success status
+        grep -q success info_output
         if [[ $? == 0 ]]; then
           xcrun stapler staple $MAC_INSTALLER
         else

--- a/.github/workflows/site_deploy.yml
+++ b/.github/workflows/site_deploy.yml
@@ -118,14 +118,14 @@ jobs:
         xcrun notarytool submit --output-format normal --no-progress --no-wait --team-id "${{ secrets.MACTEAMID }}" --apple-id "${{ secrets.MACID }}" --password "${{ secrets.MACPW }}" $MAC_INSTALLER > submit_output
         echo "output returned by notarytool submit:"
         cat submit_output
-        cat submit_output | grep UUID | cut -d " " -f3 > UUID
+        cat submit_output | grep "id:" | cut -d ':' -f2 > UUID
         for minutes in {1..5}
         do
           sleep 60
           xcrun notarytool info --output-format normal --no-progress --team-id "${{ secrets.MACTEAMID }}" --apple-id "${{ secrets.MACID }}" --password "${{ secrets.MACPW }}" `cat UUID` > info_output
           echo "output returned by notarytool info:"
           cat info_output
-          grep -q success info_output
+          grep -q Accepted info_output
           if [[ $? == 0 ]]; then
             echo "notarized succesfully"
             break
@@ -133,7 +133,7 @@ jobs:
             echo "wait another minute and check again"
           fi
         done
-        grep -q success info_output
+        grep -q Accepted info_output
         if [[ $? == 0 ]]; then
           xcrun stapler staple $MAC_INSTALLER
         else

--- a/vcell-api/src/main/java/org/vcell/rest/health/HealthService.java
+++ b/vcell-api/src/main/java/org/vcell/rest/health/HealthService.java
@@ -34,7 +34,7 @@ public class HealthService {
 	
 	private static final long LOGIN_TIME_WARNING = 10*1000;
 	private static final long LOGIN_TIME_ERROR = 30*1000;
-	private static final long SIMULATION_TIME_WARNING = 25*1000;
+	private static final long SIMULATION_TIME_WARNING = 45*1000;
 	private static final long SIMULATION_TIMEOUT = 8*60*1000;
 	private static final long LOGIN_LOOP_START_DELAY = 40*1000;
 	private static final long LOGIN_LOOP_SLEEP = 3*60*1000;


### PR DESCRIPTION
see #918 
use Apple's latest tool `notarytool` to notarize Macos Installers for VCell client, replacing the unsupported and soon to be discontinued `altool`.