### PR TITLE
mangle reserved SBML reaction names, e.g. x becomes RESERVED_x

### DIFF
--- a/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/vcell/SBMLImporter.java
@@ -3189,15 +3189,20 @@ public class SBMLImporter {
                 }
                 Structure reactionStructure = getReactionStructure(sbmlModel, sbmlReaction, vcBioModel, lambdaFunctions, sbmlSymbolMapping, vcLogger);
                 final ReactionStep vcReaction;
+                String reactionStepName = sbmlReaction.getId();
+                // see if reactionStepName is in the reserved words of Model (e.g. x,y,z,t)
+                if(vcModel.getReservedSymbolByName(reactionStepName) != null){
+                    reactionStepName = TokenMangler.fixTokenStrict("RESERVED_"+reactionStepName);
+                }
                 if(bIsFluxReaction){
                     if(!(reactionStructure instanceof Membrane)){
                         throw new SBMLImportException("Flux reaction on " + reactionStructure.getClass().getSimpleName() + ", not a membrane.");
                     }
-                    vcReaction = new FluxReaction(vcModel, (Membrane) reactionStructure, null, sbmlReaction.getId(), bReversible);
+                    vcReaction = new FluxReaction(vcModel, (Membrane) reactionStructure, null, reactionStepName, bReversible);
                     sbmlSymbolMapping.putReactionMapping(sbmlReaction, vcReaction);
                     vcReaction.setModel(vcModel);
                 } else {
-                    vcReaction = new SimpleReaction(vcModel, reactionStructure, sbmlReaction.getId(), bReversible);
+                    vcReaction = new SimpleReaction(vcModel, reactionStructure, reactionStepName, bReversible);
                     sbmlSymbolMapping.putReactionMapping(sbmlReaction, vcReaction);
                 }
 

--- a/vcell-core/src/test/java/org/vcell/sbml/BMDB_SBMLImportTest.java
+++ b/vcell-core/src/test/java/org/vcell/sbml/BMDB_SBMLImportTest.java
@@ -86,7 +86,6 @@ public class BMDB_SBMLImportTest {
 
 	public static Map<Integer, SBMLTestSuiteTest.FAULT> knownFaults() {
 		HashMap<Integer, SBMLTestSuiteTest.FAULT> faults = new HashMap();
-		faults.put(15, SBMLTestSuiteTest.FAULT.UNCATEGORIZED);  // cause:  cannot use reserved symbol 'x' as a Reaction name
 		faults.put(24, SBMLTestSuiteTest.FAULT.DELAY);  // cause:  UnsupportedConstruct: unsupported SBML element 'delay' in expression ' <math><apply><times/><ci> compartment_0000004 </ci><ci> rP </ci><apply><power/><apply><csymbol encoding="tex
 		faults.put(25, SBMLTestSuiteTest.FAULT.DELAY);  // cause:  UnsupportedConstruct: unsupported SBML element 'delay' in expression ' <math><piecewise><piece><cn> 0 </cn><apply><lt/><apply><minus/><apply><csymbol encoding="text" definitionURL
 		faults.put(34, SBMLTestSuiteTest.FAULT.DELAY);  // cause:  UnsupportedConstruct: unsupported SBML element 'delay' in expression ' <math><apply><times/><ci> compartment_0000001 </ci><apply><csymbol encoding="text" definitionURL="http://www


### PR DESCRIPTION
SBML models may have reactions with id of x,y,z,t, which is not allowed in VCell.  These names are mangled now with "RESERVED_" prefix.