### PR TITLE
Synchronize old "Annotations" with Formal annotations in Sims

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SimulationSummaryPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SimulationSummaryPanel.java
@@ -948,7 +948,7 @@ private void initialize() {
 		constraintsJLabel2.gridy = gridy;
 		constraintsJLabel2.anchor = GridBagConstraints.LINE_END;
 		constraintsJLabel2.insets = new Insets(4, 4, 4, 4);
-		add(new JLabel("Annotation:"), constraintsJLabel2);
+		add(new JLabel("Description:"), constraintsJLabel2);
 
 		GridBagConstraints constraintsJScrollPane1 = new GridBagConstraints();
 		constraintsJScrollPane1.gridx = 1; 


### PR DESCRIPTION
Synchronize old "Annotations" with Formal annotations in Sims
Issue #216
in Simulation Object properties: replace label "Annotation" with "Description" since we have a separate panel for formal annotations
part of hackaton 01/07/2005