### PR TITLE
Replace unsupported legacy native hdf5 library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
 		<jfreechart.version>1.5.0</jfreechart.version>
 		<jgrapht.version>1.3.0</jgrapht.version>
 		<jhdf.version>0.8.4</jhdf.version>
+		<jhdf5.cisd.version>19.04.1</jhdf5.cisd.version> <!-- deprecated -->
 		<jhdf5-2-10.version>2.9</jhdf5-2-10.version>
 		<jmatio.version>1.0</jmatio.version>
 		<joda-time.version>2.12.2</joda-time.version>

--- a/vcell-core/pom.xml
+++ b/vcell-core/pom.xml
@@ -404,10 +404,26 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
+		<dependency> <!-- deprecated -->
 			<groupId>org.scala-saddle</groupId>
 			<artifactId>jhdf5_2.10</artifactId>
 			<version>${jhdf5-2-10.version}</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/cisd/jhdf5 -->
+		<dependency>
+			<groupId>cisd</groupId>
+			<artifactId>jhdf5</artifactId>
+			<version>${jhdf5.cisd.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/vcell-core/src/main/java/cbit/vcell/export/server/ASCIIExporter.java
+++ b/vcell-core/src/main/java/cbit/vcell/export/server/ASCIIExporter.java
@@ -10,48 +10,29 @@
 
 package cbit.vcell.export.server;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.Vector;
-
+import cbit.vcell.export.server.FileDataContainerManager.FileDataContainerID;
+import cbit.vcell.geometry.SinglePoint;
+import cbit.vcell.math.VariableType;
 import cbit.vcell.resource.NativeLib;
+import cbit.vcell.simdata.*;
+import cbit.vcell.solver.ode.ODESimData;
+import cbit.vcell.solvers.CartesianMesh;
+import edu.uchc.connjur.wb.ExecutionTrace;
+import hdf.hdf5lib.H5;
+import hdf.hdf5lib.HDF5Constants;
+import hdf.hdf5lib.exceptions.HDF5Exception;
+import hdf.hdf5lib.exceptions.HDF5LibraryException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vcell.solver.smoldyn.SmoldynVCellMapper;
 import org.vcell.solver.smoldyn.SmoldynVCellMapper.SmoldynKeyword;
 import org.vcell.util.*;
-import org.vcell.util.document.TSJobResultsNoStats;
-import org.vcell.util.document.TimeSeriesJobSpec;
-import org.vcell.util.document.User;
-import org.vcell.util.document.VCDataIdentifier;
-import org.vcell.util.document.VCDataJobID;
+import org.vcell.util.document.*;
 
-import cbit.vcell.export.server.FileDataContainerManager.FileDataContainerID;
-import cbit.vcell.geometry.SinglePoint;
-import cbit.vcell.math.VariableType;
-import cbit.vcell.simdata.DataServerImpl;
-import cbit.vcell.simdata.OutputContext;
-import cbit.vcell.simdata.ParticleDataBlock;
-import cbit.vcell.simdata.SimDataBlock;
-import cbit.vcell.simdata.SimulationData;
-import cbit.vcell.simdata.SpatialSelection;
-import cbit.vcell.simdata.SpatialSelectionMembrane;
-import cbit.vcell.simdata.SpatialSelectionVolume;
-import cbit.vcell.solver.ode.ODESimData;
-import cbit.vcell.solvers.CartesianMesh;
-import edu.uchc.connjur.wb.ExecutionTrace;
-import ncsa.hdf.hdf5lib.H5;
-import ncsa.hdf.hdf5lib.HDF5Constants;
-import ncsa.hdf.hdf5lib.exceptions.HDF5Exception;
-import ncsa.hdf.hdf5lib.exceptions.HDF5LibraryException;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Insert the type's description here.
@@ -84,10 +65,10 @@ public class ASCIIExporter implements ExportConstants {
      * @throws NullPointerException (unsure how this occurs)
      * @throws HDF5Exception if the hdf5 library encounters something unusual
      */
-    public static void insertDoubles(int hdf5GroupID,String dataspaceName,long[] dims,List<Double> data) throws NullPointerException, HDF5Exception {
+    public static void insertDoubles(long hdf5GroupID,String dataspaceName,long[] dims,List<Double> data) throws NullPointerException, HDF5Exception, HDF5LibraryException {
         double[] hdfData = org.apache.commons.lang.ArrayUtils.toPrimitive(((ArrayList<Double>)data).toArray(new Double[0]));
-        int hdf5DataspaceID = H5.H5Screate_simple(dims.length, dims, null);
-        int hdf5DatasetID = H5.H5Dcreate(hdf5GroupID, dataspaceName,HDF5Constants.H5T_NATIVE_DOUBLE, hdf5DataspaceID,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+        long hdf5DataspaceID = H5.H5Screate_simple(dims.length, dims, null);
+        long hdf5DatasetID = H5.H5Dcreate(hdf5GroupID, dataspaceName,HDF5Constants.H5T_NATIVE_DOUBLE, hdf5DataspaceID,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
         H5.H5Dwrite_double(hdf5DatasetID, HDF5Constants.H5T_NATIVE_DOUBLE, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL, HDF5Constants.H5P_DEFAULT, hdfData);
         H5.H5Dclose(hdf5DatasetID);
         H5.H5Sclose(hdf5DataspaceID);
@@ -103,9 +84,9 @@ public class ASCIIExporter implements ExportConstants {
      * @throws NullPointerException (unsure how this occurs)
      * @throws HDF5Exception if the hdf5 library encounters something unusual
      */
-    public static void insertDoubles(int hdf5GroupID,String dataspaceName,long[] dims,double[] data) throws NullPointerException, HDF5Exception {
-        int hdf5DataspaceID = H5.H5Screate_simple(dims.length, dims, null);
-        int hdf5DatasetID = H5.H5Dcreate(hdf5GroupID, dataspaceName,HDF5Constants.H5T_NATIVE_DOUBLE, hdf5DataspaceID,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+    public static void insertDoubles(long hdf5GroupID,String dataspaceName,long[] dims,double[] data) throws NullPointerException, HDF5Exception {
+        long hdf5DataspaceID = H5.H5Screate_simple(dims.length, dims, null);
+        long hdf5DatasetID = H5.H5Dcreate(hdf5GroupID, dataspaceName,HDF5Constants.H5T_NATIVE_DOUBLE, hdf5DataspaceID,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
         H5.H5Dwrite_double(hdf5DatasetID, HDF5Constants.H5T_NATIVE_DOUBLE, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL, HDF5Constants.H5P_DEFAULT, (double[])data);
         H5.H5Dclose(hdf5DatasetID);
         H5.H5Sclose(hdf5DataspaceID);
@@ -121,9 +102,9 @@ public class ASCIIExporter implements ExportConstants {
      * @throws NullPointerException (unsure how this occurs)
      * @throws HDF5Exception if the hdf5 library encounters something unusual
      */
-    public static void insertInts(int hdf5GroupID,String dataspaceName,long[] dims,int[] data) throws NullPointerException, HDF5Exception {
-        int hdf5DataspaceID = H5.H5Screate_simple(dims.length, dims, null);
-        int hdf5DatasetID = H5.H5Dcreate(hdf5GroupID, dataspaceName,HDF5Constants.H5T_NATIVE_INT, hdf5DataspaceID,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+    public static void insertInts(long hdf5GroupID,String dataspaceName,long[] dims,int[] data) throws NullPointerException, HDF5Exception {
+        long hdf5DataspaceID = H5.H5Screate_simple(dims.length, dims, null);
+        long hdf5DatasetID = H5.H5Dcreate(hdf5GroupID, dataspaceName,HDF5Constants.H5T_NATIVE_INT, hdf5DataspaceID,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
         H5.H5Dwrite_int(hdf5DatasetID, HDF5Constants.H5T_NATIVE_INT, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL, HDF5Constants.H5P_DEFAULT, (int[])data);
         H5.H5Dclose(hdf5DatasetID);
         H5.H5Sclose(hdf5DataspaceID);
@@ -139,7 +120,7 @@ public class ASCIIExporter implements ExportConstants {
      * @throws NullPointerException (unsure how this occurs)
      * @throws HDF5Exception if the hdf5 library encounters something unusual
      */
-    public static void insertStrings(int hdf5GroupID,String datasetName,long[] dims,List<String> data) throws NullPointerException, HDF5Exception {
+    public static void insertStrings(long hdf5GroupID,String datasetName,long[] dims,List<String> data) throws NullPointerException, HDF5Exception {
         int largestStrLen = 0;
         for(int i=0;i<data.size();i++) {
             largestStrLen = Math.max(largestStrLen, data.get(i).length());
@@ -150,10 +131,10 @@ public class ASCIIExporter implements ExportConstants {
             System.arraycopy(data.get(i).getBytes(), 0, bytes, index, data.get(i).length());
             index+= largestStrLen;
         }
-        int h5tcs1 = H5.H5Tcopy(HDF5Constants.H5T_C_S1);
+        long h5tcs1 = H5.H5Tcopy(HDF5Constants.H5T_C_S1);
         H5.H5Tset_size(h5tcs1, largestStrLen);
-        int hdf5DataspaceID = H5.H5Screate_simple(dims.length, dims, null);
-        int hdf5DatasetID = H5.H5Dcreate(hdf5GroupID, datasetName,h5tcs1, hdf5DataspaceID,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+        long hdf5DataspaceID = H5.H5Screate_simple(dims.length, dims, null);
+        long hdf5DatasetID = H5.H5Dcreate(hdf5GroupID, datasetName,h5tcs1, hdf5DataspaceID,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
         //final byte[] bytes = allStringSB.toString().getBytes();
         H5.H5Dwrite(hdf5DatasetID, h5tcs1, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL, HDF5Constants.H5P_DEFAULT, bytes);
         H5.H5Tclose(h5tcs1);
@@ -170,19 +151,19 @@ public class ASCIIExporter implements ExportConstants {
      * @throws NullPointerException (unsure how this occurs)
      * @throws HDF5Exception if the hdf5 library encounters something unusual
      */
-    public static void insertAttribute(int hdf5GroupID,String attributeName,String data) throws NullPointerException, HDF5Exception {
+    public static void insertAttribute(long hdf5GroupID,String attributeName,String data) throws NullPointerException, HDF5Exception {
         //insertAttributes(hdf5GroupID, dataspaceName, new ArrayList<String>(Arrays.asList(new String[] {data})));
         //String[] attr = data.toArray(new String[0]);
 
         String attr = data + '\u0000';
 
         //https://support.hdfgroup.org/ftp/HDF5/examples/misc-examples/vlstra.c
-        int h5attrcs1 = H5.H5Tcopy(HDF5Constants.H5T_C_S1);
+        long h5attrcs1 = H5.H5Tcopy(HDF5Constants.H5T_C_S1);
         H5.H5Tset_size (h5attrcs1, attr.length() /*HDF5Constants.H5T_VARIABLE*/);
-        int dataspace_id = -1;
+        long dataspace_id = -1;
         //dataspace_id = H5.H5Screate_simple(dims.length, dims,null);
         dataspace_id = H5.H5Screate(HDF5Constants.H5S_SCALAR);
-        int attribute_id = H5.H5Acreate(hdf5GroupID, attributeName, h5attrcs1, dataspace_id, HDF5Constants.H5P_DEFAULT,HDF5Constants.H5P_DEFAULT);
+        long attribute_id = H5.H5Acreate(hdf5GroupID, attributeName, h5attrcs1, dataspace_id, HDF5Constants.H5P_DEFAULT,HDF5Constants.H5P_DEFAULT);
         H5.H5Awrite(attribute_id, h5attrcs1, attr.getBytes());
         H5.H5Sclose(dataspace_id);
         H5.H5Aclose(attribute_id);
@@ -592,7 +573,7 @@ public class ASCIIExporter implements ExportConstants {
             exportOutputV.add(new ExportOutput[]{sofyaFormat(outputContext, jobID, user, dataServerImpl, orig_vcdID, variableSpecs, timeSpecs, geometrySpecs, asciiSpecs, contextName, fileDataContainerManager)});
         } else {
             try {
-                int hdf5FileID = -1;//Used if HDF5 format
+                long hdf5FileID = -1;//Used if HDF5 format
                 if(asciiSpecs.isHDF5()){
                     hdf5TempFile = File.createTempFile("pde", ".hdf5");
                     lg.debug("========> VCell-style hdf5 file location: " + hdf5TempFile.getAbsolutePath());
@@ -630,7 +611,7 @@ public class ASCIIExporter implements ExportConstants {
                                         " '" + psName + "'=" + simNameSimDataIDs[v].getExportParamScanInfo().getParamScanConstantValues()[simJobIndex][i];
                             }
                         }
-                        int hdf5GroupID = -1;//Used if HDF5 format
+                        long hdf5GroupID = -1;//Used if HDF5 format
                         if(asciiSpecs.isHDF5()){
                             hdf5GroupID = H5.H5Gcreate(hdf5FileID, vcdID.toString(), HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                         }
@@ -685,12 +666,12 @@ public class ASCIIExporter implements ExportConstants {
                                     //StringBuilder data1 = new StringBuilder(data.toString());
                                     ExportOutput exportOutput1 = new ExportOutput(true, dataType, simID, dataID/* + variableSpecs.getVariableNames()[i]*/, fileDataContainerManager);
                                     fileDataContainerManager.append(exportOutput1.getFileDataContainerID(), fileDataContainerID_header);
-                                    int hdf5GroupPointID = -1;//Used if HDF5 format
+                                    long hdf5GroupPointID = -1;//Used if HDF5 format
                                     if(asciiSpecs.isHDF5()){
                                         hdf5GroupPointID = H5.H5Gcreate(hdf5GroupID, "Points", HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                                     }
                                     for(int varNameIndx = 0; varNameIndx < variableSpecs.getVariableNames().length; varNameIndx++){
-                                        int hdf5GroupVarID = -1;//Used if HDF5 format
+                                        long hdf5GroupVarID = -1;//Used if HDF5 format
                                         if(asciiSpecs.isHDF5()){
                                             hdf5GroupVarID = H5.H5Gcreate(hdf5GroupPointID, variableSpecs.getVariableNames()[varNameIndx], HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                                         }
@@ -714,13 +695,13 @@ public class ASCIIExporter implements ExportConstants {
                                     //StringBuilder data1 = new StringBuilder(data.toString());
                                     ExportOutput exportOutput1 = new ExportOutput(true, dataType, simID, dataID/* + variableSpecs.getVariableNames()[i]*/, fileDataContainerManager);
                                     fileDataContainerManager.append(exportOutput1.getFileDataContainerID(), fileDataContainerID_header);
-                                    int hdf5GroupPointID = -1;//Used if HDF5 format
+                                    long hdf5GroupPointID = -1;//Used if HDF5 format
                                     if(asciiSpecs.isHDF5()){
                                         hdf5GroupPointID = H5.H5Gcreate(hdf5GroupID, "Curves", HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
 
                                     }
                                     for(int varNameIndx = 0; varNameIndx < variableSpecs.getVariableNames().length; varNameIndx++){
-                                        int hdf5GroupVarID = -1;//Used if HDF5 format
+                                        long hdf5GroupVarID = -1;//Used if HDF5 format
                                         if(asciiSpecs.isHDF5()){
                                             hdf5GroupVarID = H5.H5Gcreate(hdf5GroupPointID, variableSpecs.getVariableNames()[varNameIndx], HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                                         }
@@ -843,7 +824,7 @@ public class ASCIIExporter implements ExportConstants {
      * @return java.lang.String
      * @throws IOException
      */
-    private FileDataContainerID getCurveTimeSeries(int hdf5GroupVarID, PointsCurvesSlices pointsCurvesSlices, OutputContext outputContext, User user, DataServerImpl dataServerImpl, VCDataIdentifier vcdID, String variableName, SpatialSelection curve, double[] allTimes, int beginIndex, int endIndex, boolean switchRowsColumns, FileDataContainerManager fileDataContainerManager) throws DataAccessException, IOException{
+    private FileDataContainerID getCurveTimeSeries(long hdf5GroupVarID, PointsCurvesSlices pointsCurvesSlices, OutputContext outputContext, User user, DataServerImpl dataServerImpl, VCDataIdentifier vcdID, String variableName, SpatialSelection curve, double[] allTimes, int beginIndex, int endIndex, boolean switchRowsColumns, FileDataContainerManager fileDataContainerManager) throws DataAccessException, IOException{
         int[] pointIndexes = null;
         double[] distances = null;
         int[] crossingMembraneIndexes = null;
@@ -960,7 +941,7 @@ public class ASCIIExporter implements ExportConstants {
 
         if(hdf5GroupVarID != -1){
             try {
-                int hdf5GroupCurveID = H5.H5Gcreate(hdf5GroupVarID, getSpatialSelectionDescription(curve), HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+                long hdf5GroupCurveID = H5.H5Gcreate(hdf5GroupVarID, getSpatialSelectionDescription(curve), HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                 insertInts(hdf5GroupCurveID, PCS.CURVEINDEXES.name(), new long[]{((int[]) treePCS.get(PCS.CURVEINDEXES)).length}, (int[]) treePCS.get(PCS.CURVEINDEXES));//UiTableExporterToHDF5.writeHDF5Dataset(hdf5GroupCurveID, PCS.CURVEINDEXES.name(), new long[] {((int[])treePCS.get(PCS.CURVEINDEXES)).length}, (int[])treePCS.get(PCS.CURVEINDEXES),false);
                 insertDoubles(hdf5GroupCurveID, PCS.CURVEDISTANCES.name(), new long[]{((double[]) treePCS.get(PCS.CURVEDISTANCES)).length}, (double[]) treePCS.get(PCS.CURVEDISTANCES));//UiTableExporterToHDF5.writeHDF5Dataset(hdf5GroupCurveID, PCS.CURVEDISTANCES.name(), new long[] {((double[])treePCS.get(PCS.CURVEDISTANCES)).length}, (double[])treePCS.get(PCS.CURVEDISTANCES),false);
                 if(treePCS.get(PCS.CURVECROSSMEMBRINDEX) != null){
@@ -1089,7 +1070,7 @@ public class ASCIIExporter implements ExportConstants {
      * @return java.lang.String
      * @throws IOException
      */
-    private FileDataContainerID getPointsTimeSeries(PointsCurvesSlices pcs, int hdf5GroupID, OutputContext outputContext, User user,
+    private FileDataContainerID getPointsTimeSeries(PointsCurvesSlices pcs, long hdf5GroupID, OutputContext outputContext, User user,
                                                     DataServerImpl dataServerImpl, VCDataIdentifier vcdID, String variableName, GeometrySpecs geometrySpecs,
                                                     double[] allTimes, int beginIndex, int endIndex, boolean switchRowsColumns, FileDataContainerManager fileDataContainerManager) throws DataAccessException, IOException, HDF5Exception{
 
@@ -1180,10 +1161,10 @@ public class ASCIIExporter implements ExportConstants {
 
 
     private class SliceHelper {
-        public int hdf5DataspaceIDSlice = -1;
-        public int hdf5GroupVarID = -1;
-        int hdf5DataspaceIDValues = -1;
-        int hdf5DatasetIDValues = -1;
+        public long hdf5DataspaceIDSlice = -1;
+        public long hdf5GroupVarID = -1;
+        long hdf5DataspaceIDValues = -1;
+        long hdf5DatasetIDValues = -1;
 
         public final String[] SLICE_PLANE_AXIS = {"X", "Y", "Z"};
         private final int[][][] loopIndexes = new int[][][]{{{1, 2}, {2, 1}}, {{0, 2}, {2, 0}}, {{0, 1}, {1, 0}}};
@@ -1219,7 +1200,7 @@ public class ASCIIExporter implements ExportConstants {
             innerSizeIndex = loopIndexes[slicePlaneIndex][(switchRowsColumns ? 0 : 1)][1];
         }
 
-        public void setHDF5GroupVarID(int hdf5GroupID, String varName) throws HDF5LibraryException{
+        public void setHDF5GroupVarID(long hdf5GroupID, String varName) throws HDF5LibraryException{
             if(isHDF5){
                 hdf5GroupVarID = H5.H5Gcreate(hdf5GroupID, varName, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
                 currentTimeIndex = 0;

--- a/vcell-core/src/main/java/cbit/vcell/export/server/ASCIIExporter.java
+++ b/vcell-core/src/main/java/cbit/vcell/export/server/ASCIIExporter.java
@@ -549,7 +549,12 @@ public class ASCIIExporter implements ExportConstants {
                                              GeometrySpecs geometrySpecs, ASCIISpecs asciiSpecs, String contextName, FileDataContainerManager fileDataContainerManager)
             throws DataAccessException, IOException{
 
-        NativeLib.HDF5.load();
+        // skip loading legacy native HDF5 library if the system is a macos arm64
+        // will get runtime errors for Chombo and MovingBoundary until HDF5 is updated
+        boolean MacosArm64 = System.getProperty("os.arch").equals("aarch64") && System.getProperty("os.name").equals("Mac OS X");
+        if (!MacosArm64) {
+            NativeLib.HDF5.load();
+        }
         ExportSpecs.SimNameSimDataID[] simNameSimDataIDs = asciiSpecs.getSimNameSimDataIDs();
         Vector<ExportOutput[]> exportOutputV = new Vector<ExportOutput[]>();
         double progressCounter = 0;

--- a/vcell-core/src/main/java/cbit/vcell/export/server/JhdfUtils.java
+++ b/vcell-core/src/main/java/cbit/vcell/export/server/JhdfUtils.java
@@ -1,9 +1,12 @@
 package cbit.vcell.export.server;
 
-import io.jhdf.api.Attribute;
+import io.jhdf.HdfFile;
+import io.jhdf.api.Dataset;
+import io.jhdf.api.Group;
+import io.jhdf.api.Node;
 import io.jhdf.api.WritableNode;
+import io.jhdf.object.datatype.CompoundDataType;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class JhdfUtils {
@@ -168,5 +171,37 @@ public class JhdfUtils {
 
     public static void putAttribute(WritableNode node, String name, double[] value) {
         node.putAttribute(name, value);
+    }
+
+    public static List<Node> getChildren(HdfFile hdfFile, Group group) {
+        return hdfFile.getChildren().values().stream()
+                .filter(node -> node.getParent() == group).toList();
+    }
+    
+    public static List<Group> getChildGroups(HdfFile hdfFile, Group group) {
+        return hdfFile.getChildren().values().stream()
+                .filter(node -> node.getParent() == group)
+                .filter(node -> node instanceof Group)
+                .map(node -> (Group)node).toList();
+    }
+
+    public static List<Dataset> getChildDatasets(HdfFile hdfFile, Group group) {
+        return hdfFile.getChildren().values().stream()
+                .filter(node -> node.getParent() == group)
+                .filter(node -> node instanceof Dataset)
+                .map(node -> (Dataset)node).toList();
+    }
+
+    public static String[] getCompoundDatasetMemberNames(Dataset cds) {
+        if (!cds.isCompound()) {
+            throw new IllegalArgumentException("Dataset is not compound.");
+        }
+        if (cds.getDataType() instanceof CompoundDataType compoundDataType) {
+            return compoundDataType.getMembers().stream()
+                    .map(CompoundDataType.CompoundDataMember::getName)
+                    .toArray(String[]::new);
+        } else {
+            throw new IllegalArgumentException("Dataset is not compound.");
+        }
     }
 }

--- a/vcell-core/src/main/java/cbit/vcell/simdata/MultiTrialNonspatialStochSimDataReader.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/MultiTrialNonspatialStochSimDataReader.java
@@ -1,127 +1,68 @@
 package cbit.vcell.simdata;
 
-import cbit.vcell.parser.ExpressionException;
 import cbit.vcell.solver.ode.ODESimData;
 import com.google.common.io.Files;
-import ncsa.hdf.object.FileFormat;
-import ncsa.hdf.object.Group;
-import ncsa.hdf.object.HObject;
-import ncsa.hdf.object.h5.H5ScalarDS;
+import hdf.hdf5lib.exceptions.HDF5Exception;
+import io.jhdf.HdfFile;
+import io.jhdf.api.Dataset;
 import org.vcell.util.ObjectNotFoundException;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
+
+/**
+ * This class provides methods to extract data from the HDF5 file of a Stochastic MultiTrial Nonspatial simulation.
+ * The data is stored in the HDF5 file in the following format:
+ * <pre>
+ *     Dataset "VarNames": string[n_vars]
+ *     Dataset "SimTimes": double[n_times]
+ *     Dataset "StatMean": double[n_times][n_vars]
+ *     Dataset "StatMin": double[n_times][n_vars]
+ *     Dataset "StatMax": double[n_times][n_vars]
+ *     Dataset "StatStdDev": double[n_times][n_vars]
+ * </pre>
+ */
 
 public class MultiTrialNonspatialStochSimDataReader {
 
-    public static double[] extractColumn(ODESimData odeSimData, String columnName, SummaryStatisticType summaryStatisticType) throws ExpressionException, ObjectNotFoundException {
-        FileFormat hdf5FileFormat = null;
-        File to = null;
+    public static double[] extractColumn(ODESimData odeSimData, String columnName, SummaryStatisticType summaryStatisticType) throws HDF5Exception, ObjectNotFoundException {
+        File localHdf5File = null;
         try {
             byte[] hdf5FileBytes = odeSimData.getHdf5FileBytes();
-            if(hdf5FileBytes != null) {
-                to = File.createTempFile("multitrial_nonspatial_stats_", ".hdf5");
-                Files.write(hdf5FileBytes, to);
-                FileFormat fileFormat = FileFormat.getFileFormat(FileFormat.FILE_TYPE_HDF5);
-                if (fileFormat == null){
-                    throw new Exception("Cannot find HDF5 FileFormat.");
-                }
-                // open the file with read-only access
-                hdf5FileFormat = fileFormat.createInstance(to.getAbsolutePath(), FileFormat.READ);
-                // open the file and retrieve the file structure
-                hdf5FileFormat.open();
-                Group root = (Group)((javax.swing.tree.DefaultMutableTreeNode)hdf5FileFormat.getRootNode()).getUserObject();
-                List<HObject> postProcessMembers = ((Group)root).getMemberList();
-                for(HObject nextHObject : postProcessMembers) {
-                    System.out.println(nextHObject.getName()+"   "+nextHObject.getClass().getName());
-                    H5ScalarDS h5ScalarDS = (H5ScalarDS)nextHObject;
-                    h5ScalarDS.init();
-                    try {
-                        long[] dims = h5ScalarDS.getDims();
-                        System.out.println("---"+nextHObject.getName()+" "+nextHObject.getClass().getName()+" Dimensions="+Arrays.toString(dims));
-                        Object obj = h5ScalarDS.read();
-                        if(dims.length == 2) {
-                            double[] columns = new double[(int)dims[1]];
-                            for(int row=0;row<dims[0];row++) {
-                                System.arraycopy(obj, row*columns.length, columns, 0, columns.length);
-                                System.out.println(Arrays.toString(columns));
-                            }
-                            return null;
-    //								return columns;
-                        } else {
-                            return null;
-                        }
-                    } catch(Exception e) {
-                        return null;
-                    }
-                }
+            if (hdf5FileBytes != null) {
+                localHdf5File = File.createTempFile("multitrial_nonspatial_stats_", ".hdf5");
+                Files.write(hdf5FileBytes, localHdf5File);
             }
-         } catch (Exception e) {
-            e.printStackTrace();
-        } finally {
-            if(hdf5FileFormat != null) {try{hdf5FileFormat.close();}catch(Exception e2) {e2.printStackTrace();}}
-            if(to != null){try{to.delete();}catch(Exception e2) {e2.printStackTrace();}}
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create temp file", e);
         }
-        return null;
-    }
+        try (HdfFile hdfFile = new HdfFile(localHdf5File)) {
 
-    private void example_reader(ODESimData odeSimData) {
-        //
-        //Example code for reading stats data from Stochastic multitrial non-histogram
-        //
-        FileFormat hdf5FileFormat = null;
-        File to = null;
-        try {
-                byte[] hdf5FileBytes = odeSimData.getHdf5FileBytes();
-                if(hdf5FileBytes != null) {
-                    to = File.createTempFile("multitrial_nonspatial_stats_", ".hdf5");
-                    Files.write(hdf5FileBytes, to);
-                    FileFormat fileFormat = FileFormat.getFileFormat(FileFormat.FILE_TYPE_HDF5);
-                    if (fileFormat == null){
-                        throw new Exception("Cannot find HDF5 FileFormat.");
-                    }
-                    // open the file with read-only access
-                    hdf5FileFormat = fileFormat.createInstance(to.getAbsolutePath(), FileFormat.READ);
-                    // open the file and retrieve the file structure
-                    hdf5FileFormat.open();
-                    Group root = (Group)((javax.swing.tree.DefaultMutableTreeNode)hdf5FileFormat.getRootNode()).getUserObject();
-                    List<HObject> postProcessMembers = ((Group)root).getMemberList();
-                    for(HObject nextHObject:postProcessMembers){
-                        //System.out.println(nextHObject.getName()+"\n"+nextHObject.getClass().getName());
-                        H5ScalarDS h5ScalarDS = (H5ScalarDS)nextHObject;
-                        h5ScalarDS.init();
-                        try {
-                            long[] dims = h5ScalarDS.getDims();
-                            System.out.println("---"+nextHObject.getName()+" "+nextHObject.getClass().getName()+" Dimensions="+ Arrays.toString(dims));
-                            Object obj = h5ScalarDS.read();
-                            if(dims.length == 2) {
-                                //dims[0]=numTimes (will be the same as 'SimTimes' data length)
-                                //dims[1]=numVars (will be the same as 'VarNames' data length)
-                                //if name='StatMean' this is the same as the default data saved in the odeSolverresultSet
-                                double[] columns = new double[(int)dims[1]];
-                                for(int row=0;row<dims[0];row++) {
-                                    System.arraycopy(obj, row*columns.length, columns, 0, columns.length);
-                                    System.out.println(Arrays.toString(columns));
-                                }
-                            }else {
-                                if(obj instanceof double[]) {
-                                    System.out.println(Arrays.toString((double[])obj));
-                                }else {
-                                    System.out.println(Arrays.toString((String[])obj));
-                                }
-                            }
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
-                    }
-                }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }finally {
-            if(hdf5FileFormat != null) {try{hdf5FileFormat.close();}catch(Exception e2) {e2.printStackTrace();}}
-            if(to != null){try{to.delete();}catch(Exception e2) {e2.printStackTrace();}}
+            // get the variable index from the dataset["VarNames"]
+            Dataset varNamesDataset = (Dataset) hdfFile.getChild("VarNames");
+            String[] varNames = (String[]) varNamesDataset.getData();
+            int varIndex = Arrays.stream(varNames).toList().indexOf(columnName);
+            if (varIndex == -1) {
+                throw new ObjectNotFoundException("Variable name not found: " + columnName);
+            }
+
+            // get the column data from the
+            // dataset["StatMean"], dataset["StatMin"], dataset["StatMax"], or dataset["StatStdDev"]
+            // and extract data for the specified variable index
+            String statisticsDatasetName = switch (summaryStatisticType) {
+                case Mean -> "StatMean";
+                case Min -> "StatMin";
+                case Max -> "StatMax";
+                case Std -> "StatStdDev";
+            };
+            Dataset statisticDataset = (Dataset) hdfFile.getChild(statisticsDatasetName);
+            double[][] data = (double[][]) statisticDataset.getData();
+            double[] column = new double[data.length];
+            for (int i = 0; i < data.length; i++) {
+                column[i] = data[i][varIndex];
+            }
+            return column;
         }
-
     }
 }

--- a/vcell-core/src/main/java/cbit/vcell/simdata/UiTableExporterToHDF5.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/UiTableExporterToHDF5.java
@@ -1,10 +1,10 @@
 package cbit.vcell.simdata;
 
 import cbit.vcell.math.ReservedVariable;
-import ncsa.hdf.hdf5lib.H5;
-import ncsa.hdf.hdf5lib.HDF5Constants;
-import ncsa.hdf.hdf5lib.exceptions.HDF5Exception;
-import ncsa.hdf.hdf5lib.exceptions.HDF5LibraryException;
+import hdf.hdf5lib.H5;
+import hdf.hdf5lib.HDF5Constants;
+import hdf.hdf5lib.exceptions.HDF5Exception;
+import hdf.hdf5lib.exceptions.HDF5LibraryException;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -14,7 +14,7 @@ import java.util.ListIterator;
 
 public class UiTableExporterToHDF5 {
     public static File exportTableToHDF5(boolean bHistogram, String blankCellValue, int[] columns, int[] rows, String xVarColumnName, String hdf5DescriptionText, String[] columnNames, String[] paramScanParamNames, Double[][] paramScanParamValues, Object[][] rowColValues) throws Exception {
-		int hdf5FileID = -1;//Used if HDF5 format
+		long hdf5FileID = -1;//Used if HDF5 format
 		File hdf5TempFile = null;
 		try {
 			hdf5TempFile = File.createTempFile("plot2D", ".hdf");
@@ -90,7 +90,7 @@ public class UiTableExporterToHDF5 {
 				if(selectedColCount == 0) {
 					continue;
 				}
-				int jobGroupID = -1;//(int) UiTableExporterToHDF5.createGroup(hdf5FileID, "Set "+k);
+				long jobGroupID = -1;//(int) UiTableExporterToHDF5.createGroup(hdf5FileID, "Set "+k);
 						//writeHDF5Dataset(hdf5FileID, "Set "+k, null, null, false);
 				HDF5WriteHelper help0 = null;//UiTableExporterToHDF5.createDataset(jobGroupID, "data", new long[] {selectedColCount,rows.length});
 						//(HDF5WriteHelper) UiTableExporterToHDF5.writeHDF5Dataset(jobGroupID, "data", new long[] {selectedColCount,rows.length}, new Object[] {}, false);
@@ -141,7 +141,7 @@ public class UiTableExporterToHDF5 {
 						if(!bParamsDone) {
 							bParamsDone = true;
 							int set = Integer.parseInt(colName.substring(colName.lastIndexOf("Set ")+4));
-							jobGroupID = (int) createGroup(hdf5FileID, "Set "+set);
+							jobGroupID = createGroup(hdf5FileID, "Set "+set);
 							help0 = createDataset(jobGroupID, "data", new long[] {selectedColCount,actualLength});
 							for(int z=0;z<paramScanParamNames.length;z++) {
 								paramNames.add(paramScanParamNames[z]);
@@ -159,7 +159,7 @@ public class UiTableExporterToHDF5 {
 					System.arraycopy(fromData, i* rows.length, fromData2, i*actualLength, actualLength);
 				}
 				if(help0 == null) {
-					jobGroupID = (int) createGroup(hdf5FileID, "Set "+k);
+					jobGroupID = createGroup(hdf5FileID, "Set "+k);
 					help0 = createDataset(jobGroupID, "data", new long[] {selectedColCount,actualLength});
 				}
 				copySlice(help0.hdf5DatasetValuesID,fromData2,new long[] {0,0},new long[] {selectedColCount,actualLength},new long[] {selectedColCount,actualLength},new long[] {0,0},new long[] {selectedColCount,actualLength},help0.hdf5DataSpaceID);
@@ -197,12 +197,12 @@ public class UiTableExporterToHDF5 {
 		/**
 		 * The id number of the hdf5 dataspace
 		 */
-		public int hdf5DataSpaceID;
+		public long hdf5DataSpaceID;
 
 		/**
 		 * The id number of the hdf5 dataset
 		 */
-		public int hdf5DatasetValuesID;
+		public long hdf5DatasetValuesID;
 
 		/**
 		 * Construtor of te helper
@@ -210,7 +210,7 @@ public class UiTableExporterToHDF5 {
 		 * @param hdf5DataSpaceID The id number of the hdf5 dataspace
 		 * @param hdf5DatasetValuesID The id number of the hdf5 dataset
 		 */
-		public HDF5WriteHelper(int hdf5DataSpaceID, int hdf5DatasetValuesID) {
+		public HDF5WriteHelper(long hdf5DataSpaceID, long hdf5DatasetValuesID) {
 			super();
 			this.hdf5DataSpaceID = hdf5DataSpaceID;
 			this.hdf5DatasetValuesID = hdf5DatasetValuesID;
@@ -234,11 +234,11 @@ public class UiTableExporterToHDF5 {
 	 * @return a HDF5 Writer helper class to store the relevant values
 	 * @throws HDF5Exception if the hdf5 library encounters something unusual
 	 */
-	private static HDF5WriteHelper createDataset(int hdf5GroupID,String datasetName,long[] dims) throws HDF5Exception{
+	private static HDF5WriteHelper createDataset(long hdf5GroupID,String datasetName,long[] dims) throws HDF5Exception {
 		//Create dataset and return it, must be closed when finished
 		long[] datasetDimensions = dims;
-		int hdf5DataspaceIDValues = H5.H5Screate_simple(datasetDimensions.length, datasetDimensions, null);
-		int hdf5DatasetIDValues = H5.H5Dcreate(hdf5GroupID, datasetName, HDF5Constants.H5T_NATIVE_DOUBLE, hdf5DataspaceIDValues,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+		long hdf5DataspaceIDValues = H5.H5Screate_simple(datasetDimensions.length, datasetDimensions, null);
+		long hdf5DatasetIDValues = H5.H5Dcreate(hdf5GroupID, datasetName, HDF5Constants.H5T_NATIVE_DOUBLE, hdf5DataspaceIDValues,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
 		return new HDF5WriteHelper(hdf5DataspaceIDValues,hdf5DatasetIDValues);
 	}
 
@@ -250,7 +250,7 @@ public class UiTableExporterToHDF5 {
 	 * @return the new group's ID number
 	 * @throws HDF5Exception if the hdf5 library encounters something unusual
 	 */
-	private static int createGroup(int hdf5GroupID,String groupName) throws HDF5Exception{
+	private static long createGroup(long hdf5GroupID,String groupName) throws HDF5Exception{
 		return H5.H5Gcreate(hdf5GroupID, (String)groupName,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
 	}
 
@@ -269,8 +269,8 @@ public class UiTableExporterToHDF5 {
 	 * @throws IllegalArgumentException
 	 * @throws HDF5Exception
 	 */
-	private static void copySlice(int copyToDataSet,double[] copyFromData,long[] copyToStart,long[] copyToLength,long[] copyFromDims,long[] copyFromStart,long[] copyFromLength,int dataspaceID) throws NullPointerException, IllegalArgumentException, HDF5Exception {
-		int hdf5DataspaceIDSlice = H5.H5Screate_simple(copyFromDims.length, copyFromDims, null);
+	private static void copySlice(long copyToDataSet,double[] copyFromData,long[] copyToStart,long[] copyToLength,long[] copyFromDims,long[] copyFromStart,long[] copyFromLength,long dataspaceID) throws NullPointerException, IllegalArgumentException, HDF5Exception {
+		long hdf5DataspaceIDSlice = H5.H5Screate_simple(copyFromDims.length, copyFromDims, null);
 		//Select the generated sliceData to copy-from
 		H5.H5Sselect_hyperslab(hdf5DataspaceIDSlice, HDF5Constants.H5S_SELECT_SET, copyFromStart, null, copyFromLength, null);
 		//Select next section of destination to copy-to
@@ -290,19 +290,19 @@ public class UiTableExporterToHDF5 {
 	 * @throws NullPointerException (unsure how this occurs)
 	 * @throws HDF5Exception if the hdf5 library encounters something unusual
 	 */
-	private static void insertAttribute(int hdf5GroupID,String attributeName,String data) throws NullPointerException, HDF5Exception {
+	private static void insertAttribute(long hdf5GroupID,String attributeName,String data) throws NullPointerException, HDF5Exception {
 		//insertAttributes(hdf5GroupID, dataspaceName, new ArrayList<String>(Arrays.asList(new String[] {data})));
 		//String[] attr = data.toArray(new String[0]);
 
 		String attr = data + '\u0000';
 
 		//https://support.hdfgroup.org/ftp/HDF5/examples/misc-examples/vlstra.c
-		int h5attrcs1 = H5.H5Tcopy(HDF5Constants.H5T_C_S1);
+		long h5attrcs1 = H5.H5Tcopy(HDF5Constants.H5T_C_S1);
 		H5.H5Tset_size (h5attrcs1, attr.length() /*HDF5Constants.H5T_VARIABLE*/);
-		int dataspace_id = -1;
+		long dataspace_id = -1;
 		//dataspace_id = H5.H5Screate_simple(dims.length, dims,null);
 		dataspace_id = H5.H5Screate(HDF5Constants.H5S_SCALAR);
-		int attribute_id = H5.H5Acreate(hdf5GroupID, attributeName, h5attrcs1, dataspace_id, HDF5Constants.H5P_DEFAULT,HDF5Constants.H5P_DEFAULT);
+		long attribute_id = H5.H5Acreate(hdf5GroupID, attributeName, h5attrcs1, dataspace_id, HDF5Constants.H5P_DEFAULT,HDF5Constants.H5P_DEFAULT);
 		H5.H5Awrite(attribute_id, h5attrcs1, attr.getBytes());
 		H5.H5Sclose(dataspace_id);
 		H5.H5Aclose(attribute_id);
@@ -318,7 +318,7 @@ public class UiTableExporterToHDF5 {
 	 * @throws NullPointerException (unsure how this occurs)
 	 * @throws HDF5Exception if the hdf5 library encounters something unusual
 	 */
-	private static void insertAttributes(int hdf5GroupID,String attributeName,List<String> data) throws NullPointerException, HDF5Exception {
+	private static void insertAttributes(long hdf5GroupID,String attributeName,List<String> data) throws NullPointerException, HDF5Exception {
 		String[] attr = data.toArray(new String[0]);
 		long[] dims = new long[] {attr.length}; // Always an array of length == 1
 		StringBuffer sb = new StringBuffer();
@@ -346,11 +346,11 @@ public class UiTableExporterToHDF5 {
 		}
 
 		//https://support.hdfgroup.org/ftp/HDF5/examples/misc-examples/vlstra.c
-		int h5attrcs1 = H5.H5Tcopy(HDF5Constants.H5T_C_S1);
+		long h5attrcs1 = H5.H5Tcopy(HDF5Constants.H5T_C_S1);
 		H5.H5Tset_size (h5attrcs1, MAXSTRSIZE/*HDF5Constants.H5T_VARIABLE*/);
-		int dataspace_id = -1;
+		long dataspace_id = -1;
 		dataspace_id = H5.H5Screate_simple(dims.length, dims,null);
-		int attribute_id = H5.H5Acreate(hdf5GroupID, attributeName, h5attrcs1, dataspace_id, HDF5Constants.H5P_DEFAULT,HDF5Constants.H5P_DEFAULT);
+		long attribute_id = H5.H5Acreate(hdf5GroupID, attributeName, h5attrcs1, dataspace_id, HDF5Constants.H5P_DEFAULT,HDF5Constants.H5P_DEFAULT);
 		H5.H5Awrite(attribute_id, h5attrcs1, sb.toString().getBytes());
 		H5.H5Sclose(dataspace_id);
 		H5.H5Aclose(attribute_id);

--- a/vcell-core/src/main/java/cbit/vcell/simdata/VtkMeshGenerator.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/VtkMeshGenerator.java
@@ -38,7 +38,12 @@ public class VtkMeshGenerator implements PortableCommand {
 	@Override
 	public int execute() {
 		try {
-			NativeLib.HDF5.load();
+			// skip loading legacy native HDF5 library if the system is a macos arm64
+			// will get runtime errors for Chombo and MovingBoundary until HDF5 is updated
+			boolean MacosArm64 = System.getProperty("os.arch").equals("aarch64") && System.getProperty("os.name").equals("Mac OS X");
+			if (!MacosArm64) {
+				NativeLib.HDF5.load();
+			}
 			KeyValue u = new KeyValue(userkey);
 			User owner = new User(username,u);
 			KeyValue simKey = new KeyValue(simkey);

--- a/vcell-core/src/test/java/cbit/vcell/resource/NativeLibTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/resource/NativeLibTest.java
@@ -15,6 +15,10 @@ public class NativeLibTest {
 	@Test
 	public void loadEm( ) {
 		for (NativeLib nl : NativeLib.values()) {
+			// skip if nl is HDF5 and system is a macos arm64
+			if (nl == NativeLib.HDF5 && System.getProperty("os.arch").equals("aarch64") && System.getProperty("os.name").equals("Mac OS X")) {
+				continue;
+			}
 			nl.load();
 		}
 	}

--- a/vcell-core/src/test/java/cbit/vcell/solvers/mb/MovingBoundaryH5FileStructureTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/solvers/mb/MovingBoundaryH5FileStructureTest.java
@@ -58,7 +58,12 @@ public class MovingBoundaryH5FileStructureTest {
     @BeforeAll
     public static void setup() {
         PropertyLoader.setProperty(PropertyLoader.installationRoot, new File("..").getAbsolutePath());
-        NativeLib.HDF5.load();
+        // skip loading legacy native HDF5 library if the system is a macos arm64
+        // will get runtime errors for Chombo and MovingBoundary until HDF5 is updated
+        boolean MacosArm64 = System.getProperty("os.arch").equals("aarch64") && System.getProperty("os.name").equals("Mac OS X");
+        if (!MacosArm64) {
+            NativeLib.HDF5.load();
+        }
     }
 
     //public static void main(String args[]) throws Exception {

--- a/vcell-core/src/test/java/cbit/vcell/solvers/mb/MovingBoundaryResultTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/solvers/mb/MovingBoundaryResultTest.java
@@ -23,7 +23,12 @@ public class MovingBoundaryResultTest {
 	@BeforeAll
 	public static void setup() {
 		PropertyLoader.setProperty(PropertyLoader.installationRoot, new File("..").getAbsolutePath());
-		NativeLib.HDF5.load();
+		// skip loading legacy native HDF5 library if the system is a macos arm64
+		// will get runtime errors for Chombo and MovingBoundary until HDF5 is updated
+		boolean MacosArm64 = System.getProperty("os.arch").equals("aarch64") && System.getProperty("os.name").equals("Mac OS X");
+		if (!MacosArm64) {
+			NativeLib.HDF5.load();
+		}
 	}
     public MovingBoundaryResultTest() {
 		Logger lg = LogManager.getLogger("ncsa");

--- a/vcell-core/src/test/java/cbit/vcell/solvers/mb/MovingBoundaryVH5PathTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/solvers/mb/MovingBoundaryVH5PathTest.java
@@ -36,7 +36,12 @@ public class MovingBoundaryVH5PathTest {
     @BeforeEach
     public void setup( ) throws Exception {
 		PropertyLoader.setProperty(PropertyLoader.installationRoot, new File("..").getAbsolutePath());
-		NativeLib.HDF5.load();
+		// skip loading legacy native HDF5 library if the system is a macos arm64
+		// will get runtime errors for Chombo and MovingBoundary until HDF5 is updated
+		boolean MacosArm64 = System.getProperty("os.arch").equals("aarch64") && System.getProperty("os.name").equals("Mac OS X");
+		if (!MacosArm64) {
+			NativeLib.HDF5.load();
+		}
 
 
 		// retrieve an instance of H5File


### PR DESCRIPTION
replace use of ncsa.jhdf5 library which is not supported on Mac ARM64 machines with supported HDF5 libraries (io.jhdf and cisd.jhdf5).

- ported spatial simulation HDF5 export **writer** (using cisd.jhdf5)
- ported nonspatial stochastic multi-trial data **reader** (using io.jhdf)
- ported UiTableExporter HDF5 export **writer** (using io.jhdf)
