### PR TITLE
Fix NPE in ParticleMathMapping for non-mass-action kinetics

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/ParticleMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/ParticleMathMapping.java
@@ -729,7 +729,11 @@ private void refreshMathDescription() throws MappingException, MatrixException, 
 				{
 					maFunc = (MassActionStochasticFunction)stochasticFunction;
 				}
-				if ((maFunc.forwardRate() == null && maFunc.reverseRate() == null))
+				// transformToStochastic falls back to GeneralKineticsStochasticFunction
+				// when the rate law can't be reduced to mass-action form (e.g. Hill /
+				// Michaelis-Menten kinetics). Particle math mapping requires mass-action
+				// shape, so report the same error in either case rather than NPE.
+				if (maFunc == null || (maFunc.forwardRate() == null && maFunc.reverseRate() == null))
 				{
 					throw new MappingException("Cannot generate stochastic math mapping for the reaction:" + reactionStep.getName() + "\nLooking for the rate function according to the form of k1*Reactant1^Stoir1*Reactant2^Stoir2...-k2*Product1^Stoip1*Product2^Stoip2.");
 				}


### PR DESCRIPTION
## Summary

- One-line guard fix in `ParticleMathMapping.refreshMathDescription`: NPE when a reaction's rate law cannot be reduced to mass-action form.
- `transformToStochastic` returns a `GeneralKineticsStochasticFunction` (sibling of `MassActionStochasticFunction`) for kinetics like Hill / Michaelis-Menten. The existing `instanceof` check correctly leaves `maFunc` null, but the next line dereferenced it unconditionally → NPE far from the real cause.
- Now throws the same descriptive `MappingException` (which names the offending reaction) whether `maFunc` is null or has both rates null.

## Why now

Identified during triage of a user-support-email log corpus: this NPE is the second-largest cluster of distinct-incident failures (multiple incidents across all sampled builds, multiple distinct user models). The error users currently see is a stack-trace bottoming out at `ParticleMathMapping.java:732` rather than a message naming their reaction.

## Diff

```java
// vcell-core/.../ParticleMathMapping.java:729-739
 if (stochasticFunction instanceof MassActionStochasticFunction)
 {
     maFunc = (MassActionStochasticFunction)stochasticFunction;
 }
-if ((maFunc.forwardRate() == null && maFunc.reverseRate() == null))
+// transformToStochastic falls back to GeneralKineticsStochasticFunction
+// when the rate law can't be reduced to mass-action form (e.g. Hill /
+// Michaelis-Menten kinetics). Particle math mapping requires mass-action
+// shape, so report the same error in either case rather than NPE.
+if (maFunc == null || (maFunc.forwardRate() == null && maFunc.reverseRate() == null))
 {
     throw new MappingException("Cannot generate stochastic math mapping for the reaction:" + reactionStep.getName() + ...);
 }
```

## Test plan

- [x] `mvn compile test-compile -pl vcell-core -am`
- [x] `mvn test -pl vcell-core -Dgroups="Fast"` — pre-existing `VCellDataTest.test_3D` Poetry environmental error is unrelated to this Java change
- [ ] Manual: open a stochastic application with a non-mass-action reaction (Michaelis-Menten / Hill) and confirm the error message names the reaction instead of producing an NPE

🤖 Generated with [Claude Code](https://claude.com/claude-code)