### PR TITLE
add API endpoint to generate fv solver input from vcml

### DIFF
--- a/python-restclient/README.md
+++ b/python-restclient/README.md
@@ -107,7 +107,8 @@ Class | Method | HTTP request | Description
 *SimulationResourceApi* | [**get_simulation_status**](docs/SimulationResourceApi.md#get_simulation_status) | **GET** /api/v1/Simulation/{simID}/simulationStatus | Get the status of simulation running
 *SimulationResourceApi* | [**start_simulation**](docs/SimulationResourceApi.md#start_simulation) | **POST** /api/v1/Simulation/{simID}/startSimulation | Start a simulation.
 *SimulationResourceApi* | [**stop_simulation**](docs/SimulationResourceApi.md#stop_simulation) | **POST** /api/v1/Simulation/{simID}/stopSimulation | Stop a simulation.
-*SolverResourceApi* | [**get_fv_solver_input**](docs/SolverResourceApi.md#get_fv_solver_input) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+*SolverResourceApi* | [**get_fv_solver_input_from_sbml**](docs/SolverResourceApi.md#get_fv_solver_input_from_sbml) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+*SolverResourceApi* | [**get_fv_solver_input_from_vcml**](docs/SolverResourceApi.md#get_fv_solver_input_from_vcml) | **POST** /api/v1/solver/getFVSolverInputFromVCML | Retrieve finite volume input from SBML spatial model.
 *UsersResourceApi* | [**forgot_legacy_password**](docs/UsersResourceApi.md#forgot_legacy_password) | **POST** /api/v1/users/forgotLegacyPassword | The end user has forgotten the legacy password they used for VCell, so they will be emailed it.
 *UsersResourceApi* | [**get_guest_legacy_api_token**](docs/UsersResourceApi.md#get_guest_legacy_api_token) | **POST** /api/v1/users/guestBearerToken | Method to get legacy tokens for guest users
 *UsersResourceApi* | [**get_legacy_api_token**](docs/UsersResourceApi.md#get_legacy_api_token) | **POST** /api/v1/users/bearerToken | Get token for legacy API

--- a/python-restclient/docs/SolverResourceApi.md
+++ b/python-restclient/docs/SolverResourceApi.md
@@ -4,11 +4,12 @@ All URIs are relative to *https://vcell-dev.cam.uchc.edu*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**get_fv_solver_input**](SolverResourceApi.md#get_fv_solver_input) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+[**get_fv_solver_input_from_sbml**](SolverResourceApi.md#get_fv_solver_input_from_sbml) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+[**get_fv_solver_input_from_vcml**](SolverResourceApi.md#get_fv_solver_input_from_vcml) | **POST** /api/v1/solver/getFVSolverInputFromVCML | Retrieve finite volume input from SBML spatial model.
 
 
-# **get_fv_solver_input**
-> bytearray get_fv_solver_input(sbml_file=sbml_file)
+# **get_fv_solver_input_from_sbml**
+> bytearray get_fv_solver_input_from_sbml(sbml_file=sbml_file, duration=duration, output_time_step=output_time_step)
 
 Retrieve finite volume input from SBML spatial model.
 
@@ -33,14 +34,16 @@ with vcell_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = vcell_client.SolverResourceApi(api_client)
     sbml_file = None # bytearray |  (optional)
+    duration = 5.0 # float |  (optional) (default to 5.0)
+    output_time_step = 0.1 # float |  (optional) (default to 0.1)
 
     try:
         # Retrieve finite volume input from SBML spatial model.
-        api_response = api_instance.get_fv_solver_input(sbml_file=sbml_file)
-        print("The response of SolverResourceApi->get_fv_solver_input:\n")
+        api_response = api_instance.get_fv_solver_input_from_sbml(sbml_file=sbml_file, duration=duration, output_time_step=output_time_step)
+        print("The response of SolverResourceApi->get_fv_solver_input_from_sbml:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling SolverResourceApi->get_fv_solver_input: %s\n" % e)
+        print("Exception when calling SolverResourceApi->get_fv_solver_input_from_sbml: %s\n" % e)
 ```
 
 
@@ -50,6 +53,74 @@ with vcell_client.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **sbml_file** | **bytearray**|  | [optional] 
+ **duration** | **float**|  | [optional] [default to 5.0]
+ **output_time_step** | **float**|  | [optional] [default to 0.1]
+
+### Return type
+
+**bytearray**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: multipart/form-data
+ - **Accept**: application/octet-stream
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | OK |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **get_fv_solver_input_from_vcml**
+> bytearray get_fv_solver_input_from_vcml(vcml_file=vcml_file, simulation_name=simulation_name)
+
+Retrieve finite volume input from SBML spatial model.
+
+### Example
+
+```python
+import time
+import os
+import vcell_client
+from vcell_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to https://vcell-dev.cam.uchc.edu
+# See configuration.py for a list of all supported configuration parameters.
+configuration = vcell_client.Configuration(
+    host = "https://vcell-dev.cam.uchc.edu"
+)
+
+
+# Enter a context with an instance of the API client
+with vcell_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = vcell_client.SolverResourceApi(api_client)
+    vcml_file = None # bytearray |  (optional)
+    simulation_name = 'simulation_name_example' # str |  (optional)
+
+    try:
+        # Retrieve finite volume input from SBML spatial model.
+        api_response = api_instance.get_fv_solver_input_from_vcml(vcml_file=vcml_file, simulation_name=simulation_name)
+        print("The response of SolverResourceApi->get_fv_solver_input_from_vcml:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling SolverResourceApi->get_fv_solver_input_from_vcml: %s\n" % e)
+```
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **vcml_file** | **bytearray**|  | [optional] 
+ **simulation_name** | **str**|  | [optional] 
 
 ### Return type
 

--- a/python-restclient/vcell_client/api/solver_resource_api.py
+++ b/python-restclient/vcell_client/api/solver_resource_api.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     from typing_extensions import Annotated
 
-from pydantic import StrictBytes, StrictStr
+from pydantic import StrictBytes, StrictFloat, StrictInt, StrictStr
 
 from typing import Optional, Union
 
@@ -48,9 +48,11 @@ class SolverResourceApi:
 
 
     @validate_call
-    def get_fv_solver_input(
+    def get_fv_solver_input_from_sbml(
         self,
         sbml_file: Optional[Union[StrictBytes, StrictStr]] = None,
+        duration: Optional[Union[StrictFloat, StrictInt]] = None,
+        output_time_step: Optional[Union[StrictFloat, StrictInt]] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -69,6 +71,10 @@ class SolverResourceApi:
 
         :param sbml_file:
         :type sbml_file: bytearray
+        :param duration:
+        :type duration: float
+        :param output_time_step:
+        :type output_time_step: float
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -91,8 +97,10 @@ class SolverResourceApi:
         :return: Returns the result object.
         """ # noqa: E501
 
-        _param = self._get_fv_solver_input_serialize(
+        _param = self._get_fv_solver_input_from_sbml_serialize(
             sbml_file=sbml_file,
+            duration=duration,
+            output_time_step=output_time_step,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -115,9 +123,11 @@ class SolverResourceApi:
 
 
     @validate_call
-    def get_fv_solver_input_with_http_info(
+    def get_fv_solver_input_from_sbml_with_http_info(
         self,
         sbml_file: Optional[Union[StrictBytes, StrictStr]] = None,
+        duration: Optional[Union[StrictFloat, StrictInt]] = None,
+        output_time_step: Optional[Union[StrictFloat, StrictInt]] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -136,6 +146,10 @@ class SolverResourceApi:
 
         :param sbml_file:
         :type sbml_file: bytearray
+        :param duration:
+        :type duration: float
+        :param output_time_step:
+        :type output_time_step: float
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -158,8 +172,10 @@ class SolverResourceApi:
         :return: Returns the result object.
         """ # noqa: E501
 
-        _param = self._get_fv_solver_input_serialize(
+        _param = self._get_fv_solver_input_from_sbml_serialize(
             sbml_file=sbml_file,
+            duration=duration,
+            output_time_step=output_time_step,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -182,9 +198,11 @@ class SolverResourceApi:
 
 
     @validate_call
-    def get_fv_solver_input_without_preload_content(
+    def get_fv_solver_input_from_sbml_without_preload_content(
         self,
         sbml_file: Optional[Union[StrictBytes, StrictStr]] = None,
+        duration: Optional[Union[StrictFloat, StrictInt]] = None,
+        output_time_step: Optional[Union[StrictFloat, StrictInt]] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -203,6 +221,10 @@ class SolverResourceApi:
 
         :param sbml_file:
         :type sbml_file: bytearray
+        :param duration:
+        :type duration: float
+        :param output_time_step:
+        :type output_time_step: float
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -225,8 +247,10 @@ class SolverResourceApi:
         :return: Returns the result object.
         """ # noqa: E501
 
-        _param = self._get_fv_solver_input_serialize(
+        _param = self._get_fv_solver_input_from_sbml_serialize(
             sbml_file=sbml_file,
+            duration=duration,
+            output_time_step=output_time_step,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -244,9 +268,11 @@ class SolverResourceApi:
         return response_data.response
 
 
-    def _get_fv_solver_input_serialize(
+    def _get_fv_solver_input_from_sbml_serialize(
         self,
         sbml_file,
+        duration,
+        output_time_step,
         _request_auth,
         _content_type,
         _headers,
@@ -272,6 +298,10 @@ class SolverResourceApi:
         # process the form parameters
         if sbml_file is not None:
             _files['sbmlFile'] = sbml_file
+        if duration is not None:
+            _form_params.append(('duration', duration))
+        if output_time_step is not None:
+            _form_params.append(('output_time_step', output_time_step))
         # process the body parameter
 
 
@@ -303,6 +333,292 @@ class SolverResourceApi:
         return self.api_client.param_serialize(
             method='POST',
             resource_path='/api/v1/solver/getFVSolverInput',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
+    def get_fv_solver_input_from_vcml(
+        self,
+        vcml_file: Optional[Union[StrictBytes, StrictStr]] = None,
+        simulation_name: Optional[StrictStr] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> bytearray:
+        """Retrieve finite volume input from SBML spatial model.
+
+
+        :param vcml_file:
+        :type vcml_file: bytearray
+        :param simulation_name:
+        :type simulation_name: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_fv_solver_input_from_vcml_serialize(
+            vcml_file=vcml_file,
+            simulation_name=simulation_name,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "bytearray"
+            
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def get_fv_solver_input_from_vcml_with_http_info(
+        self,
+        vcml_file: Optional[Union[StrictBytes, StrictStr]] = None,
+        simulation_name: Optional[StrictStr] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[bytearray]:
+        """Retrieve finite volume input from SBML spatial model.
+
+
+        :param vcml_file:
+        :type vcml_file: bytearray
+        :param simulation_name:
+        :type simulation_name: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_fv_solver_input_from_vcml_serialize(
+            vcml_file=vcml_file,
+            simulation_name=simulation_name,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "bytearray"
+            
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def get_fv_solver_input_from_vcml_without_preload_content(
+        self,
+        vcml_file: Optional[Union[StrictBytes, StrictStr]] = None,
+        simulation_name: Optional[StrictStr] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Retrieve finite volume input from SBML spatial model.
+
+
+        :param vcml_file:
+        :type vcml_file: bytearray
+        :param simulation_name:
+        :type simulation_name: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_fv_solver_input_from_vcml_serialize(
+            vcml_file=vcml_file,
+            simulation_name=simulation_name,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "bytearray"
+            
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _get_fv_solver_input_from_vcml_serialize(
+        self,
+        vcml_file,
+        simulation_name,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> Tuple:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+            
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, str] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        if vcml_file is not None:
+            _files['vcmlFile'] = vcml_file
+        if simulation_name is not None:
+            _form_params.append(('simulation_name', simulation_name))
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/octet-stream'
+            ]
+        )
+
+        # set the HTTP header `Content-Type`
+        if _content_type:
+            _header_params['Content-Type'] = _content_type
+        else:
+            _default_content_type = (
+                self.api_client.select_header_content_type(
+                    [
+                        'multipart/form-data'
+                    ]
+                )
+            )
+            if _default_content_type is not None:
+                _header_params['Content-Type'] = _default_content_type
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/api/v1/solver/getFVSolverInputFromVCML',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/tools/SolverResourceApi.patch
+++ b/tools/SolverResourceApi.patch
@@ -1,5 +1,5 @@
 diff --git a/vcell-restclient/src/main/java/org/vcell/restclient/api/SolverResourceApi.java b/vcell-restclient/src/main/java/org/vcell/restclient/api/SolverResourceApi.java
-index 41f2bf8e1..39e9cd951 100644
+index 07b5565..097148c 100644
 --- a/vcell-restclient/src/main/java/org/vcell/restclient/api/SolverResourceApi.java
 +++ b/vcell-restclient/src/main/java/org/vcell/restclient/api/SolverResourceApi.java
 @@ -12,6 +12,8 @@
@@ -11,23 +11,33 @@ index 41f2bf8e1..39e9cd951 100644
  import org.vcell.restclient.ApiClient;
  import org.vcell.restclient.ApiException;
  import org.vcell.restclient.ApiResponse;
-@@ -119,11 +121,14 @@ public class SolverResourceApi {
+@@ -123,10 +125,13 @@ public class SolverResourceApi {
          if (localVarResponse.statusCode()/ 100 != 2) {
-           throw getApiException("getFVSolverInput", localVarResponse);
+           throw getApiException("getFVSolverInputFromSBML", localVarResponse);
          }
--        return new ApiResponse<File>(
--          localVarResponse.statusCode(),
--          localVarResponse.headers().map(),
++        InputStream inputStream = localVarResponse.body();
++        File file = File.createTempFile("finite-volume-input-" + RandomStringUtils.randomAlphabetic(10), ".tmp");
++        FileUtils.copyInputStreamToFile(inputStream, file);
+         return new ApiResponse<File>(
+           localVarResponse.statusCode(),
+           localVarResponse.headers().map(),
 -          localVarResponse.body() == null ? null : memberVarObjectMapper.readValue(localVarResponse.body(), new TypeReference<File>() {}) // closes the InputStream
--        );
-+          InputStream inputStream = localVarResponse.body();
-+          File file = File.createTempFile("finite-volume-input-" + RandomStringUtils.randomAlphabetic(10), ".tmp");
-+          FileUtils.copyInputStreamToFile(inputStream, file);
-+          return new ApiResponse<File>(
-+                  localVarResponse.statusCode(),
-+                  localVarResponse.headers().map(),
-+                  localVarResponse.body() == null ? null : file // closes the InputStream
-+          );
++          localVarResponse.body() == null ? null : file // closes the InputStream
+         );
        } finally {
        }
-     } catch (IOException e) {
+@@ -227,10 +232,13 @@ public class SolverResourceApi {
+         if (localVarResponse.statusCode()/ 100 != 2) {
+           throw getApiException("getFVSolverInputFromVCML", localVarResponse);
+         }
++        InputStream inputStream = localVarResponse.body();
++        File file = File.createTempFile("finite-volume-input-" + RandomStringUtils.randomAlphabetic(10), ".tmp");
++        FileUtils.copyInputStreamToFile(inputStream, file);
+         return new ApiResponse<File>(
+           localVarResponse.statusCode(),
+           localVarResponse.headers().map(),
+-          localVarResponse.body() == null ? null : memberVarObjectMapper.readValue(localVarResponse.body(), new TypeReference<File>() {}) // closes the InputStream
++          localVarResponse.body() == null ? null : file // closes the InputStream
+         );
+       } finally {
+       }

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -439,7 +439,7 @@ paths:
       tags:
       - Solver Resource
       summary: Retrieve finite volume input from SBML spatial model.
-      operationId: getFVSolverInput
+      operationId: getFVSolverInputFromSBML
       requestBody:
         content:
           multipart/form-data:
@@ -448,6 +448,39 @@ paths:
               properties:
                 sbmlFile:
                   format: binary
+                  type: string
+                duration:
+                  format: double
+                  default: 5.0
+                  type: number
+                output_time_step:
+                  format: double
+                  default: 0.1
+                  type: number
+      responses:
+        "200":
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                format: binary
+                type: string
+  /api/v1/solver/getFVSolverInputFromVCML:
+    post:
+      tags:
+      - Solver Resource
+      summary: Retrieve finite volume input from SBML spatial model.
+      operationId: getFVSolverInputFromVCML
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                vcmlFile:
+                  format: binary
+                  type: string
+                simulation_name:
                   type: string
       responses:
         "200":

--- a/vcell-rest/src/main/java/org/vcell/restq/handlers/SolverResource.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/handlers/SolverResource.java
@@ -9,6 +9,9 @@ import cbit.vcell.solver.Simulation;
 import cbit.vcell.solver.SolverException;
 import cbit.vcell.solver.TimeBounds;
 import cbit.vcell.solver.UniformOutputTimeSpec;
+import cbit.vcell.xml.XMLSource;
+import cbit.vcell.xml.XmlHelper;
+import cbit.vcell.xml.XmlParseException;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -16,18 +19,21 @@ import net.lingala.zip4j.ZipFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.jboss.resteasy.reactive.RestForm;
 import org.vcell.sbml.FiniteVolumeRunUtil;
 import org.vcell.sbml.vcell.SBMLExporter;
 import org.vcell.sbml.vcell.SBMLImporter;
 import org.w3c.www.http.HTTP;
 
+import javax.swing.text.html.Option;
 import java.beans.PropertyVetoException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.Optional;
 
 @Path("/api/v1/solver")
 @RequestScoped
@@ -38,14 +44,18 @@ public class SolverResource {
 
     @POST
     @Path("/getFVSolverInput")
-    @Operation(operationId = "getFVSolverInput", summary = "Retrieve finite volume input from SBML spatial model.")
+    @Operation(operationId = "getFVSolverInputFromSBML", summary = "Retrieve finite volume input from SBML spatial model.")
+    @Parameter(name = "duration", description = "Duration of simulation in sbml time units (defaults to seconds)")
+    @Parameter(name = "output_time_step", description = "Output time step in sbml time units (defaults to seconds)")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    public File retrieveFiniteVolumeInputFromSpatialModel(@RestForm File sbmlFile) throws IOException {
+    public File retrieveFiniteVolumeInputFromSBMLSpatial(@RestForm File sbmlFile,
+                                                         @RestForm @DefaultValue("5.0") double duration,
+                                                         @RestForm @DefaultValue("0.1") double output_time_step) throws IOException {
         File workingDir = Files.createTempDirectory("vcell-").toFile();
         File zipFile = Files.createTempFile("finite-volume", ".zip").toFile();
         try {
-            sbmlToFiniteVolumeInput(sbmlFile, workingDir);
+            sbmlToFiniteVolumeInput(sbmlFile, workingDir, duration, output_time_step);
             ZipFile zip = new ZipFile(zipFile);
             for (File file : workingDir.listFiles()) {
                 zip.addFile(file);
@@ -63,22 +73,64 @@ public class SolverResource {
         }
     }
 
-    public static void sbmlToFiniteVolumeInput(File sbmlFile, File outputDir) throws IOException, MappingException, VCLoggerException, PropertyVetoException, SolverException, ExpressionException {
+    public static void sbmlToFiniteVolumeInput(File sbmlFile, File outputDir, double duration, double output_time_step)
+            throws IOException, MappingException, VCLoggerException, PropertyVetoException, SolverException, ExpressionException {
+        SimulationContext simContext = getSimulationContext(sbmlFile);
+        Simulation sim = new Simulation(simContext.getMathDescription(), simContext);
+        sim.getSolverTaskDescription().setTimeBounds(new TimeBounds(0.0, duration));
+        sim.getSolverTaskDescription().setOutputTimeSpec(new UniformOutputTimeSpec(output_time_step));
+
+        FiniteVolumeRunUtil.writeInputFilesOnly(outputDir, sim);
+    }
+
+    private static SimulationContext getSimulationContext(File sbmlFile) throws IOException, VCLoggerException, MappingException {
         SBMLExporter.MemoryVCLogger vcl = new SBMLExporter.MemoryVCLogger();
         boolean bValidateSBML = true;
         InputStream is = new FileInputStream(sbmlFile);
         SBMLImporter importer = new SBMLImporter(is, vcl, bValidateSBML);
+        if (!vcl.highPriority.isEmpty()) {
+            throw new IOException("Error parsing SBML: "+vcl.highPriority);
+        }
         BioModel bioModel = importer.getBioModel();
         bioModel.updateAll(false);
 
-        final double duration = 5.0;  // endpoint arg
-        final double time_step = 0.1;  // endpoint arg
-        //final ISize meshSize = new ISize(10, 10, 10);  // future endpoint arg
-        SimulationContext simContext = bioModel.getSimulationContext(0);
-        Simulation sim = new Simulation(simContext.getMathDescription(), simContext);
-        sim.getSolverTaskDescription().setTimeBounds(new TimeBounds(0.0, duration));
-        sim.getSolverTaskDescription().setOutputTimeSpec(new UniformOutputTimeSpec(time_step));
+        return bioModel.getSimulationContext(0);
+    }
 
+
+    @POST
+    @Path("/getFVSolverInputFromVCML")
+    @Operation(operationId = "getFVSolverInputFromVCML", summary = "Retrieve finite volume input from SBML spatial model.")
+    @Parameter(name = "simulation_name", description = "name of simulation in VCML file")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    public File retrieveFiniteVolumeInputFromVCML(@RestForm File vcmlFile, @RestForm String simulation_name) throws IOException {
+        File workingDir = Files.createTempDirectory("vcell-").toFile();
+        File zipFile = Files.createTempFile("finite-volume", ".zip").toFile();
+        try {
+            vcmlToFiniteVolumeInput(vcmlFile, simulation_name, workingDir);
+            ZipFile zip = new ZipFile(zipFile);
+            for (File file : workingDir.listFiles()) {
+                zip.addFile(file);
+            }
+            zip.close();
+            return zipFile;
+        }catch (XmlParseException | MappingException | SolverException | ExpressionException e){
+            lg.error(e);
+            throw new WebApplicationException("Error processing spatial model: "+e.getMessage(), HTTP.NOT_ACCEPTABLE);
+        } finally {
+            for (File file: workingDir.listFiles()){
+                file.delete();
+            }
+            workingDir.delete();
+        }
+    }
+
+    public static void vcmlToFiniteVolumeInput(File vcmlFile, String simulation_name, File outputDir) throws XmlParseException, MappingException, SolverException, ExpressionException {
+        SBMLExporter.MemoryVCLogger vcl = new SBMLExporter.MemoryVCLogger();
+        BioModel bioModel = XmlHelper.XMLToBioModel(new XMLSource(vcmlFile));
+        bioModel.updateAll(false);
+        Simulation sim = bioModel.getSimulation(simulation_name);
         FiniteVolumeRunUtil.writeInputFilesOnly(outputDir, sim);
     }
 

--- a/vcell-rest/src/test/resources/TinySpacialProject_Application0.vcml
+++ b/vcell-rest/src/test/resources/TinySpacialProject_Application0.vcml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--This biomodel was generated in VCML Version Alpha_Version_7.7.0_build_15-->
+<vcml xmlns="http://sourceforge.net/projects/vcell/vcml" Version="Alpha_Version_7.7.0_build_15">
+  <BioModel Name="TinySpacialProject_Application0">
+    <Model Name="unnamed">
+      <ModelParameters>
+        <Parameter Name="Kf_r0" Role="user defined" Unit="s-1">1.0</Parameter>
+        <Parameter Name="Kr_r0" Role="user defined" Unit="s-1">0.5</Parameter>
+      </ModelParameters>
+      <Compound Name="s0">
+        <Annotation>s0</Annotation>
+      </Compound>
+      <Compound Name="s1">
+        <Annotation>s1</Annotation>
+      </Compound>
+      <Feature Name="c0" />
+      <LocalizedCompound Name="s0" SbmlName="s0" CompoundRef="s0" Structure="c0" OverrideName="true" />
+      <LocalizedCompound Name="s1" SbmlName="s1" CompoundRef="s1" Structure="c0" OverrideName="true" />
+      <SimpleReaction Structure="c0" Name="r0" Reversible="true" FluxOption="MolecularOnly" SbmlName="r0">
+        <Reactant LocalizedCompoundRef="s0" Stoichiometry="1" />
+        <Product LocalizedCompoundRef="s1" Stoichiometry="1" />
+        <Kinetics KineticsType="GeneralKinetics">
+          <Parameter Name="J" Role="reaction rate" Unit="umol.l-1.s-1">((Kf_r0 * s0) - (Kr_r0 * s1))</Parameter>
+        </Kinetics>
+      </SimpleReaction>
+      <Diagram Name="c0" Structure="c0">
+        <LocalizedCompoundShape NodeReferenceModeAttrTag="full" LocalizedCompoundRef="s1" LocationX="470" LocationY="220" />
+        <SimpleReactionShape NodeReferenceModeAttrTag="full" SimpleReactionRef="r0" LocationX="244" LocationY="129" />
+        <LocalizedCompoundShape NodeReferenceModeAttrTag="full" LocalizedCompoundRef="s0" LocationX="14" LocationY="34" />
+      </Diagram>
+      <ModelUnitSystem VolumeSubstanceUnit="umol" MembraneSubstanceUnit="umol" LumpedReactionSubstanceUnit="umol" VolumeUnit="l" AreaUnit="dm2" LengthUnit="dm" TimeUnit="s" />
+    </Model>
+    <SimulationSpec Name="unnamed_spatialGeom" Stochastic="false" UseConcentration="true" SpringSaLaD="false" RuleBased="false" MassConservationModelReduction="false" InsufficientIterations="false" InsufficientMaxMolecules="false" CharacteristicSize="0.021090187684898395">
+      <NetworkConstraints RbmMaxIteration="1" RbmMaxMoleculesPerSpecies="10" RbmSpeciesLimit="800" RbmReactionsLimit="2500" />
+      <Annotation />
+      <Geometry Name="spatialGeom" Dimension="1">
+        <Extent X="10.0" Y="1.0" Z="1.0" />
+        <Origin X="0.0" Y="0.0" Z="0.0" />
+        <SubVolume Name="subdomain0" Handle="0" Type="Analytical">
+          <AnalyticExpression>1.0</AnalyticExpression>
+        </SubVolume>
+        <SurfaceDescription NumSamplesX="50" NumSamplesY="1" NumSamplesZ="1" CutoffFrequency="0.3">
+          <VolumeRegion Name="subdomain00" RegionID="0" SubVolume="subdomain0" Size="10.0" Unit="um" />
+        </SurfaceDescription>
+      </Geometry>
+      <GeometryContext>
+        <FeatureMapping Feature="c0" GeometryClass="subdomain0" SubVolume="subdomain0" Size="50000.0" VolumePerUnitVolume="1.0">
+          <BoundariesTypes Xm="Flux" Xp="Flux" Ym="Flux" Yp="Flux" Zm="Flux" Zp="Flux" />
+        </FeatureMapping>
+      </GeometryContext>
+      <ReactionContext>
+        <LocalizedCompoundSpec LocalizedCompoundRef="s0" ForceConstant="false" WellMixed="false" ForceContinuous="false">
+          <InitialConcentration>(100000.0 * x)</InitialConcentration>
+          <Diffusion>1.0E-9</Diffusion>
+          <Boundaries Xm="0.0" Xp="0.0" />
+        </LocalizedCompoundSpec>
+        <LocalizedCompoundSpec LocalizedCompoundRef="s1" ForceConstant="false" WellMixed="false" ForceContinuous="false">
+          <InitialConcentration>(10.0 - (1.0 * 100000.0 * x))</InitialConcentration>
+          <Diffusion>1.0E-9</Diffusion>
+          <Boundaries Xm="0.0" Xp="0.0" />
+        </LocalizedCompoundSpec>
+        <ReactionSpec ReactionStepRef="r0" ReactionMapping="included" />
+      </ReactionContext>
+      <MathDescription Name="unnamed_spatialGeom_generated">
+        <Constant Name="_F_">96485.3321</Constant>
+        <Constant Name="_F_nmol_">9.64853321E-5</Constant>
+        <Constant Name="_K_GHK_">1.0E-9</Constant>
+        <Constant Name="_N_pmol_">6.02214179E11</Constant>
+        <Constant Name="_PI_">3.141592653589793</Constant>
+        <Constant Name="_R_">8314.46261815</Constant>
+        <Constant Name="_T_">300.0</Constant>
+        <Constant Name="K_millivolts_per_volt">1000.0</Constant>
+        <Constant Name="Kf_r0">1.0</Constant>
+        <Constant Name="KMOLE">0.001660538783162726</Constant>
+        <Constant Name="Kr_r0">0.5</Constant>
+        <Constant Name="s0_boundaryXm">0.0</Constant>
+        <Constant Name="s0_boundaryXp">0.0</Constant>
+        <Constant Name="s0_diffusionRate">1.0E-9</Constant>
+        <Constant Name="s1_boundaryXm">0.0</Constant>
+        <Constant Name="s1_boundaryXp">0.0</Constant>
+        <Constant Name="s1_diffusionRate">1.0E-9</Constant>
+        <Constant Name="VolumePerUnitVolume_c0">1.0</Constant>
+        <VolumeVariable Name="s0" Domain="subdomain0" />
+        <VolumeVariable Name="s1" Domain="subdomain0" />
+        <Function Name="J_r0" Domain="subdomain0">((Kf_r0 * s0) - (Kr_r0 * s1))</Function>
+        <Function Name="s0_init_umol_l_1" Domain="subdomain0">(100000.0 * x)</Function>
+        <Function Name="s1_init_umol_l_1" Domain="subdomain0">(10.0 - (1.0 * 100000.0 * x))</Function>
+        <Function Name="Size_c0" Domain="subdomain0">(VolumePerUnitVolume_c0 * vcRegionVolume('subdomain0'))</Function>
+        <Function Name="vobj_subdomain00_size" Domain="subdomain0">vcRegionVolume('subdomain0')</Function>
+        <CompartmentSubDomain Name="subdomain0">
+          <BoundaryType Boundary="Xm" Type="Flux" />
+          <BoundaryType Boundary="Xp" Type="Flux" />
+          <BoundaryType Boundary="Ym" Type="Value" />
+          <BoundaryType Boundary="Yp" Type="Value" />
+          <BoundaryType Boundary="Zm" Type="Value" />
+          <BoundaryType Boundary="Zp" Type="Value" />
+          <PdeEquation Name="s0" SolutionType="Unknown">
+            <Boundaries Xm="s0_boundaryXm" Xp="s0_boundaryXp" />
+            <Rate>- J_r0</Rate>
+            <Diffusion>s0_diffusionRate</Diffusion>
+            <Initial>s0_init_umol_l_1</Initial>
+          </PdeEquation>
+          <PdeEquation Name="s1" SolutionType="Unknown">
+            <Boundaries Xm="s1_boundaryXm" Xp="s1_boundaryXp" />
+            <Rate>J_r0</Rate>
+            <Diffusion>s1_diffusionRate</Diffusion>
+            <Initial>s1_init_umol_l_1</Initial>
+          </PdeEquation>
+        </CompartmentSubDomain>
+      </MathDescription>
+      <Simulation Name="Simulation0">
+        <SolverTaskDescription TaskType="Unsteady" UseSymbolicJacobian="false" Solver="Sundials Stiff PDE Solver (Variable Time Step)">
+          <TimeBound StartTime="0.0" EndTime="1.0" />
+          <TimeStep DefaultTime="0.05" MinTime="0.0" MaxTime="0.1" />
+          <ErrorTolerance Absolut="1.0E-9" Relative="1.0E-7" />
+          <OutputOptions OutputTimeStep="0.05" />
+          <SundialsSolverOptions>
+            <maxOrderAdvection>2</maxOrderAdvection>
+          </SundialsSolverOptions>
+          <NumberProcessors>1</NumberProcessors>
+        </SolverTaskDescription>
+        <MathOverrides />
+        <MeshSpecification>
+          <Size X="200" Y="1" Z="1" />
+        </MeshSpecification>
+      </Simulation>
+      <SpatialObjects>
+        <SpatialObject Name="vobj_subdomain00" Type="Volume" subVolume="subdomain0" regionId="0">
+          <QuantityCategoryList>
+            <QuantityCategory Name="VolumeCentroid" Enabled="false" />
+            <QuantityCategory Name="InteriorVelocity" Enabled="false" />
+            <QuantityCategory Name="VolumeRegionSize" Enabled="true" />
+          </QuantityCategoryList>
+        </SpatialObject>
+      </SpatialObjects>
+      <MicroscopeMeasurement Name="fluor">
+        <ConvolutionKernel Type="ProjectionZKernel" />
+      </MicroscopeMeasurement>
+    </SimulationSpec>
+    <pathwayModel>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" version="3.0" />
+    </pathwayModel>
+    <relationshipModel>
+      <RMNS version="3.0" />
+    </relationshipModel>
+    <vcmetadata>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" />
+      <nonrdfAnnotationList />
+      <uriBindingList />
+    </vcmetadata>
+  </BioModel>
+</vcml>
+

--- a/vcell-restclient/README.md
+++ b/vcell-restclient/README.md
@@ -141,8 +141,10 @@ Class | Method | HTTP request | Description
 *SimulationResourceApi* | [**startSimulationWithHttpInfo**](docs/SimulationResourceApi.md#startSimulationWithHttpInfo) | **POST** /api/v1/Simulation/{simID}/startSimulation | Start a simulation.
 *SimulationResourceApi* | [**stopSimulation**](docs/SimulationResourceApi.md#stopSimulation) | **POST** /api/v1/Simulation/{simID}/stopSimulation | Stop a simulation.
 *SimulationResourceApi* | [**stopSimulationWithHttpInfo**](docs/SimulationResourceApi.md#stopSimulationWithHttpInfo) | **POST** /api/v1/Simulation/{simID}/stopSimulation | Stop a simulation.
-*SolverResourceApi* | [**getFVSolverInput**](docs/SolverResourceApi.md#getFVSolverInput) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
-*SolverResourceApi* | [**getFVSolverInputWithHttpInfo**](docs/SolverResourceApi.md#getFVSolverInputWithHttpInfo) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+*SolverResourceApi* | [**getFVSolverInputFromSBML**](docs/SolverResourceApi.md#getFVSolverInputFromSBML) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+*SolverResourceApi* | [**getFVSolverInputFromSBMLWithHttpInfo**](docs/SolverResourceApi.md#getFVSolverInputFromSBMLWithHttpInfo) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model.
+*SolverResourceApi* | [**getFVSolverInputFromVCML**](docs/SolverResourceApi.md#getFVSolverInputFromVCML) | **POST** /api/v1/solver/getFVSolverInputFromVCML | Retrieve finite volume input from SBML spatial model.
+*SolverResourceApi* | [**getFVSolverInputFromVCMLWithHttpInfo**](docs/SolverResourceApi.md#getFVSolverInputFromVCMLWithHttpInfo) | **POST** /api/v1/solver/getFVSolverInputFromVCML | Retrieve finite volume input from SBML spatial model.
 *UsersResourceApi* | [**forgotLegacyPassword**](docs/UsersResourceApi.md#forgotLegacyPassword) | **POST** /api/v1/users/forgotLegacyPassword | The end user has forgotten the legacy password they used for VCell, so they will be emailed it.
 *UsersResourceApi* | [**forgotLegacyPasswordWithHttpInfo**](docs/UsersResourceApi.md#forgotLegacyPasswordWithHttpInfo) | **POST** /api/v1/users/forgotLegacyPassword | The end user has forgotten the legacy password they used for VCell, so they will be emailed it.
 *UsersResourceApi* | [**getGuestLegacyApiToken**](docs/UsersResourceApi.md#getGuestLegacyApiToken) | **POST** /api/v1/users/guestBearerToken | Method to get legacy tokens for guest users

--- a/vcell-restclient/api/openapi.yaml
+++ b/vcell-restclient/api/openapi.yaml
@@ -476,12 +476,33 @@ paths:
       x-accepts: application/json
   /api/v1/solver/getFVSolverInput:
     post:
-      operationId: getFVSolverInput
+      operationId: getFVSolverInputFromSBML
       requestBody:
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/getFVSolverInput_request'
+              $ref: '#/components/schemas/getFVSolverInputFromSBML_request'
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                format: binary
+                type: string
+          description: OK
+      summary: Retrieve finite volume input from SBML spatial model.
+      tags:
+      - Solver Resource
+      x-content-type: multipart/form-data
+      x-accepts: application/octet-stream
+  /api/v1/solver/getFVSolverInputFromVCML:
+    post:
+      operationId: getFVSolverInputFromVCML
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/getFVSolverInputFromVCML_request'
       responses:
         "200":
           content:
@@ -1726,10 +1747,26 @@ components:
         fileName:
           type: string
       type: object
-    getFVSolverInput_request:
+    getFVSolverInputFromSBML_request:
       properties:
         sbmlFile:
           format: binary
+          type: string
+        duration:
+          default: 5.0
+          format: double
+          type: number
+        output_time_step:
+          default: 0.1
+          format: double
+          type: number
+      type: object
+    getFVSolverInputFromVCML_request:
+      properties:
+        vcmlFile:
+          format: binary
+          type: string
+        simulation_name:
           type: string
       type: object
   securitySchemes:

--- a/vcell-restclient/docs/SolverResourceApi.md
+++ b/vcell-restclient/docs/SolverResourceApi.md
@@ -4,14 +4,16 @@ All URIs are relative to *https://vcell-dev.cam.uchc.edu*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**getFVSolverInput**](SolverResourceApi.md#getFVSolverInput) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model. |
-| [**getFVSolverInputWithHttpInfo**](SolverResourceApi.md#getFVSolverInputWithHttpInfo) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model. |
+| [**getFVSolverInputFromSBML**](SolverResourceApi.md#getFVSolverInputFromSBML) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model. |
+| [**getFVSolverInputFromSBMLWithHttpInfo**](SolverResourceApi.md#getFVSolverInputFromSBMLWithHttpInfo) | **POST** /api/v1/solver/getFVSolverInput | Retrieve finite volume input from SBML spatial model. |
+| [**getFVSolverInputFromVCML**](SolverResourceApi.md#getFVSolverInputFromVCML) | **POST** /api/v1/solver/getFVSolverInputFromVCML | Retrieve finite volume input from SBML spatial model. |
+| [**getFVSolverInputFromVCMLWithHttpInfo**](SolverResourceApi.md#getFVSolverInputFromVCMLWithHttpInfo) | **POST** /api/v1/solver/getFVSolverInputFromVCML | Retrieve finite volume input from SBML spatial model. |
 
 
 
-## getFVSolverInput
+## getFVSolverInputFromSBML
 
-> File getFVSolverInput(sbmlFile)
+> File getFVSolverInputFromSBML(sbmlFile, duration, outputTimeStep)
 
 Retrieve finite volume input from SBML spatial model.
 
@@ -32,11 +34,13 @@ public class Example {
 
         SolverResourceApi apiInstance = new SolverResourceApi(defaultClient);
         File sbmlFile = new File("/path/to/file"); // File | 
+        Double duration = 5.0D; // Double | 
+        Double outputTimeStep = 0.1D; // Double | 
         try {
-            File result = apiInstance.getFVSolverInput(sbmlFile);
+            File result = apiInstance.getFVSolverInputFromSBML(sbmlFile, duration, outputTimeStep);
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling SolverResourceApi#getFVSolverInput");
+            System.err.println("Exception when calling SolverResourceApi#getFVSolverInputFromSBML");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Reason: " + e.getResponseBody());
             System.err.println("Response headers: " + e.getResponseHeaders());
@@ -52,6 +56,8 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **sbmlFile** | **File**|  | [optional] |
+| **duration** | **Double**|  | [optional] [default to 5.0] |
+| **outputTimeStep** | **Double**|  | [optional] [default to 0.1] |
 
 ### Return type
 
@@ -72,9 +78,9 @@ No authorization required
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 
-## getFVSolverInputWithHttpInfo
+## getFVSolverInputFromSBMLWithHttpInfo
 
-> ApiResponse<File> getFVSolverInput getFVSolverInputWithHttpInfo(sbmlFile)
+> ApiResponse<File> getFVSolverInputFromSBML getFVSolverInputFromSBMLWithHttpInfo(sbmlFile, duration, outputTimeStep)
 
 Retrieve finite volume input from SBML spatial model.
 
@@ -96,13 +102,15 @@ public class Example {
 
         SolverResourceApi apiInstance = new SolverResourceApi(defaultClient);
         File sbmlFile = new File("/path/to/file"); // File | 
+        Double duration = 5.0D; // Double | 
+        Double outputTimeStep = 0.1D; // Double | 
         try {
-            ApiResponse<File> response = apiInstance.getFVSolverInputWithHttpInfo(sbmlFile);
+            ApiResponse<File> response = apiInstance.getFVSolverInputFromSBMLWithHttpInfo(sbmlFile, duration, outputTimeStep);
             System.out.println("Status code: " + response.getStatusCode());
             System.out.println("Response headers: " + response.getHeaders());
             System.out.println("Response body: " + response.getData());
         } catch (ApiException e) {
-            System.err.println("Exception when calling SolverResourceApi#getFVSolverInput");
+            System.err.println("Exception when calling SolverResourceApi#getFVSolverInputFromSBML");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Response headers: " + e.getResponseHeaders());
             System.err.println("Reason: " + e.getResponseBody());
@@ -118,6 +126,142 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **sbmlFile** | **File**|  | [optional] |
+| **duration** | **Double**|  | [optional] [default to 5.0] |
+| **outputTimeStep** | **Double**|  | [optional] [default to 0.1] |
+
+### Return type
+
+ApiResponse<[**File**](File.md)>
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: multipart/form-data
+- **Accept**: application/octet-stream
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | OK |  -  |
+
+
+## getFVSolverInputFromVCML
+
+> File getFVSolverInputFromVCML(vcmlFile, simulationName)
+
+Retrieve finite volume input from SBML spatial model.
+
+### Example
+
+```java
+// Import classes:
+import org.vcell.restclient.ApiClient;
+import org.vcell.restclient.ApiException;
+import org.vcell.restclient.Configuration;
+import org.vcell.restclient.models.*;
+import org.vcell.restclient.api.SolverResourceApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("https://vcell-dev.cam.uchc.edu");
+
+        SolverResourceApi apiInstance = new SolverResourceApi(defaultClient);
+        File vcmlFile = new File("/path/to/file"); // File | 
+        String simulationName = "simulationName_example"; // String | 
+        try {
+            File result = apiInstance.getFVSolverInputFromVCML(vcmlFile, simulationName);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling SolverResourceApi#getFVSolverInputFromVCML");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **vcmlFile** | **File**|  | [optional] |
+| **simulationName** | **String**|  | [optional] |
+
+### Return type
+
+[**File**](File.md)
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: multipart/form-data
+- **Accept**: application/octet-stream
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | OK |  -  |
+
+## getFVSolverInputFromVCMLWithHttpInfo
+
+> ApiResponse<File> getFVSolverInputFromVCML getFVSolverInputFromVCMLWithHttpInfo(vcmlFile, simulationName)
+
+Retrieve finite volume input from SBML spatial model.
+
+### Example
+
+```java
+// Import classes:
+import org.vcell.restclient.ApiClient;
+import org.vcell.restclient.ApiException;
+import org.vcell.restclient.ApiResponse;
+import org.vcell.restclient.Configuration;
+import org.vcell.restclient.models.*;
+import org.vcell.restclient.api.SolverResourceApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("https://vcell-dev.cam.uchc.edu");
+
+        SolverResourceApi apiInstance = new SolverResourceApi(defaultClient);
+        File vcmlFile = new File("/path/to/file"); // File | 
+        String simulationName = "simulationName_example"; // String | 
+        try {
+            ApiResponse<File> response = apiInstance.getFVSolverInputFromVCMLWithHttpInfo(vcmlFile, simulationName);
+            System.out.println("Status code: " + response.getStatusCode());
+            System.out.println("Response headers: " + response.getHeaders());
+            System.out.println("Response body: " + response.getData());
+        } catch (ApiException e) {
+            System.err.println("Exception when calling SolverResourceApi#getFVSolverInputFromVCML");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            System.err.println("Reason: " + e.getResponseBody());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **vcmlFile** | **File**|  | [optional] |
+| **simulationName** | **String**|  | [optional] |
 
 ### Return type
 

--- a/vcell-restclient/src/main/java/org/vcell/restclient/api/SolverResourceApi.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/api/SolverResourceApi.java
@@ -93,11 +93,13 @@ public class SolverResourceApi {
    * Retrieve finite volume input from SBML spatial model.
    * 
    * @param sbmlFile  (optional)
+   * @param duration  (optional, default to 5.0)
+   * @param outputTimeStep  (optional, default to 0.1)
    * @return File
    * @throws ApiException if fails to make API call
    */
-  public File getFVSolverInput(File sbmlFile) throws ApiException {
-    ApiResponse<File> localVarResponse = getFVSolverInputWithHttpInfo(sbmlFile);
+  public File getFVSolverInputFromSBML(File sbmlFile, Double duration, Double outputTimeStep) throws ApiException {
+    ApiResponse<File> localVarResponse = getFVSolverInputFromSBMLWithHttpInfo(sbmlFile, duration, outputTimeStep);
     return localVarResponse.getData();
   }
 
@@ -105,11 +107,13 @@ public class SolverResourceApi {
    * Retrieve finite volume input from SBML spatial model.
    * 
    * @param sbmlFile  (optional)
+   * @param duration  (optional, default to 5.0)
+   * @param outputTimeStep  (optional, default to 0.1)
    * @return ApiResponse&lt;File&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<File> getFVSolverInputWithHttpInfo(File sbmlFile) throws ApiException {
-    HttpRequest.Builder localVarRequestBuilder = getFVSolverInputRequestBuilder(sbmlFile);
+  public ApiResponse<File> getFVSolverInputFromSBMLWithHttpInfo(File sbmlFile, Double duration, Double outputTimeStep) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = getFVSolverInputFromSBMLRequestBuilder(sbmlFile, duration, outputTimeStep);
     try {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
@@ -119,16 +123,16 @@ public class SolverResourceApi {
       }
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
-          throw getApiException("getFVSolverInput", localVarResponse);
+          throw getApiException("getFVSolverInputFromSBML", localVarResponse);
         }
-          InputStream inputStream = localVarResponse.body();
-          File file = File.createTempFile("finite-volume-input-" + RandomStringUtils.randomAlphabetic(10), ".tmp");
-          FileUtils.copyInputStreamToFile(inputStream, file);
-          return new ApiResponse<File>(
-                  localVarResponse.statusCode(),
-                  localVarResponse.headers().map(),
-                  localVarResponse.body() == null ? null : file // closes the InputStream
-          );
+        InputStream inputStream = localVarResponse.body();
+        File file = File.createTempFile("finite-volume-input-" + RandomStringUtils.randomAlphabetic(10), ".tmp");
+        FileUtils.copyInputStreamToFile(inputStream, file);
+        return new ApiResponse<File>(
+          localVarResponse.statusCode(),
+          localVarResponse.headers().map(),
+          localVarResponse.body() == null ? null : file // closes the InputStream
+        );
       } finally {
       }
     } catch (IOException e) {
@@ -140,7 +144,7 @@ public class SolverResourceApi {
     }
   }
 
-  private HttpRequest.Builder getFVSolverInputRequestBuilder(File sbmlFile) throws ApiException {
+  private HttpRequest.Builder getFVSolverInputFromSBMLRequestBuilder(File sbmlFile, Double duration, Double outputTimeStep) throws ApiException {
 
     HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
@@ -154,6 +158,114 @@ public class SolverResourceApi {
     boolean hasFiles = false;
     multiPartBuilder.addBinaryBody("sbmlFile", sbmlFile);
     hasFiles = true;
+    multiPartBuilder.addTextBody("duration", duration.toString());
+    multiPartBuilder.addTextBody("output_time_step", outputTimeStep.toString());
+    HttpEntity entity = multiPartBuilder.build();
+    HttpRequest.BodyPublisher formDataPublisher;
+    if (hasFiles) {
+        Pipe pipe;
+        try {
+            pipe = Pipe.open();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        new Thread(() -> {
+            try (OutputStream outputStream = Channels.newOutputStream(pipe.sink())) {
+                entity.writeTo(outputStream);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).start();
+        formDataPublisher = HttpRequest.BodyPublishers.ofInputStream(() -> Channels.newInputStream(pipe.source()));
+    } else {
+        ByteArrayOutputStream formOutputStream = new ByteArrayOutputStream();
+        try {
+            entity.writeTo(formOutputStream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        formDataPublisher = HttpRequest.BodyPublishers
+            .ofInputStream(() -> new ByteArrayInputStream(formOutputStream.toByteArray()));
+    }
+    localVarRequestBuilder
+        .header("Content-Type", entity.getContentType().getValue())
+        .method("POST", formDataPublisher);
+    if (memberVarReadTimeout != null) {
+      localVarRequestBuilder.timeout(memberVarReadTimeout);
+    }
+    if (memberVarInterceptor != null) {
+      memberVarInterceptor.accept(localVarRequestBuilder);
+    }
+    return localVarRequestBuilder;
+  }
+  /**
+   * Retrieve finite volume input from SBML spatial model.
+   * 
+   * @param vcmlFile  (optional)
+   * @param simulationName  (optional)
+   * @return File
+   * @throws ApiException if fails to make API call
+   */
+  public File getFVSolverInputFromVCML(File vcmlFile, String simulationName) throws ApiException {
+    ApiResponse<File> localVarResponse = getFVSolverInputFromVCMLWithHttpInfo(vcmlFile, simulationName);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Retrieve finite volume input from SBML spatial model.
+   * 
+   * @param vcmlFile  (optional)
+   * @param simulationName  (optional)
+   * @return ApiResponse&lt;File&gt;
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<File> getFVSolverInputFromVCMLWithHttpInfo(File vcmlFile, String simulationName) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = getFVSolverInputFromVCMLRequestBuilder(vcmlFile, simulationName);
+    try {
+      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+          localVarRequestBuilder.build(),
+          HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }
+      try {
+        if (localVarResponse.statusCode()/ 100 != 2) {
+          throw getApiException("getFVSolverInputFromVCML", localVarResponse);
+        }
+        InputStream inputStream = localVarResponse.body();
+        File file = File.createTempFile("finite-volume-input-" + RandomStringUtils.randomAlphabetic(10), ".tmp");
+        FileUtils.copyInputStreamToFile(inputStream, file);
+        return new ApiResponse<File>(
+          localVarResponse.statusCode(),
+          localVarResponse.headers().map(),
+          localVarResponse.body() == null ? null : file // closes the InputStream
+        );
+      } finally {
+      }
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ApiException(e);
+    }
+  }
+
+  private HttpRequest.Builder getFVSolverInputFromVCMLRequestBuilder(File vcmlFile, String simulationName) throws ApiException {
+
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
+    String localVarPath = "/api/v1/solver/getFVSolverInputFromVCML";
+
+    localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
+
+    localVarRequestBuilder.header("Accept", "application/octet-stream");
+
+    MultipartEntityBuilder multiPartBuilder = MultipartEntityBuilder.create();
+    boolean hasFiles = false;
+    multiPartBuilder.addBinaryBody("vcmlFile", vcmlFile);
+    hasFiles = true;
+    multiPartBuilder.addTextBody("simulation_name", simulationName.toString());
     HttpEntity entity = multiPartBuilder.build();
     HttpRequest.BodyPublisher formDataPublisher;
     if (hasFiles) {

--- a/vcell-restclient/src/test/java/org/vcell/restclient/api/SolverResourceApiTest.java
+++ b/vcell-restclient/src/test/java/org/vcell/restclient/api/SolverResourceApiTest.java
@@ -46,7 +46,7 @@ public class SolverResourceApiTest {
     public void getFVSolverInputTest() throws ApiException {
         File sbmlFile = null;
         File response = 
-        api.getFVSolverInput(sbmlFile);
+        api.getFVSolverInputFromSBML(sbmlFile, 5.0, 0.1);
         
         // TODO: test validations
     }

--- a/webapp-ng/src/app/core/modules/openapi/api/solver-resource.service.ts
+++ b/webapp-ng/src/app/core/modules/openapi/api/solver-resource.service.ts
@@ -108,13 +108,15 @@ export class SolverResourceService implements SolverResourceServiceInterface {
     /**
      * Retrieve finite volume input from SBML spatial model.
      * @param sbmlFile 
+     * @param duration 
+     * @param outputTimeStep 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getFVSolverInput(sbmlFile?: Blob, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<Blob>;
-    public getFVSolverInput(sbmlFile?: Blob, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<HttpResponse<Blob>>;
-    public getFVSolverInput(sbmlFile?: Blob, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<HttpEvent<Blob>>;
-    public getFVSolverInput(sbmlFile?: Blob, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<any> {
+    public getFVSolverInputFromSBML(sbmlFile?: Blob, duration?: number, outputTimeStep?: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<Blob>;
+    public getFVSolverInputFromSBML(sbmlFile?: Blob, duration?: number, outputTimeStep?: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<HttpResponse<Blob>>;
+    public getFVSolverInputFromSBML(sbmlFile?: Blob, duration?: number, outputTimeStep?: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<HttpEvent<Blob>>;
+    public getFVSolverInputFromSBML(sbmlFile?: Blob, duration?: number, outputTimeStep?: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<any> {
 
         let localVarHeaders = this.defaultHeaders;
 
@@ -157,8 +159,85 @@ export class SolverResourceService implements SolverResourceServiceInterface {
         if (sbmlFile !== undefined) {
             localVarFormParams = localVarFormParams.append('sbmlFile', <any>sbmlFile) as any || localVarFormParams;
         }
+        if (duration !== undefined) {
+            localVarFormParams = localVarFormParams.append('duration', <any>duration) as any || localVarFormParams;
+        }
+        if (outputTimeStep !== undefined) {
+            localVarFormParams = localVarFormParams.append('output_time_step', <any>outputTimeStep) as any || localVarFormParams;
+        }
 
         let localVarPath = `/api/v1/solver/getFVSolverInput`;
+        return this.httpClient.request('post', `${this.configuration.basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+                responseType: "blob",
+                withCredentials: this.configuration.withCredentials,
+                headers: localVarHeaders,
+                observe: observe,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * Retrieve finite volume input from SBML spatial model.
+     * @param vcmlFile 
+     * @param simulationName 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public getFVSolverInputFromVCML(vcmlFile?: Blob, simulationName?: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<Blob>;
+    public getFVSolverInputFromVCML(vcmlFile?: Blob, simulationName?: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<HttpResponse<Blob>>;
+    public getFVSolverInputFromVCML(vcmlFile?: Blob, simulationName?: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<HttpEvent<Blob>>;
+    public getFVSolverInputFromVCML(vcmlFile?: Blob, simulationName?: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/octet-stream', context?: HttpContext}): Observable<any> {
+
+        let localVarHeaders = this.defaultHeaders;
+
+        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+        if (localVarHttpHeaderAcceptSelected === undefined) {
+            // to determine the Accept header
+            const httpHeaderAccepts: string[] = [
+                'application/octet-stream'
+            ];
+            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        }
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        let localVarHttpContext: HttpContext | undefined = options && options.context;
+        if (localVarHttpContext === undefined) {
+            localVarHttpContext = new HttpContext();
+        }
+
+        // to determine the Content-Type header
+        const consumes: string[] = [
+            'multipart/form-data'
+        ];
+
+        const canConsumeForm = this.canConsumeForm(consumes);
+
+        let localVarFormParams: { append(param: string, value: any): any; };
+        let localVarUseForm = false;
+        let localVarConvertFormParamsToString = false;
+        // use FormData to transmit files using content-type "multipart/form-data"
+        // see https://stackoverflow.com/questions/4007969/application-x-www-form-urlencoded-or-multipart-form-data
+        localVarUseForm = canConsumeForm;
+        if (localVarUseForm) {
+            localVarFormParams = new FormData();
+        } else {
+            localVarFormParams = new HttpParams({encoder: this.encoder});
+        }
+
+        if (vcmlFile !== undefined) {
+            localVarFormParams = localVarFormParams.append('vcmlFile', <any>vcmlFile) as any || localVarFormParams;
+        }
+        if (simulationName !== undefined) {
+            localVarFormParams = localVarFormParams.append('simulation_name', <any>simulationName) as any || localVarFormParams;
+        }
+
+        let localVarPath = `/api/v1/solver/getFVSolverInputFromVCML`;
         return this.httpClient.request('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,

--- a/webapp-ng/src/app/core/modules/openapi/api/solver-resource.serviceInterface.ts
+++ b/webapp-ng/src/app/core/modules/openapi/api/solver-resource.serviceInterface.ts
@@ -27,7 +27,17 @@ export interface SolverResourceServiceInterface {
      * Retrieve finite volume input from SBML spatial model.
      * 
      * @param sbmlFile 
+     * @param duration 
+     * @param outputTimeStep 
      */
-    getFVSolverInput(sbmlFile?: Blob, extraHttpRequestParams?: any): Observable<Blob>;
+    getFVSolverInputFromSBML(sbmlFile?: Blob, duration?: number, outputTimeStep?: number, extraHttpRequestParams?: any): Observable<Blob>;
+
+    /**
+     * Retrieve finite volume input from SBML spatial model.
+     * 
+     * @param vcmlFile 
+     * @param simulationName 
+     */
+    getFVSolverInputFromVCML(vcmlFile?: Blob, simulationName?: string, extraHttpRequestParams?: any): Observable<Blob>;
 
 }


### PR DESCRIPTION
There is now 2 endpoints to generate FiniteVolume input files:
1. added `/api/v1/solver/getFVSolverInputFromVCML` endpoint (which accepts a VCML file and a spatial simulation)

2. extended the existing endpoint `/api/v1/solver/getFVSolverInput` (which accepts SBML Spatial) to add parameters for duration and output time interval).