### PR TITLE
The is2D flag is always set to false

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/MolecularTypeSpecsTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/MolecularTypeSpecsTableModel.java
@@ -17,8 +17,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 import javax.swing.DefaultCellEditor;
 import javax.swing.DefaultComboBoxModel;
@@ -33,34 +31,20 @@ import org.vcell.model.rbm.MolecularComponentPattern;
 import org.vcell.model.rbm.MolecularType;
 import org.vcell.model.rbm.MolecularTypePattern;
 import org.vcell.model.rbm.SpeciesPattern;
-import org.vcell.util.Displayable;
 import org.vcell.util.gui.GuiUtils;
 import org.vcell.util.gui.ScrollTable;
 
-import cbit.gui.ScopedExpression;
-import cbit.vcell.client.PopupGenerator;
 import cbit.vcell.client.desktop.biomodel.VCellSortTableModel;
-import cbit.vcell.geometry.GeometryClass;
-import cbit.vcell.mapping.AssignmentRule;
 import cbit.vcell.mapping.GeometryContext;
-import cbit.vcell.mapping.MolecularInternalLinkSpec;
-import cbit.vcell.mapping.RateRule;
 import cbit.vcell.mapping.ReactionContext;
 import cbit.vcell.mapping.SimulationContext;
 import cbit.vcell.mapping.SiteAttributesSpec;
 import cbit.vcell.mapping.SpeciesContextSpec;
-import cbit.vcell.mapping.StructureMapping;
-import cbit.vcell.mapping.SpeciesContextSpec.SpeciesContextSpecParameter;
-import cbit.vcell.mapping.gui.SpeciesContextSpecsTableModel.ColumnType;
-import cbit.vcell.mapping.gui.SpeciesContextSpecsTableModel.RulesProvenance;
 import cbit.vcell.model.Parameter;
 import cbit.vcell.model.SpeciesContext;
 import cbit.vcell.model.Structure;
-import cbit.vcell.parser.AutoCompleteSymbolFilter;
 import cbit.vcell.parser.Expression;
-import cbit.vcell.parser.ExpressionBindingException;
-import cbit.vcell.parser.ExpressionException;
-import cbit.vcell.parser.SymbolTableEntry;
+
 /**
  * Insert the type's description here.
  * Creation date: (2/23/01 10:52:36 PM)

--- a/vcell-core/src/main/java/org/vcell/solver/langevin/LangevinLngvWriter.java
+++ b/vcell-core/src/main/java/org/vcell/solver/langevin/LangevinLngvWriter.java
@@ -860,8 +860,8 @@ public class LangevinLngvWriter {
 				throw new RuntimeException("Initial concentration must be a number");
 			}
 
-			// TODO: verify if the molecule is flat or not; for now we assume it is "flat" on YZ axis projection
-			boolean is2D = true;		// the x-coordinate is the same for all the sites
+			// TODO: is2D seems to always be false in the original SS, even for membrane molecules. Not sure what it actually means
+			boolean is2D = false;		// the x-coordinate is the same for all the sites
 
 			sb.append("MOLECULE: \"" + lpmt.getName() + "\" " + subDomain.getName() + 
 					" Number " + scount + 

--- a/vcell-core/src/test/java/cbit/vcell/biomodel/SpringSaLaDGoodReactionsTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/biomodel/SpringSaLaDGoodReactionsTest.java
@@ -50,7 +50,7 @@ public class SpringSaLaDGoodReactionsTest {
 	
 	private static final String reactionTestString = "'r0' ::     'MT0' : 'Site1' : 'state0' --> 'state1'  Rate 50.0  Condition Free";
 	private static final String L_x = "L_x: 0.1";
-	private static final String molecule = "MOLECULE: \"MT0\" Intracellular Number 10 Site_Types 2 Total_Sites 2 Total_Links 1 is2D true";
+	private static final String molecule = "MOLECULE: \"MT0\" Intracellular Number 10 Site_Types 2 Total_Sites 2 Total_Links 1 is2D false";
 	private static final String analyticExpressionIntra = "(z < 0.09)";
 
 	private static String previousInstallDir = null;


### PR DESCRIPTION
In a binding reaction, the results are not correlated with the expectations if set to true
It's always false in the models built with the older SS interface. It may be an abandoned flag, I'll try to see what's going on once we start revamping the solver.