### PR TITLE
Field data hot fix

### DIFF
--- a/python-restclient/docs/User.md
+++ b/python-restclient/docs/User.md
@@ -6,8 +6,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **user_name** | **str** |  | [optional] 
 **key** | [**KeyValue**](KeyValue.md) |  | [optional] 
-**name** | **str** |  | [optional] 
-**test_account** | **bool** |  | [optional] 
 
 ## Example
 

--- a/python-restclient/vcell_client/models/user.py
+++ b/python-restclient/vcell_client/models/user.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Any, ClassVar, Dict, List, Optional
-from pydantic import BaseModel, StrictBool, StrictStr
+from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from vcell_client.models.key_value import KeyValue
 try:
@@ -34,9 +34,7 @@ class User(BaseModel):
     """ # noqa: E501
     user_name: Optional[StrictStr] = Field(default=None, alias="userName")
     key: Optional[KeyValue] = None
-    name: Optional[StrictStr] = None
-    test_account: Optional[StrictBool] = Field(default=None, alias="testAccount")
-    __properties: ClassVar[List[str]] = ["userName", "key", "name", "testAccount"]
+    __properties: ClassVar[List[str]] = ["userName", "key"]
 
     model_config = {
         "populate_by_name": True,
@@ -95,9 +93,7 @@ class User(BaseModel):
 
         _obj = cls.model_validate({
             "userName": obj.get("userName"),
-            "key": KeyValue.from_dict(obj.get("key")) if obj.get("key") is not None else None,
-            "name": obj.get("name"),
-            "testAccount": obj.get("testAccount")
+            "key": KeyValue.from_dict(obj.get("key")) if obj.get("key") is not None else None
         })
         return _obj
 

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -1382,10 +1382,6 @@ components:
           type: string
         key:
           $ref: '#/components/schemas/KeyValue'
-        name:
-          type: string
-        testAccount:
-          type: boolean
     UserIdentityJSONSafe:
       type: object
       properties:

--- a/vcell-client/src/main/java/cbit/vcell/field/gui/FieldDataGUIPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/field/gui/FieldDataGUIPanel.java
@@ -54,7 +54,7 @@ public class FieldDataGUIPanel extends JPanel {
 
     private static final String FIELD_DATA_INFO = "Field Data Info";
     public static final String FIELD_NAME = "fieldName";
-    public static final String USER_DEFINED_FDOS = "userDefinedFDOS";
+    public static final String HASHTABLE_FDOS = "fdos";
 
     private final JPopupMenu jPopupMenu = new JPopupMenu();
     private static final int COPY_CSV = 0;
@@ -689,7 +689,7 @@ public class FieldDataGUIPanel extends JPanel {
                 }
 
                 imagesMetaDataOpSpec.owner = clientRequestManager.getDocumentManager().getUser();
-                hashTable.put("fdos", imagesMetaDataOpSpec);
+                hashTable.put(HASHTABLE_FDOS, imagesMetaDataOpSpec);
                 hashTable.put("file", imageFile);
                 hashTable.put("initFDName", imageFile.getName());
             }
@@ -1029,7 +1029,7 @@ public class FieldDataGUIPanel extends JPanel {
             @Override
             public void run(Hashtable<String, Object> hashTable) throws Exception {
                 //Allow user to review/change info about fielddata
-                FieldDataSpec generatedFieldDataOpSpec = (FieldDataSpec) hashTable.get("fdos");
+                FieldDataSpec generatedFieldDataOpSpec = (FieldDataSpec) hashTable.get(HASHTABLE_FDOS);
                 FieldDataSpec userDefinedFDOS = new FieldDataSpec();
                 String initialExtDataName = (String) hashTable.get("initFDName");
 
@@ -1080,7 +1080,7 @@ public class FieldDataGUIPanel extends JPanel {
                             generatedFieldDataOpSpec.times = userDefinedFDOS.times;
                         }
                         generatedFieldDataOpSpec.annotation = userDefinedFDOS.annotation;
-                        hashTable.put(USER_DEFINED_FDOS, userDefinedFDOS);
+                        hashTable.put(HASHTABLE_FDOS, generatedFieldDataOpSpec);
                         hashTable.put(FIELD_NAME, fieldDataInfoPanel.getFieldName());
                         break;
                     } else {
@@ -1097,7 +1097,7 @@ public class FieldDataGUIPanel extends JPanel {
                 //save Database
                 String fieldName = (String) hashTable.get(FIELD_NAME);
                 FieldDataSpec fieldDataSpec
-                        = (FieldDataSpec) hashTable.get("fdos");
+                        = (FieldDataSpec) hashTable.get(HASHTABLE_FDOS);
                 DocumentManager documentManager = clientRequestManager.getDocumentManager();
                 fieldDataSpec.fileName = fieldName;
                 try {
@@ -1114,7 +1114,7 @@ public class FieldDataGUIPanel extends JPanel {
         AsynchClientTask task3 = new AsynchClientTask("refreshing field data", AsynchClientTask.TASKTYPE_SWING_BLOCKING) {
             @Override
             public void run(Hashtable<String, Object> hashTable) throws Exception {
-                FieldDataSpec fieldDataSpec = (FieldDataSpec) hashTable.get("fdos");
+                FieldDataSpec fieldDataSpec = (FieldDataSpec) hashTable.get(HASHTABLE_FDOS);
                 ExternalDataIdentifier resultEDI = (ExternalDataIdentifier) hashTable.get("result_edi");
                 DefaultMutableTreeNode root = ((DefaultMutableTreeNode) fieldDataGUIPanel.getFieldDataTree().getModel().getRoot());
                 if (root.getChildCount() == 0) {

--- a/vcell-core/src/main/java/cbit/vcell/field/FieldDataFileConversion.java
+++ b/vcell-core/src/main/java/cbit/vcell/field/FieldDataFileConversion.java
@@ -137,6 +137,7 @@ public class FieldDataFileConversion {
                 : new Origin(0, 0, 0));
         spec.extent = (domainInfo.getExtent() != null) ? (domainInfo.getExtent()) : (new Extent(1, 1, 1));
         spec.iSize = domainInfo.getiSize();
+        spec.file = imageFile;
 
         return spec;
     }

--- a/vcell-core/src/main/java/org/vcell/util/document/User.java
+++ b/vcell-core/src/main/java/org/vcell/util/document/User.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.vcell.util.Immutable;
 import org.vcell.util.Matchable;
 
@@ -47,9 +48,14 @@ public class User implements java.io.Serializable, Matchable, Immutable {
 		public String toDatabaseString(){
 			return name();
 		}
-	};//Must match a name 'special' column of 'vc_specialusers' table
+	};//Must match a name 'special' column of 'vc_specialusers'// table
+
+	@JsonProperty
 	private String userName = null;
+	@JsonProperty
 	private KeyValue key = null;
+
+
 	public static final String VCellTestAccountName = "vcelltestaccount";
 
 	public static final User tempUser = new User("temp",new KeyValue("123"));
@@ -157,6 +163,7 @@ public KeyValue getID() {
  * This method was created in VisualAge.
  * @return java.lang.String
  */
+@JsonIgnore
 public String getName() {
 	return userName;
 }
@@ -175,6 +182,7 @@ public int hashCode() {
 /**
  * @return true if this is test account
  */
+@JsonIgnore
 public boolean isTestAccount() {
 	return isTestAccount(getName( ));
 }
@@ -183,6 +191,7 @@ public boolean isTestAccount() {
  * @param accountName non null
  * @return true if accountName is test account
  */
+@JsonIgnore
 public static boolean isTestAccount(String accountName) {
 	return accountName.equals(VCellTestAccountName);
 }

--- a/vcell-rest/src/main/java/org/vcell/restq/handlers/FieldData/FieldDataDB.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/handlers/FieldData/FieldDataDB.java
@@ -259,8 +259,13 @@ public class FieldDataDB {
         FieldDataExternalDataIDEntry entry = new FieldDataExternalDataIDEntry(user, newFieldDataName, "");
         ExternalDataIdentifier edi = databaseServer.saveFieldDataEDI(entry);
 
-        // Save new file with reference to DB entry
-        dataSetController.fieldDataCopySim(simKeyValue, simInfo.getOwner(), edi, jobIndex, user);
+        try{
+            // Save new file with reference to DB entry
+            dataSetController.fieldDataCopySim(simKeyValue, simInfo.getOwner(), edi, jobIndex, user);
+        } catch (RuntimeException e){
+            databaseServer.deleteFieldDataID(user, edi);
+            throw e;
+        }
     }
 
     public void deleteFieldData(ExternalDataIdentifier edi) throws DataAccessException {

--- a/vcell-rest/src/main/java/org/vcell/restq/handlers/FieldData/FieldDataDB.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/handlers/FieldData/FieldDataDB.java
@@ -43,15 +43,15 @@ import java.util.zip.DataFormatException;
 public class FieldDataDB {
     private static final Logger logger = LogManager.getLogger(FieldDataDB.class);
 
-    private final DatabaseServerImpl databaseServer;
-    private final DataSetControllerImpl dataSetController;
+    private final DatabaseServerImpl databaseServerImpl;
+    private final DataSetControllerImpl dataSetControllerImpl;
 
     @Inject
     public FieldDataDB(AgroalConnectionFactory agroalConnectionFactory) throws DataAccessException, FileNotFoundException {
-        databaseServer = new DatabaseServerImpl(agroalConnectionFactory, agroalConnectionFactory.getKeyFactory());
+        databaseServerImpl = new DatabaseServerImpl(agroalConnectionFactory, agroalConnectionFactory.getKeyFactory());
         String primarySimDataDir = PropertyLoader.getProperty(PropertyLoader.primarySimDataDirInternalProperty, "/simdata");
         String secondarySimDataDir = PropertyLoader.getProperty(PropertyLoader.secondarySimDataDirInternalProperty, "/simdata");
-        dataSetController = new DataSetControllerImpl(null,
+        dataSetControllerImpl = new DataSetControllerImpl(null,
                 new File(primarySimDataDir),
                 new File(secondarySimDataDir));
     }
@@ -68,11 +68,11 @@ public class FieldDataDB {
         // If the requester does not have access to the Model an exception should be thrown to stop this function
         ArrayList<SimulationOwner> modelsListOfContext = new ArrayList<>();
         if(documentType.equalsIgnoreCase(VersionableType.MathModelMetaData.getTypeName())){
-            BigString mathModelXML = databaseServer.getMathModelXML(requester, documentKey);
+            BigString mathModelXML = databaseServerImpl.getMathModelXML(requester, documentKey);
             vcDocument = XmlHelper.XMLToMathModel(new XMLSource(mathModelXML.toString()));
             modelsListOfContext.add(((MathModel)vcDocument));
         }else if(documentType.equalsIgnoreCase(VersionableType.BioModelMetaData.getTypeName())){
-            BigString bioModelXML = databaseServer.getBioModelXML(requester, documentKey);
+            BigString bioModelXML = databaseServerImpl.getBioModelXML(requester, documentKey);
             vcDocument = XmlHelper.XMLToBioModel(new XMLSource(bioModelXML.toString()));
             SimulationContext[] contexts = ((BioModel)vcDocument).getSimulationContexts();
             modelsListOfContext.addAll(Arrays.asList(contexts));
@@ -101,7 +101,7 @@ public class FieldDataDB {
         }
 
         // Find which ID's are appropriate
-        FieldDataAllDBEntries allIDs = databaseServer.getFieldDataIDs(ogOwner);
+        FieldDataAllDBEntries allIDs = databaseServerImpl.getFieldDataIDs(ogOwner);
         ArrayList<ExternalDataIdentifier> edis = new ArrayList<>();
         ArrayList<String> annotations = new ArrayList<>();
         for (int i = 0; i < allIDs.ids.length; i++){
@@ -127,10 +127,10 @@ public class FieldDataDB {
             // Tie those DB entries to newly created copies of the original field data that the requester owns
             for (int i = 0; i < edis.size(); i++){
                 // Create DB entries where new field data names are created
-                CopyFieldDataResult dbResults = databaseServer.copyFieldData(requester,
+                CopyFieldDataResult dbResults = databaseServerImpl.copyFieldData(requester,
                         edis.get(i), annotations.get(i), documentType, vcDocument.getVersion().getName());
 
-                dataSetController.fieldDataCopySim(dbResults.oldID.getDataKey() ,ogOwner, dbResults.newID, FieldDataSpec.JOBINDEX_DEFAULT, requester);
+                dataSetControllerImpl.fieldDataCopySim(dbResults.oldID.getDataKey() ,ogOwner, dbResults.newID, FieldDataSpec.JOBINDEX_DEFAULT, requester);
 
                 oldNameNewID.put(edis.get(i).getName(), dbResults.newID);
             }
@@ -150,7 +150,7 @@ public class FieldDataDB {
     }
 
     public ArrayList<FieldDataResource.FieldDataReference> getAllFieldDataIDs(User user) throws SQLException, DataAccessException {
-        FieldDataAllDBEntries results = databaseServer.getFieldDataIDs(user);
+        FieldDataAllDBEntries results = databaseServerImpl.getFieldDataIDs(user);
         ArrayList<FieldDataResource.FieldDataReference> fieldDataReferenceList = new ArrayList<>();
         for (int i =0; i < results.ids.length; i++){
             Vector<KeyValue> simRefs = new Vector<>();
@@ -164,7 +164,7 @@ public class FieldDataDB {
     }
 
     public FieldDataShape getFieldDataShapeFromID(User user, KeyValue keyValue, int jobParameter) throws ObjectNotFoundException {
-        return dataSetController.fieldDataInfo(keyValue, user, jobParameter);
+        return dataSetControllerImpl.fieldDataInfo(keyValue, user, jobParameter);
     }
 
     public FieldDataResource.FieldData analyzeFieldDataFromFile(File imageFile, String fileName) throws DataAccessException, ImageException, DataFormatException {
@@ -197,7 +197,7 @@ public class FieldDataDB {
                                                  String annotation,
                                                  User user) throws DataAccessException {
         // Ensure name is unique for user
-        FieldDataAllDBEntries usersFieldData = databaseServer.getFieldDataIDs(user);
+        FieldDataAllDBEntries usersFieldData = databaseServerImpl.getFieldDataIDs(user);
         Set<String> namesUsed = new HashSet<>();
         for (ExternalDataIdentifier edi : usersFieldData.ids){
             namesUsed.add(edi.getName());
@@ -207,7 +207,7 @@ public class FieldDataDB {
         }
 
         FieldDataExternalDataIDEntry entry = new FieldDataExternalDataIDEntry(user, fieldDataName, annotation);
-        return databaseServer.saveFieldDataEDI(entry);
+        return databaseServerImpl.saveFieldDataEDI(entry);
     }
 
     private void createFieldDataFiles(String[] varNames,
@@ -232,45 +232,42 @@ public class FieldDataDB {
                 new RegionImage(new VCImageUncompressed(null, new byte[iSize.getXYZ()],//empty regions
                         extent, iSize.getX(), iSize.getY(), iSize.getZ()),
                         0, null, null, RegionImage.NO_SMOOTHING));
-        dataSetController.fieldDataAdd(fieldData, newEdi);
+        dataSetControllerImpl.fieldDataAdd(fieldData, newEdi);
     }
 
     public ExternalDataIdentifier saveNewFieldDataFromFile(String fieldDataName, String[] varNames,
                                                                   short[][][] imageData, double[][][] doubleImageData, String annotation,
                                                                   User user, double[] times, Origin origin,
                                                                   Extent extent, ISize iSize) throws DataAccessException, ImageException, DataFormatException, IOException {
-        ExternalDataIdentifier newEdi = null;
+
+        ExternalDataIdentifier newEdi = createDBEntry(fieldDataName, varNames, annotation, user);
         try {
-            newEdi = createDBEntry(fieldDataName, varNames, annotation, user);
             createFieldDataFiles(varNames, imageData, doubleImageData,annotation, user, times, origin, extent, iSize, newEdi);
-            return newEdi;
-        } catch (DataAccessException | ImageException | IOException e) {
-            if (newEdi != null){
-                databaseServer.deleteFieldDataID(user, newEdi); // remove from DB
-                dataSetController.fieldDataDelete(newEdi); // remove from File System
-            }
+        } catch (ImageException | IOException e) {
+            databaseServerImpl.deleteFieldDataID(user, newEdi); // remove from DB
             throw e;
         }
+        return newEdi;
     }
 
     public void saveFieldDataFromSimulation(User user, KeyValue simKeyValue, int jobIndex, String newFieldDataName) throws DataAccessException {
         // Create DB entry
-        SimulationInfo simInfo = databaseServer.getSimulationInfo(user, simKeyValue);
+        SimulationInfo simInfo = databaseServerImpl.getSimulationInfo(user, simKeyValue);
         FieldDataExternalDataIDEntry entry = new FieldDataExternalDataIDEntry(user, newFieldDataName, "");
-        ExternalDataIdentifier edi = databaseServer.saveFieldDataEDI(entry);
+        ExternalDataIdentifier edi = databaseServerImpl.saveFieldDataEDI(entry);
 
         try{
             // Save new file with reference to DB entry
-            dataSetController.fieldDataCopySim(simKeyValue, simInfo.getOwner(), edi, jobIndex, user);
+            dataSetControllerImpl.fieldDataCopySim(simKeyValue, simInfo.getOwner(), edi, jobIndex, user);
         } catch (RuntimeException e){
-            databaseServer.deleteFieldDataID(user, edi);
+            databaseServerImpl.deleteFieldDataID(user, edi);
             throw e;
         }
     }
 
     public void deleteFieldData(ExternalDataIdentifier edi) throws DataAccessException {
-        databaseServer.deleteFieldDataID(edi.getOwner(), edi); // remove from DB
-        dataSetController.fieldDataDelete(edi); // remove from File System
+        databaseServerImpl.deleteFieldDataID(edi.getOwner(), edi); // remove from DB
+        dataSetControllerImpl.fieldDataDelete(edi); // remove from File System
     }
 
 }

--- a/vcell-rest/src/main/java/org/vcell/restq/handlers/FieldData/FieldDataResource.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/handlers/FieldData/FieldDataResource.java
@@ -31,6 +31,7 @@ import org.w3c.www.http.HTTP;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Hashtable;
@@ -129,7 +130,7 @@ public class FieldDataResource {
                     channelNames, fieldData.shortSpecData, annotation,
                     user, times, origin, extent, iSize);
             return new FieldDataSavedResults(edi.getName(), edi.getKey().toString());
-        } catch (ImageException | DataFormatException | DataAccessException e) {
+        } catch (ImageException | IOException | DataFormatException | DataAccessException e) {
             throw new WebApplicationException("Can't create new field data file", e, HTTP.INTERNAL_SERVER_ERROR);
         }
     }
@@ -141,7 +142,7 @@ public class FieldDataResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Operation(operationId = "createFromFile", summary = "Submit a .zip or .tif file that converts into field data, with all defaults derived from the file submitted.")
     public FieldDataSavedResults createFromFileWithDefaults(@RestForm @PartType(MediaType.APPLICATION_OCTET_STREAM) File file,
-                                                            @RestForm String fieldDataName) throws DataAccessException, ImageException, DataFormatException {
+                                                            @RestForm String fieldDataName) throws DataAccessException, ImageException, DataFormatException, IOException {
         User user = userRestDB.getUserFromIdentity(securityIdentity, UserRestDB.UserRequirement.REQUIRE_USER);
         if (!Pattern.matches(allowedFieldDataNamesRegex, fieldDataName) || fieldDataName.length() > 100 || fieldDataName.isEmpty()){
             throw new WebApplicationException("Invalid file name.", HTTP.BAD_REQUEST);
@@ -186,7 +187,7 @@ public class FieldDataResource {
                    saveFieldData.varNames, saveFieldData.shortSpecData, saveFieldData.doubleSpecData, saveFieldData.annotation,
                     user, saveFieldData.times, saveFieldData.origin, saveFieldData.extent, saveFieldData.isize);
             fieldDataSavedResults = new FieldDataSavedResults(edi.getName(), edi.getKey().toString());
-        } catch (ImageException | DataFormatException | DataAccessException e) {
+        } catch (ImageException | IOException | DataFormatException | DataAccessException e) {
             throw new WebApplicationException(e.getMessage(), e, HTTP.INTERNAL_SERVER_ERROR);
         }
         return fieldDataSavedResults;

--- a/vcell-restclient/api/openapi.yaml
+++ b/vcell-restclient/api/openapi.yaml
@@ -1120,8 +1120,6 @@ components:
     ExternalDataIdentifier:
       example:
         owner:
-          testAccount: true
-          name: name
           userName: userName
           key:
             value: 0.8008281904610115
@@ -1234,8 +1232,6 @@ components:
         annotation: annotation
         fieldDataID:
           owner:
-            testAccount: true
-            name: name
             userName: userName
             key:
               value: 0.8008281904610115
@@ -1607,8 +1603,6 @@ components:
             jobNumber: 6
         fieldVCSimID:
           owner:
-            testAccount: true
-            name: name
             userName: userName
             key:
               value: 0.8008281904610115
@@ -1755,8 +1749,6 @@ components:
               jobNumber: 6
           fieldVCSimID:
             owner:
-              testAccount: true
-              name: name
               userName: userName
               key:
                 value: 0.8008281904610115
@@ -1788,8 +1780,6 @@ components:
       type: object
     User:
       example:
-        testAccount: true
-        name: name
         userName: userName
         key:
           value: 0.8008281904610115
@@ -1798,10 +1788,6 @@ components:
           type: string
         key:
           $ref: '#/components/schemas/KeyValue'
-        name:
-          type: string
-        testAccount:
-          type: boolean
       type: object
     UserIdentityJSONSafe:
       example:
@@ -1854,8 +1840,6 @@ components:
     VCSimulationIdentifier:
       example:
         owner:
-          testAccount: true
-          name: name
           userName: userName
           key:
             value: 0.8008281904610115

--- a/vcell-restclient/docs/User.md
+++ b/vcell-restclient/docs/User.md
@@ -9,8 +9,6 @@
 |------------ | ------------- | ------------- | -------------|
 |**userName** | **String** |  |  [optional] |
 |**key** | [**KeyValue**](KeyValue.md) |  |  [optional] |
-|**name** | **String** |  |  [optional] |
-|**testAccount** | **Boolean** |  |  [optional] |
 
 
 

--- a/vcell-restclient/src/main/java/org/vcell/restclient/model/User.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/model/User.java
@@ -34,9 +34,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   User.JSON_PROPERTY_USER_NAME,
-  User.JSON_PROPERTY_KEY,
-  User.JSON_PROPERTY_NAME,
-  User.JSON_PROPERTY_TEST_ACCOUNT
+  User.JSON_PROPERTY_KEY
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class User {
@@ -45,12 +43,6 @@ public class User {
 
   public static final String JSON_PROPERTY_KEY = "key";
   private KeyValue key;
-
-  public static final String JSON_PROPERTY_NAME = "name";
-  private String name;
-
-  public static final String JSON_PROPERTY_TEST_ACCOUNT = "testAccount";
-  private Boolean testAccount;
 
   public User() { 
   }
@@ -105,56 +97,6 @@ public class User {
   }
 
 
-  public User name(String name) {
-    this.name = name;
-    return this;
-  }
-
-   /**
-   * Get name
-   * @return name
-  **/
-  @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public String getName() {
-    return name;
-  }
-
-
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setName(String name) {
-    this.name = name;
-  }
-
-
-  public User testAccount(Boolean testAccount) {
-    this.testAccount = testAccount;
-    return this;
-  }
-
-   /**
-   * Get testAccount
-   * @return testAccount
-  **/
-  @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_TEST_ACCOUNT)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public Boolean getTestAccount() {
-    return testAccount;
-  }
-
-
-  @JsonProperty(JSON_PROPERTY_TEST_ACCOUNT)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setTestAccount(Boolean testAccount) {
-    this.testAccount = testAccount;
-  }
-
-
   /**
    * Return true if this User object is equal to o.
    */
@@ -168,14 +110,12 @@ public class User {
     }
     User user = (User) o;
     return Objects.equals(this.userName, user.userName) &&
-        Objects.equals(this.key, user.key) &&
-        Objects.equals(this.name, user.name) &&
-        Objects.equals(this.testAccount, user.testAccount);
+        Objects.equals(this.key, user.key);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(userName, key, name, testAccount);
+    return Objects.hash(userName, key);
   }
 
   @Override
@@ -184,8 +124,6 @@ public class User {
     sb.append("class User {\n");
     sb.append("    userName: ").append(toIndentedString(userName)).append("\n");
     sb.append("    key: ").append(toIndentedString(key)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    testAccount: ").append(toIndentedString(testAccount)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -241,16 +179,6 @@ public class User {
     // add `key` to the URL query string
     if (getKey() != null) {
       joiner.add(getKey().toUrlQueryString(prefix + "key" + suffix));
-    }
-
-    // add `name` to the URL query string
-    if (getName() != null) {
-      joiner.add(String.format("%sname%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf(getName()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
-    }
-
-    // add `testAccount` to the URL query string
-    if (getTestAccount() != null) {
-      joiner.add(String.format("%stestAccount%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf(getTestAccount()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
     return joiner.toString();

--- a/webapp-ng/src/app/core/modules/openapi/model/user.ts
+++ b/webapp-ng/src/app/core/modules/openapi/model/user.ts
@@ -15,7 +15,5 @@ import { KeyValue } from './key-value';
 export interface User { 
     userName?: string;
     key?: KeyValue;
-    name?: string;
-    testAccount?: boolean;
 }
 


### PR DESCRIPTION
Fixed the following bugs remaining with field data:

- Creation using a file didn't work on the Java client because the file was not being uploaded
- Error handling on the server did not delete database entries when creation failed
- When the user object was returned with an external data identifier, it did not have enough information to act as a User object on the client