### PR TITLE
Fix NPE in StochMathMapping for symbol-less rate expressions

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/mapping/StochMathMapping.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/StochMathMapping.java
@@ -142,7 +142,11 @@ public class StochMathMapping extends AbstractStochMathMapping {
 
 		// collect symbolTableEntries for speciesContexts within netRateExpr and replace with concentration parameter
 		netRateExpr = new Expression(netRateExpr);
-		for (String symbol : netRateExpr.getSymbols()) {
+		// Expression.getSymbols() returns null when the expression has no free symbols
+		// (e.g. a constant rate, or a rate that only references already-resolved values).
+		String[] symbols = netRateExpr.getSymbols();
+		for (int i = 0; symbols != null && i < symbols.length; i++) {
+			String symbol = symbols[i];
 			SymbolTableEntry symbolTableEntry = netRateExpr.getSymbolBinding(symbol);
 			if (symbolTableEntry instanceof Kinetics.KineticsProxyParameter proxyParameter
 					&& proxyParameter.getTarget() instanceof SpeciesContext sc) {


### PR DESCRIPTION
## Summary

- One-line null-guard fix in `StochMathMapping.getProbabilityRate(... GeneralKineticsStochasticFunction ...)`. `Expression.getSymbols()` is documented to return null when the expression has no free symbols (see `Expression.java:545`); the for-each at line 145 didn't guard for that, producing an NPE.
- The corpus error signature is unambiguous: `Cannot read the array length because "<local7>" is null at StochMathMapping.getProbabilityRate(StochMathMapping.java:145)`.
- Fix mirrors the established null-guard pattern already used in `AbstractStochMathMapping.getSubstitutedExpr` (line 155).

## Why now

Triage of a user-support-email log corpus identified this as the next-largest unaddressed cluster: 6 distinct user incidents, 25 stack traces, multiple distinct user models. Users currently see a deep NPE rather than a successful stochastic math generation.

## Why this trips

The `GeneralKineticsStochasticTransformer` fallback is the intended path for non-mass-action rate laws (Michaelis-Menten, Hill, etc.) — it takes the authoritative reaction rate as a net flux and uses `max(rate, 0)` as the irreversible forward rate, which is exactly the right shape for stochastic simulation. The NPE was preventing that path from completing whenever the rate expression flattened to no free symbols (e.g. a constant rate, or a rate where all parameters and species have already been resolved upstream).

## Diff

```java
// vcell-core/.../StochMathMapping.java:142-146
 // collect symbolTableEntries for speciesContexts within netRateExpr and replace with concentration parameter
 netRateExpr = new Expression(netRateExpr);
-for (String symbol : netRateExpr.getSymbols()) {
+// Expression.getSymbols() returns null when the expression has no free symbols
+// (e.g. a constant rate, or a rate that only references already-resolved values).
+String[] symbols = netRateExpr.getSymbols();
+for (int i = 0; symbols != null && i < symbols.length; i++) {
+    String symbol = symbols[i];
     SymbolTableEntry symbolTableEntry = netRateExpr.getSymbolBinding(symbol);
```

## Test plan

- [x] `mvn compile -pl vcell-core -am` — builds clean
- [x] `mvn test -pl vcell-core -Dgroups="Fast"` — same pass/fail count as master; only failure is the pre-existing unrelated `VCellDataTest.test_3D` Poetry environmental error
- [ ] Manual: open a stochastic application with a non-mass-action reaction whose rate flattens to no free symbols and confirm math generation completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)