### PR TITLE
Fix Incapability to Export Locally Loaded Simulation Results

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/data/PDEExportDataPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/PDEExportDataPanel.java
@@ -9,53 +9,6 @@
  */
 
 package cbit.vcell.client.data;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Frame;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.channels.FileChannel;
-import java.util.*;
-
-import javax.swing.ButtonGroup;
-import javax.swing.DefaultListCellRenderer;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JSlider;
-import javax.swing.JTextField;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingConstants;
-import javax.swing.border.LineBorder;
-
-import cbit.vcell.export.server.*;
-import cbit.vcell.geometry.SubVolume;
-import cbit.vcell.solver.*;
-import org.vcell.util.gui.GeneralGuiUtils;
-import org.vcell.util.UserCancelException;
-import org.vcell.util.document.LocalVCDataIdentifier;
-import org.vcell.util.document.User;
-import org.vcell.util.document.VCDataIdentifier;
-import org.vcell.util.document.VCDocument;
-import org.vcell.util.gui.DefaultListModelCivilized;
-import org.vcell.util.gui.DialogUtils;
-import org.vcell.util.gui.LineBorderBean;
-import org.vcell.util.gui.NoEventRadioButton;
-import org.vcell.util.gui.PropertyChangeButtonGroup;
-import org.vcell.util.gui.TitledBorderBean;
 
 import cbit.image.DisplayAdapterService;
 import cbit.image.DisplayPreferences;
@@ -67,24 +20,34 @@ import cbit.vcell.client.PopupGenerator;
 import cbit.vcell.client.UserMessage;
 import cbit.vcell.client.task.AsynchClientTask;
 import cbit.vcell.client.task.ClientTaskDispatcher;
+import cbit.vcell.export.server.*;
 import cbit.vcell.export.server.ExportSpecs.SimNameSimDataID;
+import cbit.vcell.geometry.SubVolume;
 import cbit.vcell.mapping.SimulationContext;
 import cbit.vcell.math.VariableType;
 import cbit.vcell.mathmodel.MathModel;
 import cbit.vcell.resource.PropertyLoader;
 import cbit.vcell.resource.ResourceUtil;
-import cbit.vcell.simdata.ClientPDEDataContext;
-import cbit.vcell.simdata.DataIdentifier;
-import cbit.vcell.simdata.DataInfoProvider;
-import cbit.vcell.simdata.DataServerImpl;
-import cbit.vcell.simdata.DataSetControllerImpl;
-import cbit.vcell.simdata.OutputContext;
-import cbit.vcell.simdata.PDEDataContext;
-import cbit.vcell.simdata.SimDataConstants;
-import cbit.vcell.simdata.SpatialSelection;
-import cbit.vcell.simdata.SpatialSelectionMembrane;
-import cbit.vcell.simdata.SpatialSelectionVolume;
+import cbit.vcell.simdata.*;
+import cbit.vcell.solver.*;
 import cbit.vcell.solvers.CartesianMesh;
+import org.vcell.util.UserCancelException;
+import org.vcell.util.document.LocalVCDataIdentifier;
+import org.vcell.util.document.User;
+import org.vcell.util.document.VCDataIdentifier;
+import org.vcell.util.document.VCDocument;
+import org.vcell.util.gui.*;
+
+import javax.swing.*;
+import javax.swing.border.LineBorder;
+import java.awt.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.FileChannel;
+import java.util.*;
 /**
  * This type was created in VisualAge.
  */
@@ -373,7 +336,7 @@ private void updateChoiceROI() {
 				getDefaultListModelCivilizedSelections().addElement(getSpatialSelectionsMembrane()[i]);
 			}
 		}
-		
+
 //		if(getJRadioButtonSelection().isSelected() && getDefaultListModelCivilizedSelections().getSize() == 0){
 //			if(getJRadioButtonSlice().isEnabled()){
 //				getJRadioButtonSlice().setSelected(true);
@@ -1746,7 +1709,10 @@ private void setFormatChoices_0(/*boolean bMembrane*/){
 		cb.addItem(ExportFormat.ANIMATED_GIF);
 		cb.addItem(ExportFormat.FORMAT_JPEG);
 		cb.addItem(ExportFormat.NRRD);
-		cb.addItem(ExportFormat.N5);
+
+		if (!(getPdeDataContext().getVCDataIdentifier() instanceof LocalVCDataIdentifier)){
+			cb.addItem(ExportFormat.N5);
+		}
 //		cb.addItem(ExportFormat.IMAGEJ);
 		cb.addItem(ExportFormat.UCD);
 		cb.addItem(ExportFormat.PLY);

--- a/vcell-client/src/main/java/cbit/vcell/client/data/PDEExportDataPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/PDEExportDataPanel.java
@@ -1710,7 +1710,7 @@ private void setFormatChoices_0(/*boolean bMembrane*/){
 		cb.addItem(ExportFormat.FORMAT_JPEG);
 		cb.addItem(ExportFormat.NRRD);
 
-		if (!(getPdeDataContext().getVCDataIdentifier() instanceof LocalVCDataIdentifier)){
+		if (getPdeDataContext() != null && !(getPdeDataContext().getVCDataIdentifier() instanceof LocalVCDataIdentifier)){
 			cb.addItem(ExportFormat.N5);
 		}
 //		cb.addItem(ExportFormat.IMAGEJ);

--- a/vcell-core/src/main/java/cbit/vcell/export/server/ExportServiceImpl.java
+++ b/vcell-core/src/main/java/cbit/vcell/export/server/ExportServiceImpl.java
@@ -233,7 +233,6 @@ public ExportEvent makeRemoteFile(OutputContext outputContext,User user, DataSer
 
 		String exportBaseURL = PropertyLoader.getRequiredProperty(PropertyLoader.exportBaseURLProperty);
 		String exportBaseDir = PropertyLoader.getRequiredProperty(PropertyLoader.exportBaseDirInternalProperty);
-		String exportN5Dir = PropertyLoader.getRequiredProperty(PropertyLoader.n5DataDir);
 
 		
 //		// see if we've done this before, and try to get it


### PR DESCRIPTION
### Problem
The ExportServiceImpl class declared that it required an N5 related directory which it did not need. This resulted in a required property error being thrown.

### Solution
Remove that required property since it wasn't used, and make it impossible to export N5 files if the simulation is locally loaded onto a clients device.