### PR TITLE
The enableSpringSaLaD property default value is set to false.

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/resource/PropertyLoader.java
+++ b/vcell-core/src/main/java/cbit/vcell/resource/PropertyLoader.java
@@ -281,7 +281,7 @@ public class PropertyLoader {
 
 	public static final String imageJ = record("vcell.imageJ", ValueType.EXE);
 	public static final String enableSpringSaLaD = record("vcell.enableSpringSaLaD", ValueType.BOOL);
-	public static final boolean enableSpringSalad_default_value=true;
+	public static final boolean enableSpringSalad_default_value=false;
 
 	/**
 	 * native library directory, server side


### PR DESCRIPTION
Disable SpringSaLaD application visibility in vcell in preparation for vcell release.
Visibility can be enabled by setting the enableSpringSaLaD property to true.