### PR TITLE
Add JmsFailoverWatchdog and bound failover reconnect

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/jms/ConsumerContextJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/ConsumerContextJms.java
@@ -113,6 +113,7 @@ public class ConsumerContextJms implements Runnable {
 		int acknowledgeMode = Session.AUTO_ACKNOWLEDGE;
 		try {
 			this.jmsConnection = vcMessagingServiceJms.createConnectionFactory().createConnection();
+			vcMessagingServiceJms.getFailoverWatchdog().attach(this.jmsConnection);
 			this.jmsConnection.setExceptionListener(new ExceptionListener() {
 				public void onException(JMSException arg0) {
 					ConsumerContextJms.this.onException(arg0);

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/JmsFailoverWatchdog.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/JmsFailoverWatchdog.java
@@ -1,0 +1,73 @@
+package cbit.vcell.message.jms;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import javax.jms.Connection;
+
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.transport.TransportListener;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Attaches a {@link TransportListener} to an {@link ActiveMQConnection} that
+ * runs a caller-supplied terminal action when the underlying failover transport
+ * gives up (e.g. {@code maxReconnectAttempts} exhausted, or a "Timer already
+ * cancelled" inactivity-monitor wedge).
+ *
+ * Production wiring should pass {@link #jvmExitOnTerminal()} so K8s recycles
+ * the pod. Tests can pass any {@link Runnable} (e.g. a {@code CountDownLatch}
+ * countdown) to verify the watchdog fires without killing the JVM.
+ */
+public final class JmsFailoverWatchdog {
+
+	private static final Logger lg = LogManager.getLogger(JmsFailoverWatchdog.class);
+
+	private final Runnable onTerminal;
+
+	public JmsFailoverWatchdog(Runnable onTerminal) {
+		this.onTerminal = Objects.requireNonNull(onTerminal, "onTerminal");
+	}
+
+	/**
+	 * Exit the JVM with status 1 so K8s recycles the pod. Use this only at
+	 * server entry points where pod recycling is the desired response to a
+	 * sustained JMS outage (e.g. SimDataServer).
+	 */
+	public static JmsFailoverWatchdog jvmExitOnTerminal() {
+		return new JmsFailoverWatchdog(() -> System.exit(1));
+	}
+
+	/**
+	 * Default for everything else: the TransportListener still logs the
+	 * interrupted/resumed/terminal events but takes no further action.
+	 */
+	public static JmsFailoverWatchdog logOnly() {
+		return new JmsFailoverWatchdog(() -> {});
+	}
+
+	public void attach(Connection connection) {
+		if (!(connection instanceof ActiveMQConnection)) {
+			return;
+		}
+		((ActiveMQConnection) connection).addTransportListener(new TransportListener() {
+			@Override
+			public void onCommand(Object command) {
+			}
+			@Override
+			public void onException(IOException error) {
+				lg.fatal("JMS transport unrecoverable, invoking terminal handler", error);
+				onTerminal.run();
+			}
+			@Override
+			public void transportInterupted() {
+				lg.warn("JMS transport interrupted, failover reconnecting");
+			}
+			@Override
+			public void transportResumed() {
+				lg.info("JMS transport resumed");
+			}
+		});
+	}
+}

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
@@ -51,6 +51,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
 //			Thread.dumpStack();
         this.vcMessagingServiceJms = vcMessagingServiceJms;
         this.connection = vcMessagingServiceJms.createConnectionFactory().createConnection();
+        vcMessagingServiceJms.getFailoverWatchdog().attach(this.connection);
         this.connection.setExceptionListener(new ExceptionListener() {
             public void onException(JMSException arg0){
                 MessageProducerSessionJms.this.onException(arg0);

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/VCMessagingServiceJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/VCMessagingServiceJms.java
@@ -37,6 +37,7 @@ public abstract class VCMessagingServiceJms implements VCMessagingService {
 	private VCMessagingDelegate delegate = new SimpleMessagingDelegate();
 	protected String jmshost = null;
 	protected Integer jmsport = null;
+	private JmsFailoverWatchdog failoverWatchdog = JmsFailoverWatchdog.logOnly();
 
 	private Timer garbageCollectorTimer = new Timer(true);
 	private final static long BlobGarbageCollector_initialDelayMS 	= 1000*3600;		// one hour
@@ -95,6 +96,19 @@ public abstract class VCMessagingServiceJms implements VCMessagingService {
 		this.delegate = delegate;
 		this.jmshost = jmshost;
 		this.jmsport = jmsport;
+	}
+
+	/**
+	 * Override the default {@link JmsFailoverWatchdog} (production default exits
+	 * the JVM on terminal transport failure). Call before any connections are
+	 * opened — typically at server startup, or from tests.
+	 */
+	public void setFailoverWatchdog(JmsFailoverWatchdog failoverWatchdog) {
+		this.failoverWatchdog = java.util.Objects.requireNonNull(failoverWatchdog, "failoverWatchdog");
+	}
+
+	JmsFailoverWatchdog getFailoverWatchdog() {
+		return failoverWatchdog;
 	}
 	
 	@Override

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/activeMQ/VCMessagingServiceActiveMQ.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/activeMQ/VCMessagingServiceActiveMQ.java
@@ -53,7 +53,16 @@ public class VCMessagingServiceActiveMQ extends VCMessagingServiceJms implements
 	 * @return static string
 	 */
 	private String jmsUrl(String jmshost, int jmsport) {
-		String jmsurl = "failover:(tcp://"+jmshost+":"+jmsport+")";
-		return jmsurl;
+		// Bound the failover reconnect loop so a wedged transport (e.g. ActiveMQ client
+		// "Timer already cancelled" race) eventually surfaces an IOException to the
+		// TransportListener, letting the JVM exit and K8s recycle the pod.
+		// startupMaxReconnectAttempts=-1 keeps initial connect unbounded so pod boot
+		// tolerates a slow broker.
+		return "failover:(tcp://" + jmshost + ":" + jmsport + ")"
+				+ "?maxReconnectAttempts=20"
+				+ "&startupMaxReconnectAttempts=-1"
+				+ "&useExponentialBackOff=true"
+				+ "&initialReconnectDelay=1000"
+				+ "&maxReconnectDelay=30000";
 	}
 }

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
@@ -1,0 +1,58 @@
+package cbit.vcell.message.jms;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.broker.TransportConnector;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("Fast")
+public class JmsFailoverWatchdogTest {
+
+	/**
+	 * Spin up an embedded broker, attach the watchdog to a connection backed by
+	 * a tightly-bounded failover URL, then stop the broker. After the failover
+	 * transport exhausts its reconnect budget, the TransportListener fires with
+	 * an IOException and the watchdog should run the injected terminal handler.
+	 */
+	@Test
+	public void attach_firesTerminalHandlerWhenFailoverGivesUp() throws Exception {
+		BrokerService broker = new BrokerService();
+		broker.setPersistent(false);
+		broker.setUseJmx(false);
+		broker.setUseShutdownHook(false);
+		TransportConnector connector = broker.addConnector("tcp://localhost:0");
+		broker.start();
+		broker.waitUntilStarted();
+		int port = connector.getConnectUri().getPort();
+
+		String url = "failover:(tcp://localhost:" + port + ")"
+				+ "?maxReconnectAttempts=2"
+				+ "&startupMaxReconnectAttempts=-1"
+				+ "&initialReconnectDelay=50"
+				+ "&maxReconnectDelay=100";
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(url);
+		Connection connection = factory.createConnection();
+		try {
+			CountDownLatch terminal = new CountDownLatch(1);
+			new JmsFailoverWatchdog(terminal::countDown).attach(connection);
+			connection.start();
+
+			broker.stop();
+			broker.waitUntilStopped();
+
+			assertTrue(terminal.await(10, TimeUnit.SECONDS),
+					"watchdog terminal handler should fire after maxReconnectAttempts exhausted");
+		} finally {
+			try { connection.close(); } catch (Exception ignored) {}
+			try { broker.stop(); } catch (Exception ignored) {}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Problem.** On 2026-05-06 the prod data pod wedged its ActiveMQ Classic client connection with `IllegalStateException: Timer already cancelled.` repeating in the FailoverTransport reconnect loop. JMS traffic stopped; manual `kubectl rollout restart` was the only recovery. The root cause is in `org.apache.activemq.transport.AbstractInactivityMonitor`: a JVM-wide static `Timer` shared by every `InactivityMonitor`, refcounted by `CHECKER_COUNTER`. If any TimerTask throws an unchecked exception, `TimerThread` self-terminates silently and the static fields still point at the corpse Timer; `CHECKER_COUNTER > 0` blocks the lazy-init guard, so every subsequent reconnect's `schedule()` throws forever. The data pod's high JMS-connection churn (~30 fresh `Connection` + `InactivityMonitor` per minute, since `MessageProducerSessionJms` constructs one per RPC reply) makes this latent failure essentially inevitable on long-running pods.
- **Defense-in-depth fix.** Bound the failover reconnect budget, attach a `TransportListener` that exits the JVM on terminal IOException so K8s recycles the pod. Default behavior is log-only — only `SimDataServer` (the pod that wedged) opts into JVM exit. Other daemons (DatabaseServer, SimulationDispatcher, HtcSimulationWorker, the vcell-rest Guice binding) intentionally not opted in here; review individually before adding.
- **Version bump (does not fix the wedge).** activemq-broker/-client 5.18.3 → 5.18.7 picks up unrelated OpenWire validation hardening + dependency updates. The InactivityMonitor / FailoverTransport files are byte-identical between 5.18.3 and 5.18.7 (verified by diff against upstream). Commit message explicitly disclaims a wedge fix.
- **Note for reviewers:** the last commit (`6d1f44bd8d`) is a doc-only update to `.claude/commands/loki-query.md` cherry-picked from #loki-query-kubectl-direct. Whichever PR merges first will absorb it; the second will show no overlap.

## Investigation evidence (in case you want to verify)

Reconstructed via `/loki-query` for the data pod and `kubectl exec` against the broker:

| Time (UTC) | Event |
|---|---|
| 2026-05-05 15:16 | Old data pod `data-55b4888797-gm82j` starts |
| sometime in next 15h | A TimerTask on the JVM-wide static heartbeat Timer throws unchecked → TimerThread dies silently (no log) |
| 2026-05-06 06:41:05 | Broker WARN \`Transport Connection to: tcp://10.42.3.55:40214 failed: java.io.EOFException\` — exposes the latent wedge |
| 06:41:05+ | FailoverTransport tries to reconnect, schedule() on dead Timer throws, 10 instant-fail attempts in 32s |
| 06:41:37 | First "after: 10 attempt(s) with Timer already cancelled." surfaces in pod logs |

The wedge isn't *caused* by the network event — that's just what *exposes* it. In steady state the bug is invisible.

## Test plan

- [x] `mvn test -pl vcell-server -Dtest=JmsFailoverWatchdogTest` — passes (~0.7s) using embedded BrokerService + latch handler
- [x] `mvn compile test-compile -pl vcell-server,vcell-rest -am` — BUILD SUCCESS
- [ ] Run Fast group: `mvn test -Dgroups="Fast"` — sanity check no regression in JMS paths from the version bump
- [ ] Stage rollout: kill `activemqint` for >10min, observe `data` pod log for `FATAL JMS transport unrecoverable` followed by K8s pod recycle within ~5-8 minutes (maxReconnectAttempts=20 × exponential backoff capped at 30s)
- [ ] Confirm only SimDataServer opts in — other daemons should log `JMS transport interrupted, failover reconnecting` but not exit when activemqint is unavailable
- [ ] After deploy, monitor for any unexpected exits (the watchdog should fire only when the failover transport genuinely gives up)

## Follow-ups not in this PR

- AMQP 1.0 migration of OpenWire daemons (data, db, sched, submit) — folds into the in-flight Quarkus 3.27 + Artemis work; eliminates the bug class entirely (different heartbeat mechanism, no shared static Timer).
- Reconfigure activemqint/activemqsim/artemismq to log to stdout (currently supervisord-PID-1 swallows broker logs — see the doc commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)