### PR TITLE
Editing or adding a new molecule / species is now properly addressed in existing SS application

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/SpeciesPropertiesPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/SpeciesPropertiesPanel.java
@@ -930,6 +930,7 @@ private void updateShape() {
 							fieldSpeciesContext.setSpeciesPattern(sp);
 						}
 						fieldSpeciesContext.getSpeciesPattern().addMolecularTypePattern(molecularTypePattern);
+						fieldSpeciesContext.firePropertyChange(SpeciesContext.PROPERTY_NAME_SPECIES_PATTERN_CHANGED, null, fieldSpeciesContext);
 					}
 				});
 			}

--- a/vcell-core/src/main/java/cbit/vcell/mapping/ReactionContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/ReactionContext.java
@@ -289,6 +289,9 @@ public void propertyChange(java.beans.PropertyChangeEvent evt) {
 	if (evt.getSource().equals(getModel()) && evt.getPropertyName().equals(RbmModelContainer.PROPERTY_NAME_REACTION_RULE_LIST)){
 		refreshAll();
 	}
+	if(evt.getSource().equals(getModel()) && evt.getPropertyName().equals(Model.PROPERTY_NAME_SPECIES_CONTEXT_SPECIES_PATTERN)) {
+		refreshSpeciesContextSpecsSpeciesPatterns();	// only for springsalad, because we care about the sites (site attributes spec, internal link spec)
+	}
 	if (evt.getSource().equals(getModel()) && evt.getPropertyName().equals(RbmModelContainer.PROPERTY_NAME_MOLECULAR_TYPE_LIST)){
 		;	// do nothing
 	}
@@ -612,6 +615,13 @@ private void refreshSpeciesContextSpecs() throws MappingException {
 			throw new MappingException(e.getMessage(), e);
 		}
 	}
+	if(Application.SPRINGSALAD == simContext.getApplicationType()) {
+		for(SpeciesContextSpec scs : fieldSpeciesContextSpecs) {
+			scs.initializeForSpringSaLaD(null);
+		}
+	}
+}
+private void refreshSpeciesContextSpecsSpeciesPatterns() {
 	if(Application.SPRINGSALAD == simContext.getApplicationType()) {
 		for(SpeciesContextSpec scs : fieldSpeciesContextSpecs) {
 			scs.initializeForSpringSaLaD(null);

--- a/vcell-core/src/main/java/cbit/vcell/model/Model.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/Model.java
@@ -83,6 +83,7 @@ public class Model implements Versionable, Matchable, Relatable, PropertyChangeL
     public static final String PROPERTY_NAME_SPECIES_CONTEXTS = "speciesContexts";
     private static final String PROPERTY_NAME_SPECIES = "species";
     public static final String PROPERTY_NAME_MODEL_ENTITY_NAME = "modelEntityName";
+    public static final String PROPERTY_NAME_SPECIES_CONTEXT_SPECIES_PATTERN = "speciesContextSpeciesPattern";
 
     public static final String PROPERTY_NAME_RATERULEVARIABLES = "rateruleVariables";
 
@@ -3302,6 +3303,7 @@ public class Model implements Versionable, Matchable, Relatable, PropertyChangeL
                 fieldDiagrams[i].renameNode((String) evt.getOldValue(), (String) evt.getNewValue());
             }
         }
+
         if(evt.getSource() instanceof ReactionStep && evt.getPropertyName().equals("name")){
             for(int i = 0; i < fieldDiagrams.length; i++){
                 fieldDiagrams[i].renameNode((String) evt.getOldValue(), (String) evt.getNewValue());
@@ -3356,6 +3358,9 @@ public class Model implements Versionable, Matchable, Relatable, PropertyChangeL
                     throw new RuntimeException(e.getMessage(), e);
                 }
             }
+        }
+        if(evt.getSource() instanceof SpeciesContext && evt.getPropertyName().equals(PROPERTY_NAME_SPECIES_CONTEXTS)) {
+            firePropertyChange(PROPERTY_NAME_SPECIES_CONTEXT_SPECIES_PATTERN, evt.getOldValue(), evt.getNewValue());
         }
 
         if((evt.getSource() instanceof ModelParameter ||

--- a/vcell-core/src/main/java/cbit/vcell/model/Model.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/Model.java
@@ -3359,7 +3359,9 @@ public class Model implements Versionable, Matchable, Relatable, PropertyChangeL
                 }
             }
         }
-        if(evt.getSource() instanceof SpeciesContext && evt.getPropertyName().equals(PROPERTY_NAME_SPECIES_CONTEXTS)) {
+
+        if(evt.getSource() instanceof SpeciesContext && evt.getPropertyName().equals(SpeciesContext.PROPERTY_NAME_SPECIES_PATTERN_CHANGED)) {
+            System.out.println("Model: SpeciesContext test event: " + evt.getPropertyName());
             firePropertyChange(PROPERTY_NAME_SPECIES_CONTEXT_SPECIES_PATTERN, evt.getOldValue(), evt.getNewValue());
         }
 

--- a/vcell-core/src/main/java/cbit/vcell/model/SpeciesContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/SpeciesContext.java
@@ -63,7 +63,8 @@ public class SpeciesContext implements Cacheable, Matchable, Relatable, Editable
 
 	private String speciesPatternString = null;
 
-	public static final String PROPERTY_NAME_SPECIES_PATTERN = "speciesPattern";
+	public static final String PROPERTY_NAME_SPECIES_PATTERN = "speciesPattern";	// fired with an empty sp, not very useful
+	public static final String PROPERTY_NAME_SPECIES_PATTERN_CHANGED = "speciesPatternChanged";
 	
 	// store SBML unit for speciesContext from SBML species.
 //	private transient VCUnitDefinition sbmlSpeciesUnit = null;


### PR DESCRIPTION
Changes to molecule / species (done within the biomodel UI) are now properly reflected in the species context spec of an existing application