### PR TITLE
fix: update runtime dependencies to resolve conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,17 +92,18 @@
 		<!-- NB: Disable javadoc doclint -->
 		<doclint>none</doclint>
 
-		<activemq-broker.version>5.15.9</activemq-broker.version>
-		<activemq-client.version>5.15.9</activemq-client.version>
+		<activemq-broker.version>5.18.3</activemq-broker.version>
+		<activemq-client.version>5.18.3</activemq-client.version>
 		<axis.version>1.4</axis.version>
 		<axis-wsdl4j.version>1.2</axis-wsdl4j.version>
 		<bio-formats.version>6.7.0</bio-formats.version>
 		<bio-formats_plugins.version>${bio-formats.version}</bio-formats_plugins.version>
+		<biojava.version>6.0.4</biojava.version>
 		<biomodels-wslib.version>1.21</biomodels-wslib.version>
 		<colt.version>1.2.0</colt.version>
 		<commons-beanutils.version>1.9.4</commons-beanutils.version>
 		<commons-codec.version>1.11</commons-codec.version>
-		<commons-compress.version>1.20</commons-compress.version>
+		<commons-compress.version>1.21</commons-compress.version>
 		<commons-configuration2.version>2.9.0</commons-configuration2.version>
 		<commons-csv.version>1.7</commons-csv.version>
 		<commons-discovery.version>0.5</commons-discovery.version>
@@ -111,8 +112,8 @@
 		<commons-lang3.version>3.12.0</commons-lang3.version>
 		<commons-math3.version>3.6.1</commons-math3.version>
 		<commons-pool2.version>2.5.0</commons-pool2.version>
-		<gson.version>2.8.6</gson.version>
-		<guava.version>30.1.1-jre</guava.version>
+		<gson.version>2.9.1</gson.version>
+		<guava.version>33.0.0-jre</guava.version>
 		<guice.version>7.0.0</guice.version>
 		<httpclient.version>4.5.11</httpclient.version>
 		<httpcore.version>4.4.13</httpcore.version>
@@ -144,15 +145,15 @@
 		<jung-graph-impl.version>2.1.1</jung-graph-impl.version>
 		<jung-samples.version>2.1.1</jung-samples.version>
 		<junit-jupiter.version>5.10.1</junit-jupiter.version>
-		<log4j-slf4j-impl.version>2.17.1</log4j-slf4j-impl.version>
-		<log4j-1.2-api.version>2.17.1</log4j-1.2-api.version>
-		<log4j-api.version>2.17.1</log4j-api.version>
-		<log4j-core.version>2.17.1</log4j-core.version>
-		<log4j-jul.version>2.17.1</log4j-jul.version>
-		<log4j-layout-template-json.version>2.17.1</log4j-layout-template-json.version>
+		<log4j-slf4j2-impl.version>2.22.1</log4j-slf4j2-impl.version>
+		<log4j-1.2-api.version>2.22.1</log4j-1.2-api.version>
+		<log4j-api.version>2.22.1</log4j-api.version>
+		<log4j-core.version>2.22.1</log4j-core.version>
+		<log4j-jul.version>2.22.1</log4j-jul.version>
+		<log4j-layout-template-json.version>2.22.1</log4j-layout-template-json.version>
 		<lz4.version>1.8.0</lz4.version>
 		<mongo-java-driver.version>3.12.11</mongo-java-driver.version>
-		<n5.version>2.5.1</n5.version>
+		<n5.version>3.0.0</n5.version>
 		<netcdf.version>4.3.22</netcdf.version>
 		<netty.version>3.2.10.Final</netty.version>
 		<nitrite.version>2.1.1</nitrite.version>
@@ -166,9 +167,10 @@
 		<sesame-rio-api.version>2.9.0</sesame-rio-api.version>
 		<sesame-rio-rdfxml.version>2.9.0</sesame-rio-rdfxml.version>
 		<sesame-rio-n3.version>2.9.0</sesame-rio-n3.version>
-		<slf4j-api.version>1.7.25</slf4j-api.version>
-		<sshj.version>0.35.0</sshj.version>
+		<slf4j-api.version>2.0.9</slf4j-api.version>
+		<sshj.version>0.38.0</sshj.version>
 		<xercesImpl.version>2.8.0</xercesImpl.version>
+		<xstream.version>1.4.20</xstream.version>
 		<xom.version>1.2.5</xom.version>
 	</properties>
 

--- a/vcell-cli/pom.xml
+++ b/vcell-cli/pom.xml
@@ -101,8 +101,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j-slf4j-impl.version}</version>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j-slf4j2-impl.version}</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>

--- a/vcell-core/pom.xml
+++ b/vcell-core/pom.xml
@@ -316,7 +316,7 @@
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-slf4j2-impl</artifactId>
+					<artifactId>log4j-slf4j-impl</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>

--- a/vcell-core/pom.xml
+++ b/vcell-core/pom.xml
@@ -269,7 +269,7 @@
 				</exclusion>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>
-					<artifactId>log4j-slf4j2-impl</artifactId>
+					<artifactId>log4j-slf4j-impl</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>

--- a/vcell-core/pom.xml
+++ b/vcell-core/pom.xml
@@ -111,6 +111,17 @@
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
 			<version>${guice.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>${guava.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.media.jai</groupId>
@@ -257,8 +268,71 @@
 					<artifactId>slf4j-api</artifactId>
 				</exclusion>
 				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-slf4j2-impl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-core</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>junit</groupId>
 					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.sbml.jsbml</groupId>
+			<artifactId>jsbml-core</artifactId>
+			<version>${jsbml.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-1.2-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.thoughtworks.xstream</groupId>
+					<artifactId>xstream</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.thoughtworks.xstream</groupId>
+			<artifactId>xstream</artifactId>
+			<version>${xstream.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.biojava</groupId>
+			<artifactId>biojava-ontology</artifactId>
+			<version>${biojava.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-slf4j2-impl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-impl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -338,6 +412,26 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j-api.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j-core.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j-api.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-1.2-api</artifactId>
+			<version>${log4j-1.2-api.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>${log4j-slf4j2-impl.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>xom</groupId>

--- a/vcell-core/src/main/java/cbit/vcell/export/server/N5Specs.java
+++ b/vcell-core/src/main/java/cbit/vcell/export/server/N5Specs.java
@@ -13,10 +13,8 @@ package cbit.vcell.export.server;
 import cbit.vcell.math.MathException;
 import cbit.vcell.simdata.VCData;
 import org.janelia.saalfeldlab.n5.*;
-import org.vcell.util.Compare;
 import org.vcell.util.DataAccessException;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 
@@ -111,7 +109,7 @@ public class N5Specs extends FormatSpecificSpecs implements Serializable {
 
 		try {
 			n5FSWriter.setAttributes(datasetPath, metaData);
-		} catch (IOException e) {
+		} catch (N5Exception e) {
 			throw new RuntimeException(e);
 		}
 

--- a/vcell-util/pom.xml
+++ b/vcell-util/pom.xml
@@ -140,8 +140,8 @@
 		</dependency>
 		<dependency>
 		  <groupId>org.apache.logging.log4j</groupId>
-		  <artifactId>log4j-slf4j-impl</artifactId>
-		  <version>${log4j-slf4j-impl.version}</version>
+		  <artifactId>log4j-slf4j2-impl</artifactId>
+		  <version>${log4j-slf4j2-impl.version}</version>
 		  <scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -149,20 +149,20 @@
 			<artifactId>log4j-layout-template-json</artifactId>
 			<version>${log4j-layout-template-json.version}</version>
 		</dependency>
-<dependency>
-  <groupId>javax.xml.bind</groupId>
-  <artifactId>jaxb-api</artifactId>
-  <version>${jaxb-api.version}</version>
-</dependency>
-<dependency>
-  <groupId>com.sun.xml.bind</groupId>
-  <artifactId>jaxb-core</artifactId>
-  <version>${jaxb-core.version}</version>
-</dependency>
-<dependency>
-  <groupId>com.sun.xml.bind</groupId>
-  <artifactId>jaxb-impl</artifactId>
-  <version>${jaxb-impl.version}</version>
-</dependency>
+		<dependency>
+		  <groupId>javax.xml.bind</groupId>
+		  <artifactId>jaxb-api</artifactId>
+		  <version>${jaxb-api.version}</version>
+		</dependency>
+		<dependency>
+		  <groupId>com.sun.xml.bind</groupId>
+		  <artifactId>jaxb-core</artifactId>
+		  <version>${jaxb-core.version}</version>
+		</dependency>
+		<dependency>
+		  <groupId>com.sun.xml.bind</groupId>
+		  <artifactId>jaxb-impl</artifactId>
+		  <version>${jaxb-impl.version}</version>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
upgraded and resolved java dependencies to fix runtime errors.  Ordinarily, maven would identify conflicts at build time, but prior `exclusions` in the maven pom file strategically forced use of newer versions of transitive dependencies that those declared.  Some exclusions were revisited, and was tested by rebuilding and running the docker-compose file locally with all services.