### PR TITLE
Admin CLI for model listing and ACLs

### DIFF
--- a/.github/workflows/nightly-model-testing.yml
+++ b/.github/workflows/nightly-model-testing.yml
@@ -127,7 +127,7 @@ jobs:
         # Do the conversion
       - name: Begin Conversion
         #$(docker image ls | grep "<none>" | awk '{print $3;}')  to get image id
-        run: docker run -v $GITHUB_WORKSPACE:/root $(docker image ls | grep "<none>" | awk '{print $3;}') export-omex-batch -i "/root/public/biomodel/vcml" -o "/root/export_conversion/output" -m SBML --offline # grabs image and runs
+        run: docker run -v $GITHUB_WORKSPACE:/root $(docker image ls | grep "<none>" | awk '{print $3;}') export-omex-batch -i "/root/public/biomodel/vcml" -o "/root/export_conversion/output" -m SBML # grabs image and runs
 
       # Parse the results
       - name: Parse Results

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/AdminCLI.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/AdminCLI.java
@@ -10,12 +10,14 @@ import org.vcell.admin.cli.db.DatabaseCompareSchemaCommand;
 import org.vcell.admin.cli.db.DatabaseDestroyAndRecreateCommand;
 import org.vcell.admin.cli.mathverifier.ModeldbLoadTestCommand;
 import org.vcell.admin.cli.mathverifier.ModeldbMathGenTestCommand;
+import org.vcell.admin.cli.models.ModelCommands;
 import org.vcell.admin.cli.sim.JobInfoCommand;
 import org.vcell.admin.cli.sim.ResultSetCrawlerCommand;
 import org.vcell.admin.cli.sim.SimDataVerifierCommand;
 import org.vcell.admin.cli.tools.UsageCommand;
 import org.vcell.dependency.server.VCellServerModule;
 import org.vcell.util.document.KeyValue;
+import org.vcell.util.document.User;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -30,6 +32,7 @@ import picocli.CommandLine.Command;
         SimDataVerifierCommand.class,
         JobInfoCommand.class,
         CommandLine.HelpCommand.class,
+        ModelCommands.class
 })
 public class AdminCLI {
 
@@ -45,6 +48,7 @@ public class AdminCLI {
             AdminCLI adminCLI = injector.getInstance(AdminCLI.class);
             CommandLine commandLine = new CommandLine(adminCLI);
             commandLine.registerConverter(KeyValue.class, new KeyValueTypeConverter());
+            commandLine.registerConverter(User.class, new UserTypeConverter());
             commandLine.registerConverter(MathVerifier.DatabaseMode.class, new DatabaseModeTypeConverter());
             exitCode = commandLine.execute(args);
         } catch (Throwable t){
@@ -59,6 +63,13 @@ public class AdminCLI {
         @Override
         public KeyValue convert(String value) {
             return new KeyValue(value);
+        }
+    }
+
+    static class UserTypeConverter implements CommandLine.ITypeConverter<User> {
+        @Override
+        public User convert(String value) {
+            return new User(value.split(":")[0], new KeyValueTypeConverter().convert(value.split(":")[1]));
         }
     }
 

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/CLIDatabaseService.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/CLIDatabaseService.java
@@ -125,4 +125,56 @@ public class CLIDatabaseService implements AutoCloseable {
         SimulationDatabase simulationDatabase = new SimulationDatabaseDirect(adminDBTopLevel, dbServerImpl,false);
         return new JobAdmin(adminDBTopLevel, dbServerImpl, simulationDatabase);
     }
+
+    public GroupAccess addGroupAccess(BioModelInfo bioModelInfo, User userToAdd) throws DataAccessException {
+        boolean bHidden = false;
+        VersionInfo newVersionInfo = getDatabaseServer().groupAddUser(
+                bioModelInfo.getVersion().getOwner(),
+                VersionableType.BioModelMetaData, bioModelInfo.getVersion().getVersionKey(),
+                userToAdd.getName(), bHidden);
+        return newVersionInfo.getVersion().getGroupAccess();
+    }
+
+    public GroupAccess removeGroupAccess(BioModelInfo bioModelInfo, User userToAdd) throws DataAccessException {
+        boolean bHidden = false;
+        VersionInfo newVersionInfo = getDatabaseServer().groupRemoveUser(
+                bioModelInfo.getVersion().getOwner(),
+                VersionableType.BioModelMetaData, bioModelInfo.getVersion().getVersionKey(),
+                userToAdd.getName(), bHidden);
+        return newVersionInfo.getVersion().getGroupAccess();
+    }
+
+    public GroupAccess addGroupAccess(MathModelInfo mathModelInfo, User userToAdd) throws DataAccessException {
+        boolean bHidden = false;
+        VersionInfo newVersionInfo = getDatabaseServer().groupAddUser(
+                mathModelInfo.getVersion().getOwner(),
+                VersionableType.MathModelMetaData, mathModelInfo.getVersion().getVersionKey(),
+                userToAdd.getName(), bHidden);
+        return newVersionInfo.getVersion().getGroupAccess();
+    }
+
+    public GroupAccess removeGroupAccess(MathModelInfo mathModelInfo, User userToAdd) throws DataAccessException {
+        boolean bHidden = false;
+        VersionInfo newVersionInfo = getDatabaseServer().groupRemoveUser(
+                mathModelInfo.getVersion().getOwner(),
+                VersionableType.MathModelMetaData, mathModelInfo.getVersion().getVersionKey(),
+                userToAdd.getName(), bHidden);
+        return newVersionInfo.getVersion().getGroupAccess();
+    }
+
+    public BioModelInfo queryBiomodelInfo(User owner, KeyValue biomodelId) throws DataAccessException {
+        return getDatabaseServer().getBioModelInfo(owner, biomodelId);
+    }
+
+    public MathModelInfo queryMathmodelInfo(User owner, KeyValue mathmodelId) throws DataAccessException {
+        return getDatabaseServer().getMathModelInfo(owner, mathmodelId);
+    }
+
+    public List<BioModelInfo> queryBiomodelsByOwner(User owner) throws DataAccessException {
+        return Arrays.asList(getDatabaseServer().getBioModelInfos(owner, false));
+    }
+
+    public List<MathModelInfo> queryMathmodelsByOwner(User owner) throws DataAccessException {
+        return Arrays.asList(getDatabaseServer().getMathModelInfos(owner, false));
+    }
 }

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/models/ModelCommands.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/models/ModelCommands.java
@@ -1,0 +1,31 @@
+package org.vcell.admin.cli.models;
+
+import cbit.vcell.resource.PropertyLoader;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.vcell.admin.cli.CLIDatabaseService;
+import org.vcell.util.document.*;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+@Command(name = "model", description = "administrative operations on biomodels and mathmodels", subcommands = {
+        ModelListCommand.class,
+        ModelPermissionCommand.class,
+})
+public class ModelCommands {
+
+    private final static Logger logger = LogManager.getLogger(ModelCommands.class);
+
+    @Option(names = {"-d", "--debug"}, description = "full application debug mode")
+    private boolean bDebug = false;
+
+    @Option(names = {"-h", "--help"}, description = "show this help message and exit", usageHelp = true)
+    private boolean help;
+
+}

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/models/ModelListCommand.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/models/ModelListCommand.java
@@ -1,0 +1,64 @@
+package org.vcell.admin.cli.models;
+
+import cbit.vcell.resource.PropertyLoader;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.vcell.admin.cli.CLIDatabaseService;
+import org.vcell.util.document.*;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+@Command(name = "ls", description = "list biomodels and mathmodels by user")
+public class ModelListCommand implements Callable<Integer> {
+
+    private final static Logger logger = LogManager.getLogger(ModelListCommand.class);
+
+    @Option(names = "--owner", required = true, description = "model owner (format is 'userid:key')")
+    private User owner;
+
+    @Option(names = {"-d", "--debug"}, description = "full application debug mode")
+    private boolean bDebug = false;
+
+    @Option(names = {"-h", "--help"}, description = "show this help message and exit", usageHelp = true)
+    private boolean help;
+
+    public Integer call() {
+        Level logLevel = bDebug ? Level.DEBUG : logger.getLevel();
+        
+        LoggerContext config = (LoggerContext)(LogManager.getContext(false));
+        config.getConfiguration().getLoggerConfig(LogManager.getLogger("org.vcell").getName()).setLevel(logLevel);
+        config.getConfiguration().getLoggerConfig(LogManager.getLogger("cbit").getName()).setLevel(logLevel);
+        config.updateLoggers();
+
+        try {
+            
+            PropertyLoader.loadProperties();
+
+            try (CLIDatabaseService cliDatabaseService = new CLIDatabaseService()) {
+
+                List<BioModelInfo> bioModelInfos = cliDatabaseService.queryBiomodelsByOwner(owner);
+                for (BioModelInfo bioModelInfo : bioModelInfos) {
+                    System.out.println("BioModel: "+bioModelInfo);
+                }
+                List<MathModelInfo> mathModelInfos = cliDatabaseService.queryMathmodelsByOwner(owner);
+                for (MathModelInfo mathModelInfo : mathModelInfos) {
+                    System.out.println("MathModel: "+mathModelInfo);
+                }
+            }
+
+            return 0;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
+        } finally {
+            logger.debug("BioModel XML download completed");
+        }
+    }
+
+}

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/models/ModelPermissionCommand.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/models/ModelPermissionCommand.java
@@ -1,0 +1,108 @@
+package org.vcell.admin.cli.models;
+
+import cbit.vcell.resource.PropertyLoader;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.vcell.admin.cli.CLIDatabaseService;
+import org.vcell.util.document.*;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.util.concurrent.Callable;
+
+@Command(name = "acl", description = "add or remove user access to a biomodel or mathmodel")
+public class ModelPermissionCommand implements Callable<Integer> {
+
+    enum Operation {
+        add,
+        remove
+    };
+
+    private final static Logger logger = LogManager.getLogger(ModelPermissionCommand.class);
+
+    @Option(names = "--biomodel-id", description = "id of single biomodel")
+    private KeyValue biomodelID;
+
+    @Option(names = "--mathmodel-id", description = "id of single mathmodel")
+    private KeyValue mathmodelID;
+
+    @Option(names = "--owner", required = true, description = "model owner (format is 'userid:key')")
+    private User owner;
+
+    @Option(names = "--user", required = true, description = "user to add/remove (format is 'userid:key')")
+    private User user;
+
+    @Option(names = "--operation", required = true, description = "operation to perform (add/remove)")
+    private Operation operation;
+
+    @Option(names = {"-d", "--debug"}, description = "full application debug mode")
+    private boolean bDebug = false;
+
+    @Option(names = {"-h", "--help"}, description = "show this help message and exit", usageHelp = true)
+    private boolean help;
+
+    public Integer call() {
+        Level logLevel = bDebug ? Level.DEBUG : logger.getLevel();
+        
+        LoggerContext config = (LoggerContext)(LogManager.getContext(false));
+        config.getConfiguration().getLoggerConfig(LogManager.getLogger("org.vcell").getName()).setLevel(logLevel);
+        config.getConfiguration().getLoggerConfig(LogManager.getLogger("cbit").getName()).setLevel(logLevel);
+        config.updateLoggers();
+
+        try {
+            
+            PropertyLoader.loadProperties();
+
+            if (biomodelID!=null && mathmodelID!=null) {
+                throw new RuntimeException("cannot specify both --biomodel-id and --mathmodel-id");
+            }
+
+            if (biomodelID==null && mathmodelID==null) {
+                throw new RuntimeException("must specify either --biomodel-id or --mathmodel-id");
+            }
+
+            try (CLIDatabaseService cliDatabaseService = new CLIDatabaseService()) {
+                if (biomodelID != null){
+                    BioModelInfo bioModelInfo = cliDatabaseService.queryBiomodelInfo(owner, biomodelID);
+                    if (bioModelInfo == null) {
+                        throw new RuntimeException("biomodel key "+biomodelID+" not found as a biomodel owned by "+owner);
+                    }
+                    GroupAccess oldGroupAccess = bioModelInfo.getVersion().getGroupAccess();
+                    GroupAccess newGroupAccess = null;
+                    if (operation == Operation.remove) {
+                        newGroupAccess = cliDatabaseService.removeGroupAccess(bioModelInfo, user);
+                    }else if (operation == Operation.add) {
+                        newGroupAccess = cliDatabaseService.addGroupAccess(bioModelInfo, user);
+                    }else{
+                        throw new RuntimeException("unknown operation "+operation);
+                    }
+                    System.out.println("biomodel "+biomodelID+" group access changed from "+oldGroupAccess+" to "+newGroupAccess);
+                }else if (mathmodelID != null) {
+                    MathModelInfo mathModelInfo = cliDatabaseService.queryMathmodelInfo(owner, mathmodelID);
+                    if (mathModelInfo == null) {
+                        throw new RuntimeException("mathmodel key "+mathmodelID+" not found as a mathmodel owned by "+owner);
+                    }
+                    GroupAccess oldGroupAccess = mathModelInfo.getVersion().getGroupAccess();
+                    GroupAccess newGroupAccess = null;
+                    if (operation == Operation.remove) {
+                        newGroupAccess = cliDatabaseService.removeGroupAccess(mathModelInfo, user);
+                    }else if (operation == Operation.add) {
+                        newGroupAccess = cliDatabaseService.addGroupAccess(mathModelInfo, user);
+                    }else{
+                        throw new RuntimeException("unknown operation "+operation);
+                    }
+                    System.out.println("mathmodel "+mathmodelID+" group access changed from "+oldGroupAccess+" to "+newGroupAccess);
+                }
+            }
+
+            return 0;
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        } finally {
+            logger.debug("BioModel XML download completed");
+        }
+    }
+
+}

--- a/vcell-cli/src/main/java/org/vcell/cli/vcml/ExportOmexBatchCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/vcml/ExportOmexBatchCommand.java
@@ -29,15 +29,6 @@ public class ExportOmexBatchCommand implements Callable<Integer> {
     @Option(names = {"-d", "--debug"}, description = "full application debug mode")
     private boolean bDebug = false;
 
-    @Option(names = "--hasDataOnly")
-    boolean bHasDataOnly;
-
-    @Option(names = "--makeLogsOnly")
-    boolean bMakeLogsOnly;
-
-    @Option(names = "--nonSpatialOnly")
-    boolean bNonSpatialOnly;
-
     @Option(names = "--validate")
     boolean bValidateOmex;
 
@@ -46,12 +37,6 @@ public class ExportOmexBatchCommand implements Callable<Integer> {
 
     @Option(names = { "--skipUnsupportedApps" }, defaultValue = "false", description = "skip unsupported applications (e.g. electrical in SBML)")
     private boolean bSkipUnsupportedApps = false;
-
-    @Option(names = "--keepFlushingLogs")
-    boolean bKeepFlushingLogs;
-
-    @Option(names = "--offline", hidden = true, defaultValue = "true", description = "offline parameter is not used anymore, database access is removed")
-    boolean bOffline=true;
 
     @Option(names = {"-h", "--help"}, description = "show this help message and exit", usageHelp = true)
     private boolean help;
@@ -63,10 +48,6 @@ public class ExportOmexBatchCommand implements Callable<Integer> {
         config.getConfiguration().getLoggerConfig(LogManager.getLogger("org.vcell").getName()).setLevel(logLevel);
         config.getConfiguration().getLoggerConfig(LogManager.getLogger("cbit").getName()).setLevel(logLevel);
         config.updateLoggers();
-
-        if (!bOffline){
-            throw new RuntimeException("offline parameter is not used anymore, database access has been removed");
-        }
 
         try {
 

--- a/vcell-core/src/main/java/org/vcell/util/document/BioModelInfo.java
+++ b/vcell-core/src/main/java/org/vcell/util/document/BioModelInfo.java
@@ -223,7 +223,8 @@ public int hashCode() {
  * @return java.lang.String
  */
 public String toString() {
-	return "BioModelInfo(modelKey="+modelKey+",Version="+version+",softwareVersion="+softwareVersion+")";
+	String swVersion = (softwareVersion == null ? "null" : softwareVersion.getSoftwareVersionString());
+	return "BioModelInfo(modelKey="+modelKey+",Version="+version+",softwareVersion="+swVersion+")";
 }
 public VersionableType getVersionType() {	
 	return VersionableType.BioModelMetaData;

--- a/vcell-core/src/main/java/org/vcell/util/document/MathModelInfo.java
+++ b/vcell-core/src/main/java/org/vcell/util/document/MathModelInfo.java
@@ -170,7 +170,8 @@ public int hashCode() {
  * @return java.lang.String
  */
 public String toString() {
-	return "MathModelInfo(mathKey="+mathKey+",Version="+version+", softwareVersion="+softwareVersion+")";
+	String swVersion = (softwareVersion == null ? "null" : softwareVersion.getSoftwareVersionString());
+	return "MathModelInfo(mathKey="+mathKey+",Version="+version+", softwareVersion="+swVersion+")";
 }
 public VersionableType getVersionType() {	
 	return VersionableType.MathModelMetaData;

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/DatabaseServerImpl.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/DatabaseServerImpl.java
@@ -324,7 +324,12 @@ public VersionableFamily getAllReferences(User user, VersionableType vType, KeyV
  * @exception java.rmi.RemoteException The exception description.
  */
 public BioModelInfo getBioModelInfo(User user, KeyValue key) throws DataAccessException, ObjectNotFoundException {
-	return ((BioModelInfo[])getVersionInfos(user, key, VersionableType.BioModelMetaData, true, true))[0];
+	VersionInfo[] versionInfos = getVersionInfos(user, key, VersionableType.BioModelMetaData, true, true);
+	if (versionInfos.length == 0) {
+		return null;
+	}else{
+		return ((BioModelInfo[]) versionInfos)[0];
+	}
 }
 
 
@@ -564,7 +569,12 @@ public BigString getGeometryXML(User user, KeyValue key) throws DataAccessExcept
  * @exception java.rmi.RemoteException The exception description.
  */
 public MathModelInfo getMathModelInfo(User user, KeyValue key) throws DataAccessException, ObjectNotFoundException {
-	return ((MathModelInfo[])getVersionInfos(user, key, VersionableType.MathModelMetaData, false, true))[0];
+	VersionInfo[] versionInfos = getVersionInfos(user, key, VersionableType.MathModelMetaData, true, true);
+	if (versionInfos.length == 0) {
+		return null;
+	}else {
+		return ((MathModelInfo[]) versionInfos)[0];
+	}
 }
 
 


### PR DESCRIPTION
Admin cli for model listing and permissions

### list biomodels and math models by user (see vcell-su model --help)

vcell-su model ls

### add/remove users from model ACLs (Access Control Lists)

vcell-su model acl

### Examples
 
model ls --owner=schaff:17
model ls --help
model acl --operation=add --owner=schaff:17 --user=ion:81 --biomodel-id=12600904
model acl --operation=remove --owner=schaff:17 --user=ion:81 --biomodel-id=12600904
model acl --help
