### PR TITLE
Change Endpoint From 'Get' to 'Post'

### DIFF
--- a/python-restclient/README.md
+++ b/python-restclient/README.md
@@ -107,7 +107,7 @@ Class | Method | HTTP request | Description
 *SimulationResourceApi* | [**get_simulation_status**](docs/SimulationResourceApi.md#get_simulation_status) | **GET** /api/v1/Simulation/{simID}/simulationStatus | Get the status of simulation running
 *SimulationResourceApi* | [**start_simulation**](docs/SimulationResourceApi.md#start_simulation) | **POST** /api/v1/Simulation/{simID}/startSimulation | Start a simulation.
 *SimulationResourceApi* | [**stop_simulation**](docs/SimulationResourceApi.md#stop_simulation) | **POST** /api/v1/Simulation/{simID}/stopSimulation | Stop a simulation.
-*SolverResourceApi* | [**get_fv_solver_input**](docs/SolverResourceApi.md#get_fv_solver_input) | **GET** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+*SolverResourceApi* | [**get_fv_solver_input**](docs/SolverResourceApi.md#get_fv_solver_input) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
 *UsersResourceApi* | [**forgot_legacy_password**](docs/UsersResourceApi.md#forgot_legacy_password) | **POST** /api/v1/users/forgotLegacyPassword | The end user has forgotten the legacy password they used for VCell, so they will be emailed it.
 *UsersResourceApi* | [**get_guest_legacy_api_token**](docs/UsersResourceApi.md#get_guest_legacy_api_token) | **POST** /api/v1/users/guestBearerToken | Method to get legacy tokens for guest users
 *UsersResourceApi* | [**get_legacy_api_token**](docs/UsersResourceApi.md#get_legacy_api_token) | **POST** /api/v1/users/bearerToken | Get token for legacy API

--- a/python-restclient/docs/SolverResourceApi.md
+++ b/python-restclient/docs/SolverResourceApi.md
@@ -4,7 +4,7 @@ All URIs are relative to *https://vcell-dev.cam.uchc.edu*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**get_fv_solver_input**](SolverResourceApi.md#get_fv_solver_input) | **GET** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+[**get_fv_solver_input**](SolverResourceApi.md#get_fv_solver_input) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
 
 
 # **get_fv_solver_input**

--- a/python-restclient/vcell_client/api/solver_resource_api.py
+++ b/python-restclient/vcell_client/api/solver_resource_api.py
@@ -301,7 +301,7 @@ class SolverResourceApi:
         ]
 
         return self.api_client.param_serialize(
-            method='GET',
+            method='POST',
             resource_path='/api/v1/solver/getFVSolverInput',
             path_params=_path_params,
             query_params=_query_params,

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -435,7 +435,7 @@ paths:
       - openId:
         - user
   /api/v1/solver/getFVSolverInput:
-    get:
+    post:
       tags:
       - Solver Resource
       summary: Retrieve finite volume input from SBML spatial model.

--- a/vcell-rest/src/main/java/org/vcell/restq/handlers/SolverResource.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/handlers/SolverResource.java
@@ -13,6 +13,8 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import net.lingala.zip4j.ZipFile;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.jboss.resteasy.reactive.RestForm;
 import org.vcell.sbml.FiniteVolumeRunUtil;
@@ -32,7 +34,9 @@ import java.nio.file.Files;
 public class SolverResource {
     public SolverResource() { }
 
-    @GET
+    private static final Logger lg = LogManager.getLogger(SolverResource.class);
+
+    @POST
     @Path("/getFVSolverInput")
     @Operation(operationId = "getFVSolverInput", summary = "Retrieve finite volume input from SBML spatial model.")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -49,6 +53,7 @@ public class SolverResource {
             zip.close();
             return zipFile;
         }catch (Exception e){
+            lg.error(e);
             throw new WebApplicationException("Error processing spatial model", HTTP.INTERNAL_SERVER_ERROR);
         } finally {
             for (File file: workingDir.listFiles()){

--- a/vcell-restclient/README.md
+++ b/vcell-restclient/README.md
@@ -141,8 +141,8 @@ Class | Method | HTTP request | Description
 *SimulationResourceApi* | [**startSimulationWithHttpInfo**](docs/SimulationResourceApi.md#startSimulationWithHttpInfo) | **POST** /api/v1/Simulation/{simID}/startSimulation | Start a simulation.
 *SimulationResourceApi* | [**stopSimulation**](docs/SimulationResourceApi.md#stopSimulation) | **POST** /api/v1/Simulation/{simID}/stopSimulation | Stop a simulation.
 *SimulationResourceApi* | [**stopSimulationWithHttpInfo**](docs/SimulationResourceApi.md#stopSimulationWithHttpInfo) | **POST** /api/v1/Simulation/{simID}/stopSimulation | Stop a simulation.
-*SolverResourceApi* | [**getFVSolverInput**](docs/SolverResourceApi.md#getFVSolverInput) | **GET** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
-*SolverResourceApi* | [**getFVSolverInputWithHttpInfo**](docs/SolverResourceApi.md#getFVSolverInputWithHttpInfo) | **GET** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+*SolverResourceApi* | [**getFVSolverInput**](docs/SolverResourceApi.md#getFVSolverInput) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+*SolverResourceApi* | [**getFVSolverInputWithHttpInfo**](docs/SolverResourceApi.md#getFVSolverInputWithHttpInfo) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
 *UsersResourceApi* | [**forgotLegacyPassword**](docs/UsersResourceApi.md#forgotLegacyPassword) | **POST** /api/v1/users/forgotLegacyPassword | The end user has forgotten the legacy password they used for VCell, so they will be emailed it.
 *UsersResourceApi* | [**forgotLegacyPasswordWithHttpInfo**](docs/UsersResourceApi.md#forgotLegacyPasswordWithHttpInfo) | **POST** /api/v1/users/forgotLegacyPassword | The end user has forgotten the legacy password they used for VCell, so they will be emailed it.
 *UsersResourceApi* | [**getGuestLegacyApiToken**](docs/UsersResourceApi.md#getGuestLegacyApiToken) | **POST** /api/v1/users/guestBearerToken | Method to get legacy tokens for guest users

--- a/vcell-restclient/api/openapi.yaml
+++ b/vcell-restclient/api/openapi.yaml
@@ -475,7 +475,7 @@ paths:
       - Publication Resource
       x-accepts: application/json
   /api/v1/solver/getFVSolverInput:
-    get:
+    post:
       operationId: getFVSolverInput
       requestBody:
         content:

--- a/vcell-restclient/docs/SolverResourceApi.md
+++ b/vcell-restclient/docs/SolverResourceApi.md
@@ -4,8 +4,8 @@ All URIs are relative to *https://vcell-dev.cam.uchc.edu*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**getFVSolverInput**](SolverResourceApi.md#getFVSolverInput) | **GET** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model. |
-| [**getFVSolverInputWithHttpInfo**](SolverResourceApi.md#getFVSolverInputWithHttpInfo) | **GET** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model. |
+| [**getFVSolverInput**](SolverResourceApi.md#getFVSolverInput) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model. |
+| [**getFVSolverInputWithHttpInfo**](SolverResourceApi.md#getFVSolverInputWithHttpInfo) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model. |
 
 
 

--- a/vcell-restclient/src/main/java/org/vcell/restclient/api/SolverResourceApi.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/api/SolverResourceApi.java
@@ -183,7 +183,7 @@ public class SolverResourceApi {
     }
     localVarRequestBuilder
         .header("Content-Type", entity.getContentType().getValue())
-        .method("GET", formDataPublisher);
+        .method("POST", formDataPublisher);
     if (memberVarReadTimeout != null) {
       localVarRequestBuilder.timeout(memberVarReadTimeout);
     }

--- a/webapp-ng/src/app/core/modules/openapi/api/solver-resource.service.ts
+++ b/webapp-ng/src/app/core/modules/openapi/api/solver-resource.service.ts
@@ -159,7 +159,7 @@ export class SolverResourceService implements SolverResourceServiceInterface {
         }
 
         let localVarPath = `/api/v1/solver/getFVSolverInput`;
-        return this.httpClient.request('get', `${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,


### PR DESCRIPTION
The generated python client was not submitting files to the finite volume solver endpoint because the endpoint required the header 'GET'. Changed the header to 'POST' and now files are being submitted.