### PR TITLE
PubMed links disappeared from Annotations tabs

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/biomodel/meta/VCMetaDataMiriamManager.java
+++ b/vcell-core/src/main/java/cbit/vcell/biomodel/meta/VCMetaDataMiriamManager.java
@@ -534,7 +534,7 @@ public class VCMetaDataMiriamManager implements MiriamManager, Serializable {
 	public static List<DataType> getSpecificDataTypes(Identifiable entity) {
 		List<DataType> list = new ArrayList<>();
 		//temp comment ontologies not supported by search feature
-//		list.add(VCMetaDataDataType.DataType_PUBMED);
+		list.add(VCMetaDataDataType.DataType_PUBMED);	// dan aug 25 - uncomment it
 //		list.add(VCMetaDataDataType.DataType_DOI);
 		list.add(VCMetaDataDataType.DataType_Ncit);
 		list.add(VCMetaDataDataType.DataType_GO);

--- a/vcell-core/src/main/java/cbit/vcell/biomodel/meta/VCMetaDataMiriamManager.java
+++ b/vcell-core/src/main/java/cbit/vcell/biomodel/meta/VCMetaDataMiriamManager.java
@@ -534,7 +534,7 @@ public class VCMetaDataMiriamManager implements MiriamManager, Serializable {
 	public static List<DataType> getSpecificDataTypes(Identifiable entity) {
 		List<DataType> list = new ArrayList<>();
 		//temp comment ontologies not supported by search feature
-		list.add(VCMetaDataDataType.DataType_PUBMED);	// dan aug 25 - uncomment it
+		list.add(VCMetaDataDataType.DataType_PUBMED);
 //		list.add(VCMetaDataDataType.DataType_DOI);
 		list.add(VCMetaDataDataType.DataType_Ncit);
 		list.add(VCMetaDataDataType.DataType_GO);


### PR DESCRIPTION
Issue #1575 PubMed links disappeared from Annotations tabs
Fix:
PubMed is back in the Annotations Tab
Closes #1575