### PR TITLE
Avoids a stale cache condition during CI-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,21 @@ LABEL \
     maintainer="BioSimulators Team <info@biosimulators.org>"
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt -y update && apt install -y software-properties-common
-RUN apt install -y --no-install-recommends curl python3.10 python3-pip build-essential dnsutils \
-    apt-utils libfreetype6 fontconfig fonts-dejavu
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        software-properties-common \
+        curl \
+        python3.10 \
+        python3-pip \
+        build-essential \
+        dnsutils \
+        apt-utils \
+        libfreetype6 \
+        fontconfig \
+        fonts-dejavu \
+    ; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/local/app/vcell/lib && \
     mkdir -p /usr/local/app/vcell/simulation && \


### PR DESCRIPTION
CI-build failed with the following:
```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/e/expat/libexpat1_2.4.7-1ubuntu0.7_amd64.deb  404  Not Found 
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
ERROR: process "/bin/sh -c apt -y update && apt install -y software-properties-common" did not complete successfully: exit code: 100
```

Diagnostics: run apt update in one layer, docker caches the layer, ubuntu rotates security updates
run apt install using the cached, stale data

Fix: combine update and install into a single run

Fixes #1641