### PR TITLE
fix permissions on ssh from docker

### DIFF
--- a/docker/swarm/docker-compose.yml
+++ b/docker/swarm/docker-compose.yml
@@ -119,6 +119,8 @@ services:
       - dbpswd
       - jmspswd
       - source: batchuserkeyfile
+        uid: "10001"
+        gid: "10000"
         mode: 0400
     networks:
       - vcellnet
@@ -202,6 +204,8 @@ services:
       - jmspswd
       - jmsrestpswd # "echo -ne  {activemq console user:passwd} | base64", this is hard-coded in some solvers
       - source: batchuserkeyfile
+        uid: "10001"
+        gid: "10000"
         mode: 0400
     networks:
       - vcellnet


### PR DESCRIPTION
some docker containers now run as non-root, must set the userid of the ssh secrets file to be owned by that user, or cannot access.