### PR TITLE
Links are now editable

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/LinkSpecsTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/LinkSpecsTableModel.java
@@ -161,9 +161,6 @@ public class LinkSpecsTableModel extends VCellSortTableModel<MolecularInternalLi
         };
     }
 
-
-
-
     public void setSimulationContext(SimulationContext simulationContext) {
         SimulationContext oldValue = fieldSimulationContext;
         int oldColumnCount = getColumnCount();
@@ -289,8 +286,6 @@ public class LinkSpecsTableModel extends VCellSortTableModel<MolecularInternalLi
             refreshColumns();
             fireTableStructureChanged();
         }
-
     }
-
 
 }

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/LinkSpecsTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/LinkSpecsTableModel.java
@@ -7,10 +7,12 @@ import cbit.vcell.model.SpeciesContext;
 import cbit.vcell.model.Structure;
 import cbit.vcell.parser.Expression;
 import org.vcell.model.rbm.*;
+import org.vcell.util.Coordinate;
 import org.vcell.util.gui.GuiUtils;
 import org.vcell.util.gui.ScrollTable;
 import org.vcell.util.springsalad.NamedColor;
 
+import javax.swing.*;
 import java.beans.PropertyChangeEvent;
 import java.util.*;
 
@@ -86,13 +88,40 @@ public class LinkSpecsTableModel extends VCellSortTableModel<MolecularInternalLi
     @Override
     public void setValueAt(Object aValue, int row, int col) {
         MolecularInternalLinkSpec mils = getValueAt(row);
+        if(mils == null) {
+            return;
+        }
         ColumnType columnType = columns.get(col);
-        switch (columnType) {
-            case COLUMN_LINK:
+        SpeciesContextSpec scs = getSpeciesContextSpec();
 
+        MolecularComponentPattern mcpOne = mils.getMolecularComponentPatternOne();
+        MolecularComponentPattern mcpTwo = mils. getMolecularComponentPatternTwo();
+        SiteAttributesSpec sasOne = mils. getSite1();
+        SiteAttributesSpec sasTwo = mils. getSite2();
+
+        switch (columnType) {
+            case COLUMN_LINK:   // not editable
                 return;
             case COLUMN_LENGTH:
-
+                if (aValue instanceof String newExpressionString) {
+                    double res = 0.0;
+                    try {
+                        res = Double.parseDouble(newExpressionString);
+                    } catch(NumberFormatException ex) {
+                        JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
+                        return;
+                    }
+                    // the link is a derived value, we don't store it - we just show it in the table
+                    // instead, we adjust the x, y, z of the molecules involved
+                    double[] unitVector = mils.unitVector();
+                    double newX = sasOne.getX() + res*unitVector[0];
+                    double newY = sasOne.getY() + res*unitVector[1];
+                    double newZ = sasOne.getZ() + res*unitVector[2];
+                    Coordinate coord = new Coordinate (newX, newY, newZ);
+                    sasTwo.setCoordinate(coord);
+                    refreshData();
+                    scs.firePropertyChange(SpeciesContextSpec.PROPERTY_NAME_LINK_LENGTH, null, mils);
+                }
                 return;
             default:
                 return;
@@ -103,8 +132,9 @@ public class LinkSpecsTableModel extends VCellSortTableModel<MolecularInternalLi
         ColumnType columnType = columns.get(col);
         switch (columnType) {
             case COLUMN_LINK:
-            case COLUMN_LENGTH:
                 return false;
+            case COLUMN_LENGTH:
+                return true;
             default:
                 return false;
         }

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/ModelProcessSpecsPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/ModelProcessSpecsPanel.java
@@ -17,8 +17,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JTable;
+import javax.swing.table.TableColumn;
 import javax.swing.table.TableModel;
 
+import cbit.vcell.graph.GraphConstants;
+import cbit.vcell.parser.Expression;
 import org.vcell.model.rbm.SpeciesPattern;
 import org.vcell.util.gui.DefaultScrollTableCellRenderer;
 import org.vcell.util.gui.sorttable.JSortTable;
@@ -38,6 +41,9 @@ import cbit.vcell.model.ProductPattern;
 import cbit.vcell.model.ReactantPattern;
 import cbit.vcell.model.ReactionRule;
 import cbit.vcell.model.ReactionStep;
+import org.vcell.util.springsalad.NamedColor;
+
+import static cbit.vcell.mapping.gui.ModelProcessSpecsTableModel.ColumnType.COLUMN_BOND_LENGTH;
 
 /**
  * Insert the type's description here.
@@ -294,10 +300,53 @@ private void initConnections() throws java.lang.Exception {
 			}
 		}
 	};
-	
-	
+
+	// The Expression cell renderer  in the ModelProcessSpecsTable
+	DefaultScrollTableCellRenderer expressionTableCellRenderer = new DefaultScrollTableCellRenderer() {
+		String darkRed = NamedColor.getHex(GraphConstants.darkred);	// "#8B0000"
+		@Override
+		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus,
+													   int row, int column) {
+			super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+			if (table.getModel() instanceof ModelProcessSpecsTableModel) {
+				if (value instanceof Double) {
+					TableColumn tc = table.getColumnModel().getColumn(column);
+					Object headerValue = tc.getHeaderValue();
+					if(!(headerValue instanceof String)) {
+						throw new RuntimeException("Expecting HeaderValue to be a String");
+					}
+					/*
+					 * This is the correct way to recover the column type - using the label!!!
+					 * Because the index may be wrong if some columns have been removed or relocated
+					 */
+					ModelProcessSpecsTableModel.ColumnType columnType = ModelProcessSpecsTableModel.ColumnType.fromLabel((String) headerValue);
+					int cellWidth = table.getColumnModel().getColumn(column).getWidth();
+					switch (columnType) {
+						case COLUMN_BOND_LENGTH:
+							if(cellWidth > 70) {
+								if(!isSelected) {
+									String text = "<html>" + value + "<span style='color:" + darkRed + ";'> [nm]</span></html>";
+									setText(text);
+								} else {
+									setText(value + " [nm]");
+								}
+							} else {
+								setText(value + "");		// if it's too busy, just show the numbers
+							}
+							setToolTipText(value + " [nm]");	// we always show the units in the tooltip
+							break;
+						default:
+							break;
+					}
+				}
+			}
+			return this;
+		}
+	};
+
 	getScrollPaneTable().setDefaultRenderer(SpeciesPattern.class, rbmReactionShapeDepictionCellRenderer);
-	
+	getScrollPaneTable().setDefaultRenderer(Expression.class, expressionTableCellRenderer);	// Expression field cell renderer
+
 //	ivjScrollPaneTable.getColumnModel().getColumn(ModelProcessSpecsTableModel.ColumnType.COLUMN_DEPICTION.ordinal()).setCellRenderer(rbmReactionShapeDepictionCellRenderer);
 //	ivjScrollPaneTable.getColumnModel().getColumn(ModelProcessSpecsTableModel.ColumnType.COLUMN_DEPICTION.ordinal()).setPreferredWidth(180);
 	

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/ModelProcessSpecsTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/ModelProcessSpecsTableModel.java
@@ -47,19 +47,28 @@ public class ModelProcessSpecsTableModel extends VCellSortTableModel<ModelProces
 		COLUMN_NAME("Name"),
 		COLUMN_DEPICTION("Depiction"),
 		COLUMN_TYPE("Type"),
-		COLUMN_SUBTYPE("Subtype"),
-		COLUMN_CONDITION("Condition"),
 		COLUMN_ENABLED("Enabled"),
 		COLUMN_FAST("Fast"),
+		COLUMN_SUBTYPE("Subtype"),
+		COLUMN_CONDITION("Condition"),
 		COLUMN_BOND_LENGTH("Bond Length");
-		
+
 		public final String label;
-		private ColumnType(String label){
+		private ColumnType(String label) {
 			this.label = label;
 		}
-	}
-	ArrayList<ColumnType> columns = new ArrayList<ColumnType>();
 
+		public static ColumnType fromLabel(String label) {
+			for (ColumnType value : ColumnType.values()) {
+				if (value.label.equals(label)) {
+					return value;
+				}
+			}
+			throw new IllegalArgumentException("No enum constant with label " + label);
+		}
+	}
+
+	ArrayList<ColumnType> columns = new ArrayList<ColumnType>();
 	private SimulationContext fieldSimulationContext = null;
 	
 /**
@@ -92,10 +101,10 @@ private void refreshColumns(){
 		columns.remove(ColumnType.COLUMN_FAST);
 	}
 	if(getSimulationContext().getApplicationType() == Application.SPRINGSALAD) {
-		columns.add(ColumnType.COLUMN_BOND_LENGTH);
+		columns.remove(ColumnType.COLUMN_FAST);
 		columns.add(ColumnType.COLUMN_SUBTYPE);
 		columns.add(ColumnType.COLUMN_CONDITION);
-		columns.remove(ColumnType.COLUMN_FAST);
+		columns.add(ColumnType.COLUMN_BOND_LENGTH);
 	}
 }
 @Override

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/MolecularStructuresPropertiesPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/MolecularStructuresPropertiesPanel.java
@@ -65,6 +65,8 @@ public class MolecularStructuresPropertiesPanel extends DocumentEditorSubPanel {
         public void propertyChange(PropertyChangeEvent evt) {
             if(evt.getSource() instanceof SpeciesContextSpec && evt.getPropertyName().equals(SpeciesContextSpec.PROPERTY_NAME_SITE_ATTRIBUTE)) {
                 updateShape();
+            } else if(evt.getSource() instanceof SpeciesContextSpec && evt.getPropertyName().equals(SpeciesContextSpec.PROPERTY_NAME_LINK_LENGTH)) {
+                updateShape();
             }
         }
     }

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/MolecularTypeSpecsTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/MolecularTypeSpecsTableModel.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.swing.*;
+import javax.swing.border.LineBorder;
 import javax.swing.table.TableCellRenderer;
 
 import org.vcell.model.rbm.ComponentStatePattern;
@@ -29,6 +30,7 @@ import org.vcell.model.rbm.MolecularTypePattern;
 import org.vcell.model.rbm.SpeciesPattern;
 import org.vcell.util.Coordinate;
 import org.vcell.util.gui.ColorIcon;
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.GuiUtils;
 import org.vcell.util.gui.ScrollTable;
 
@@ -57,7 +59,7 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 
 	public enum ColumnType {
 		COLUMN_SITE("Site"),
-		COLUMN_MOLECULE("Molecule"),
+//		COLUMN_MOLECULE("Molecule"),
 		COLUMN_STRUCTURE("Location"),
 		COLUMN_STATE("State"),
 		COLUMN_X(" X "),
@@ -88,8 +90,8 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 		switch (columnType) {
 		case COLUMN_SITE:
 			return MolecularComponentPattern.class;
-		case COLUMN_MOLECULE:
-				return MolecularType.class;
+//		case COLUMN_MOLECULE:
+//				return MolecularType.class;
 		case COLUMN_STRUCTURE:
 				return Structure.class;
 		case COLUMN_STATE:
@@ -131,8 +133,8 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 			switch (columnType) {
 			case COLUMN_SITE:
 				return mcp.getMolecularComponent().getName();
-			case COLUMN_MOLECULE:
-				return mtp.getMolecularType().getName();
+//			case COLUMN_MOLECULE:
+//				return mtp.getMolecularType().getName();
 			case COLUMN_STRUCTURE:
 				if(sas == null) {
 					return null;
@@ -197,12 +199,11 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 		SiteAttributesSpec sas = scs.getSiteAttributesMap().get(mcp);
 		switch (columnType) {
 		case COLUMN_SITE:
-		case COLUMN_MOLECULE:
+//		case COLUMN_MOLECULE:
 		case COLUMN_STATE:
 			return;
 		case COLUMN_STRUCTURE:
-			if(aValue instanceof Structure) {
-				Structure structure = (Structure)aValue;
+			if(aValue instanceof Structure structure) {
 				if(sas == null) {
 					sas = new SiteAttributesSpec(scs, mcp, structure);
 				} else {
@@ -212,15 +213,15 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 			}
 			return;
 		case COLUMN_X:
-			if (aValue instanceof String) {
+			if (aValue instanceof String newExpressionString) {
 				if(sas == null) {
 					sas = new SiteAttributesSpec(scs, mcp, scs.getSpeciesContext().getStructure());
 				}
-				String newExpressionString = (String)aValue;
 				double res = 0.0;
 				try {
 					res = Double.parseDouble(newExpressionString);
 				} catch(NumberFormatException e) {
+					JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
 					return;
 				}
 				Coordinate c = sas.getCoordinate();
@@ -232,16 +233,16 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 			}
 			return;
 		case COLUMN_Y:
-			if (aValue instanceof String) {
+			if (aValue instanceof String newExpressionString) {
 				if(sas == null) {
 					// TODO: is this necessary?
 					sas = new SiteAttributesSpec(scs, mcp, scs.getSpeciesContext().getStructure());
 				}
-				String newExpressionString = (String)aValue;
 				double res = 0.0;
 				try {
 					res = Double.parseDouble(newExpressionString);
 				} catch(NumberFormatException e) {
+					JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
 					return;
 				}
 				Coordinate c = sas.getCoordinate();
@@ -253,16 +254,27 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 			}
 			return;
 		case COLUMN_Z:
-			if (aValue instanceof String) {
+			if (aValue instanceof String newExpressionString) {
 				if(sas == null) {
 					sas = new SiteAttributesSpec(scs, mcp, scs.getSpeciesContext().getStructure());
 				}
-				String newExpressionString = (String)aValue;
 				double res = 0.0;
 				try {
 					res = Double.parseDouble(newExpressionString);
-				} catch(NumberFormatException e) {
-					return;
+				} catch(NumberFormatException ex) {
+					JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
+//					DialogUtils.showErrorDialog(ownerTable.getParent(), "Number expected");
+//					SwingUtilities.invokeLater(new Runnable() {
+//						public void run() {
+//							ownerTable.requestFocus();
+//							ownerTable.setRowSelectionInterval(row, row);
+//							ownerTable.setColumnSelectionInterval(col, col);
+//							ownerTable.changeSelection(row, col, false, false);
+//							((JComponent)getComponent()).setBorder(new LineBorder(Color.red));
+//							textFieldAutoCompletion.requestFocus();
+//						}
+//					});
+//					return;
 				}
 				Coordinate c = sas.getCoordinate();
 				if(c.getX() != res) {
@@ -274,30 +286,47 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 			}
 			return;
 		case COLUMN_RADIUS:
-			if (aValue instanceof String) {
-				String newExpressionString = (String)aValue;
-				double result = Double.parseDouble(newExpressionString);
+			if (aValue instanceof String newExpressionString) {
+				double res = 0.0;
+				try {
+					res = Double.parseDouble(newExpressionString);
+				} catch(NumberFormatException ex) {
+					JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
+					return;
+				}
+				if(res <= 0.0) {
+					JOptionPane.showMessageDialog(null, "Site radius must be a positive number", "Error", JOptionPane.ERROR_MESSAGE);
+					return;
+				}
 				if(sas == null) {
 					sas = new SiteAttributesSpec(scs, mcp, scs.getSpeciesContext().getStructure());
 				}
-				sas.setRadius(result);
+				sas.setRadius(res);
 				scs.firePropertyChange(SpeciesContextSpec.PROPERTY_NAME_SITE_ATTRIBUTE, null, sas);
 			}
 			return;
 		case COLUMN_DIFFUSION:
-			if (aValue instanceof String) {
-				String newExpressionString = (String)aValue;
-				double result = Double.parseDouble(newExpressionString);
+			if (aValue instanceof String newExpressionString) {
+				double res = 0.0;
+				try {
+					res = Double.parseDouble(newExpressionString);
+				} catch(NumberFormatException ex) {
+					JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
+					return;
+				}
+				if(res <= 0.0) {
+					JOptionPane.showMessageDialog(null, "Site diffusion coefficient must be a positive number", "Error", JOptionPane.ERROR_MESSAGE);
+					return;
+				}
 				if(sas == null) {
 					sas = new SiteAttributesSpec(scs, mcp, scs.getSpeciesContext().getStructure());
 				}
-				sas.setDiffusionRate(result);
+				sas.setDiffusionRate(res);
 				scs.firePropertyChange(SpeciesContextSpec.PROPERTY_NAME_SITE_ATTRIBUTE, null, sas);
 				return;
 			}
 		case COLUMN_COLOR:
-			if (aValue instanceof NamedColor) {
-				NamedColor namedColor = (NamedColor)aValue;
+			if (aValue instanceof NamedColor namedColor) {
 				if(sas == null) {
 					sas = new SiteAttributesSpec(scs, mcp, scs.getSpeciesContext().getStructure());
 				}
@@ -322,7 +351,7 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 //		}
 		switch (columnType) {
 		case COLUMN_SITE:
-		case COLUMN_MOLECULE:
+//		case COLUMN_MOLECULE:
 		case COLUMN_STATE:
 			return false;
 		case COLUMN_STRUCTURE:
@@ -351,7 +380,7 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 				ColumnType columnType = columns.get(col);
 				switch (columnType) {
 				case COLUMN_SITE:
-				case COLUMN_MOLECULE:
+//				case COLUMN_MOLECULE:
 				case COLUMN_STRUCTURE:
 				case COLUMN_STATE:
 				case COLUMN_X:
@@ -510,8 +539,7 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 														  int index, boolean isSelected, boolean cellHasFocus) {
 				super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
 				setHorizontalTextPosition(SwingConstants.LEFT);
-				if (value instanceof NamedColor) {
-					NamedColor namedColor = (NamedColor)value;
+				if (value instanceof NamedColor namedColor) {
 					setText(namedColor.getName());
 					Icon icon = new ColorIcon(10,10,namedColor.getColor(), true);	// small square icon with subdomain color
 					setHorizontalTextPosition(SwingConstants.RIGHT);
@@ -540,8 +568,7 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<MolecularC
 					int index, boolean isSelected, boolean cellHasFocus) {
 				super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
 				setHorizontalTextPosition(SwingConstants.LEFT);
-				if (value instanceof Structure) {
-					Structure structure = (Structure)value;
+				if (value instanceof Structure structure) {
 					setText(structure.getName());
 
 				}

--- a/vcell-client/src/main/java/org/vcell/model/springsalad/gui/MolecularStructuresPanel.java
+++ b/vcell-client/src/main/java/org/vcell/model/springsalad/gui/MolecularStructuresPanel.java
@@ -419,7 +419,7 @@ public class MolecularStructuresPanel extends DocumentEditorSubPanel implements 
 		gbc = new GridBagConstraints();
 		gbc.gridx = 0;
 		gbc.gridy = 0;
-		gbc.weightx = 1.0;
+		gbc.weightx = 0.9;
 		gbc.weighty = 1.0;
 		gbc.gridwidth = 3;
 		gbc.fill = GridBagConstraints.BOTH;

--- a/vcell-client/src/main/java/org/vcell/model/springsalad/gui/MolecularStructuresPanel.java
+++ b/vcell-client/src/main/java/org/vcell/model/springsalad/gui/MolecularStructuresPanel.java
@@ -479,14 +479,31 @@ public class MolecularStructuresPanel extends DocumentEditorSubPanel implements 
 				super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 				if (table.getModel() instanceof MolecularTypeSpecsTableModel) {
 					MolecularTypeSpecsTableModel model = (MolecularTypeSpecsTableModel)table.getModel();
-					if (value instanceof Double) {
+					if (value instanceof Double dvalue) {
+						Integer intValue = dvalue.intValue();
+						String formattedValue = Integer.toString(intValue);		// we initialize with the int value
+						if(dvalue % 1 != 0) {									// if it has a non-zero fractional part,
+							formattedValue = String.format("%.1f", dvalue);		// we truncate the double to the first decimal (angstrom)
+						}
 						MolecularTypeSpecsTableModel.ColumnType columnType = MolecularTypeSpecsTableModel.ColumnType.values()[column];
 						int cellWidth = table.getColumnModel().getColumn(column).getWidth();
 						switch(columnType) {
 							case COLUMN_X:
 							case COLUMN_Y:
 							case COLUMN_Z:
-							case COLUMN_RADIUS:
+								if(cellWidth > 70) {			// we show units only if there's enough space
+									if(!isSelected) {
+										String text = "<html>" + formattedValue + "<span style='color:" + darkRed + ";'> [nm]</span></html>";
+										setText(text);
+									} else {
+										setText(formattedValue + " [nm]");
+									}
+								} else {
+									setText(formattedValue + "");		// if it's too busy, just show the numbers
+								}
+								setToolTipText(formattedValue + " [nm]");	// we always show the units in the tooltip
+								break;
+							case COLUMN_RADIUS:					// for Diffusion and Radius we show what the user explicitely entered, no truncation
 								if(cellWidth > 70) {			// we show units only if there's enough space
 									if(!isSelected) {
 										String text = "<html>" + value + "<span style='color:" + darkRed + ";'> [nm]</span></html>";
@@ -518,22 +535,27 @@ public class MolecularStructuresPanel extends DocumentEditorSubPanel implements 
 					}
 				} else if(table.getModel() instanceof LinkSpecsTableModel) {
 					LinkSpecsTableModel model = (LinkSpecsTableModel)table.getModel();
-					if(value instanceof Double) {
+					if(value instanceof Double dvalue) {
+						Integer intValue = dvalue.intValue();
+						String formattedValue = Integer.toString(intValue);		// we initialize with the int value
+						if(dvalue % 1 != 0) {									// if it has a non-zero fractional part,
+							formattedValue = String.format("%.1f", dvalue);		// we truncate the double to the first decimal (angstrom)
+						}
 						LinkSpecsTableModel.ColumnType columnType = LinkSpecsTableModel.ColumnType.values()[column];
 						int cellWidth = table.getColumnModel().getColumn(column).getWidth();
 						switch(columnType) {
 							case COLUMN_LENGTH:
 								if(cellWidth > 70) {
 									if(!isSelected) {
-										String text = "<html>" + value + "<span style='color:" + darkRed + ";'> [nm]</span></html>";
+										String text = "<html>" + formattedValue + "<span style='color:" + darkRed + ";'> [nm]</span></html>";
 										setText(text);
 									} else {
-										setText(value + " [nm]");
+										setText(formattedValue + " [nm]");
 									}
 								} else {
-									setText(value + "");		// if it's too busy, just show the numbers
+									setText(formattedValue + "");		// if it's too busy, just show the numbers
 								}
-								setToolTipText(value + " [nm]");	// we always show the units in the tooltip
+								setToolTipText(formattedValue + " [nm]");	// we always show the units in the tooltip
 								break;
 							default:
 								break;

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
@@ -70,7 +70,8 @@ public class SpeciesContextSpec implements Matchable, ScopedSymbolTable, Seriali
     public static final String PARAMETER_NAME_PROXY_PARAMETERS = "proxyParameters";
     private static final String PROPERTY_NAME_WELL_MIXED = "wellMixed";
     private static final String PROPERTY_NAME_FORCECONTINUOUS = "forceContinuous";
-    public static final String PROPERTY_NAME_SITE_ATTRIBUTE = "SiteAttributes";
+    public static final String PROPERTY_NAME_SITE_ATTRIBUTE = "SiteAttributes";     // springsalad
+    public static final String PROPERTY_NAME_LINK_LENGTH = "LinkLength";            // springsalad
     private static final int INITIAL_YZ_SITE_OFFSET = 4;
 
     public static final boolean TrackClusters = true;            // SpringSaLaD specific


### PR DESCRIPTION
Links are now editable, coordinates will be recalculated
Cosmetic fixes, rendering precision for coordinates and links rendering truncated to angstrom (one decimal unit)
In the table cell renderer the ColumType enum is recovered by column label instead of by column index (because some columns might have been moved around or removed at runtime)

dan-ss-links branch