### PR TITLE
Rename DB Classes to Services

### DIFF
--- a/vcell-rest/src/main/java/org/vcell/restq/handlers/AdminResource.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/handlers/AdminResource.java
@@ -20,8 +20,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.jboss.resteasy.reactive.NoCache;
-import org.vcell.restq.db.AdminRestDB;
-import org.vcell.restq.db.UserRestDB;
+import org.vcell.restq.services.AdminRestService;
+import org.vcell.restq.services.UserRestService;
 import org.vcell.restq.errors.exceptions.DataAccessWebException;
 import org.vcell.restq.errors.exceptions.NotAuthenticatedWebException;
 import org.vcell.restq.errors.exceptions.PermissionWebException;
@@ -41,13 +41,13 @@ public class AdminResource {
     @Inject
     SecurityIdentity securityIdentity;
 
-    private final AdminRestDB adminRestDB;
-    private final UserRestDB userRestDB;
+    private final AdminRestService adminRestService;
+    private final UserRestService userRestService;
 
     @Inject
-    public AdminResource(AdminRestDB adminRestDB, UserRestDB userRestDB) {
-        this.adminRestDB = adminRestDB;
-        this.userRestDB = userRestDB;
+    public AdminResource(AdminRestService adminRestService, UserRestService userRestService) {
+        this.adminRestService = adminRestService;
+        this.userRestService = userRestService;
     }
 
     @GET
@@ -65,9 +65,9 @@ public class AdminResource {
         if (securityIdentity.isAnonymous()){
             throw new NotAuthenticatedWebException("not authenticated");
         }
-        User vcellUser = userRestDB.getUserFromIdentity(securityIdentity, UserRestDB.UserRequirement.REQUIRE_USER);
+        User vcellUser = userRestService.getUserFromIdentity(securityIdentity, UserRestService.UserRequirement.REQUIRE_USER);
         try {
-            String htmlString = adminRestDB.getUsageSummaryHtml(vcellUser);
+            String htmlString = adminRestService.getUsageSummaryHtml(vcellUser);
             StreamingOutput fileStream = output -> {
                 try {
                     Document document = new Document();

--- a/vcell-rest/src/main/java/org/vcell/restq/handlers/PublicationResource.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/handlers/PublicationResource.java
@@ -8,8 +8,8 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.vcell.restq.db.PublicationService;
-import org.vcell.restq.db.UserRestDB;
+import org.vcell.restq.services.PublicationService;
+import org.vcell.restq.services.UserRestService;
 import org.vcell.restq.errors.exceptions.*;
 import org.vcell.restq.models.Publication;
 import org.vcell.util.DataAccessException;
@@ -29,7 +29,7 @@ public class PublicationResource {
     SecurityIdentity securityIdentity;
 
     @Inject
-    UserRestDB userRestDB;
+    UserRestService userRestService;
 
     @Inject
     public PublicationResource(PublicationService publicationService) {
@@ -41,7 +41,7 @@ public class PublicationResource {
     @Operation(operationId = "getPublicationById", summary = "Get publication by ID")
     public Publication get_by_id(@PathParam("id") Long publicationID) throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException {
         try {
-            User vcellUser = userRestDB.getUserFromIdentity(securityIdentity, UserRestDB.UserRequirement.ALLOW_ANONYMOUS);
+            User vcellUser = userRestService.getUserFromIdentity(securityIdentity, UserRestService.UserRequirement.ALLOW_ANONYMOUS);
             return publicationService.getPublication(new KeyValue(publicationID.toString()), vcellUser);
         } catch (PermissionException e){
             throw new PermissionWebException(e.getMessage(), e);
@@ -57,7 +57,7 @@ public class PublicationResource {
     @Operation(operationId = "getPublications", summary = "Get all publications")
     public Publication[] get_list() throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException {
         try {
-            User vcellUser = userRestDB.getUserFromIdentity(securityIdentity, UserRestDB.UserRequirement.ALLOW_ANONYMOUS);
+            User vcellUser = userRestService.getUserFromIdentity(securityIdentity, UserRestService.UserRequirement.ALLOW_ANONYMOUS);
             return publicationService.getPublications(DatabaseServerImpl.OrderBy.year_desc, vcellUser);
         } catch (PermissionException e){
             throw new PermissionWebException(e.getMessage(), e);
@@ -76,7 +76,7 @@ public class PublicationResource {
     public Long add(Publication publication) throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException {
         Log.debug(securityIdentity.getPrincipal().getName()+" with roles " + securityIdentity.getRoles() + " is adding publication "+publication.title());
         try {
-            User vcellUser = userRestDB.getUserFromIdentity(securityIdentity, UserRestDB.UserRequirement.REQUIRE_USER);
+            User vcellUser = userRestService.getUserFromIdentity(securityIdentity, UserRestService.UserRequirement.REQUIRE_USER);
             KeyValue key = publicationService.savePublication(publication, vcellUser);
             return Long.parseLong(key.toString());
         } catch (PermissionException e){
@@ -97,7 +97,7 @@ public class PublicationResource {
     public Publication update(Publication publication) throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException {
         Log.debug(securityIdentity.getPrincipal().getName()+" with roles " + securityIdentity.getRoles() + " is adding publication "+publication.title());
         try {
-            User vcellUser = userRestDB.getUserFromIdentity(securityIdentity, UserRestDB.UserRequirement.REQUIRE_USER);
+            User vcellUser = userRestService.getUserFromIdentity(securityIdentity, UserRestService.UserRequirement.REQUIRE_USER);
             Publication pub = publicationService.updatePublication(publication, vcellUser);
             return pub;
         } catch (PermissionException e){
@@ -117,7 +117,7 @@ public class PublicationResource {
     @Operation(operationId = "deletePublication", summary = "Delete publication")
     public void delete(@PathParam("id") Long publicationID) throws PermissionWebException, NotAuthenticatedWebException, NotFoundWebException, DataAccessWebException {
         try {
-            User vcellUser = userRestDB.getUserFromIdentity(securityIdentity, UserRestDB.UserRequirement.REQUIRE_USER);
+            User vcellUser = userRestService.getUserFromIdentity(securityIdentity, UserRestService.UserRequirement.REQUIRE_USER);
             int numRecordsDeleted = publicationService.deletePublication(new KeyValue(publicationID.toString()), vcellUser);
             if (numRecordsDeleted != 1) {
                 throw new NotFoundWebException("failed to delete publication, record not found");

--- a/vcell-rest/src/main/java/org/vcell/restq/handlers/SimulationResource.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/handlers/SimulationResource.java
@@ -9,8 +9,8 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.vcell.restq.Simulations.SimulationStatusPersistentRecord;
 import org.vcell.restq.Simulations.StatusMessage;
-import org.vcell.restq.db.SimulationRestDB;
-import org.vcell.restq.db.UserRestDB;
+import org.vcell.restq.services.SimulationRestService;
+import org.vcell.restq.services.UserRestService;
 import org.vcell.restq.errors.exceptions.DataAccessWebException;
 import org.vcell.restq.errors.exceptions.NotAuthenticatedWebException;
 import org.vcell.restq.errors.exceptions.PermissionWebException;
@@ -27,13 +27,13 @@ public class SimulationResource {
     @Inject
     SecurityIdentity securityIdentity;
 
-    private final SimulationRestDB simulationRestDB;
-    private final UserRestDB userRestDB;
+    private final SimulationRestService simulationRestService;
+    private final UserRestService userRestService;
 
     @Inject
-    public SimulationResource(SimulationRestDB simulationRestDB, UserRestDB userRestDB) {
-        this.simulationRestDB = simulationRestDB;
-        this.userRestDB = userRestDB;
+    public SimulationResource(SimulationRestService simulationRestService, UserRestService userRestService) {
+        this.simulationRestService = simulationRestService;
+        this.userRestService = userRestService;
     }
 
 
@@ -44,8 +44,8 @@ public class SimulationResource {
     @Produces(MediaType.APPLICATION_JSON)
     public ArrayList<StatusMessage> startSimulation(@PathParam("simID") String simID) throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException {
         try {
-            User user = userRestDB.getUserFromIdentity(securityIdentity, UserRestDB.UserRequirement.REQUIRE_USER);
-            return simulationRestDB.startSimulation(simID, user);
+            User user = userRestService.getUserFromIdentity(securityIdentity, UserRestService.UserRequirement.REQUIRE_USER);
+            return simulationRestService.startSimulation(simID, user);
         } catch (DataAccessException e){
             throw new DataAccessWebException(e.getMessage(), e);
         } catch (SQLException e) {
@@ -59,8 +59,8 @@ public class SimulationResource {
     @Operation(operationId = "stopSimulation", summary = "Stop a simulation.")
     public ArrayList<StatusMessage> stopSimulation(@PathParam("simID") String simID) throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException {
         try {
-            User user = userRestDB.getUserFromIdentity(securityIdentity, UserRestDB.UserRequirement.REQUIRE_USER);
-            return simulationRestDB.stopSimulation(simID, user);
+            User user = userRestService.getUserFromIdentity(securityIdentity, UserRestService.UserRequirement.REQUIRE_USER);
+            return simulationRestService.stopSimulation(simID, user);
         } catch (DataAccessException e){
             throw new DataAccessWebException(e.getMessage(), e);
         } catch (SQLException | VCMessagingException e) {
@@ -75,8 +75,8 @@ public class SimulationResource {
     public SimulationStatusPersistentRecord getSimulationStatus(@PathParam("simID") String simID,
                                     @QueryParam("bioModelID") String bioModelID, @QueryParam("mathModelID") String mathModelID) throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException {
         try {
-            User user = userRestDB.getUserFromIdentity(securityIdentity, UserRestDB.UserRequirement.REQUIRE_USER);
-            return simulationRestDB.getBioModelSimulationStatus(simID, bioModelID, user);
+            User user = userRestService.getUserFromIdentity(securityIdentity, UserRestService.UserRequirement.REQUIRE_USER);
+            return simulationRestService.getBioModelSimulationStatus(simID, bioModelID, user);
         } catch (DataAccessException e){
             throw new DataAccessWebException(e.getMessage(), e);
         } catch (SQLException e) {

--- a/vcell-rest/src/main/java/org/vcell/restq/services/AdminRestService.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/services/AdminRestService.java
@@ -1,9 +1,9 @@
-package org.vcell.restq.db;
+package org.vcell.restq.services;
 
 import cbit.vcell.modeldb.AdminDBTopLevel;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.WebApplicationException;
+import org.vcell.restq.db.AgroalConnectionFactory;
 import org.vcell.restq.errors.exceptions.PermissionWebException;
 import org.vcell.util.DataAccessException;
 import org.vcell.util.document.User;
@@ -11,12 +11,12 @@ import org.vcell.util.document.User;
 import java.sql.SQLException;
 
 @ApplicationScoped
-public class AdminRestDB {
+public class AdminRestService {
 
     private final AdminDBTopLevel adminDBTopLevel;
 
     @Inject
-    public AdminRestDB(AgroalConnectionFactory agroalConnectionFactory) throws DataAccessException {
+    public AdminRestService(AgroalConnectionFactory agroalConnectionFactory) throws DataAccessException {
         try {
             adminDBTopLevel = new AdminDBTopLevel(agroalConnectionFactory);
         } catch (SQLException e) {

--- a/vcell-rest/src/main/java/org/vcell/restq/services/BioModelRestService.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/services/BioModelRestService.java
@@ -1,4 +1,4 @@
-package org.vcell.restq.db;
+package org.vcell.restq.services;
 
 import cbit.vcell.biomodel.BioModel;
 import cbit.vcell.modeldb.*;
@@ -7,6 +7,7 @@ import cbit.vcell.xml.XmlHelper;
 import cbit.vcell.xml.XmlParseException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.vcell.restq.db.AgroalConnectionFactory;
 import org.vcell.util.BigString;
 import org.vcell.util.DataAccessException;
 import org.vcell.util.ObjectNotFoundException;
@@ -18,19 +19,19 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 
 @ApplicationScoped
-public class BioModelRestDB {
+public class BioModelRestService {
     private final DatabaseServerImpl databaseServerImpl;
-    private final SimulationRestDB simulationRestDB;
+    private final SimulationRestService simulationRestService;
 
     @Inject
-    public BioModelRestDB(AgroalConnectionFactory agroalConnectionFactory) throws DataAccessException, SQLException {
+    public BioModelRestService(AgroalConnectionFactory agroalConnectionFactory) throws DataAccessException, SQLException {
         databaseServerImpl = new DatabaseServerImpl(agroalConnectionFactory, agroalConnectionFactory.getKeyFactory());
-        simulationRestDB = new SimulationRestDB(agroalConnectionFactory);
+        simulationRestService = new SimulationRestService(agroalConnectionFactory);
     }
 
-    public BioModelRestDB(SimulationRestDB simulationRestDB, DatabaseServerImpl databaseServer) {
+    public BioModelRestService(SimulationRestService simulationRestService, DatabaseServerImpl databaseServer) {
         databaseServerImpl = databaseServer;
-        this.simulationRestDB = simulationRestDB;
+        this.simulationRestService = simulationRestService;
     }
 
     public BioModelRep getBioModelRep(KeyValue bmKey, User vcellUser) throws DataAccessException {
@@ -56,14 +57,14 @@ public class BioModelRestDB {
             for (BioModelRep bioModelRep : bioModelReps) {
                 KeyValue[] simContextKeys = bioModelRep.getSimContextKeyList();
                 for (KeyValue scKey : simContextKeys) {
-                    SimContextRep scRep = simulationRestDB.getSimContextRep(scKey);
+                    SimContextRep scRep = simulationRestService.getSimContextRep(scKey);
                     if (scRep != null){
                         bioModelRep.addSimContextRep(scRep);
                     }
                 }
                 KeyValue[] simulationKeys = bioModelRep.getSimKeyList();
                 for (KeyValue simKey : simulationKeys) {
-                    SimulationRep simulationRep = simulationRestDB.getSimulationRep(simKey);
+                    SimulationRep simulationRep = simulationRestService.getSimulationRep(simKey);
                     if (simulationRep != null){
                         bioModelRep.addSimulationRep(simulationRep);
                     }

--- a/vcell-rest/src/main/java/org/vcell/restq/services/FieldDataService.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/services/FieldDataService.java
@@ -1,4 +1,4 @@
-package org.vcell.restq.handlers.FieldData;
+package org.vcell.restq.services;
 
 import cbit.image.ImageException;
 import cbit.image.VCImageUncompressed;
@@ -29,25 +29,25 @@ import jakarta.inject.Inject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vcell.restq.db.AgroalConnectionFactory;
+import org.vcell.restq.handlers.FieldDataResource;
 import org.vcell.util.*;
 import org.vcell.util.document.*;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.*;
 import java.util.zip.DataFormatException;
 
 @ApplicationScoped
-public class FieldDataDB {
-    private static final Logger logger = LogManager.getLogger(FieldDataDB.class);
+public class FieldDataService {
+    private static final Logger logger = LogManager.getLogger(FieldDataService.class);
 
     private final DatabaseServerImpl databaseServerImpl;
     private final DataSetControllerImpl dataSetControllerImpl;
 
     @Inject
-    public FieldDataDB(AgroalConnectionFactory agroalConnectionFactory) throws DataAccessException, FileNotFoundException {
+    public FieldDataService(AgroalConnectionFactory agroalConnectionFactory) throws DataAccessException, FileNotFoundException {
         databaseServerImpl = new DatabaseServerImpl(agroalConnectionFactory, agroalConnectionFactory.getKeyFactory());
         String primarySimDataDir = PropertyLoader.getProperty(PropertyLoader.primarySimDataDirInternalProperty, "/simdata");
         String secondarySimDataDir = PropertyLoader.getProperty(PropertyLoader.secondarySimDataDirInternalProperty, "/simdata");

--- a/vcell-rest/src/main/java/org/vcell/restq/services/PublicationService.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/services/PublicationService.java
@@ -1,4 +1,4 @@
-package org.vcell.restq.db;
+package org.vcell.restq.services;
 
 import cbit.vcell.modeldb.DatabaseServerImpl;
 import cbit.vcell.modeldb.DatabaseServerImpl.OrderBy;
@@ -6,6 +6,7 @@ import cbit.vcell.modeldb.PublicationRep;
 import cbit.vcell.modeldb.PublicationTable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.vcell.restq.db.AgroalConnectionFactory;
 import org.vcell.restq.models.Publication;
 import org.vcell.util.DataAccessException;
 import org.vcell.util.ObjectNotFoundException;

--- a/vcell-rest/src/main/java/org/vcell/restq/services/UserRestService.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/services/UserRestService.java
@@ -1,4 +1,4 @@
-package org.vcell.restq.db;
+package org.vcell.restq.services;
 
 import cbit.vcell.modeldb.AdminDBTopLevel;
 import cbit.vcell.modeldb.ApiAccessToken;
@@ -7,10 +7,10 @@ import cbit.vcell.modeldb.UserIdentity;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.WebApplicationException;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.vcell.auth.JWTUtils;
 import org.vcell.restq.auth.CustomSecurityIdentityAugmentor;
+import org.vcell.restq.db.AgroalConnectionFactory;
 import org.vcell.restq.errors.exceptions.*;
 import org.vcell.restq.handlers.UsersResource;
 import org.vcell.util.DataAccessException;
@@ -20,7 +20,6 @@ import org.vcell.util.document.KeyValue;
 import org.vcell.util.document.User;
 import org.vcell.util.document.UserInfo;
 import org.vcell.util.document.UserLoginInfo;
-import org.w3c.www.http.HTTP;
 
 import java.sql.SQLException;
 import java.util.Date;
@@ -28,13 +27,13 @@ import java.util.List;
 import java.util.UUID;
 
 @ApplicationScoped
-public class UserRestDB {
+public class UserRestService {
 
     private final AdminDBTopLevel adminDBTopLevel;
     public final static String DEFAULT_CLIENTID = "85133f8d-26f7-4247-8356-d175399fc2e6";
 
     @Inject
-    public UserRestDB(AgroalConnectionFactory agroalConnectionFactory) {
+    public UserRestService(AgroalConnectionFactory agroalConnectionFactory) {
         try {
             adminDBTopLevel = new AdminDBTopLevel(agroalConnectionFactory);
         } catch (SQLException e) {

--- a/vcell-rest/src/test/java/org/vcell/restq/AdminResourceTest.java
+++ b/vcell-rest/src/test/java/org/vcell/restq/AdminResourceTest.java
@@ -17,8 +17,6 @@ import org.vcell.util.DataAccessException;
 
 import java.beans.PropertyVetoException;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.SQLException;
 
 import static io.restassured.RestAssured.given;

--- a/vcell-rest/src/test/java/org/vcell/restq/BioModelTest.java
+++ b/vcell-rest/src/test/java/org/vcell/restq/BioModelTest.java
@@ -1,7 +1,6 @@
 package org.vcell.restq;
 
 import cbit.vcell.biomodel.BioModel;
-import cbit.vcell.modeldb.DatabaseServerImpl;
 import cbit.vcell.resource.PropertyLoader;
 import cbit.vcell.xml.XMLSource;
 import cbit.vcell.xml.XmlHelper;

--- a/vcell-rest/src/test/java/org/vcell/restq/PublicationResourceTest.java
+++ b/vcell-rest/src/test/java/org/vcell/restq/PublicationResourceTest.java
@@ -15,7 +15,7 @@ import org.vcell.restclient.ApiException;
 import org.vcell.restclient.api.UsersResourceApi;
 import org.vcell.restq.config.CDIVCellConfigProvider;
 import org.vcell.restq.db.AgroalConnectionFactory;
-import org.vcell.restq.db.PublicationService;
+import org.vcell.restq.services.PublicationService;
 import org.vcell.restq.models.BiomodelRef;
 import org.vcell.restq.models.MathmodelRef;
 import org.vcell.restq.models.Publication;


### PR DESCRIPTION
The 'DB' classes weren't strictly related to the DB layer, but instead where invoking it alongside other functionality. So they are better represented by services.