### PR TITLE
Changed Spatial Results Export Selection to be CheckBox based

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/data/CheckBoxScrollList.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/CheckBoxScrollList.java
@@ -1,0 +1,166 @@
+package cbit.vcell.client.data;
+
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.util.*;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.swing.*;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+
+public class CheckBoxScrollList extends JPanel {
+	private static final Map<ListModel<String>, CheckBoxEntries> modelMapping = new WeakHashMap<>();
+	private ListModel<String> listModel = null;
+	private final JList<String> allEntries = new JList<>();
+
+	public CheckBoxScrollList(){
+		this(new DefaultListModel<>());
+	}
+
+	public CheckBoxScrollList(ListModel<String> model){
+		this.setLayout(new BorderLayout());
+		this.processAndSetNewModel(model);
+		this.allEntries.setCellRenderer(new CheckBoxRenderer()); // Private Class, see below
+		this.allEntries.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+		this.allEntries.setBounds(0, 0, 160, 120);
+		this.add(new JScrollPane(this.allEntries), BorderLayout.CENTER);
+
+		// Toggle checkbox on click
+		this.allEntries.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mousePressed(MouseEvent e) {
+				Point clickPoint = e.getPoint();
+				int index = CheckBoxScrollList.this.allEntries.locationToIndex(clickPoint);
+				CheckBoxEntries cbe = CheckBoxScrollList.modelMapping.get(CheckBoxScrollList.this.listModel);
+				int maxIndex = cbe.entryToCheckBoxMap.size();
+				if (index < 0 || index >= maxIndex) return;
+				// the above "locationToIndex" finds the closest index. We need to confirm it's *actually* the item.
+				Rectangle cellBounds = CheckBoxScrollList.this.allEntries.getCellBounds(index, index);
+				if (cellBounds == null || !cellBounds.contains(e.getPoint())) return;
+				JCheckBox checkBox = cbe.getEntryCheckBox(index);
+				checkBox.doClick();
+				CheckBoxScrollList.this.allEntries.repaint();
+			}
+		});
+	}
+
+	private void processAndSetNewModel(@Nonnull ListModel<String> model){
+		if (model == this.listModel) return;
+		boolean isNewModel = !modelMapping.containsKey(model);
+		if (isNewModel) CheckBoxScrollList.modelMapping.put(model, new CheckBoxEntries(model));
+		this.listModel = model;
+		this.allEntries.setModel(model);
+	}
+
+	public boolean hasItemsSelected(){
+		return CheckBoxScrollList.modelMapping.get(this.listModel).hasItemsSelected();
+	}
+
+	public List<String> getCheckedItems() {
+		return CheckBoxScrollList.modelMapping.get(this.listModel).getCheckedItems();
+	}
+
+	public void applyListModelToEntries(javax.swing.ListModel<String> model){
+		this.processAndSetNewModel(model);
+	}
+
+	public void addListSelectionListener(java.beans.PropertyChangeListener newListener){
+		this.addPropertyChangeListener(newListener);
+	}
+
+	// Renderer: draws each row as a JCheckBox
+	private class CheckBoxRenderer implements ListCellRenderer<String> {
+		@Override
+		public Component getListCellRendererComponent(
+				JList<? extends String> list, String value,
+				int index, boolean isSelected, boolean cellHasFocus) {
+
+			CheckBoxEntries entries = CheckBoxScrollList.modelMapping.get(CheckBoxScrollList.this.listModel);
+			JCheckBox checkBox = entries.getEntryCheckBox(index);
+			checkBox.setBackground(checkBox.isSelected() ? list.getSelectionBackground() : list.getBackground());
+			checkBox.setForeground(checkBox.isSelected() ? list.getSelectionForeground() : list.getForeground());
+			return checkBox;
+		}
+	}
+
+	private class CheckBoxEntries{
+		private final ListModel<String> model;
+		private final Map<String, JCheckBox> entryToCheckBoxMap;
+		private final Set<Integer> checkedIndices;
+
+		public CheckBoxEntries(ListModel<String> model){
+			this.model = model;
+			this.entryToCheckBoxMap = new HashMap<>();
+			this.checkedIndices = new HashSet<>();
+
+			// Add Listener
+			ListDataListener modelListDataListener = new ListDataListener() {
+				@Override
+				public void intervalAdded(ListDataEvent e) {
+					CheckBoxEntries.this.buildFromScratch();
+				}
+
+				@Override
+				public void intervalRemoved(ListDataEvent e) {
+					CheckBoxEntries.this.buildFromScratch();
+				}
+
+				@Override
+				public void contentsChanged(ListDataEvent e) {
+					CheckBoxEntries.this.buildFromScratch();
+				}
+			};
+			this.model.addListDataListener(modelListDataListener);
+
+			// Update
+			this.buildFromScratch();
+		}
+
+		public Set<Integer> getCheckedIndices() {
+			return this.checkedIndices;
+		}
+
+		public Map<String, JCheckBox> getEntryToCheckBoxMap() {
+			return this.entryToCheckBoxMap;
+		}
+
+		public JCheckBox getEntryCheckBox(int index){
+			if (index >= 0 && index < this.model.getSize()) return this.entryToCheckBoxMap.get(this.model.getElementAt(index));
+			throw new IndexOutOfBoundsException(String.format("Index %d out of bounds for length %d", index, this.model.getSize()));
+		}
+
+		public boolean hasItemsSelected(){
+			return !this.checkedIndices.isEmpty();
+		}
+
+		public List<String> getCheckedItems() {
+			return this.checkedIndices.stream().sorted().map(this.model::getElementAt).toList();
+		}
+
+		private void buildFromScratch(){
+			this.entryToCheckBoxMap.clear();
+			this.checkedIndices.clear();
+
+			for (int i = 0; i < this.model.getSize(); i++){
+				final int indexCopy = i;
+				String elem = this.model.getElementAt(i);
+				JCheckBox newCheckBox = new JCheckBox(elem);
+				newCheckBox.addActionListener(e -> {
+					if (!(e.getSource() instanceof JCheckBox jcb)) return;
+					boolean isSelected = jcb.isSelected();
+					if (isSelected) CheckBoxEntries.this.checkedIndices.add(indexCopy);
+					else CheckBoxEntries.this.checkedIndices.remove(indexCopy);
+					CheckBoxScrollList.this.firePropertyChange(String.format("CheckBox[%s]::isSelected", jcb.getText()), !isSelected, isSelected);
+				});
+				this.entryToCheckBoxMap.put(elem, newCheckBox);
+			}
+		}
+
+	}
+}

--- a/vcell-client/src/main/java/cbit/vcell/client/data/PDEExportDataPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/PDEExportDataPanel.java
@@ -65,7 +65,7 @@ public class PDEExportDataPanel extends JPanel {
 	private JPanel ivjJPanelExport = null;
 	private ExportSettings ivjExportSettings1 = null;
 	IvjEventHandler ivjEventHandler = new IvjEventHandler();
-	private JScrollPane ivjJScrollPane1 = null;
+	private CheckBoxScrollList checkboxScrollPane = null;
 	private JSlider ivjJSlider1 = null;
 	private JSlider ivjJSlider2 = null;
 	private JTextField ivjJTextField1 = null;
@@ -224,6 +224,9 @@ class IvjEventHandler implements java.awt.event.ActionListener, java.awt.event.F
 						if ((getpdeDataContext1() != null)) {
 							PDEExportDataPanel.this.updateAllChoices(getpdeDataContext1());
 						}
+				if (evt.getSource() == PDEExportDataPanel.this.getCheckboxScrollPane() && evt.getPropertyName().contains("isSelected")){
+					PDEExportDataPanel.this.updateInterface();
+				}
 			}
 			catch (Throwable ivjExc){
 				handleException(ivjExc);
@@ -245,10 +248,10 @@ class IvjEventHandler implements java.awt.event.ActionListener, java.awt.event.F
 
 		public void valueChanged(javax.swing.event.ListSelectionEvent e) {
 			try{
-				if (e.getSource() == PDEExportDataPanel.this.getJListVariables())
-						PDEExportDataPanel.this.updateInterface();
-				if (e.getSource() == PDEExportDataPanel.this.getROISelections())
-						PDEExportDataPanel.this.updateInterface();
+				if (
+					e.getSource() == PDEExportDataPanel.this.getCheckboxScrollPane() ||
+					e.getSource() == PDEExportDataPanel.this.getROISelections()
+				) PDEExportDataPanel.this.updateInterface();
 			}
 			catch (Throwable ivjExc){
 				handleException(ivjExc);
@@ -393,7 +396,7 @@ private ExportFormat getSelectedFormat( ) {
 private void connPtoP1SetTarget() {
 	/* Set the target from the source */
 	try {
-		getJListVariables().setModel(getDefaultListModelCivilizedVariables());
+		getCheckboxScrollPane().applyListModelToEntries(getDefaultListModelCivilizedVariables());
 		// user code begin {1}
 		// user code end
 	} catch (java.lang.Throwable ivjExc) {
@@ -629,11 +632,7 @@ private ExportSettings getExportSettings1() {
  */
 private ExportSpecs getExportSpecs() {
 	@SuppressWarnings("deprecation")
-	Object[] variableSelections = getJListVariables().getSelectedValues();
-	String[] variableNames = new String[variableSelections.length];
-	for (int i = 0; i < variableSelections.length; i++){
-		variableNames[i] = (String)variableSelections[i];
-	}
+	String[] variableNames = getCheckboxScrollPane().getCheckedItems().toArray(String[]::new);
 	VariableSpecs variableSpecs = new VariableSpecs(variableNames, ExportEnums.VariableMode.VARIABLE_MULTI);
 	TimeSpecs timeSpecs = new TimeSpecs(getJSlider1().getValue(), getJSlider2().getValue(), getPdeDataContext().getTimePoints(), ExportEnums.TimeMode.TIME_RANGE);
 	ExportEnums.GeometryMode geoMode = ExportEnums.GeometryMode.GEOMETRY_SELECTIONS;
@@ -1075,28 +1074,6 @@ private javax.swing.JList<Object> getROISelections() {
 }
 
 /**
- * Return the JList1 property value.
- * @return javax.swing.JList
- */
-/* WARNING: THIS METHOD WILL BE REGENERATED. */
-private javax.swing.JList<?> getJListVariables() {
-	if (ivjJListVariables == null) {
-		try {
-			ivjJListVariables = new javax.swing.JList<Object>();
-			ivjJListVariables.setName("JListVariables");
-			ivjJListVariables.setBounds(0, 0, 160, 120);
-			// user code begin {1}
-			// user code end
-		} catch (java.lang.Throwable ivjExc) {
-			// user code begin {2}
-			// user code end
-			handleException(ivjExc);
-		}
-	}
-	return ivjJListVariables;
-}
-
-/**
  * Return the JPanelExport property value.
  * @return javax.swing.JPanel
  */
@@ -1369,7 +1346,7 @@ private javax.swing.JPanel getJPanelVariables() {
 			gridBagConstraints_2.gridy = 1;
 			gridBagConstraints_2.gridx = 1;
 			ivjJPanelVariables.add(getMembVarRadioButton(), gridBagConstraints_2);
-			getJPanelVariables().add(getJScrollPane1(), gridBagConstraints_1);
+			ivjJPanelVariables.add(getCheckboxScrollPane(), gridBagConstraints_1);
 			// user code begin {1}
 			// user code end
 		} catch (java.lang.Throwable ivjExc) {
@@ -1456,8 +1433,8 @@ private javax.swing.JRadioButton getJRadioButtonSlice() {
  * @return javax.swing.JScrollPane
  */
 /* WARNING: THIS METHOD WILL BE REGENERATED. */
-private javax.swing.JScrollPane getJScrollPane1() {
-	if (ivjJScrollPane1 == null) {
+private CheckBoxScrollList getCheckboxScrollPane() {
+	if (checkboxScrollPane == null) {
 		try {
 			final GridBagConstraints gridBagConstraints_3 = new GridBagConstraints();
 			gridBagConstraints_3.gridwidth = 3;
@@ -1468,10 +1445,9 @@ private javax.swing.JScrollPane getJScrollPane1() {
 			gridBagConstraints.gridy = 1;
 			gridBagConstraints.gridx = 2;
 			getJPanelVariables().add(getBothVarRadioButton(), gridBagConstraints);
-			ivjJPanelVariables.add(getSelectVariablesLabel(), gridBagConstraints_3);
-			ivjJScrollPane1 = new javax.swing.JScrollPane();
-			ivjJScrollPane1.setName("JScrollPane1");
-			getJScrollPane1().setViewportView(getJListVariables());
+			getJPanelVariables().add(getSelectVariablesLabel(), gridBagConstraints_3);
+			checkboxScrollPane = new CheckBoxScrollList();
+			checkboxScrollPane.setName("ObservablesCheckboxSelectionListPane");
 			// user code begin {1}
 			// user code end
 		} catch (java.lang.Throwable ivjExc) {
@@ -1480,7 +1456,7 @@ private javax.swing.JScrollPane getJScrollPane1() {
 			handleException(ivjExc);
 		}
 	}
-	return ivjJScrollPane1;
+	return checkboxScrollPane;
 }
 
 /**
@@ -1703,7 +1679,7 @@ private void initConnections() throws java.lang.Exception {
 	getJButtonExport().addActionListener(ivjEventHandler);
 	this.addPropertyChangeListener(ivjEventHandler);
 	getExportSettings1().addPropertyChangeListener(ivjEventHandler);
-	getJListVariables().addListSelectionListener(ivjEventHandler);
+	getCheckboxScrollPane().addListSelectionListener(ivjEventHandler);
 	getButtonGroupCivilized1().addPropertyChangeListener(ivjEventHandler);
 	getDefaultListModelCivilizedSelections().addListDataListener(ivjEventHandler);
 	getROISelections().addListSelectionListener(ivjEventHandler);
@@ -1996,7 +1972,7 @@ private void startExport() {
 	}
 	DisplayPreferences[] displayPreferences = null;
 	@SuppressWarnings("deprecation")
-	Object[] variableSelections = getJListVariables().getSelectedValues();
+	Object[] variableSelections = getCheckboxScrollPane().getCheckedItems().toArray();
 	boolean selectionHasVolumeVariables = false;
 	boolean selectionHasMembraneVariables = false;
 	switch (getExportSettings1().getSelectedFormat()) {
@@ -2341,7 +2317,7 @@ private void updateInterface() {
 	}
 	//
 	boolean startExportEnabled =
-		(getJListVariables().getSelectedIndex() != -1)
+		(getCheckboxScrollPane().hasItemsSelected())
 		&&
 		(
 		(getJRadioButtonROI().isSelected() && getROISelections().getSelectedIndex() != -1)


### PR DESCRIPTION
previously, selecting species to export was a delicate process. Mis-clicks when multi-selecting would result in needing to start over. On models with over 30 species, this could prove very frustrating.

The JPane now uses checkbox-like selection, and has a very rudimentary memory system.

Limitations:
- It's limited to just the session of VCell. If you quit VCell, it will reset.
- It's limited to a single run of a single simulation. Re-running the simulation will reset the selections.
- It's limited to server runs only. Local runs are considered one-off, so each blue-button simulation is a "re-run" so-to-speak.
- Switching Export Formats clears the selections.

The future export refactor should address these limitations.