### PR TITLE
Make InternalUnitDefinition.round thread-safe

### DIFF
--- a/vcell-math/src/main/java/cbit/vcell/units/InternalUnitDefinition.java
+++ b/vcell-math/src/main/java/cbit/vcell/units/InternalUnitDefinition.java
@@ -43,8 +43,6 @@ import ucar.units_vcell.UnitName;
 class InternalUnitDefinition implements Matchable, Serializable {
 
     public static final String TBD_SYMBOL = "tbd";
-    private static final java.text.NumberFormat numberFormatForRounding =
-        new java.text.DecimalFormat("#0.0#E0#");
 
     //VC standard Unit definitions
     public static final InternalUnitDefinition UNIT_s;
@@ -110,8 +108,6 @@ class InternalUnitDefinition implements Matchable, Serializable {
     //private static ucar.units_vcell.PrefixDB prefixDB = null;
 
     static {
-        numberFormatForRounding.setMaximumFractionDigits(12);
-
         defs = new ArrayList<InternalUnitDefinition>();
 
         InternalUnitDefinition unit_s = null;
@@ -674,19 +670,20 @@ public boolean isTBD() {
 
 
 /**
- * Insert the method's description here.
- * Creation date: (6/13/2004 3:03:36 PM)
- * @return double
- * @param value double
+ * Round a value to at most 12 significant digits.
+ *
+ * Implementation note: previously used a shared static DecimalFormat
+ * for round-trip format/parse. DecimalFormat is not thread-safe and the
+ * shared instance produced corrupted strings (e.g., "11E.11-83E-83")
+ * under concurrent access from background-thread unit arithmetic,
+ * causing NumberFormatException to escape the catch block. This
+ * implementation is stateless and locale-independent.
  */
 public static double round(double value) {
-	try {
-		double roundedValue = numberFormatForRounding.parse(numberFormatForRounding.format(value)).doubleValue();
-		return roundedValue;
-	}catch (java.text.ParseException e){
-		e.printStackTrace(System.out);
+	if (Double.isNaN(value) || Double.isInfinite(value)) {
 		return value;
 	}
+	return Double.parseDouble(String.format(java.util.Locale.US, "%.12e", value));
 }
 
 

--- a/vcell-math/src/test/java/cbit/vcell/units/InternalUnitDefinitionRoundTest.java
+++ b/vcell-math/src/test/java/cbit/vcell/units/InternalUnitDefinitionRoundTest.java
@@ -1,0 +1,89 @@
+package cbit.vcell.units;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("Fast")
+public class InternalUnitDefinitionRoundTest {
+
+    @Test
+    public void roundOfOrdinaryValuesIsIdempotentToTwelveDigits() {
+        double[] values = {
+                1.0, -1.0, 0.0, 1234.5678, -1234.5678,
+                1.234567890123456789, 1e-83, 1e83, Math.PI, Math.E,
+        };
+        for (double v : values) {
+            double r = InternalUnitDefinition.round(v);
+            // Twelve significant digits should be preserved exactly.
+            assertEquals(r, InternalUnitDefinition.round(r),
+                    "round must be idempotent for value " + v);
+            // The rounded value must match the original to 12 sig figs.
+            if (v != 0.0) {
+                double relErr = Math.abs((r - v) / v);
+                assertTrue(relErr < 1e-11,
+                        "relative error too large for " + v + ": " + relErr);
+            }
+        }
+    }
+
+    @Test
+    public void roundPreservesSpecialValues() {
+        assertTrue(Double.isNaN(InternalUnitDefinition.round(Double.NaN)));
+        assertEquals(Double.POSITIVE_INFINITY,
+                InternalUnitDefinition.round(Double.POSITIVE_INFINITY));
+        assertEquals(Double.NEGATIVE_INFINITY,
+                InternalUnitDefinition.round(Double.NEGATIVE_INFINITY));
+        assertEquals(0.0, InternalUnitDefinition.round(0.0));
+        // round(-0.0) returns -0.0 (sign preserved); both are mathematically zero.
+        assertEquals(0.0, Math.abs(InternalUnitDefinition.round(-0.0)));
+    }
+
+    @Test
+    public void roundIsThreadSafe() throws InterruptedException {
+        // Regression test: a previous implementation used a shared static
+        // DecimalFormat. Concurrent access produced strings like
+        // "11E.11-83E-83" (= "1E-83" formatted twice with digits
+        // interleaved), which then failed Double.parseDouble with
+        // NumberFormatException ("multiple points" or "For input string").
+        int threads = 16;
+        int iterationsPerThread = 5_000;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        AtomicInteger failures = new AtomicInteger(0);
+        AtomicInteger badResults = new AtomicInteger(0);
+        try {
+            for (int t = 0; t < threads; t++) {
+                final double base = 1.0 + t * 0.0001;
+                pool.submit(() -> {
+                    for (int i = 0; i < iterationsPerThread; i++) {
+                        double value = base * Math.pow(10, (i % 100) - 50);
+                        try {
+                            double r = InternalUnitDefinition.round(value);
+                            if (Double.isNaN(r) != Double.isNaN(value)) {
+                                badResults.incrementAndGet();
+                            }
+                        } catch (RuntimeException e) {
+                            failures.incrementAndGet();
+                        }
+                    }
+                });
+            }
+        } finally {
+            pool.shutdown();
+            assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS),
+                    "thread pool did not terminate in time");
+        }
+        assertEquals(0, failures.get(),
+                "round() threw under concurrent access");
+        assertEquals(0, badResults.get(),
+                "round() returned wrong-typed result under concurrent access");
+    }
+}


### PR DESCRIPTION
## Summary

`InternalUnitDefinition.round(double)` shared a single static `DecimalFormat` instance across all callers. `DecimalFormat` is documented as not thread-safe — its internal `DigitList` field is mutated during both `format()` and `parse()`. Concurrent calls (background math-mapping refresh + UI work) raced through that state and produced character-level interleavings of two threads' format outputs, e.g. `"11E.11-83E-83"` (= `"1E-83"` formatted twice with digits interleaved). `Double.parseDouble` then threw `NumberFormatException`, which the `catch (ParseException)` did not catch, so it escaped through `StructureAnalyzer.refresh` and surfaced to the user as **"Failed to determine metadata for data symbols"** when opening the ODE data viewer.

This was the most common surface failure in a recent corpus of user-submitted support emails: 52 of ~400 traces, across 7 distinct user incidents.

## Fix

Replace the format/parse round-trip with a stateless, locale-fixed implementation:

```java
return Double.parseDouble(String.format(Locale.US, "%.12e", value));
```

`%.12e` produces 12 fraction digits in scientific notation, matching the previous `DecimalFormat` pattern `#0.0#E0#` with `setMaximumFractionDigits(12)`. Special values (NaN, infinities) are short-circuited.

Also removes the now-unused static `numberFormatForRounding` field and its configuration line in the static initializer. No other code references it.

## Evidence the user-visible failure messages were genuine corruption (not bad input)

From the support-email corpus, distinct `NumberFormatException` messages observed across 5 independent user incidents:

```
"For input string: \"11E.11-83E-83\""
"For input string: \"11E.11-83E\""
"For input string: \".11EE37\""
"For input string: \".11EE3737\""
"multiple points"
```

Each is a different interleaving of two concurrent format outputs — independent races, not one bad value.

## Test plan

- [x] New `InternalUnitDefinitionRoundTest` (`@Tag("Fast")`) with three tests:
  - **ordinary values** — idempotent and within 1e-11 relative error for ten representative magnitudes
  - **special values** — `NaN`, ±infinities, ±0.0 preserved
  - **concurrent access** — 16 threads × 5,000 iterations through `round()` with no `RuntimeException` thrown (regression test for the race)
- [x] All 6,545 existing `vcell-math` `Fast` tests still pass
- [x] `mvn compile test-compile -pl vcell-core -am` succeeds (no downstream breakage)

## Note on related work

There's a second cluster in the same support-email corpus — `MathSymbolMapping.put` throwing NPE inside `TreeMap.fixAfterInsertion` (7 incidents) — that is suspected to be another concurrency issue. That's not addressed here; if confirmed it should be a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)