### PR TITLE
Changes to VCell to support migration to new Slurm cluster

### DIFF
--- a/docker/build/Dockerfile-sched-dev
+++ b/docker/build/Dockerfile-sched-dev
@@ -68,6 +68,7 @@ ENV softwareVersion=SOFTWARE-VERSION-NOT-SET \
 	maxOdeJobsPerUser="max-ode-jobs-per-user-not-set" \
 	vcell_ssh_cmd_cmdtimeout="cmdSrvcSshCmdTimeoutMS-not-set" \
     vcell_ssh_cmd_restoretimeout="cmdSrvcSshCmdRestoreTimeoutFactor-not-set" \
+    vcell_ssh_cmd_options_csv="cmdSrvcSshCmdRestoreOptionsCsv-not-set" \
 	maxPdeJobsPerUser="max-pde-jobs-per-user-not-set" \
 	htcMinMemoryMB="htc-min-memory-not-set" \
 	htcMaxMemoryMB="htc-max-memory-not-set" \
@@ -123,6 +124,7 @@ ENTRYPOINT java \
 	-Dvcell.server.maxPdeJobsPerUser=${maxPdeJobsPerUser} \
 	-Dvcell.ssh.cmd.cmdtimeout=${vcell_ssh_cmd_cmdtimeout} \
 	-Dvcell.ssh.cmd.restoretimeout=${vcell_ssh_cmd_restoretimeout} \
+	-Dvcell.ssh.cmd.options.csv=${vcell_ssh_cmd_options_csv}
 	-Dvcell.htc.memory.min.mb=${htcMinMemoryMB} \
 	-Dvcell.htc.memory.max.mb=${htcMaxMemoryMB} \
 	-Dvcell.htc.memory.pu.floor.mb=${htcPowerUserMemoryFloorMB} \

--- a/docker/build/Dockerfile-sched-dev
+++ b/docker/build/Dockerfile-sched-dev
@@ -124,7 +124,7 @@ ENTRYPOINT java \
 	-Dvcell.server.maxPdeJobsPerUser=${maxPdeJobsPerUser} \
 	-Dvcell.ssh.cmd.cmdtimeout=${vcell_ssh_cmd_cmdtimeout} \
 	-Dvcell.ssh.cmd.restoretimeout=${vcell_ssh_cmd_restoretimeout} \
-	-Dvcell.ssh.cmd.options.csv=${vcell_ssh_cmd_options_csv}
+	-Dvcell.ssh.cmd.options.csv=${vcell_ssh_cmd_options_csv} \
 	-Dvcell.htc.memory.min.mb=${htcMinMemoryMB} \
 	-Dvcell.htc.memory.max.mb=${htcMaxMemoryMB} \
 	-Dvcell.htc.memory.pu.floor.mb=${htcPowerUserMemoryFloorMB} \

--- a/docker/build/Dockerfile-submit-dev
+++ b/docker/build/Dockerfile-submit-dev
@@ -90,6 +90,7 @@ ENV softwareVersion=SOFTWARE-VERSION-NOT-SET \
     jmsblob_minsize=100000 \
     vcell_ssh_cmd_cmdtimeout="cmdSrvcSshCmdTimeoutMS-not-set" \
     vcell_ssh_cmd_restoretimeout="cmdSrvcSshCmdRestoreTimeoutFactor-not-set" \
+    vcell_ssh_cmd_options_csv="cmdSrvcSshCmdRestoreOptionsCsv-not-set" \
     simdatadir_archive_external="simdatadir_archive_external-not-set" \
     simdatadir_archive_internal="simdatadir_archive_internal-not-set" \
     htcMinMemoryMB="htc-min-memory-not-set" \
@@ -174,6 +175,7 @@ ENTRYPOINT java \
 	-Dvcell.simdatadir.archive.external=${simdatadir_archive_external} \
 	-Dvcell.ssh.cmd.cmdtimeout=${vcell_ssh_cmd_cmdtimeout} \
 	-Dvcell.ssh.cmd.restoretimeout=${vcell_ssh_cmd_restoretimeout} \
+	-Dvcell.ssh.cmd.options.csv=${vcell_ssh_cmd_options_csv} \
 	-Dvcell.htc.memory.min.mb=${htcMinMemoryMB} \
     -Dvcell.htc.memory.max.mb=${htcMaxMemoryMB} \
     -Dvcell.htc.memory.pu.floor.mb=${htcPowerUserMemoryFloorMB} \

--- a/vcell-core/src/main/java/cbit/vcell/resource/PropertyLoader.java
+++ b/vcell-core/src/main/java/cbit/vcell/resource/PropertyLoader.java
@@ -280,6 +280,9 @@ public class PropertyLoader {
 	public static final String imageJVcellPluginURL = record("vcell.imagej.plugin.url", ValueType.GEN);
 	public static final String cmdSrvcSshCmdTimeoutMS = record("vcell.ssh.cmd.cmdtimeout", ValueType.GEN);
 	public static final String cmdSrvcSshCmdRestoreTimeoutFactor = record("vcell.ssh.cmd.restoretimeout", ValueType.GEN);
+	public static final String cmdSrvcSshCmdOptionsCSV = record("vcell.ssh.cmd.options.csv", ValueType.GEN);
+	public static final String cmdSrvcSshCmdOptionsCSV_default =
+			"StrictHostKeyChecking=No,ControlMaster=auto,ControlPath=~/.ssh/%r@%h:%p,ControlPersist=1m";
 	
 	public static final String cliWorkingDir = record("cli.workingDir", ValueType.DIR);
 	public static final String vtkPythonDir = record("vcell.vtk.pythonDir", ValueType.DIR);


### PR DESCRIPTION
- make ssh cmd options configurable via properties from K8s config (ControlPath option needed tweaking)
  -  K8s ConfigMaps and Dockerfiles use env var `vcell_ssh_cmd_options_csv`
  - Java code uses property `vcell.ssh.cmd.options.csv` 
  - default value: `StrictHostKeyChecking=No,ControlMaster=auto,ControlPath=~/.ssh/%r@%h:%p,ControlPersist=1m`
  - corresponding ssh option syntax: `-o StrictHostKeyChecking=No -o ControlMaster=auto -o ControlPath=~/.ssh/%r@%h:%p -o ControlPersist=1m`