### PR TITLE
Register vcell-su download-vcml subcommand and resolve users by id

### DIFF
--- a/vcell-admin/src/main/java/org/vcell/admin/cli/AdminCLI.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/AdminCLI.java
@@ -15,6 +15,7 @@ import org.vcell.admin.cli.models.ModelCommands;
 import org.vcell.admin.cli.sim.JobInfoCommand;
 import org.vcell.admin.cli.sim.ResultSetCrawlerCommand;
 import org.vcell.admin.cli.sim.SimDataVerifierCommand;
+import org.vcell.admin.cli.tools.DatabaseCommand;
 import org.vcell.admin.cli.tools.UsageCommand;
 import org.vcell.admin.cli.tools.UsersQueryCommand;
 import org.vcell.db.DatabaseSyntax;
@@ -33,6 +34,7 @@ import picocli.CommandLine.Command;
         DatabaseCreateScriptCommand.class,
         UsageCommand.class,
         UsersQueryCommand.class,
+        DatabaseCommand.class,
         ResultSetCrawlerCommand.class,
         SimDataVerifierCommand.class,
         JobInfoCommand.class,

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/CLIDatabaseService.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/CLIDatabaseService.java
@@ -170,6 +170,15 @@ public class CLIDatabaseService implements AutoCloseable {
         return getDatabaseServer().getBioModelInfo(owner, biomodelId);
     }
 
+    public User resolveUser(String userid) throws DataAccessException, SQLException {
+        AdminDBTopLevel adminDbTopLevel = new AdminDBTopLevel(conFactory);
+        User user = adminDbTopLevel.getUser(userid, true);
+        if (user == null) {
+            throw new DataAccessException("user '" + userid + "' not found");
+        }
+        return user;
+    }
+
     public MathModelInfo queryMathmodelInfo(User owner, KeyValue mathmodelId) throws DataAccessException {
         return getDatabaseServer().getMathModelInfo(owner, mathmodelId);
     }

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/tools/DatabaseCommand.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/tools/DatabaseCommand.java
@@ -35,6 +35,9 @@ public class DatabaseCommand implements Callable<Integer> {
     @Option(names = "--user", description = "userid and key for private models --biomodel-id (format is 'userid:key')")
     private User user = User.tempUser;
 
+    @Option(names = "--userid", description = "userid alone for private --biomodel-id; user key resolved via DB lookup")
+    private String userid;
+
     @Option(names = {"-d", "--debug"}, description = "full application debug mode")
     private boolean bDebug = false;
 
@@ -61,6 +64,10 @@ public class DatabaseCommand implements Callable<Integer> {
                 throw new RuntimeException("outputDir '" + (outputDir == null ? "" : outputDir) + "' is not a 'valid directory'");
 
             try (CLIDatabaseService cliDatabaseService = new CLIDatabaseService()) {
+                if (userid != null) {
+                    user = cliDatabaseService.resolveUser(userid);
+                    logger.info("resolved userid '" + userid + "' to user " + user.getName() + ":" + user.getID());
+                }
                 if (biomodelsFile != null) {
                     List<String> lines = Files.readAllLines(biomodelsFile.toPath());
                     for (String line : lines) {


### PR DESCRIPTION
## Summary

- `DatabaseCommand` (the `download-vcml` admin subcommand for fetching cached VCML directly from the database) existed in `vcell-admin/.../tools/DatabaseCommand.java` but was never wired into the `AdminCLI` subcommand list, so `vcell-su download-vcml` was unreachable. This adds it.
- Adds a `--userid <name>` option that resolves the User key via `AdminDBTopLevel.getUser(...)`, so admins can fetch private biomodels by username alone instead of needing the `userid:userkey` pair. The existing `--user userid:key` option still works.

## Why

Used during investigation of two biomodels failing to load from the primary Oracle DB. The existing tooling required the user-key (a numeric internal id), which we don't have for arbitrary users. With `--userid`, an admin can fetch any private biomodel by `--biomodel-id <id> --userid <name>`.

## Test plan

- [x] `mvn -pl vcell-admin -am compile -DskipTests` clean
- [x] `vcell-su -h` lists `download-vcml` as a subcommand
- [x] `vcell-su download-vcml --biomodel-id=<id> --userid=<name> -o <dir> --regenerateXML=false --publishedOnly=false` retrieves the cached VCML for a private biomodel
- [ ] Verify the `--user userid:key` form still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)