### PR TITLE
Fixes bug where logs do not properly get updated in significant size simulations.

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/CLIPythonManager.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIPythonManager.java
@@ -101,6 +101,9 @@ public class CLIPythonManager {
         // Exit the living Python Process
         lg.debug("Closing Python Instance");
         if (this.pythonOSW != null && this.pythonISB != null) this.sendNewCommand("exit()"); // Sends kill command ("exit()") to python.exe instance;
+        try {
+            for (int i = 1; i <= 5; i++) if (this.pythonProcess != null && this.pythonProcess.isAlive()) Thread.sleep(1000 * i);
+        } catch (InterruptedException ignored) {} // Just want to try and give the process a chance to close gracefully
         if (this.pythonProcess != null && this.pythonProcess.isAlive()) this.pythonProcess.destroyForcibly(); // Making sure it's quite dead
 
         // Making sure we clean up

--- a/vcell-cli/src/main/java/org/vcell/cli/CLIPythonManager.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIPythonManager.java
@@ -194,6 +194,16 @@ public class CLIPythonManager {
                 }
             } catch (IOException | InterruptedException e4){
                 throw new PythonStreamException("Python process encountered an exception:\n" + e4.getMessage(), e4);
+            } finally { // Let's make sure our buffer isn't clogged; for now, we'll log, but discard any extra output
+                StringBuilder remainder = new StringBuilder("Leftovers in buffer: \n");
+                try {
+                    while (this.pythonISB.ready()){
+                        remainder.append(this.getResultsOfLastCommand()).append("\n");
+                    }
+                } catch (IOException | InterruptedException cleaningException){
+                    lg.warn("Received exception while trying to clear buffer:", cleaningException);
+                }
+                lg.debug(remainder.toString());
             }
         }
     }

--- a/vcell-cli/src/main/java/org/vcell/cli/CLIPythonManager.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIPythonManager.java
@@ -35,7 +35,7 @@ public class CLIPythonManager {
     private static final String PYTHON_EXE_NAME = OperatingSystemInfo.getInstance().isWindows() ? "python" : "python3";
 
     private static CLIPythonManager instance = null;
-    private static final int DEFAULT_TIMEOUT = 7000; // was 600 seconds (10 minutes), now 5 seconds
+    private static final int DEFAULT_TIMEOUT = 15000; // was 600 seconds (10 minutes), now 15 seconds
 
     private static final boolean USE_SHARED_SHELL = true;
 

--- a/vcell-cli/src/main/java/org/vcell/cli/biosimulation/BiosimulationsCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/biosimulation/BiosimulationsCommand.java
@@ -96,7 +96,7 @@ public class BiosimulationsCommand implements Callable<Integer> {
             try {
                 CLIPythonManager.getInstance().instantiatePythonProcess();
                 ExecuteImpl.singleMode(ARCHIVE, tmpDir, cliRecorder, true);
-                FileUtils.copyDirectoryContents(tmpDir, OUT_DIR, true, null);
+                CLIPythonManager.getInstance().closePythonProcess(); // Give the process time to finish
                 if (!Tracer.hasErrors()) return 0;
                 if (!bQuiet) {
                     logger.error("Errors occurred during execution");
@@ -110,6 +110,7 @@ public class BiosimulationsCommand implements Callable<Integer> {
                     logger.error(e.getMessage(), e);
                 }
                 logger.debug("Finished all execution.");
+                FileUtils.copyDirectoryContents(tmpDir, OUT_DIR, true, null);
             }
         } catch (Exception e) {
             if (!bQuiet) {

--- a/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteCommand.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/ExecuteCommand.java
@@ -129,9 +129,9 @@ public class ExecuteCommand implements Callable<Integer> {
                             bEncapsulateOutput, bSmallMeshOverride);
                 }
             }
-            FileUtils.copyDirectoryContents(tmpDir, outputFilePath, true, null);
             CLIPythonManager.getInstance().closePythonProcess();
             // WARNING: Python needs re-instantiation once the above line is called!
+            FileUtils.copyDirectoryContents(tmpDir, outputFilePath, true, null);
             return 0;
         } catch (Exception e) { ///TODO: Break apart into specific exceptions to maximize logging.
             org.apache.logging.log4j.LogManager.getLogger(this.getClass()).error(e.getMessage(), e);

--- a/vcell-cli/src/main/java/org/vcell/cli/run/ExecutionJob.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/ExecutionJob.java
@@ -191,6 +191,7 @@ public class ExecutionJob {
             
         }
         PythonCalls.setOutputMessage("null", "null", outputDir, "omex", logOmexMessage.toString());
+
         logger.debug("Finished Execution of Archive: " + bioModelBaseName);
     }
 

--- a/vcell-cli/src/main/java/org/vcell/cli/run/PythonCalls.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/run/PythonCalls.java
@@ -148,22 +148,16 @@ public class PythonCalls {
         CLIPythonManager cliPythonManager = CLIPythonManager.getInstance();
         String results = cliPythonManager.callPython("genPlotsPseudoSedml", sedmlPath, resultOutDir);
         cliPythonManager.parsePythonReturn(results);
-        /**
-         * replace with the following once the leak is fixed
-         */
-//        CLIPythonManager cliPythonManager = CLIPythonManager.getInstance();
-//        String results = cliPythonManager.callPython("genPlotsPseudoSedml", sedmlPath, resultOutDir);
-//        cliPythonManager.printPythonErrors(results);
     }
 
     private static String stripIllegalChars(String s){
-        String fStr = "";
+        StringBuilder fStr = new StringBuilder();
         for (char c : s.toCharArray()){
             char cAppend = ((int)c) < 16 ? ' ' : c;
             if (cAppend == '"') 
             	cAppend = '\'';
-            fStr += cAppend;
+            fStr.append(cAppend);
         }
-        return fStr;
+        return fStr.toString();
     }
 }


### PR DESCRIPTION
Identified two sibling race conditions causing logs to be inaccurate under certain circumstances:

If VCell CLI ran a "heavier" simulation, it would encounter one of two different race conditions:

1) Java attempts to move the "final" log files from the temporary directory to the actual output directory, however python was not yet finished editing the file.
2) Java attempts to forcefully close the python shell it was using, before python had the chance to update the logs.

Both cases have been remedied.