### PR TITLE
Membrane Langevin jump processes not loading from VCML #1361

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/NetworkTransformer.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/NetworkTransformer.java
@@ -591,6 +591,10 @@ public class NetworkTransformer implements SimContextTransformer {
 					name = name.substring(0, name.indexOf(ReactionRule.InverseHalf));
 				}
 				ReactionRule rr = model.getRbmModelContainer().getReactionRule(name);
+				if(rr == null) {
+					// temp code, trying to catch a rare random bug, may be a race condition of some sort
+					System.out.println("ReactionRule " + name + " not found.");
+				}
 
 				Structure structure = rr.getStructure();
 				boolean bReversible = reverseBNGReaction != null;

--- a/vcell-core/src/main/java/cbit/vcell/solver/NFsimSimulationOptions.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/NFsimSimulationOptions.java
@@ -237,19 +237,19 @@ public class NFsimSimulationOptions implements Serializable, Matchable, Vetoable
 				observableComputationOff = Boolean.parseBoolean(token);
 			} else if(token.equalsIgnoreCase(VCML.NFSimSimulationOptions_moleculeDistance)) {
 				token = tokens.nextToken();
-				moleculeDistance = new Integer(token);
+				moleculeDistance = Integer.parseInt(token);
 			} else if(token.equalsIgnoreCase(VCML.NFSimSimulationOptions_aggregateBookkeeping)) {
 				token = tokens.nextToken();
 				aggregateBookkeeping = Boolean.parseBoolean(token);
 			} else if(token.equalsIgnoreCase(VCML.NFSimSimulationOptions_maxMoleculesPerType)) {
 				token = tokens.nextToken();
-				maxMoleculesPerType = new Integer(token);
+				maxMoleculesPerType = Integer.parseInt(token);
 			} else if(token.equalsIgnoreCase(VCML.NFSimSimulationOptions_equilibrateTime)) {
 				token = tokens.nextToken();
-				equilibrateTime = new Integer(token);
+				equilibrateTime = Integer.parseInt(token);
 			} else if(token.equalsIgnoreCase(VCML.NFSimSimulationOptions_randomSeed)) {
 				token = tokens.nextToken();
-				randomSeed = new Integer(token);
+				randomSeed = Integer.parseInt(token);
 			} else if(token.equalsIgnoreCase(VCML.NFSimSimulationOptions_preventIntraBonds)) {
 				token = tokens.nextToken();
 				preventIntraBonds = Boolean.parseBoolean(token);

--- a/vcell-core/src/main/java/cbit/vcell/solver/SolverTaskDescription.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/SolverTaskDescription.java
@@ -217,7 +217,8 @@ public class SolverTaskDescription implements Matchable, java.beans.PropertyChan
             }
         }
         try {
-            setSolverDescription(SolverDescription.getDefaultSolverDescription(md));
+            SolverDescription sd = SolverDescription.getDefaultSolverDescription(md);
+            setSolverDescription(sd);
         } catch(PropertyVetoException e){
             throw new RuntimeException("failed to set SolverDescription for simulation " + getSimulation().getName(), e);
         }

--- a/vcell-core/src/main/java/cbit/vcell/xml/XmlReader.java
+++ b/vcell-core/src/main/java/cbit/vcell/xml/XmlReader.java
@@ -4351,6 +4351,16 @@ public RateRuleVariable[] getRateRuleVariables(Element rateRuleVarsElement, Mode
             }
         }
 
+        iterator = param.getChildren(XMLTags.LangevinParticleJumpProcessTag, vcNamespace).iterator();
+        while (iterator.hasNext()) {
+            Element tempelement = (Element) iterator.next();
+            try {
+                subDomain.addParticleJumpProcess(getParticleJumpProcess(tempelement, mathDesc));
+            } catch(MathException e){
+                throw new XmlParseException("A MathException was fired when adding a jump process to the MembraneSubDomain " + name, e);
+            }
+        }
+
         iterator = param.getChildren(XMLTags.ParticlePropertiesTag, vcNamespace).iterator();
         while (iterator.hasNext()) {
             Element tempelement = (Element) iterator.next();

--- a/vcell-core/src/main/java/org/vcell/model/ssld/SsldUtils.java
+++ b/vcell-core/src/main/java/org/vcell/model/ssld/SsldUtils.java
@@ -578,7 +578,10 @@ public class SsldUtils {
                 m.put(ssldType, mc);
                 mt.addMolecularComponent(mc);
             }
-            // TODO: if membrane molecule, anchor it to membrane
+            if(ssldMolecule.hasAnchorType()) {  // if membrane molecule, anchor it to membrane
+                mt.addAnchor(membr);
+                mt.setAnchorAll(false);
+            }
             m.put(ssldMolecule, mt);
             model.getRbmModelContainer().addMolecularType(mt, false);
         }
@@ -731,7 +734,7 @@ public class SsldUtils {
             Structure structure = model.getStructure(location);
 
             double ssldKf = ssldReaction.getRate();
-            Expression kf = new Expression(ssldKf);
+            Expression kf = new Expression(ssldKf);     // the unit is s-1
             ReactionRule reactionRule = new ReactionRule(model, ssldReaction.getName(), structure, reversible);
             RbmKineticLaw.RateLawType rateLawType = RbmKineticLaw.RateLawType.MassAction;
             reactionRule.setKineticLaw(new RbmKineticLaw(reactionRule, rateLawType));
@@ -766,7 +769,7 @@ public class SsldUtils {
             Molecule ssldReactantTwo = ssldReaction.getMolecule(1);
             String locationOne = ssldReactantOne.getLocation();
             String locationTwo = ssldReactantTwo.getLocation();
-            Structure structure;
+            Structure structure;    // if one reactant is on the membrane, the reaction's structure is the membrane as well
             if(locationOne.contentEquals(SystemGeometry.MEMBRANE) || locationTwo.contentEquals(SystemGeometry.MEMBRANE)) {
                 // reaction is on the Membrane if at least one reactant is on the Membrane, the product stay on the membrane
                 // actually the membrane molecule must be anchored to the membrane
@@ -777,9 +780,9 @@ public class SsldUtils {
             }
 
             double ssldKf = ssldReaction.getkon();
-            Expression kf = new Expression(ssldKf);
+            Expression kf = new Expression(ssldKf);     // unit is s-1.uM-1
             double ssldKr = ssldReaction.getkoff();
-            Expression kr = new Expression(ssldKr);
+            Expression kr = new Expression(ssldKr);     // unit is s-1
             ReactionRule reactionRule = new ReactionRule(model, ssldReaction.getName(), structure, reversible);
             RbmKineticLaw.RateLawType rateLawType = RbmKineticLaw.RateLawType.MassAction;
             reactionRule.setKineticLaw(new RbmKineticLaw(reactionRule, rateLawType));


### PR DESCRIPTION
Issue #1361

Langevin jump processes located on a membrane are not being loaded from VCML
in XMLReader.getMembraneSubdomain()
because the XMLTags.LangevinParticleJumpProcessTag was ignored

properly set the MolecularType anchor elements when importing from ssld