### PR TITLE
parse all special user permissions instead of first

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/modeldb/UserDbDriver.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/UserDbDriver.java
@@ -74,7 +74,7 @@ public User.SpecialUser getUserFromUserid(Connection con, String userid) throws 
 	ArrayList<User.SPECIAL_CLAIM> specials = new ArrayList<>();
 	try {
 		rset = stmt.executeQuery(sql);
-		if (rset.next()) {
+		while (rset.next()) {
 			BigDecimal bigDecimal = rset.getBigDecimal("userkey");
 			if(userKey == null) {
 				userKey = bigDecimal;


### PR DESCRIPTION
users with multiple 'special' permissions, would only be associated with one of them due to a bug in the database layer.  

Rather than processing one special permission, it should process all of them.