### PR TITLE
Fix Oracle CLOB read: charset-aware character stream

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/modeldb/DbDriver.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/DbDriver.java
@@ -41,6 +41,7 @@ import org.vcell.util.*;
 import org.vcell.util.document.*;
 import org.vcell.util.document.VCDocument.VCDocumentType;
 
+import java.io.Reader;
 import java.math.BigDecimal;
 import java.sql.*;
 import java.text.SimpleDateFormat;
@@ -1060,15 +1061,26 @@ public abstract class DbDriver {
                     //If its a CLOB return a String
                 } else if(lob_object instanceof java.sql.Clob){
                     java.sql.Clob clob_object = (java.sql.Clob) lob_object;
-                    byte[] ins = new byte[(int) clob_object.length()];
                     try {
-                        clob_object.getAsciiStream().read(ins);
+                        long lenChars = clob_object.length();
+                        if (lenChars > Integer.MAX_VALUE) {
+                            throw new DataAccessException("CLOB too large to read into a String: "
+                                    + lenChars + " chars (column=" + column.getUnqualifiedColName() + ")");
+                        }
+                        char[] cbuf = new char[(int) lenChars];
+                        int off = 0;
+                        try (Reader r = clob_object.getCharacterStream()) {
+                            int n;
+                            while (off < cbuf.length && (n = r.read(cbuf, off, cbuf.length - off)) != -1) {
+                                off += n;
+                            }
+                        }
+                        return new String(cbuf, 0, off);
                     } catch(Exception e){
                         throw new DataAccessException(e.toString());
                     } finally {
                         clob_object.free();
                     }
-                    return new String(ins);
                 }
                 //
                 throw new DataAccessException(


### PR DESCRIPTION
## Summary
- `DbDriver.getLOB` Oracle branch was reading every CLOB through `clob.getAsciiStream()` into a `byte[]`, then converting that byte buffer to a `String` via the JVM's platform-default charset. Both steps are lossy:
  - `getAsciiStream` coerces each character into a single byte (truncating to the low 8 bits); a stored `–` (en-dash, U+2013) becomes `0x13`, an invalid XML 1.0 control character. A stored `μ` (U+00B5) becomes `0xB5`, then mis-decoded again on the `new String(byte[])` step.
  - `new String(byte[])` uses `Charset.defaultCharset()` — Cp1252 on legacy Windows, UTF-8 on modern macOS/Linux — so even ASCII reads were platform-dependent for any non-ASCII byte that survived step 1.
- Replaced with `clob.getCharacterStream()` reading into a `char[]` sized by `clob.length()` (chars, per JDBC spec). One-method change, Oracle branch only; Postgres branch already used `rs.getString` and was correct.

## Why
The two biomodels (311226221 / shiVcell, 311875206 / mblinov) that have been failing to load in `VCellClientMain` from the database both contain en-dash characters in reaction names. The stored CLOBs are honest — a direct `clob.getCharacterStream()` scan of all 116k biomodel + mathmodel rows finds zero invalid XML chars. The corruption was being injected on every read by the buggy `getLOB`, and SAX then rejected the result on the client. PR #1676 (charset hygiene on import paths) and PR #1677 (input validation on setSbmlName/setName) were both addressing the consequences; this PR fixes the actual cause.

## Test plan
- [x] Build succeeds: `mvn -pl vcell-server,vcell-admin -am -DskipTests install`
- [x] Local repro:
  - Before: `serverDocumentManager.getBioModelXML(qh, mblinov, 311875206, false)` → SAX `"invalid XML char Unicode 0x13 in attribute Name"`
  - After: same call → `XMLToBioModel` succeeds, `updateAll(true)` succeeds, returned XML preserves the original 12 en-dashes (`0xE2 0x80 0x93`) and contains zero invalid bytes
- [x] Same for 311226221 (`shiVcell`).
- [ ] Run SEDML/SBML integration tests on this branch to surface anything that was being masked by lossy ASCII reads (other tables read via `getLOB`: kinetics, geometry curves, math descriptions, analysis tasks).
- [ ] After merge: previously-broken BioModels load in the GUI without DB repair.

## Notes
- All other `getLOB` callers (`MathDescTable`, `GeomDbDriver`, `SimulationContextDbDriver`, generic clob_text) get the same fix automatically — any non-ASCII char they were silently mangling is now preserved.
- Independent of PRs #1676 / #1677 / #1678. Those remain valuable as defense-in-depth (catch corruption at write-time) but aren't load-bearing for this particular family of failures anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)