### PR TITLE
955 database timezone

### DIFF
--- a/docker/build/Dockerfile-admin-dev
+++ b/docker/build/Dockerfile-admin-dev
@@ -3,7 +3,11 @@ FROM ubuntu:18.04
 RUN apt-get -y update && \
     apt-get install -y curl openjdk-8-jre dnsutils && \
     mkdir -p /usr/local/app/lib 
-	
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+RUN unlink /etc/localtime || true
+RUN ln -s /usr/share/zoneinfo/America/New_York /etc/localtime
+
 WORKDIR /usr/local/app
 
 COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \

--- a/docker/build/Dockerfile-api-dev
+++ b/docker/build/Dockerfile-api-dev
@@ -3,7 +3,11 @@ FROM ubuntu:18.04
 RUN apt-get -y update && \
     apt-get install -y curl openjdk-8-jre dnsutils && \
     mkdir -p /usr/local/app/lib 
-	
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+RUN unlink /etc/localtime || true
+RUN ln -s /usr/share/zoneinfo/America/New_York /etc/localtime
+
 WORKDIR /usr/local/app
 
 COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \
@@ -60,6 +64,7 @@ ENTRYPOINT java \
 	-Dvcell.server.dbDriverName="${dbdriver}" \
 	-Dvcell.server.dbUserid="${dbuser}" \
 	-Dvcell.db.pswdfile="${dbpswdfile}" \
+	-Duser.timezone="${userTimezone}" \
 	-Dvcell.jms.int.host.internal="${jmshost_int_internal}" \
 	-Dvcell.jms.int.port.internal="${jmsport_int_internal}" \
 	-Dvcell.jms.blobMessageUseMongo=true \

--- a/docker/build/Dockerfile-batch-dev
+++ b/docker/build/Dockerfile-batch-dev
@@ -86,6 +86,10 @@ RUN apt-get -y update && \
 #	wget --no-check-certificate https://download.opensuse.org/repositories/home:/fbergman:/COPASI/xUbuntu_17.10/amd64/python-copasi_4.22.170-1_amd64.deb && \
 #	gdebi -n -q python-copasi_4.22.170-1_amd64.deb
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+RUN unlink /etc/localtime || true
+RUN ln -s /usr/share/zoneinfo/America/New_York /etc/localtime
+
 RUN mkdir -p /usr/local/app/localsolvers && ln -s /vcellbin  /usr/local/app/localsolvers/linux64
 WORKDIR /usr/local/app
 

--- a/docker/build/Dockerfile-data-dev
+++ b/docker/build/Dockerfile-data-dev
@@ -60,6 +60,10 @@ RUN mkdir -p /usr/local/app && \
     apk add openssh-client && \
     apk add screen
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+RUN unlink /etc/localtime || true
+RUN ln -s /usr/share/zoneinfo/America/New_York /etc/localtime
+
 WORKDIR /usr/local/app
 
 COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \

--- a/docker/build/Dockerfile-db-dev
+++ b/docker/build/Dockerfile-db-dev
@@ -4,6 +4,10 @@ RUN mkdir -p /usr/local/app && \
 	apk update && \
     apk add screen
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+RUN unlink /etc/localtime || true
+RUN ln -s /usr/share/zoneinfo/America/New_York /etc/localtime
+
 WORKDIR /usr/local/app
 
 COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \

--- a/docker/build/Dockerfile-sched-dev
+++ b/docker/build/Dockerfile-sched-dev
@@ -6,6 +6,10 @@ RUN mkdir -p /usr/local/app && \
     apk add curl && \
     apk add screen
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+RUN unlink /etc/localtime || true
+RUN ln -s /usr/share/zoneinfo/America/New_York /etc/localtime
+
 WORKDIR /usr/local/app
 
 COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \

--- a/docker/build/Dockerfile-submit-dev
+++ b/docker/build/Dockerfile-submit-dev
@@ -5,6 +5,10 @@ RUN mkdir -p /usr/local/app && \
     apk add openssh-client && \
     apk add screen
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+RUN unlink /etc/localtime || true
+RUN ln -s /usr/share/zoneinfo/America/New_York /etc/localtime
+
 WORKDIR /usr/local/app
 
 COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \

--- a/docker/build/Dockerfile-web-dev
+++ b/docker/build/Dockerfile-web-dev
@@ -4,6 +4,10 @@ RUN apt-get -y update && \
     apt-get install -y curl openjdk-8-jre wget dnsutils && \
     mkdir -p /usr/local/app/lib
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+RUN unlink /etc/localtime || true
+RUN ln -s /usr/share/zoneinfo/America/New_York /etc/localtime
+
 WORKDIR /usr/local/app
 
 COPY ./vcell-web/target/vcell-web-0.0.1-SNAPSHOT.jar \

--- a/docker/database/backup_scripts/README.md
+++ b/docker/database/backup_scripts/README.md
@@ -1,0 +1,1 @@
+run ./archivedb.sh as root or with sudo to generate a dump in /data/backup

--- a/docker/database/backup_scripts/archivedb.sh
+++ b/docker/database/backup_scripts/archivedb.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run export of oracle 19c database running in the container named 'oracle-database' using the Data Pump 'expdp' command
+sudo docker exec -it oracle-database /opt/oracle/backup/scripts/run.sh 2>&1 | tee -a ../archivedb_$(date +%Y_%m_%d_%H_%M_%S).log
+
+# copy move dump file to remote storage
+echo "move dump files to remote storage - not yet mounted - do this manually"

--- a/docker/database/backup_scripts/newscn.sql
+++ b/docker/database/backup_scripts/newscn.sql
@@ -1,0 +1,3 @@
+set heading off
+Select CURRENT_SCN from v$database;
+quit

--- a/docker/database/backup_scripts/password.txt
+++ b/docker/database/backup_scripts/password.txt
@@ -1,0 +1,1 @@
+cbittech

--- a/docker/database/backup_scripts/run.sh
+++ b/docker/database/backup_scripts/run.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# export the oracle 19c database running in the container named 'oracle-database' using the Data Pump 'expdp' command
+# the export is written to the directory /data/backup on the database host with a timestamped .dmp file and .log file
+#
+# this script (archive.sh) is to be placed in /data/backup/scripts on the database host, along with newscn.sql and dbpswd.txt
+# usage
+#     sudo docker exec -it oracle-database /opt/oracle/backup/scripts/run.sh
+#   or
+#     sudo docker exec -it oracle-database /opt/oracle/backup/scripts/run.sh 2>&1 | tee -a archivedb_$(date +%Y_%m_%d_%H_%M).log
+#
+
+cd /opt/oracle/backup/scripts || echo "failed to cd to /opt/oracle/backup/scripts" || exit 1
+
+dateString=$(date +%Y_%m_%d_%H_%M_%S)
+logfile=orclpdb1_${dateString}.log
+dumpfile=orclpdb1_${dateString}.dmp
+
+password=$(cat /opt/oracle/backup/scripts/password.txt)
+
+# data the database SCN (system change number) at the time of the export
+SCN=$(sqlplus -S -L "system/${password}@ORCLPDB1" @newscn.sql | xargs) || echo "error getting scn" || exit 1
+echo SCN is "'${SCN}'"
+
+# dump to EXT_DATA_PUMP_DIR /opt/oracle/backup mounted to host /data/backup with timestamped .dmp and .log files
+expdp \
+  "system/${password}@localhost:1521/ORCLPDB1" \
+  directory=EXT_DATA_PUMP_DIR \
+  dumpfile="${dumpfile}" \
+  logfile="${logfile}" \
+  schemas=vcell \
+  flashback_scn="${SCN}"
+
+expdp_returnCode=$?
+if [ $expdp_returnCode != 0 ]; then
+  echo "Error exporting database"
+  exit 1
+else
+  echo "database dump to ${dumpfile} complete, please check logs in ${logfile}"
+  exit 0
+fi


### PR DESCRIPTION
see #955

Hard coded the timezone in the Dockerfiles to New_York (will follow EDT or EST depending on time of year) for all containerized VCell services.

For the future:
1. make the container follow the host timezone
2. make VCell insensitive to time zone (e.g. client displays in local timezone or users UTC for those things that should be absolute).