### PR TITLE
Filter springsalad simulation results

### DIFF
--- a/vcell-client/src/main/java/cbit/plot/gui/PlotPane.java
+++ b/vcell-client/src/main/java/cbit/plot/gui/PlotPane.java
@@ -483,7 +483,6 @@ private void connPtoP4SetTarget() {
 /**
  * Insert the method's description here.
  * Creation date: (12/16/2004 3:00:42 PM)
- * @param range cbit.util.Range
  */
 public void forceXYRange(Range xRange, Range yRange) {
 
@@ -1208,7 +1207,7 @@ public void setBCompact(boolean bCompact) {
 	getJLabelRight().setVisible(!bCompact);
 	boolean oldValue = fieldBCompact;
 	fieldBCompact = bCompact;
-	firePropertyChange("bCompact", new Boolean(oldValue), new Boolean(bCompact));
+	firePropertyChange("bCompact", oldValue, bCompact);
 }
 
 public void setHDF5DescriptionText(String descr) {

--- a/vcell-client/src/main/java/cbit/plot/gui/PlotPane.java
+++ b/vcell-client/src/main/java/cbit/plot/gui/PlotPane.java
@@ -31,6 +31,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
 import javax.swing.border.LineBorder;
 
+import cbit.vcell.client.data.SimulationWorkspaceModelInfo;
 import org.vcell.util.Range;
 import org.vcell.util.gui.ButtonGroupCivilized;
 import org.vcell.util.gui.EnhancedJLabel;
@@ -1365,6 +1366,13 @@ private void updateLegend() {
 				VCUnitDefinition ud = metaData.unit;
 				if(ud != null) {
 					unitSymbol += ud.getSymbolUnicode();
+				}
+			} else if(metaData != null && metaData.unit == null) {	// metadata for langevin-generated entities
+				if(metaData.filterCategory == SimulationWorkspaceModelInfo.BioModelCategoryType.Molecules ||
+						metaData.filterCategory == SimulationWorkspaceModelInfo.BioModelCategoryType.BoundSites ||
+						metaData.filterCategory == SimulationWorkspaceModelInfo.BioModelCategoryType.FreeSites ||
+						metaData.filterCategory == SimulationWorkspaceModelInfo.BioModelCategoryType.TotalSites) {
+					unitSymbol = "molecules";
 				}
 			}
 			if (metaData != null && metaData.tooltipString != null){

--- a/vcell-client/src/main/java/cbit/vcell/client/FieldDataWindowManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/FieldDataWindowManager.java
@@ -290,6 +290,11 @@ private static class OutputFunctionViewer extends JPanel{
 			public DataSymbolMetadataResolver getDataSymbolMetadataResolver(){
 				return pdeDataViewer.getSimulationModelInfo().getDataSymbolMetadataResolver();
 			}
+
+			@Override
+			public boolean isSpringSaLad() {
+				return false;
+			}
 		});
 		
 		SimulationOwner simulationOwner = new SimulationOwner.FieldDataSimOwner() {

--- a/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterface.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterface.java
@@ -42,4 +42,6 @@ public interface ODEDataInterface {
 	void selectCategory(ModelCategoryType[] filterCategories);
 	
 	DataSymbolMetadataResolver getDataSymbolMetadataResolver();
+
+	boolean isSpringSaLaD();
 }

--- a/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterface.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterface.java
@@ -1,6 +1,7 @@
 package cbit.vcell.client.data;
 
 import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
 
 import cbit.vcell.simdata.SummaryStatisticType;
 import org.vcell.util.ObjectNotFoundException;
@@ -44,4 +45,6 @@ public interface ODEDataInterface {
 	DataSymbolMetadataResolver getDataSymbolMetadataResolver();
 
 	boolean isSpringSaLaD();
+
+	void checkTrivial(ArrayList<ColumnDescription> columnAedcriptions);
 }

--- a/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterfaceImpl.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterfaceImpl.java
@@ -163,4 +163,12 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 		return (simulationModelInfo!=null?simulationModelInfo.getDataSymbolMetadataResolver():null);
 	}
 
+	@Override
+	public boolean isSpringSaLaD() {
+		if(simulationModelInfo != null && simulationModelInfo.isSpringSaLad()) {
+			return true;
+		}
+		return false;
+	}
+
 }

--- a/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterfaceImpl.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterfaceImpl.java
@@ -1,6 +1,7 @@
 package cbit.vcell.client.data;
 
 import cbit.vcell.math.FunctionColumnDescription;
+import cbit.vcell.math.ODESolverResultSetColumnDescription;
 import cbit.vcell.parser.ExpressionException;
 import cbit.vcell.simdata.MultiTrialNonspatialStochSimDataReader;
 import cbit.vcell.simdata.SummaryStatisticType;
@@ -182,6 +183,36 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 			return true;
 		}
 		return false;
+	}
+
+	@Override
+	public void checkTrivial(ArrayList<ColumnDescription> columnDescriptions) {
+		for(ColumnDescription columnDedcription : columnDescriptions) {
+			if(columnDedcription instanceof ODESolverResultSetColumnDescription cd) {
+
+				double[] data = null;
+				int index = odeSolverResultSet.findColumn(cd.getName());
+				try {
+					data = odeSolverResultSet.extractColumn(index);
+				} catch (ExpressionException e) {
+					System.out.println("Failed to extract column: " + e.getMessage());
+					continue;
+				}
+				if(data == null || data.length == 0) {
+					continue;
+				}
+				double initial = data[0];
+				boolean isTrivial = true;
+				for(double d : data) {
+					if(initial != d) {
+						isTrivial = false;
+						break;	// one mismatch is enough to know it's not trivial
+					}
+				}
+				cd.setIsTrivial(isTrivial);
+			}
+		}
+
 	}
 
 }

--- a/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterfaceImpl.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterfaceImpl.java
@@ -42,7 +42,7 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 		if(resolver != null){
 			return resolver.getUniqueFilterCategories();
 		}
-		return new ModelCategoryType[0];	// TODO: simulationModelInfo.isSpringSaLad()
+		return new ModelCategoryType[0];
 	}
 
 	@Override
@@ -130,8 +130,9 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 			return getOdeSolverResultSet().getColumnDescriptions();
 		}else{
 			ArrayList<ColumnDescription> selectedColumnDescriptions = new ArrayList<ColumnDescription>();
-			for (int i = 0; i < getOdeSolverResultSet().getColumnDescriptions().length; i++) {
-				String name = getOdeSolverResultSet().getColumnDescriptions()[i].getName();
+			ColumnDescription[] columnDescriptions = getOdeSolverResultSet().getColumnDescriptions();
+			for (int i = 0; i < columnDescriptions.length; i++) {
+				String name = columnDescriptions[i].getName();
 				DataSymbolMetadataResolver dataSymbolMetadataResolver = simulationModelInfo.getDataSymbolMetadataResolver();
 				DataSymbolMetadata dataSymbolMetadata = dataSymbolMetadataResolver.getDataSymbolMetadata(name);
 				ModelCategoryType selectedFilterCategory = null;
@@ -143,12 +144,12 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 				// dataSymbolMetadata.filterCategory is null
 				for (int j = 0; j < selectedFilters.length; j++) {
 					if(selectedFilters[j].equals(selectedFilterCategory)){
-						selectedColumnDescriptions.add(getOdeSolverResultSet().getColumnDescriptions()[i]);
+						selectedColumnDescriptions.add(columnDescriptions[i]);
 						break;
 					}
 					// Langevin values just shown as species
 					if(selectedFilters[j].getName().equals("Molecules") && selectedFilterCategory == null) {
-						ColumnDescription cd = getOdeSolverResultSet().getColumnDescriptions()[i];
+						ColumnDescription cd = columnDescriptions[i];
 						String columnName = cd.getName();
 						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
 						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
@@ -156,11 +157,11 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 							break;
 						}
 						if(!lr.molecule.isEmpty() && lr.site.isEmpty() && lr.state.isEmpty()) {
-							selectedColumnDescriptions.add(getOdeSolverResultSet().getColumnDescriptions()[i]);
+							selectedColumnDescriptions.add(columnDescriptions[i]);
 							break;
 						}
 					} else if(selectedFilters[j].getName().equals("FreeSites") && selectedFilterCategory == null) {
-						ColumnDescription cd = getOdeSolverResultSet().getColumnDescriptions()[i];
+						ColumnDescription cd = columnDescriptions[i];
 						String columnName = cd.getName();
 						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
 						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
@@ -168,11 +169,11 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 							break;
 						}
 						if(lr.qualifier.equals("FREE") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
-							selectedColumnDescriptions.add(getOdeSolverResultSet().getColumnDescriptions()[i]);
+							selectedColumnDescriptions.add(columnDescriptions[i]);
 							break;
 						}
 					} else if(selectedFilters[j].getName().equals("BoundSites") && selectedFilterCategory == null) {
-						ColumnDescription cd = getOdeSolverResultSet().getColumnDescriptions()[i];
+						ColumnDescription cd = columnDescriptions[i];
 						String columnName = cd.getName();
 						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
 						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
@@ -180,11 +181,11 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 							break;
 						}
 						if(lr.qualifier.equals("BOUND") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
-							selectedColumnDescriptions.add(getOdeSolverResultSet().getColumnDescriptions()[i]);
+							selectedColumnDescriptions.add(columnDescriptions[i]);
 							break;
 						}
 					} else if(selectedFilters[j].getName().equals("TotalSites") && selectedFilterCategory == null) {
-						ColumnDescription cd = getOdeSolverResultSet().getColumnDescriptions()[i];
+						ColumnDescription cd = columnDescriptions[i];
 						String columnName = cd.getName();
 						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
 						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
@@ -192,7 +193,7 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 							break;
 						}
 						if(lr.qualifier.equals("TOTAL") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
-							selectedColumnDescriptions.add(getOdeSolverResultSet().getColumnDescriptions()[i]);
+							selectedColumnDescriptions.add(columnDescriptions[i]);
 							break;
 						}
 					}

--- a/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterfaceImpl.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterfaceImpl.java
@@ -148,55 +148,71 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 						break;
 					}
 					// Langevin values just shown as species
-					if(selectedFilters[j].getName().equals("Molecules") && selectedFilterCategory == null) {
-						ColumnDescription cd = columnDescriptions[i];
-						String columnName = cd.getName();
-						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
-						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
-							System.out.println("Ignoring LangevinResult token: " + columnName);
-							break;
-						}
-						if(!lr.molecule.isEmpty() && lr.site.isEmpty() && lr.state.isEmpty()) {
-							selectedColumnDescriptions.add(columnDescriptions[i]);
-							break;
-						}
-					} else if(selectedFilters[j].getName().equals("FreeSites") && selectedFilterCategory == null) {
-						ColumnDescription cd = columnDescriptions[i];
-						String columnName = cd.getName();
-						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
-						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
-							System.out.println("Ignoring LangevinResult token: " + columnName);
-							break;
-						}
-						if(lr.qualifier.equals("FREE") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
-							selectedColumnDescriptions.add(columnDescriptions[i]);
-							break;
-						}
-					} else if(selectedFilters[j].getName().equals("BoundSites") && selectedFilterCategory == null) {
-						ColumnDescription cd = columnDescriptions[i];
-						String columnName = cd.getName();
-						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
-						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
-							System.out.println("Ignoring LangevinResult token: " + columnName);
-							break;
-						}
-						if(lr.qualifier.equals("BOUND") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
-							selectedColumnDescriptions.add(columnDescriptions[i]);
-							break;
-						}
-					} else if(selectedFilters[j].getName().equals("TotalSites") && selectedFilterCategory == null) {
-						ColumnDescription cd = columnDescriptions[i];
-						String columnName = cd.getName();
-						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
-						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
-							System.out.println("Ignoring LangevinResult token: " + columnName);
-							break;
-						}
-						if(lr.qualifier.equals("TOTAL") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
-							selectedColumnDescriptions.add(columnDescriptions[i]);
-							break;
-						}
+					if(selectedFilters[j].getName().equals("Molecules") && selectedFilterCategory == SimulationWorkspaceModelInfo.BioModelCategoryType.Molecules) {
+						selectedColumnDescriptions.add(columnDescriptions[i]);
+						break;
+					} else if(selectedFilters[j].getName().equals("FreeSites") && selectedFilterCategory == SimulationWorkspaceModelInfo.BioModelCategoryType.FreeSites) {
+						selectedColumnDescriptions.add(columnDescriptions[i]);
+						break;
+					} else if(selectedFilters[j].getName().equals("BoundSites") && selectedFilterCategory == SimulationWorkspaceModelInfo.BioModelCategoryType.BoundSites) {
+						selectedColumnDescriptions.add(columnDescriptions[i]);
+						break;
+					} else if(selectedFilters[j].getName().equals("TotalSites") && selectedFilterCategory == SimulationWorkspaceModelInfo.BioModelCategoryType.TotalSites) {
+						selectedColumnDescriptions.add(columnDescriptions[i]);
+						break;
 					}
+
+
+
+//					if(selectedFilters[j].getName().equals("Molecules") && selectedFilterCategory == null) {
+//						ColumnDescription cd = columnDescriptions[i];
+//						String columnName = cd.getName();
+//						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
+//						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
+//							System.out.println("Ignoring LangevinResult token: " + columnName);
+//							break;
+//						}
+//						if(!lr.molecule.isEmpty() && lr.site.isEmpty() && lr.state.isEmpty()) {
+//							selectedColumnDescriptions.add(columnDescriptions[i]);
+//							break;
+//						}
+//					} else if(selectedFilters[j].getName().equals("FreeSites") && selectedFilterCategory == null) {
+//						ColumnDescription cd = columnDescriptions[i];
+//						String columnName = cd.getName();
+//						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
+//						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
+//							System.out.println("Ignoring LangevinResult token: " + columnName);
+//							break;
+//						}
+//						if(lr.qualifier.equals("FREE") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
+//							selectedColumnDescriptions.add(columnDescriptions[i]);
+//							break;
+//						}
+//					} else if(selectedFilters[j].getName().equals("BoundSites") && selectedFilterCategory == null) {
+//						ColumnDescription cd = columnDescriptions[i];
+//						String columnName = cd.getName();
+//						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
+//						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
+//							System.out.println("Ignoring LangevinResult token: " + columnName);
+//							break;
+//						}
+//						if(lr.qualifier.equals("BOUND") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
+//							selectedColumnDescriptions.add(columnDescriptions[i]);
+//							break;
+//						}
+//					} else if(selectedFilters[j].getName().equals("TotalSites") && selectedFilterCategory == null) {
+//						ColumnDescription cd = columnDescriptions[i];
+//						String columnName = cd.getName();
+//						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
+//						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
+//							System.out.println("Ignoring LangevinResult token: " + columnName);
+//							break;
+//						}
+//						if(lr.qualifier.equals("TOTAL") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
+//							selectedColumnDescriptions.add(columnDescriptions[i]);
+//							break;
+//						}
+//					}
 				}
 			}
 			return selectedColumnDescriptions.toArray(new ColumnDescription[0]);

--- a/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterfaceImpl.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataInterfaceImpl.java
@@ -161,58 +161,6 @@ class ODEDataInterfaceImpl implements ODEDataInterface {
 						selectedColumnDescriptions.add(columnDescriptions[i]);
 						break;
 					}
-
-
-
-//					if(selectedFilters[j].getName().equals("Molecules") && selectedFilterCategory == null) {
-//						ColumnDescription cd = columnDescriptions[i];
-//						String columnName = cd.getName();
-//						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
-//						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
-//							System.out.println("Ignoring LangevinResult token: " + columnName);
-//							break;
-//						}
-//						if(!lr.molecule.isEmpty() && lr.site.isEmpty() && lr.state.isEmpty()) {
-//							selectedColumnDescriptions.add(columnDescriptions[i]);
-//							break;
-//						}
-//					} else if(selectedFilters[j].getName().equals("FreeSites") && selectedFilterCategory == null) {
-//						ColumnDescription cd = columnDescriptions[i];
-//						String columnName = cd.getName();
-//						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
-//						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
-//							System.out.println("Ignoring LangevinResult token: " + columnName);
-//							break;
-//						}
-//						if(lr.qualifier.equals("FREE") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
-//							selectedColumnDescriptions.add(columnDescriptions[i]);
-//							break;
-//						}
-//					} else if(selectedFilters[j].getName().equals("BoundSites") && selectedFilterCategory == null) {
-//						ColumnDescription cd = columnDescriptions[i];
-//						String columnName = cd.getName();
-//						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
-//						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
-//							System.out.println("Ignoring LangevinResult token: " + columnName);
-//							break;
-//						}
-//						if(lr.qualifier.equals("BOUND") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
-//							selectedColumnDescriptions.add(columnDescriptions[i]);
-//							break;
-//						}
-//					} else if(selectedFilters[j].getName().equals("TotalSites") && selectedFilterCategory == null) {
-//						ColumnDescription cd = columnDescriptions[i];
-//						String columnName = cd.getName();
-//						SsldUtils.LangevinResult lr = SsldUtils.LangevinResult.fromString(columnName);
-//						if(!(lr.qualifier.equals("FREE") || lr.qualifier.equals("BOUND") || lr.qualifier.equals("TOTAL"))) {
-//							System.out.println("Ignoring LangevinResult token: " + columnName);
-//							break;
-//						}
-//						if(lr.qualifier.equals("TOTAL") && !lr.molecule.isEmpty() && !lr.site.isEmpty() && !lr.state.isEmpty()) {
-//							selectedColumnDescriptions.add(columnDescriptions[i]);
-//							break;
-//						}
-//					}
 				}
 			}
 			return selectedColumnDescriptions.toArray(new ColumnDescription[0]);

--- a/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataViewer.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataViewer.java
@@ -139,7 +139,21 @@ private void updateMetadata() {
 			public void run(Hashtable<String, Object> hashTable) throws Exception {
 				if(ODEDataViewer.this.getSimulationModelInfo() != null){
 					SimulationModelInfo simulationModelInfo = ODEDataViewer.this.getSimulationModelInfo();
-					simulationModelInfo.getDataSymbolMetadataResolver().populateDataSymbolMetadata(auxDataSymbolMap);
+					SimulationModelInfo.DataSymbolMetadataResolver dsmr = simulationModelInfo.getDataSymbolMetadataResolver();
+					dsmr.populateDataSymbolMetadata(auxDataSymbolMap);
+					// TODO: stub to calculate MetaData for langevin generated objects (?) and move the parser here?
+//					if(getSimulationModelInfo().isSpringSaLad()) {
+//						ColumnDescription[] cdArray = getOdeSolverResultSet().getColumnDescriptions();
+//						for(ColumnDescription cd : cdArray) {
+//							DataSymbolMetadata metaData = dsmr.getDataSymbolMetadata(cd.getName());
+//							if(metaData == null) {
+//								// TODO: move the parser here
+//								metaData = new DataSymbolMetadata();
+//								auxDataSymbolMap.put(cd.getName(), metaData);
+//							}
+//
+//						}
+//					}
 				}
 			}
 		};

--- a/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataViewer.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataViewer.java
@@ -141,19 +141,14 @@ private void updateMetadata() {
 					SimulationModelInfo simulationModelInfo = ODEDataViewer.this.getSimulationModelInfo();
 					SimulationModelInfo.DataSymbolMetadataResolver dsmr = simulationModelInfo.getDataSymbolMetadataResolver();
 					dsmr.populateDataSymbolMetadata(auxDataSymbolMap);
-					// TODO: stub to calculate MetaData for langevin generated objects (?) and move the parser here?
-//					if(getSimulationModelInfo().isSpringSaLad()) {
-//						ColumnDescription[] cdArray = getOdeSolverResultSet().getColumnDescriptions();
-//						for(ColumnDescription cd : cdArray) {
-//							DataSymbolMetadata metaData = dsmr.getDataSymbolMetadata(cd.getName());
-//							if(metaData == null) {
-//								// TODO: move the parser here
-//								metaData = new DataSymbolMetadata();
-//								auxDataSymbolMap.put(cd.getName(), metaData);
-//							}
-//
-//						}
-//					}
+
+					// calculate MetaData for langevin generated objects
+					if(getSimulationModelInfo().isSpringSaLad()) {
+						if(dsmr instanceof SimulationWorkspaceModelInfo.InternalDataSymbolMetadataResolver idsmr) {
+							ColumnDescription[] cdArray = getOdeSolverResultSet().getColumnDescriptions();
+							idsmr.populateDataSymbolMetadata(cdArray);
+						}
+					}
 				}
 			}
 		};

--- a/vcell-client/src/main/java/cbit/vcell/client/data/SimulationWorkspaceModelInfo.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/SimulationWorkspaceModelInfo.java
@@ -569,7 +569,17 @@ public DataSymbolMetadataResolver getDataSymbolMetadataResolver() {
 	return dataSymbolMetadataResolver;
 }
 
-private static void addOutputFunctionsToMetaData(SimulationContext simulationContext,HashMap<String, DataSymbolMetadata> metaDataMap){
+@Override
+public boolean isSpringSaLad() {
+	if(simulationOwner != null && simulationOwner instanceof SimulationContext simContext) {
+		if(simContext.getApplicationType() == SimulationContext.Application.SPRINGSALAD) {
+			return true;
+		}
+	}
+	return false;
+}
+
+	private static void addOutputFunctionsToMetaData(SimulationContext simulationContext,HashMap<String, DataSymbolMetadata> metaDataMap){
 	if(metaDataMap != null &&
 		simulationContext.getOutputFunctionContext() != null &&
 		simulationContext.getOutputFunctionContext().getOutputFunctionsList() != null){

--- a/vcell-client/src/main/java/cbit/vcell/client/data/SimulationWorkspaceModelInfo.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/SimulationWorkspaceModelInfo.java
@@ -524,9 +524,6 @@ for (SymbolTableEntry bioSymbol : sortedBioSymbols){
 	mappings.add(var.getName()+"   "+mathInfo+"    ==>    "+bioInfo+", tooltipString="+tooltipString);
 }
 tooltipString+="</html>";
-						if(filterCategory == BioModelCategoryType.GeneratedSpecies) {
-							System.out.println("var.getName");
-						}
 						metadataMap.put(var.getName(), new DataSymbolMetadata(filterCategory, unit, tooltipString, displayName));
 					}else{
 						isSymbolsNotFound = true;

--- a/vcell-client/src/main/java/cbit/vcell/client/data/SimulationWorkspaceModelInfo.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/SimulationWorkspaceModelInfo.java
@@ -10,12 +10,7 @@
 
 package cbit.vcell.client.data;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.*;
 
 import org.vcell.model.rbm.SpeciesPattern;
 import org.vcell.util.VCellThreadChecker;
@@ -306,7 +301,7 @@ public class InternalDataSymbolMetadataResolver implements DataSymbolMetadataRes
 		//
 		// if called before the map is populated, it will indicate an empty list of FilterCategoryTypes (not yet processed).
 		//
-		HashSet<ModelCategoryType> filters = new HashSet<ModelCategoryType>();
+		LinkedHashSet<ModelCategoryType> filters = new LinkedHashSet<ModelCategoryType>();
 		if(simulationOwner instanceof SimulationContext simContext) {
 			if(simContext.getApplicationType() == SimulationContext.Application.SPRINGSALAD) {
 				filters.add(BioModelCategoryType.Molecules);
@@ -537,9 +532,9 @@ public static enum BioModelCategoryType implements ModelCategoryType {
 	Other,
 	Sensitivity,
 	Molecules(true, true),
-	FreeSites(true, true, "Free Sites"),
-	BoundSites(true, true, "Bound Sites"),
-	TotalSites(true, true, "Total Sites");
+	FreeSites(false, true, "Free Sites"),
+	BoundSites(false, true, "Bound Sites"),
+	TotalSites(false, true, "Total Sites");
 	/**
 	 * should this be selected initially on GUI?
 	 */

--- a/vcell-client/src/main/java/cbit/vcell/client/data/SimulationWorkspaceModelInfo.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/SimulationWorkspaceModelInfo.java
@@ -620,10 +620,9 @@ public static enum BioModelCategoryType implements ModelCategoryType {
 	}
 
 	@Override
-	public String getName(){
+	public String getName() {
 		return name();
 	}
-	
 	@Override
 	public boolean isInitialSelect() {
 		return initialSelect;
@@ -632,19 +631,19 @@ public static enum BioModelCategoryType implements ModelCategoryType {
 	public boolean isEnabled() {
 		return enabled;
 	}
-
 	public String getDisplayName() {
 		return displayName;
 	}
 
-} // Static method to get enum by label
+	// Static method to get enum by label
 	public static BioModelCategoryType fromLabel(String label) {
-	for (BioModelCategoryType value : BioModelCategoryType.values()) {
-		if (value.getDisplayName().equals(label)) {
-			return value;
-		}
-	} throw new IllegalArgumentException("No enum constant with label " + label);
-};
+		for (BioModelCategoryType value : BioModelCategoryType.values()) {
+			if (value.getDisplayName().equals(label)) {
+				return value;
+			}
+		} throw new IllegalArgumentException("No enum constant with label " + label);
+	}
+}
 
 @Override
 public DataSymbolMetadataResolver getDataSymbolMetadataResolver() {

--- a/vcell-client/src/main/java/cbit/vcell/client/data/SimulationWorkspaceModelInfo.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/SimulationWorkspaceModelInfo.java
@@ -307,14 +307,26 @@ public class InternalDataSymbolMetadataResolver implements DataSymbolMetadataRes
 		// if called before the map is populated, it will indicate an empty list of FilterCategoryTypes (not yet processed).
 		//
 		HashSet<ModelCategoryType> filters = new HashSet<ModelCategoryType>();
+		if(simulationOwner instanceof SimulationContext simContext) {
+			if(simContext.getApplicationType() == SimulationContext.Application.SPRINGSALAD) {
+				filters.add(BioModelCategoryType.Molecules);
+				filters.add(BioModelCategoryType.BoundSites);
+				filters.add(BioModelCategoryType.FreeSites);
+				filters.add(BioModelCategoryType.TotalSites);
+				ModelCategoryType[] ret = filters.toArray(new BioModelCategoryType[0]);
+				return ret;
+			}
+		}
 		if (savedMetadataMap != null){
 			for (DataSymbolMetadata dsm : savedMetadataMap.values()){
 				if (dsm.filterCategory != null){
-					filters.add(dsm.filterCategory);
+					ModelCategoryType mct = dsm.filterCategory;
+					filters.add(mct);
 				}
 			}
-		}	
-		return filters.toArray(new BioModelCategoryType[0]);
+		}
+		ModelCategoryType[] ret = filters.toArray(new BioModelCategoryType[0]);
+		return ret;
 	}
 	
 	private SymbolTableEntry[] getSortedBiologicalSymbols(SymbolTableEntry[] bioSymbols){
@@ -523,7 +535,11 @@ public static enum BioModelCategoryType implements ModelCategoryType {
 	GeneratedSpecies,
 	ReservedXYZT(true,false),
 	Other,
-	Sensitivity;
+	Sensitivity,
+	Molecules(true, true),
+	FreeSites(true, true, "Free Sites"),
+	BoundSites(true, true, "Bound Sites"),
+	TotalSites(true, true, "Total Sites");
 	/**
 	 * should this be selected initially on GUI?
 	 */
@@ -532,6 +548,9 @@ public static enum BioModelCategoryType implements ModelCategoryType {
 	 * should this be enabled so user can select / deselect?
 	 */
 	private final boolean enabled;
+
+	// we provide a default, which is the name exactly as spelled in the enum
+	private final String displayName;
 	
 	/**
 	 * initialSelect is false, enabled is true
@@ -539,6 +558,7 @@ public static enum BioModelCategoryType implements ModelCategoryType {
 	private BioModelCategoryType( ) {
 		initialSelect = false;
 		enabled = true;
+		displayName = name();
 	}
 	/**
 	 * @param initialSelect display checked initially?
@@ -547,8 +567,14 @@ public static enum BioModelCategoryType implements ModelCategoryType {
 	private BioModelCategoryType(boolean initialSelect, boolean enabled) {
 		this.initialSelect = initialSelect;
 		this.enabled = enabled;
+		displayName = name();
 	}
-	
+	private BioModelCategoryType(boolean initialSelect, boolean enabled, String displayName) {
+		this.initialSelect = initialSelect;
+		this.enabled = enabled;
+		this.displayName = displayName;
+	}
+
 	@Override
 	public String getName(){
 		return name();
@@ -562,6 +588,18 @@ public static enum BioModelCategoryType implements ModelCategoryType {
 	public boolean isEnabled() {
 		return enabled;
 	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+} // Static method to get enum by label
+	public static BioModelCategoryType fromLabel(String label) {
+	for (BioModelCategoryType value : BioModelCategoryType.values()) {
+		if (value.getDisplayName().equals(label)) {
+			return value;
+		}
+	} throw new IllegalArgumentException("No enum constant with label " + label);
 };
 
 @Override

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/ODESolverPlotSpecificationPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/ODESolverPlotSpecificationPanel.java
@@ -1434,11 +1434,11 @@ private JPanel getPanel() {
 	return panel;
 }
 
-private HashMap<JCheckBox, ModelCategoryType> filterSettings;
+private LinkedHashMap<JCheckBox, ModelCategoryType> filterSettings;
 private JLabel yAxisJLabel;
 private JCheckBox getFilterSetting(ModelCategoryType filterCategory){
 	if(filterSettings == null){
-		filterSettings = new HashMap<JCheckBox, ModelCategoryType>();
+		filterSettings = new LinkedHashMap<>();
 	}
 	for(JCheckBox jCheckBox:filterSettings.keySet()){
 		if(filterSettings.get(jCheckBox).equals(filterCategory)){
@@ -1464,16 +1464,18 @@ private JCheckBox getFilterSetting(ModelCategoryType filterCategory){
 	return newJCheckBox;		
 }
 private void showFilterSettings() {
-	if(getMyDataInterface() != null &&
-		getMyDataInterface().getSupportedFilterCategories() != null &&
-		getMyDataInterface().getSupportedFilterCategories().length > 0){
-		
+	ODEDataInterface di = getMyDataInterface();
+	if(di == null) {
+		return;
+	}
+	ModelCategoryType[] filterCategories = di.getSupportedFilterCategories();
+	if(filterCategories != null && filterCategories.length > 0) {
+
 		getFilterPanel().getContentPanel().removeAll();
 		getFilterPanel().getContentPanel().setLayout(null);
 		HashMap<JCheckBox, ModelCategoryType> oldFilterSettings = filterSettings;
 		filterSettings = null;
 
-		ModelCategoryType[] filterCategories = getMyDataInterface().getSupportedFilterCategories();
 		for (int i = 0; i < filterCategories.length; i++) {
 			JCheckBox newFiltersJCheckBox = getFilterSetting(filterCategories[i]);//generate filter set
 			if(oldFilterSettings != null){
@@ -1505,13 +1507,15 @@ private void showFilterSettings() {
 	
 //	filterPanel.setBorder(new LineBorder(Color.black));
 	JCheckBox[] sortedJCheckBoxes = filterSettings.keySet().toArray(new JCheckBox[0]);
-	Arrays.sort(sortedJCheckBoxes, new Comparator<JCheckBox>() {
-		@Override
-		public int compare(JCheckBox o1, JCheckBox o2) {
-			// TODO Auto-generated method stub
-			return o1.getText().compareToIgnoreCase(o2.getText());
-		}
-	});
+	if(!getMyDataInterface().isSpringSaLaD()) {
+		Arrays.sort(sortedJCheckBoxes, new Comparator<JCheckBox>() {
+			@Override
+			public int compare(JCheckBox o1, JCheckBox o2) {
+				// TODO Auto-generated method stub
+				return o1.getText().compareToIgnoreCase(o2.getText());
+			}
+		});
+	}
 	for (int i = 0; i < sortedJCheckBoxes.length; i++) {
 		sortedJCheckBoxes[i].removeItemListener(ivjEventHandler);
 		sortedJCheckBoxes[i].addItemListener(ivjEventHandler);

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/ODESolverPlotSpecificationPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/ODESolverPlotSpecificationPanel.java
@@ -19,6 +19,7 @@ import cbit.vcell.mapping.AbstractMathMapping;
 import cbit.vcell.mapping.DiffEquMathMapping;
 import cbit.vcell.math.Constant;
 import cbit.vcell.math.FunctionColumnDescription;
+import cbit.vcell.math.ODESolverResultSetColumnDescription;
 import cbit.vcell.math.ReservedVariable;
 import cbit.vcell.parser.Expression;
 import cbit.vcell.parser.ExpressionException;
@@ -77,7 +78,26 @@ public class ODESolverPlotSpecificationPanel extends JPanel {
 	private ODEDataInterface oDEDataInterface = null;
 	
 	private static ImageIcon function_icon = null;
-	
+
+//	private ListCellRenderer<Object> yAxisChoiceListRenderer = new DefaultListCellRenderer() {
+//		@Override
+//		public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+//			Component component = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+//			if (value instanceof ODESolverResultSetColumnDescription cd && component instanceof JLabel label) {
+//
+//				label.setText(cd.getName());
+//				if(cd.isTrivial()) {
+//					setForeground(Color.lightGray);
+//				} else {
+//					setForeground(Color.black);
+//				}
+//			setOpaque(true);
+//			}
+//			return component;
+//		}
+//	};
+
+
 	public static final String ODE_DATA_CHANGED = "ODE_DATA_CHANGED";
 	public static final String ODE_FILTER_CHANGED = "ODE_FILTER_CHANGED";
 	public static final String ODESOLVERRESULTSET_CHANGED = "ODESOLVERRESULTSET_CHANGED";
@@ -794,6 +814,14 @@ private void initConnections() throws java.lang.Exception {
 					tooltipString = varName;
 				}
 				setToolTipText(tooltipString);
+				if (cd instanceof ODESolverResultSetColumnDescription odeSolverResultSetColumnDescription) {
+					if (odeSolverResultSetColumnDescription.isTrivial()) {
+						setForeground(Color.gray);
+					} else {
+						setForeground(Color.black);
+					}
+				}
+//			setOpaque(true);
 			}
 			return this;
 		}
@@ -1279,6 +1307,11 @@ private synchronized void updateChoices(ODEDataInterface odedi) throws Expressio
         	sensitivityColumnDescriptions.add(cd);
         }
     }
+
+	if(odedi.isSpringSaLaD()) {
+		odedi.checkTrivial(variableColumnDescriptions);
+	}
+
     sortColumnDescriptions(variableColumnDescriptions);
     sortColumnDescriptions(sensitivityColumnDescriptions); 
     

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/ODESolverPlotSpecificationPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/ODESolverPlotSpecificationPanel.java
@@ -79,25 +79,6 @@ public class ODESolverPlotSpecificationPanel extends JPanel {
 	
 	private static ImageIcon function_icon = null;
 
-//	private ListCellRenderer<Object> yAxisChoiceListRenderer = new DefaultListCellRenderer() {
-//		@Override
-//		public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
-//			Component component = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-//			if (value instanceof ODESolverResultSetColumnDescription cd && component instanceof JLabel label) {
-//
-//				label.setText(cd.getName());
-//				if(cd.isTrivial()) {
-//					setForeground(Color.lightGray);
-//				} else {
-//					setForeground(Color.black);
-//				}
-//			setOpaque(true);
-//			}
-//			return component;
-//		}
-//	};
-
-
 	public static final String ODE_DATA_CHANGED = "ODE_DATA_CHANGED";
 	public static final String ODE_FILTER_CHANGED = "ODE_FILTER_CHANGED";
 	public static final String ODESOLVERRESULTSET_CHANGED = "ODESOLVERRESULTSET_CHANGED";

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/ODESolverPlotSpecificationPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/ODESolverPlotSpecificationPanel.java
@@ -62,6 +62,7 @@ public class ODESolverPlotSpecificationPanel extends JPanel {
 	private JPanel speciesOptionsPanel = null;
 	JCheckBox concentrationCheckBox = null;
 	JCheckBox countCheckBox = null;
+	JCheckBox trivialCheckBox = null;		// springsalad specific: filters out trivial result sets (where nothing happens)
 	private JLabel ivjCurLabel = null;
 	private JSlider ivjSensitivityParameterSlider = null;
 	private JScrollPane ivjJScrollPaneYAxis = null;
@@ -92,7 +93,7 @@ public class ODESolverPlotSpecificationPanel extends JPanel {
 				firePropertyChange(ODE_DATA_CHANGED, false, true);
 			}else if(filterSettings != null && filterSettings.containsKey(e.getSource())){
 				processFilterSelection();
-			} else if(e.getSource() == concentrationCheckBox || e.getSource() == countCheckBox) {
+			} else if(e.getSource() == concentrationCheckBox || e.getSource() == countCheckBox || e.getSource() == trivialCheckBox) {
 				try {
 					updateChoices(getMyDataInterface());
 				}catch(Exception exc){
@@ -493,7 +494,6 @@ private javax.swing.JLabel getMinLabel() {
 /**
  * Gets the odeSolverResultSet property (cbit.vcell.solver.ode.ODESolverResultSet) value.
  * @return The odeSolverResultSet property value.
- * @see #setOdeSolverResultSet
  */
 public ODEDataInterface getMyDataInterface() {
 	return oDEDataInterface;
@@ -1172,10 +1172,8 @@ private void regeneratePlot2D() throws ExpressionException,ObjectNotFoundExcepti
 
 
 /**
- * Sets the odeSolverResultSet property (cbit.vcell.solver.ode.ODESolverResultSet) value.
- * @param odeSolverResultSet The new value for the property.
- * @see #getOdeSolverResultSet
- */
+ * Sets the oDEDataInterface property
+*/
 public void setMyDataInterface(ODEDataInterface newMyDataInterface) {
 	ODEDataInterface oldValue = oDEDataInterface;
 	/* Stop listening for events from the current object */
@@ -1203,7 +1201,6 @@ public void setSymbolTable(SymbolTable symbolTable) {
 /**
  * Insert the method's description here.
  * Creation date: (2/8/2001 4:56:15 PM)
- * @param cbit.vcell.solver.ode.ODESolverResultSet
  */
 private void sortColumnDescriptions(ArrayList<ColumnDescription> columnDescriptions) {
 	Collections.sort(columnDescriptions, new Comparator<ColumnDescription>() {
@@ -1217,7 +1214,6 @@ private void sortColumnDescriptions(ArrayList<ColumnDescription> columnDescripti
 /**
  * Insert the method's description here.
  * Creation date: (2/8/2001 4:56:15 PM)
- * @param cbit.vcell.solver.ode.ODESolverResultSet
  */
 private synchronized void updateChoices(ODEDataInterface odedi) throws ExpressionException,ObjectNotFoundException {
 	if (odedi == null) {
@@ -1262,6 +1258,14 @@ private synchronized void updateChoices(ODEDataInterface odedi) throws Expressio
 					continue;
 				} else if(filterCategory instanceof BioModelCategoryType && filterCategory == BioModelCategoryType.Species && !cd.getName().endsWith(AbstractMathMapping.MATH_VAR_SUFFIX_SPECIES_COUNT) && !concentrationCheckBox.isSelected()) {
 					continue;
+				}
+			}
+
+			if(trivialCheckBox != null) {
+				if(trivialCheckBox.isSelected()) {
+					// TODO: implement filtration based on trivial results or not
+				} else {
+					// TODO: implement filtration based on trivial results or not
 				}
 			}
 			
@@ -1385,12 +1389,12 @@ public static Point2D[] generateHistogram(double[] rawData)
 	for(int i=0;i<rawData.length;i++)
 	{
 		int val = ((int)Math.round(rawData[i]));
-		if(temp.get(new Integer(val))!= null)
+		if(temp.get(val)!= null)
 		{
-			int v = temp.get(new Integer(val)).intValue();
-			temp.put(new Integer(val), new Integer(v+1));
+			int v = temp.get(val).intValue();
+			temp.put(val, v+1);
 		}
-		else temp.put(new Integer(val), new Integer(1));
+		else temp.put(val, 1);
 	}
 	//sort the hashtable ascendantly and also calculate the frequency in terms of percentage.
 	Vector<Integer> keys = new Vector<Integer>(temp.keySet());
@@ -1399,7 +1403,7 @@ public static Point2D[] generateHistogram(double[] rawData)
 	for (int i=0; i<keys.size(); i++)
 	{
         Integer key = keys.elementAt(i);
-        Double valperc = new Double(((double)temp.get(key).intValue())/((double)rawData.length));
+        Double valperc = (double)temp.get(key).intValue() / ((double)rawData.length);
         result[i] = new Point2D.Double(key,valperc);
     }
 	return result;
@@ -1541,6 +1545,21 @@ private void showFilterSettings() {
 		gbc.insets = new Insets(1, 10, 3, 0);
 		gbc.anchor = GridBagConstraints.WEST;
 		filterContentPanel.add(getSpeciesOptionsPanel(), gbc);
+		gridy++;
+	}
+	if(getMyDataInterface().isSpringSaLaD()) {
+		trivialCheckBox = new JCheckBox("Hide Trivial");
+		trivialCheckBox.setToolTipText("Hides the result sets where nothing happens.");
+		trivialCheckBox.addItemListener(ivjEventHandler);
+		trivialCheckBox.setSelected(true);
+		GridBagConstraints gbc = new GridBagConstraints();
+		gbc.gridx = gridx;
+		gbc.gridy = gridy;
+		gbc.weightx = 1;
+		gbc.anchor = GridBagConstraints.WEST;
+		gbc.fill = GridBagConstraints.HORIZONTAL;
+		filterContentPanel.add(trivialCheckBox, gbc);
+		gridy++;
 	}
 }
 

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/ODESolverPlotSpecificationPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/ODESolverPlotSpecificationPanel.java
@@ -1243,11 +1243,8 @@ private synchronized void updateChoices(ODEDataInterface odedi) throws Expressio
         //If the column is "_initConnt" generated when using concentration as initial condition, we dont' put the function in list. amended again in August, 2008.
         if (cd.getParameterName() == null) {
         	String name = cd.getName();
-			DataSymbolMetadata damd = null;
-			if (damdr != null) {
-				damd = damdr.getDataSymbolMetadata(name);
-			}
-        	
+			DataSymbolMetadata damd = damdr.getDataSymbolMetadata(name);
+
         	// filter entities measured as count vs concentration, based on the checkbox settings
 			ModelCategoryType filterCategory = null;
 			if (damd != null) {
@@ -1264,8 +1261,9 @@ private synchronized void updateChoices(ODEDataInterface odedi) throws Expressio
 			if(trivialCheckBox != null) {
 				if(trivialCheckBox.isSelected()) {
 					// TODO: implement filtration based on trivial results or not
-				} else {
-					// TODO: implement filtration based on trivial results or not
+					//  access the RowColumnResultSet and find out if data is trivial or not for this ColumnDescription
+					double[] values = odedi.extractColumn(name);
+
 				}
 			}
 			
@@ -1547,20 +1545,6 @@ private void showFilterSettings() {
 		filterContentPanel.add(getSpeciesOptionsPanel(), gbc);
 		gridy++;
 	}
-	if(getMyDataInterface().isSpringSaLaD()) {
-		trivialCheckBox = new JCheckBox("Hide Trivial");
-		trivialCheckBox.setToolTipText("Hides the result sets where nothing happens.");
-		trivialCheckBox.addItemListener(ivjEventHandler);
-		trivialCheckBox.setSelected(true);
-		GridBagConstraints gbc = new GridBagConstraints();
-		gbc.gridx = gridx;
-		gbc.gridy = gridy;
-		gbc.weightx = 1;
-		gbc.anchor = GridBagConstraints.WEST;
-		gbc.fill = GridBagConstraints.HORIZONTAL;
-		filterContentPanel.add(trivialCheckBox, gbc);
-		gridy++;
-	}
 }
 
 private JPanel getSpeciesOptionsPanel() {
@@ -1613,7 +1597,11 @@ private void processFilterSelection(){
 				selectedFilterCategories.add(filterSettings.get(jCheckBox));
 			}
 		}
-		getMyDataInterface().selectCategory(selectedFilterCategories.toArray(new ModelCategoryType[0]));
+		if(getMyDataInterface().isSpringSaLaD()) {
+			getMyDataInterface().selectCategory(selectedFilterCategories.toArray(new ModelCategoryType[0]));
+		} else {
+			getMyDataInterface().selectCategory(selectedFilterCategories.toArray(new ModelCategoryType[0]));
+		}
 	}else{
 		getMyDataInterface().selectCategory(null);
 		

--- a/vcell-client/src/main/java/org/vcell/model/springsalad/gui/MolecularStructuresPanel.java
+++ b/vcell-client/src/main/java/org/vcell/model/springsalad/gui/MolecularStructuresPanel.java
@@ -772,7 +772,6 @@ public class MolecularStructuresPanel extends DocumentEditorSubPanel implements 
 	 * Here we refresh the links table when we add or delete a link
 	 */
 	private void refreshSiteLinksList() {
-		System.out.println("refreshSiteLinksList");
 		linkSpecsTableModel.refreshData();
 	}
 
@@ -786,7 +785,6 @@ public class MolecularStructuresPanel extends DocumentEditorSubPanel implements 
 	}
 
 	private void changePosition(JTextField source) {
-		System.out.println("Site coordinates changed");
 		SiteAttributesSpec sas = fieldSpeciesContextSpec.getSiteAttributesMap().get(fieldMolecularComponentPattern);
 		String text = source.getText();
 		if(sas == null || text == null) {
@@ -799,29 +797,8 @@ public class MolecularStructuresPanel extends DocumentEditorSubPanel implements 
 		} catch(NumberFormatException e) {
 			return;
 		}
-		recalculateLinkLengths();
 	}
-	private void changeLinkLength() {
-		throw new UnsupportedOperationException("At this time the LinkLength is an uneditable derived value.");
-//		Double linkLength = Double.parseDouble(linkLengthField.getText());
-//		MolecularInternalLinkSpec selectedValue = siteLinksList.getSelectedValue();
-//		int selectedIndex = siteLinksList.getSelectedIndex();
-//		System.out.println("changeLinkLength(): selected index '" + selectedIndex + "' being set to " + linkLength);
-//		// TODO: set x,y,z for sites, link length will be always calculated from xyz
-//		recalculatePositions();
-	}
-	
-	// we only display the link length in the UI as a courtesy, this field doesn't exist in MolecularInternalLinkSpec
-	// when we need it, we compute it
-	private void recalculateLinkLengths() {
-		
-//		MolecularInternalLinkSpec mils = siteLinksList.getSelectedValue();
-		System.out.println("recalculateLinkLengths");
-		// TODO: we need to update the table row (maybe??)
-//		showLinkLength(mils);
-	}
-	private void recalculatePositions() {
-	}
+
 
 	private void addLinkActionPerformed() {
 		AddLinkPanel panel = new AddLinkPanel(this);
@@ -838,7 +815,7 @@ public class MolecularStructuresPanel extends DocumentEditorSubPanel implements 
 			MolecularComponentPattern secondMcp = panel.getSecondSiteList().getSelectedValue();
 			MolecularInternalLinkSpec mils = new MolecularInternalLinkSpec(fieldSpeciesContextSpec, firstMcp, secondMcp);
 			fieldSpeciesContextSpec.getInternalLinkSet().add(mils);
-			System.out.println("addLinkActionPerformed");
+//			System.out.println("addLinkActionPerformed");
 			return;
 		} else {
 			return;
@@ -850,7 +827,7 @@ public class MolecularStructuresPanel extends DocumentEditorSubPanel implements 
 		MolecularInternalLinkSpec selectedValue = linkSpecsTableModel.getValueAt(row);
 		if(selectedValue != null) {
 			fieldSpeciesContextSpec.getInternalLinkSet().remove(selectedValue);
-			System.out.println("deleteLinkActionPerformed");
+//			System.out.println("deleteLinkActionPerformed");
 		}
 		return;
 	}

--- a/vcell-core/src/main/java/cbit/vcell/math/ODESolverResultSetColumnDescription.java
+++ b/vcell-core/src/main/java/cbit/vcell/math/ODESolverResultSetColumnDescription.java
@@ -19,6 +19,7 @@ public class ODESolverResultSetColumnDescription implements cbit.vcell.util.Colu
 	private java.lang.String fieldDisplayName = new String();
 	private java.lang.String fieldVariableName = new String();
 	private java.lang.String fieldParameterName = null;
+	private transient boolean fieldIsTrivial = false;
 /**
  * ODESolverResultSetColDescription constructor comment.
  */
@@ -27,6 +28,7 @@ public ODESolverResultSetColumnDescription(ODESolverResultSetColumnDescription o
 	fieldVariableName = odeColumnDescription.fieldVariableName;
 	fieldParameterName = odeColumnDescription.fieldParameterName;
 	fieldDisplayName = odeColumnDescription.fieldDisplayName;
+	fieldIsTrivial = odeColumnDescription.fieldIsTrivial;
 }
 /**
  * ODESolverResultSetColDescription constructor comment.
@@ -91,6 +93,12 @@ public int hashCode() {
 	// This implementation forwards the message to super.  You may replace or supplement this.
 	// NOTE: if two objects are equal (equals(Object) returns true) they must have the same hash code
 	return getDisplayName().hashCode();
+}
+public boolean isTrivial() {
+	return fieldIsTrivial;
+}
+public void setIsTrivial(boolean isTrivial) {
+	fieldIsTrivial = isTrivial;
 }
 /**
  * Starts the application.

--- a/vcell-core/src/main/java/cbit/vcell/math/ODESolverResultSetColumnDescription.java
+++ b/vcell-core/src/main/java/cbit/vcell/math/ODESolverResultSetColumnDescription.java
@@ -54,7 +54,6 @@ public ODESolverResultSetColumnDescription(String variableName, String parameter
 /**
  * Gets the displayName property (java.lang.String) value.
  * @return The displayName property value.
- * @see #setDisplayName
  */
 public java.lang.String getDisplayName() {
 	return fieldDisplayName;
@@ -62,7 +61,6 @@ public java.lang.String getDisplayName() {
 /**
  * Gets the variableName property (java.lang.String) value.
  * @return The variableName property value.
- * @see #setVariableName
  */
 public java.lang.String getName() {
 	return (getVariableName());
@@ -70,7 +68,6 @@ public java.lang.String getName() {
 /**
  * Gets the parameterName property (java.lang.String) value.
  * @return The name of the sensitivity parameter, may be null.
- * @see #setParameterName
  */
 public java.lang.String getParameterName() {
 	return fieldParameterName;
@@ -78,7 +75,6 @@ public java.lang.String getParameterName() {
 /**
  * Gets the variableName property (java.lang.String) value.
  * @return The variableName property value.
- * @see #setVariableName
  */
 public java.lang.String getVariableName() {
 	return fieldVariableName;

--- a/vcell-core/src/main/java/cbit/vcell/math/RowColumnResultSet.java
+++ b/vcell-core/src/main/java/cbit/vcell/math/RowColumnResultSet.java
@@ -141,13 +141,14 @@ public class RowColumnResultSet implements java.io.Serializable {
     /**
      * getVariableNames method comment.
      */
-    public synchronized void addRow(double[] values){
+    public synchronized void addRow(double[] values) {
         // cbit.util.Assertion.assert(values.length == getDataColumnCount());
-        double[] v = new double[getDataColumnCount()];
-        if(values.length != getDataColumnCount()){
+        int dataColumnCount = getDataColumnCount();
+        double[] v = new double[dataColumnCount];
+        if(values.length != dataColumnCount) {
             throw new RuntimeException("number of values in row is not equal to number of columns");
         }
-        System.arraycopy(values, 0, v, 0, getDataColumnCount());
+        System.arraycopy(values, 0, v, 0, dataColumnCount);
         fieldValues.add(v);
     }
 

--- a/vcell-core/src/main/java/cbit/vcell/solver/SimulationModelInfo.java
+++ b/vcell-core/src/main/java/cbit/vcell/solver/SimulationModelInfo.java
@@ -51,4 +51,6 @@ public interface SimulationModelInfo {
 	String getVolumeNameGeometry(int subVolumeID);
 
 	DataSymbolMetadataResolver getDataSymbolMetadataResolver();
+
+	boolean isSpringSaLad();
 }

--- a/vcell-core/src/main/java/org/vcell/model/ssld/SsldUtils.java
+++ b/vcell-core/src/main/java/org/vcell/model/ssld/SsldUtils.java
@@ -9,25 +9,64 @@ import cbit.vcell.model.*;
 import cbit.vcell.parser.Expression;
 import cbit.vcell.solver.*;
 import org.vcell.model.rbm.*;
-import org.vcell.solver.langevin.LangevinLngvWriter;
 import org.vcell.util.Coordinate;
 import org.vcell.util.Extent;
-import org.vcell.util.ISize;
 import org.vcell.util.springsalad.Colors;
 import org.vcell.util.springsalad.NamedColor;
 
-import java.awt.*;
 import java.util.*;
 import java.io.BufferedReader;
 import java.io.*;
 import java.util.List;
-import java.util.prefs.Preferences;
 
-import static org.vcell.model.ssld.TransitionReaction.ANY_STATE;
 import static org.vcell.model.ssld.TransitionReaction.ANY_STATE_STRING;
 import static org.vcell.solver.langevin.LangevinLngvWriter.*;
 
 public class SsldUtils {
+
+    // result entry from langevin output
+    public static class LangevinResult {
+        public final String qualifier;
+        public final String molecule;
+        public final String site;
+        public final String state;
+
+        public static LangevinResult fromString(String str) {
+            if(str == null || str.length() == 0) {
+                throw new RuntimeException("Langevin generated molecules name must contain some text");
+            }
+            String qualifier = "";
+            String molecule = "";
+            String site = "";
+            String state = "";
+
+            String[] tokens = str.split("_{1,2}");
+            if(tokens.length <1 || tokens.length > 4) {
+                throw new RuntimeException("Langevin generated molecules name must have between one and 4 tokens");
+            }
+            for (int i=0; i<tokens.length; i++) {
+                String token = tokens[i];
+                if(i == 0) {
+                    qualifier = token;
+                } else if(i == 1) {
+                    molecule = token;
+                } else if(i == 2) {
+                    site = token;
+                } else if(i == 3) {
+                    state = token;
+                }
+            }
+           LangevinResult lr = new LangevinResult(qualifier, molecule, site, state);
+            return lr;
+        }
+
+        public LangevinResult(String qualifier, String molecule, String site, String state) {
+            this.qualifier = qualifier;
+            this.molecule = molecule;
+            this.site = site;
+            this.state = state;
+        }
+    }
 
     private class Mapping {
 


### PR DESCRIPTION
Filter the results of running a springsalad simulation.
The results are solver generated and are presented as linear combinations of each molecule's site bond / state pair
Also we highlight trivial result sets (where the data doesn't change)
branch: dan-ss-filter-results