### PR TITLE
add missing fonts from java 17 base Docker image

### DIFF
--- a/docker/build/Dockerfile-admin-dev
+++ b/docker/build/Dockerfile-admin-dev
@@ -17,7 +17,7 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 
 # now we have Java 17
 RUN apt-get -y update && \
-    apt-get install -y curl dnsutils && \
+    apt-get install -y curl dnsutils apt-utils libfreetype6 fontconfig fonts-dejavu && \
     mkdir -p /usr/local/app/lib 
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata

--- a/docker/build/Dockerfile-api-dev
+++ b/docker/build/Dockerfile-api-dev
@@ -18,7 +18,7 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 # now we have Java 17 and Python 3.9
 
 RUN apt-get -y update && \
-    apt-get install -y --no-install-recommends curl dnsutils && \
+    apt-get install -y --no-install-recommends curl dnsutils apt-utils libfreetype6 fontconfig fonts-dejavu && \
     mkdir -p /usr/local/app/lib 
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata

--- a/docker/build/Dockerfile-batch-dev
+++ b/docker/build/Dockerfile-batch-dev
@@ -2,7 +2,7 @@ FROM ghcr.io/virtualcell/vcell-solvers:v0.0.42-dev3
 
 RUN apt-get -y update && \
     apt-get install -y  curl && \
-	apt-get install -y wget gdebi-core && \
+	apt-get install -y wget gdebi-core apt-utils libfreetype6 fontconfig fonts-dejavu && \
 	pip install thrift
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata

--- a/docker/build/Dockerfile-clientgen-dev
+++ b/docker/build/Dockerfile-clientgen-dev
@@ -17,7 +17,7 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN mkdir -p /usr/local/app && \
 	apt-get -y update && \
-    apt-get -y install wget libfreetype6 fontconfig fonts-dejavu
+    apt-get -y install wget apt-utils libfreetype6 fontconfig fonts-dejavu
 
 RUN mkdir /installer && cd /installer && \
     wget --quiet -O install4j_unix_10_0_5.tar.gz \

--- a/docker/build/Dockerfile-data-dev
+++ b/docker/build/Dockerfile-data-dev
@@ -18,7 +18,7 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 # now we have Java 17 and Python 3.9
 
 RUN apt-get -y update && \
-	apt-get -y install openssh-client screen && \
+	apt-get -y install openssh-client screen apt-utils libfreetype6 fontconfig fonts-dejavu && \
     mkdir -p /usr/local/app
 
 RUN python3 -m pip install poetry &&  poetry config cache-dir "/poetry/.cache"

--- a/docker/build/Dockerfile-db-dev
+++ b/docker/build/Dockerfile-db-dev
@@ -17,7 +17,7 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN mkdir -p /usr/local/app && \
 	apt-get -y update && \
-    apt-get -y install screen
+    apt-get -y install screen apt-utils libfreetype6 fontconfig fonts-dejavu
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
 RUN unlink /etc/localtime || true

--- a/docker/build/Dockerfile-sched-dev
+++ b/docker/build/Dockerfile-sched-dev
@@ -18,7 +18,7 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN mkdir -p /usr/local/app && \
 	apt-get -y update && \
-    apt-get -y install openssh-client curl screen
+    apt-get -y install openssh-client curl screen apt-utils libfreetype6 fontconfig fonts-dejavu
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
 RUN unlink /etc/localtime || true

--- a/docker/build/Dockerfile-submit-dev
+++ b/docker/build/Dockerfile-submit-dev
@@ -17,7 +17,7 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN mkdir -p /usr/local/app && \
 	apt-get -y update && \
-    apt-get -y install openssh-client screen
+    apt-get -y install openssh-client screen apt-utils libfreetype6 fontconfig fonts-dejavu
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
 RUN unlink /etc/localtime || true

--- a/docker/build/Dockerfile-web-dev
+++ b/docker/build/Dockerfile-web-dev
@@ -15,7 +15,7 @@ ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-RUN apt-get -y update && apt-get install -y bash nano wget
+RUN apt-get -y update && apt-get install -y bash nano wget apt-utils libfreetype6 fontconfig fonts-dejavu
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
 RUN unlink /etc/localtime || true


### PR DESCRIPTION
With upgrade to java 17, the Debian base Docker images used for all vcell services did not include font support.  Installed appropriate supporting packages using apt-get.
