### PR TITLE
new vcell-services script

### DIFF
--- a/docker/swarm/vcell-services.sh
+++ b/docker/swarm/vcell-services.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+shopt -s -o nounset
+
+show_help() {
+	echo "Performs server maintenance tasks"
+	echo ""
+	echo "usage: vcell-services [OPTIONS] command site"
+	echo ""
+	echo "  REQUIRED-ARGUMENTS"
+	echo "    command          restart | status"
+	echo "                        restart - restarts all services (takes optional -a | --all option)"
+	echo "                        status  - shows status of all services"
+	echo "    site             vcell site (e.g. rel or alpha)"
+	echo "                        rel - must be run on vcellapi.cam.uchc.edu"
+	echo "                        alpha - must be run on vcellapi-beta.cam.uchc.edu"
+	echo ""
+	echo "  [OPTIONS]"
+	echo "    -a | --all       (for restart command) restart messaging and mongodb services as well"
+	echo "    -h | --help      show this message"
+	echo "    -d | --debug     print debug information"
+	echo ""
+	echo "example:"
+	echo ""
+	echo "vcell-services restart rel"
+	exit 1
+}
+
+if [[ $# -lt 2 ]]; then
+    show_help
+fi
+
+
+debug=false
+all=false
+while :; do
+	case $1 in
+		-a|--all)
+			all=true
+			;;
+		-h|--help)
+			show_help
+			exit
+			;;
+		-d|--debug)
+			debug=true
+			;;
+		-?*)
+			printf 'ERROR: Unknown option: %s\n' "$1" 1>&2
+			echo ""
+			show_help
+			;;
+		*)               # Default case: No more options, so break out of the loop.
+			break
+	esac
+	shift
+done
+
+if [[ $# -ne 2 ]] ; then
+    show_help
+fi
+
+# if debug is true print all shell commands
+if [[ "${debug}" == true ]]; then
+  set -x
+fi
+
+command=$1
+site=$2
+
+# check that command is either 'restart' or 'status'
+if [[ "${command}" != "restart" && "${command}" != "status" ]]; then
+    echo "command must be either 'restart' or 'status'" 1>&2
+    exit 1
+fi
+
+# check that site is either 'rel' or 'alpha'
+if [[ "${site}" != "rel" && "${site}" != "alpha" ]]; then
+    echo "site must be either 'rel' or 'alpha'" 1>&2
+    exit 1
+fi
+
+swarm_cluster_name="vcell${site}"
+
+head_node="vcellapi.cam.uchc.edu"
+if [[ "${site}" == "alpha" ]]; then
+  head_node="vcellapi-beta.cam.uchc.edu"
+fi
+
+# restarts a service
+# $1 is the service name
+function restart_service {
+    service=$1
+    if [[ "${debug}" == true ]]; then
+      echo "restarting ${service} service"
+    fi
+    sudo docker service update --force --detach=false ${service}
+    retcode=$?
+    # if service update failed, then exit
+    if [[ ${retcode} -ne 0 ]]; then
+      echo "" 1>&2
+      echo "failed to restart ${service} service" 1>&2
+      echo "" 1>&2
+      echo "note: for ${site} site commands, run this script on ${head_node}" 1>&2
+      exit 1
+    fi
+}
+
+# if command is restart, then stop and start all services
+if [[ "${command}" == "restart" ]]; then
+
+  # restart messaging and mongodb services if requested
+  if [[ "${all}" == true ]]; then
+    restart_service ${swarm_cluster_name}_activemqsim
+    restart_service ${swarm_cluster_name}_activemqint
+    restart_service ${swarm_cluster_name}_mongodb
+  fi
+  restart_service ${swarm_cluster_name}_db
+  restart_service ${swarm_cluster_name}_data
+  restart_service ${swarm_cluster_name}_sched
+  restart_service ${swarm_cluster_name}_submit
+  restart_service ${swarm_cluster_name}_api
+  exit 0
+fi
+
+# if command is status, then show status of all services
+if [[ "${command}" == "status" ]]; then
+  sudo docker stack ps -f "desired-state=running" ${swarm_cluster_name}
+  retcode=$?
+  if [[ ${retcode} -ne 0 ]]; then
+    echo "" 1>&2
+    echo "failed to show status of services" 1>&2
+    echo "" 1>&2
+    echo "note: for ${site} site commands, run this script on ${head_node}" 1>&2
+    exit 1
+  fi
+  exit 0
+fi


### PR DESCRIPTION
see #1051 for motivation

`vcell-services` is a bash script which is installed in `~vcell/.local/bin/vcell-services` and is in the path for user vcell.

Currently, the commands are `status` and `restart` and works for both `rel` and `alpha` sites.

> usage: vcell-services [OPTIONS] command site
> 
>   REQUIRED-ARGUMENTS
>     command          restart | status
>                         restart - restarts all services (takes optional -a | --all option)
>                         status  - shows status of all services
>     site             vcell site (e.g. rel or alpha)
>                         rel - must be run on vcellapi.cam.uchc.edu
>                         alpha - must be run on vcellapi-beta.cam.uchc.edu
> 
>   [OPTIONS]
>     -a | --all       (for restart command) restart messaging and mongodb services as well
>     -h | --help      show this message
>     -d | --debug     print debug information
> 
> example:
> 
> vcell-services restart rel