### PR TITLE
Use Exsiting VCell Connection for Parmater Estimation Request

### DIFF
--- a/vcell-apiclient/src/main/java/org/vcell/api/client/VCellApiClient.java
+++ b/vcell-apiclient/src/main/java/org/vcell/api/client/VCellApiClient.java
@@ -363,22 +363,6 @@ public class VCellApiClient implements AutoCloseable {
 						message = reader.lines().collect(Collectors.joining());
 					}
 					return message;
-//					HttpEntity entity = response.getEntity();
-//					if (lg.isInfoEnabled()) {
-//						try (BufferedReader reader = new BufferedReader(new InputStreamReader(entity.getContent()));){
-//							lg.info("optimizationId = "+reader.readLine());
-//						}
-//					}
-//			        final Header locationHeader = response.getFirstHeader("location");
-//			        if (locationHeader == null) {
-//			            // got a redirect response, but no location header
-//			            throw new ClientProtocolException(
-//			                    "Received redirect response " + response.getStatusLine()
-//			                    + " but no location header");
-//			        }
-//			        final String location = locationHeader.getValue();
-//			        URI uri = createLocationURI(location);
-//					return uri.toString();
 				} else {
 					HttpEntity entity = response.getEntity();
 					String message = null;
@@ -398,8 +382,6 @@ public class VCellApiClient implements AutoCloseable {
 		}
 
 		return responseUri;
-//		String optimizationId = responseUri.substring(responseUri.lastIndexOf('/') + 1);
-//		return optimizationId;
 	}
 	
 	/**

--- a/vcell-client/src/main/java/cbit/vcell/client/VCellClient.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/VCellClient.java
@@ -21,6 +21,7 @@ import cbit.vcell.mathmodel.MathModel;
 import cbit.vcell.server.VCellConnectionFactory;
 import com.google.inject.Inject;
 import com.install4j.api.launcher.ApplicationLauncher;
+import org.vcell.api.client.VCellApiClient;
 import org.vcell.api.messaging.RemoteProxyVCellConnectionFactory;
 import org.vcell.api.server.ClientServerManager;
 import org.vcell.api.server.ClientServerManager.InteractiveContextDefaultProvider;
@@ -141,6 +142,13 @@ public MDIManager getMdiManager() {
 
 public RequestManager getRequestManager() {
 	return requestManager;
+}
+
+public VCellApiClient getVCellApiClient(){
+	if (vcellConnectionFactory instanceof RemoteProxyVCellConnectionFactory){
+		return ((RemoteProxyVCellConnectionFactory) vcellConnectionFactory).getVCellApiClient();
+	}
+	throw new RuntimeException("Can not get VCell Api Client unless Remote Connection Factory is being used.");
 }
 
 

--- a/vcell-client/src/main/java/copasi/CopasiOptimizationSolverRemote.java
+++ b/vcell-client/src/main/java/copasi/CopasiOptimizationSolverRemote.java
@@ -1,5 +1,6 @@
 package copasi;
 
+import cbit.vcell.client.VCellClient;
 import cbit.vcell.client.server.ClientServerInfo;
 import cbit.vcell.modelopt.ParameterEstimationTask;
 import cbit.vcell.opt.OptimizationException;
@@ -30,15 +31,8 @@ public class CopasiOptimizationSolverRemote {
         // return solveLocalPython(parameterEstimationTask);
 
         try {
-            boolean bIgnoreCertProblems = PropertyLoader.getBooleanProperty(PropertyLoader.sslIgnoreCertProblems, false);
-            boolean bIgnoreHostMismatch = PropertyLoader.getBooleanProperty(PropertyLoader.sslIgnoreHostMismatch, false);
-
-            String host = clientServerInfo.getApihost();
-            int port = clientServerInfo.getApiport();
-            String pathPrefixV0 = clientServerInfo.getPathPrefix_v0();
             // e.g. vcell.serverhost=vcellapi.cam.uchc.edu:443
-            VCellApiClient apiClient = new VCellApiClient(host, port, pathPrefixV0, bIgnoreCertProblems, bIgnoreHostMismatch);
-            apiClient.authenticate(bIgnoreCertProblems);
+            VCellApiClient apiClient = VCellClient.getInstance().getVCellApiClient();
 
             OptProblem optProblem = CopasiUtils.paramTaskToOptProblem(parameterEstimationTask);
 


### PR DESCRIPTION
Instead of creating a request for every estimation the user does, utilize the existing connection to skip re-authentication.