### PR TITLE
SpeciesContextSpec's compareEqual implementation for SpringSaLaD-specific entities

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/MolecularInternalLinkSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/MolecularInternalLinkSpec.java
@@ -191,12 +191,19 @@ public class MolecularInternalLinkSpec implements Identifiable, IssueSource, Mat
 		if (!(obj instanceof MolecularInternalLinkSpec)) {
 			return false;
 		}
-		MolecularInternalLinkSpec candidate = (MolecularInternalLinkSpec)obj;
-		if(fieldSpeciesContextSpec != candidate.getSpeciesContextSpec()) {
+		MolecularInternalLinkSpec theirMils = (MolecularInternalLinkSpec)obj;
+
+		// we skip compareEqual for the SpeciesContextSpec, otherwise we end up in an infinite loop !!!
+		// we just compare the SpeciesContext (which is perfectly legit from a springsalad perspective,
+		// where we can only have one SpeciesContext object for each Molecule)
+		if(!fieldSpeciesContextSpec.getSpeciesContext().compareEqual(theirMils.getSpeciesContextSpec().getSpeciesContext())) {
 			return false;
 		}
-		if((fieldMolecularComponentPatternOne == candidate.fieldMolecularComponentPatternOne) && 
-				(fieldMolecularComponentPatternTwo == candidate.fieldMolecularComponentPatternTwo)) {
+		// note that while the link is scalar, not vector, we order one and two by the position of the
+		// MolecularComponent in the MolecularType definition
+		// hence, no need to also compare thisOne with that.Two (I hope, at least)
+		if((fieldMolecularComponentPatternOne.compareEqual(theirMils.fieldMolecularComponentPatternOne)) &&
+				(fieldMolecularComponentPatternTwo.compareEqual(theirMils.fieldMolecularComponentPatternTwo))) {
 			return true;
 		}
 		return false;

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
@@ -818,6 +818,7 @@ public class SpeciesContextSpec implements Matchable, ScopedSymbolTable, Seriali
             MolecularComponentPattern theirMcp = theirEntry.getKey();
             SiteAttributesSpec theirSas = theirEntry.getValue();
             if(ourMcp.compareEqual(theirMcp) && ourSas.compareEqual(theirSas)) {
+                // note that for the mcp we only compare the bond type, not the bond (which is mtp attribute)
                 return true;
             }
         }

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
@@ -745,11 +745,10 @@ public class SpeciesContextSpec implements Matchable, ScopedSymbolTable, Seriali
      */
     public boolean compareEqual(Matchable object){
 
-        SpeciesContextSpec scs = null;
         if(!(object instanceof SpeciesContextSpec)){
             return false;
         }
-        scs = (SpeciesContextSpec) object;
+        SpeciesContextSpec scs = (SpeciesContextSpec) object;   // we know it's not null
 
         if(!Compare.isEqual(speciesContext, scs.speciesContext)){
             return false;
@@ -783,36 +782,47 @@ public class SpeciesContextSpec implements Matchable, ScopedSymbolTable, Seriali
             return false;
         }
 
-        // TODO: redo this in a separate branch since the current one has been hijacked by persistence fix
-        if(internalLinkSet.size() != scs.internalLinkSet.size()) {
+        if(internalLinkSet.size() != scs.internalLinkSet.size()) {      // springsalad MolecularInternalLinkSpec set
             return false;
         }
-//        for(MolecularInternalLinkSpec ourMils : internalLinkSet) {
-//            // TODO: obviously this is wrong during save, all the instances are new
-//            if(!scs.internalLinkSet.contains(ourMils)) {
-//                return false;
-//            }
-//        }
+        for(MolecularInternalLinkSpec ourMils : internalLinkSet) {
+            if (!containsIsomorph(ourMils, scs.internalLinkSet)) {
+                return false;
+            }
+        }
 
-        if(siteAttributesMap.size() != scs.siteAttributesMap.size()) {
+        if(siteAttributesMap.size() != scs.siteAttributesMap.size()) {  // springsalad SiteAttributesSpec map
             return false;
         }
-//        for(Map.Entry<MolecularComponentPattern, SiteAttributesSpec> entry : siteAttributesMap.entrySet()) {
-//            MolecularComponentPattern ourMcp = entry.getKey();
-//            SiteAttributesSpec ourSas = entry.getValue();
-//            // TODO: same here, can't compare instances
-//            if(!scs.siteAttributesMap.containsKey(ourMcp)) {
-//                return false;
-//            }
-//            SiteAttributesSpec theirSas = scs.siteAttributesMap.get(ourMcp);
-//            if(!ourSas.compareEqual(theirSas)) {
-//                return false;
-//            }
-//        }
+        for(Map.Entry<MolecularComponentPattern, SiteAttributesSpec> entry : siteAttributesMap.entrySet()) {
+            if (!containsIsomorph(entry, siteAttributesMap)) {
+                return false;
+            }
+        }
 
         return true;
     }
 
+    private static boolean containsIsomorph(MolecularInternalLinkSpec ourMils, Set<MolecularInternalLinkSpec> theirMilsSet) {
+        for(MolecularInternalLinkSpec theirMils : theirMilsSet) {
+            if(ourMils.compareEqual(theirMils)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    private static boolean containsIsomorph(Map.Entry<MolecularComponentPattern, SiteAttributesSpec> ourEntry, Map<MolecularComponentPattern, SiteAttributesSpec> theirSasMap) {
+        MolecularComponentPattern ourMcp = ourEntry.getKey();
+        SiteAttributesSpec ourSas = ourEntry.getValue();
+        for(Map.Entry<MolecularComponentPattern, SiteAttributesSpec> theirEntry : theirSasMap.entrySet()) {
+            MolecularComponentPattern theirMcp = theirEntry.getKey();
+            SiteAttributesSpec theirSas = theirEntry.getValue();
+            if(ourMcp.compareEqual(theirMcp) && ourSas.compareEqual(theirSas)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * The firePropertyChange method was generated to support the propertyChange field.
@@ -2216,4 +2226,5 @@ public class SpeciesContextSpec implements Matchable, ScopedSymbolTable, Seriali
     public String getDisplayType(){
         return typeName;
     }
+
 }

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
@@ -784,19 +784,19 @@ public class SpeciesContextSpec implements Matchable, ScopedSymbolTable, Seriali
         }
 
         // TODO: redo this in a separate branch since the current one has been hijacked by persistence fix
-//        if(internalLinkSet.size() != scs.internalLinkSet.size()) {
-//            return false;
-//        }
+        if(internalLinkSet.size() != scs.internalLinkSet.size()) {
+            return false;
+        }
 //        for(MolecularInternalLinkSpec ourMils : internalLinkSet) {
 //            // TODO: obviously this is wrong during save, all the instances are new
 //            if(!scs.internalLinkSet.contains(ourMils)) {
 //                return false;
 //            }
 //        }
-//
-//        if(siteAttributesMap.size() != scs.siteAttributesMap.size()) {
-//            return false;
-//        }
+
+        if(siteAttributesMap.size() != scs.siteAttributesMap.size()) {
+            return false;
+        }
 //        for(Map.Entry<MolecularComponentPattern, SiteAttributesSpec> entry : siteAttributesMap.entrySet()) {
 //            MolecularComponentPattern ourMcp = entry.getKey();
 //            SiteAttributesSpec ourSas = entry.getValue();


### PR DESCRIPTION
SpeciesContextSpec's compareEqual implementation for SpringSaLaD
Isomorphism detection for SiteAttributesSpec and MolecularInternalLinkSpec