### PR TITLE
NullPointerException in TreeMap because of concurrent modification

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/MathSymbolMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/MathSymbolMapping.java
@@ -165,7 +165,8 @@ public class MathSymbolMapping implements SourceSymbolMapping {
                     }
                 }
             }
-            entry.setValue(origStes.toArray(new SymbolTableEntry[0]));
+            // ConcurrentSkipListMap.Entry does not implement setValue(), must use put() instead
+            mathToBiologicalHash.put(key, origStes.toArray(new SymbolTableEntry[0]));
         }
     }
 

--- a/vcell-core/src/main/java/cbit/vcell/mapping/MathSymbolMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/MathSymbolMapping.java
@@ -11,6 +11,7 @@
 package cbit.vcell.mapping;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import cbit.vcell.math.*;
 import org.vcell.util.ArrayUtils;
@@ -28,9 +29,9 @@ import cbit.vcell.parser.SymbolTableEntry;
  * @author: Jim Schaff
  */
 public class MathSymbolMapping implements SourceSymbolMapping {
-    private TreeMap<SymbolTableEntry, String> biologicalToMathSymbolNameHash = new TreeMap<SymbolTableEntry, String>();
-    private TreeMap<SymbolTableEntry, Variable> biologicalToMathHash = new TreeMap<SymbolTableEntry, Variable>();
-    private TreeMap<Variable, SymbolTableEntry[]> mathToBiologicalHash = new TreeMap<Variable, SymbolTableEntry[]>();
+    private Map<SymbolTableEntry, String> biologicalToMathSymbolNameHash = new ConcurrentSkipListMap<>();
+    private Map<SymbolTableEntry, Variable> biologicalToMathHash = new ConcurrentSkipListMap<>();
+    private Map<Variable, SymbolTableEntry[]> mathToBiologicalHash = new ConcurrentSkipListMap<>();
 
     /**
      * MathSymbolMapping constructor comment.


### PR DESCRIPTION
NullPointerException in TreeMap because of concurrent modification
Replace use of TreeMap with ConcurrentSkipListMap which is thread safe