### PR TITLE
Add admincli report toolkit for period-bounded usage reports

### DIFF
--- a/.claude/commands/admin-report.md
+++ b/.claude/commands/admin-report.md
@@ -1,0 +1,109 @@
+# admin-report — VCell usage-report toolkit
+
+Use this when someone asks for a period-bounded VCell usage report (NIH RPPR, year-end summary, custom date-range stats) or for an active-user list. The toolkit is a set of single-purpose `admincli report` subcommands that each emit one number or one CSV. Compose them in shell to assemble whatever shape the request needs.
+
+## When invoked
+
+The argument is a free-form description of what is needed (e.g. "RPPR for July 1, 2025 through May 8, 2026; we need new-user count, total-models as-of, and the active-user email list"). Translate it into a sequence of admincli invocations, capture each output to a file, and report the collected numbers + the path to the active-user CSV.
+
+The four primitives:
+
+| Command | Output | What it computes |
+| --- | --- | --- |
+| `admincli report count-new-users --start <date> --end <date>` | int on stdout | `vc_userinfo` rows whose `insertDate` is in `[start, end]` |
+| `admincli report count-sim-jobs-in-db --start <date> --end <date>` | int on stdout | `vc_simulationjob` rows whose `submitDate` is in `[start, end]`. **Undercount** — see SLURM caveat below. |
+| `admincli report count-asof --metric <m> --asof <date>` | int on stdout | Cumulative count of `<m>` as of `<date>`. See "Available `--metric` values" below. |
+| `admincli report list-active-users --start <date> --end <date> [-o <file>]` | CSV on stdout (or `-o`) | One row per distinct user who submitted a sim job in `[start, end]`: `userid,email,company,country,tld_extension`. |
+
+All commands write a one-line human-readable description to stderr; pipelines that capture stdout get just the number/CSV.
+
+## Available `--metric` values for `count-asof`
+
+Case-insensitive, hyphens or underscores both work.
+
+- `total-users` — total registered VCell users
+- `users-with-sims` — distinct users with at least one simulation
+- `biomodels`, `mathmodels`, `total-models` — model counts (total = biomodels + mathmodels)
+- `simulations` — total simulations
+- `public-biomodels`, `public-mathmodels`, `public-models` — `PRIVACY=0` model counts
+- `public-biomodel-sims`, `public-mathmodel-sims`, `public-sims` — simulations belonging to public models
+
+Each metric is evaluated as `<expr> WHERE versionDate <= asof` (for the model/sim counts) or `WHERE insertDate <= asof` (for `total-users`).
+
+## SLURM caveat for "jobs submitted"
+
+`count-sim-jobs-in-db` undercounts the historical job total because `vc_simulationjob` cascade-deletes when its parent simulation is removed/replaced. The true count of jobs submitted to the compute cluster lives in SLURM accounting. Run on the HTC head node:
+
+```bash
+sacct -S <start> -E <end> --truncate -X --noheader -o JobID | wc -l
+```
+
+The DB number is still useful as a lower bound and as a sanity check against SLURM.
+
+## Build prerequisite
+
+The driver script does **not** rebuild the Maven project. Before running it for the first time after any source change, build once from the project root:
+
+```bash
+mvn clean package dependency:copy-dependencies -DskipTests -pl '!vcell-rest'
+```
+
+(vcell-rest is excluded because Quarkus dependency-convergence enforcement fails locally; admincli doesn't depend on it.) If your sources haven't changed since the last build, skip this — `tools/report/rppr-2026.sh` will fail fast with a clear message if `vcell-admin/target/maven-jars` is missing.
+
+## Recipe — RPPR-style report
+
+The packaged driver is `tools/report/rppr-2026.sh`. It expects four DB env vars (`VCELL_DB_URL`, `VCELL_DB_DRIVER`, `VCELL_DB_USER`, `VCELL_DB_PASSWORD`) and writes one file per metric plus an active-users CSV to `tools/report/output/rppr-2026/` by default. Override the period or output dir with `REPORT_START=`/`REPORT_END=`/`REPORT_OUT_DIR=`.
+
+If you need to call the primitives by hand instead:
+
+```bash
+START=2025-07-01
+END=2026-05-08
+OUT=/tmp/rppr-2026
+mkdir -p "$OUT"
+
+admincli report count-new-users        --start "$START" --end "$END" > "$OUT/new_users.txt"
+admincli report count-sim-jobs-in-db   --start "$START" --end "$END" > "$OUT/sim_jobs_in_db.txt"
+
+for m in total-users users-with-sims total-models simulations public-models public-sims; do
+  admincli report count-asof --metric "$m" --asof "$END" > "$OUT/asof_${m}.txt"
+done
+
+admincli report list-active-users      --start "$START" --end "$END" -o "$OUT/active_users.csv"
+
+# True job-submission count (SLURM head node):
+#   sacct -S "$START" -E "$END" --truncate -X --noheader -o JobID | wc -l
+```
+
+Each `*.txt` contains a single integer; `active_users.csv` is a header-included CSV ready for spreadsheet import.
+
+## Adding a new metric next year
+
+- **New as-of metric** (e.g. "models published in the last year"): add an enum value to `cbit.vcell.modeldb.AdminDBTopLevel.AsOfMetric` and a corresponding SQL branch in `countAsOfImpl`. No new command class needed; `count-asof --metric <new-name>` works immediately.
+- **New period-bounded count** (e.g. "models created in period"): add a new method on `AdminDBTopLevel` and a new `*Command.java` in `vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/`, then register it in `ReportCommand.subcommands`. ~80 lines total. Existing commands untouched.
+- **New list output** (e.g. "active users grouped by country"): new command class, reuses or composes existing query methods.
+- **Different report shape** (PDF, slack message, …): wrap the existing primitives in a shell script. Don't touch Java.
+
+## SQL convention (when modifying the queries)
+
+`AdminDBTopLevel.getBasicStatistics()` (the older method that drives `/api/v1/admin/usage`) embeds raw column names as string literals. **Do not follow that example.** The new report queries reference columns through `Table`-class `Field` objects:
+
+```java
+UserTable.table.insertDate.getQualifiedColName()      // -> "vc_userinfo.insertDate"
+SimulationTable.table.versionDate.getQualifiedColName()
+BioModelTable.table.privacy.getQualifiedColName()
+```
+
+Date predicates use `PreparedStatement.setDate(i, java.sql.Date.valueOf(localDate))` — never string-interpolated dates.
+
+## Internal references
+
+- SQL: `vcell-server/src/main/java/cbit/vcell/modeldb/AdminDBTopLevel.java`
+  — `countNewUsers`, `countSimJobsInDb`, `countAsOf`, `countAsOfImpl`, `listActiveUsersInPeriod`, `AsOfMetric`, `ActiveUser`.
+- CLI: `vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/`.
+- Service wrapper: `vcell-admin/src/main/java/org/vcell/admin/cli/CLIDatabaseService.java`.
+- Schema (Field references):
+  - `vc_userinfo`: `UserTable.table.{insertDate, email, companyName, country, userid, id}`.
+  - Versioning columns inherited via `VersionTable` → `BioModelTable`, `MathModelTable`, `SimulationTable`: `versionDate`, `privacy`, `ownerRef`.
+  - `vc_simulationjob`: `SimulationJobTable.table.{submitDate, simRef}`.
+  - Link tables: `BioModelSimulationLinkTable`, `MathModelSimulationLinkTable`.

--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,12 @@ pythonData/test_data/zarr/
 pythonCopasiOpt/vcell-opt/.venv/
 
 pythonCopasiOpt/vcell-opt/test_data/optproblem.report
+
+tools/report/output/
+
+# User-PII artifacts from admincli reporting (emails, names, affiliations).
+# Never commit per-user lists; the CSV stays local.
+users_*.txt
+users_*.csv
+active_users*.csv
+/users.txt

--- a/tools/report/rppr-2026.sh
+++ b/tools/report/rppr-2026.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Driver for the 2026 NIH RPPR usage report.
+# Period: REPORT_START .. REPORT_END (defaults below).
+#
+# Outputs (one file per metric, plus a per-user CSV) land in REPORT_OUT_DIR.
+#
+# PRECONDITION: the Maven project must be built and dependencies copied to
+# vcell-admin/target/maven-jars BEFORE running this script. The script does
+# NOT rebuild — that decision is left to the caller so a clean build doesn't
+# block every invocation. From the project root:
+#
+#     mvn clean package dependency:copy-dependencies -DskipTests -pl '!vcell-rest'
+#
+# (vcell-rest is excluded because Quarkus dependency-convergence enforcement
+# fails locally; admincli does not depend on it.)
+#
+# Skip the rebuild if you have already built since your last source edit.
+#
+# DB credentials are NOT in this script. Source them from your environment
+# (e.g. ~/.vcell/admincli-env, your local secrets store, or paste them inline
+# for the run). Required env vars:
+#
+#   VCELL_DB_URL         e.g. jdbc:oracle:thin:@vcell-oracle.cam.uchc.edu:1521/ORCLPDB1
+#   VCELL_DB_DRIVER      e.g. oracle.jdbc.driver.OracleDriver
+#   VCELL_DB_USER        the dev/reporting role (NOT the service role)
+#   VCELL_DB_PASSWORD    password for that role
+#
+# Use the dev role (e.g. vcell_dev) so reporting credentials stay separate
+# from service credentials. Both roles point at the same database.
+#
+# See .claude/commands/admin-report.md for what each metric means and the
+# SLURM caveat for "jobs submitted to compute server".
+
+set -euo pipefail
+
+START="${REPORT_START:-2025-07-01}"
+END="${REPORT_END:-2026-05-01}"
+PROJECT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT_DIR="${REPORT_OUT_DIR:-$PROJECT_DIR/tools/report/output/rppr-2026}"
+
+JAR="$PROJECT_DIR/vcell-admin/target/vcell-admin-0.0.1-SNAPSHOT.jar"
+LIB="$PROJECT_DIR/vcell-admin/target/maven-jars"
+
+require_env() {
+    for v in VCELL_DB_URL VCELL_DB_DRIVER VCELL_DB_USER VCELL_DB_PASSWORD; do
+        if [ -z "${!v:-}" ]; then
+            echo "ERROR: $v is not set." >&2
+            exit 2
+        fi
+    done
+}
+
+ensure_built() {
+    # Verify the build artifacts exist; do NOT rebuild. The caller is responsible
+    # for ensuring the Maven project is up-to-date before invoking this script.
+    if [ ! -f "$JAR" ] || [ ! -d "$LIB" ] || [ -z "$(ls -A "$LIB" 2>/dev/null)" ]; then
+        cat >&2 <<EOF
+ERROR: Maven build artifacts missing.
+       Expected:
+         $JAR
+         $LIB/*.jar
+
+       Build first, then re-run this script:
+         (cd "$PROJECT_DIR" && \\
+          mvn clean package dependency:copy-dependencies -DskipTests -pl '!vcell-rest')
+EOF
+        exit 3
+    fi
+}
+
+run_admincli() {
+    # -Dlog4j2.statusLoggerLevel=OFF suppresses Log4j2's StatusLogger warnings
+    # (e.g. "package scanning is deprecated") that otherwise land on stdout
+    # and pollute single-integer metric outputs.
+    java \
+        -Dlog4j2.statusLoggerLevel=OFF \
+        -Dvcell.installDir="$PROJECT_DIR" \
+        -Dvcell.server.dbConnectURL="$VCELL_DB_URL" \
+        -Dvcell.server.dbDriverName="$VCELL_DB_DRIVER" \
+        -Dvcell.server.dbUserid="$VCELL_DB_USER" \
+        -Dvcell.server.dbPassword="$VCELL_DB_PASSWORD" \
+        -cp "$JAR:$LIB/*" \
+        org.vcell.admin.cli.AdminCLI "$@"
+}
+
+require_env
+ensure_built
+mkdir -p "$OUT_DIR"
+
+echo "RPPR 2026 — period [$START, $END] -> $OUT_DIR" >&2
+echo >&2
+
+# Each count command emits the integer as the final stdout line; earlier lines
+# may carry Log4j2 StatusLogger initialization warnings. `tail -1` grabs just the
+# count for the per-metric output file.
+
+run_admincli report count-new-users --start "$START" --end "$END" \
+    | tail -1 > "$OUT_DIR/new_users.txt"
+
+run_admincli report count-sim-jobs-in-db --start "$START" --end "$END" \
+    | tail -1 > "$OUT_DIR/sim_jobs_in_db.txt"
+
+for m in total-users users-with-sims biomodels mathmodels total-models simulations \
+         public-biomodels public-mathmodels public-models \
+         public-biomodel-sims public-mathmodel-sims public-sims; do
+    run_admincli report count-asof --metric "$m" --asof "$END" \
+        | tail -1 > "$OUT_DIR/asof_${m}.txt"
+done
+
+run_admincli report list-active-users \
+    --start "$START" --end "$END" \
+    -o "$OUT_DIR/active_users.csv"
+
+cat >&2 <<EOF
+
+------------------------------------------------------------------------
+Done. Outputs in: $OUT_DIR
+
+Period metrics:
+  new_users:         $(cat "$OUT_DIR/new_users.txt")
+  sim_jobs_in_db:    $(cat "$OUT_DIR/sim_jobs_in_db.txt") (undercount; see SLURM below)
+
+Cumulative as of $END:
+  total_users:           $(cat "$OUT_DIR/asof_total-users.txt")
+  users_with_sims:       $(cat "$OUT_DIR/asof_users-with-sims.txt")
+  total_models:          $(cat "$OUT_DIR/asof_total-models.txt")
+  total_simulations:     $(cat "$OUT_DIR/asof_simulations.txt")
+  public_models:         $(cat "$OUT_DIR/asof_public-models.txt")
+  public_simulations:    $(cat "$OUT_DIR/asof_public-sims.txt")
+
+active_users.csv: $(wc -l < "$OUT_DIR/active_users.csv") line(s) (incl. header)
+
+Reminder: the true count of jobs submitted to the compute cluster lives in
+SLURM accounting. On the HTC head node:
+    sacct -S "$START" -E "$END" --truncate -X --noheader -o JobID | wc -l
+------------------------------------------------------------------------
+EOF

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/AdminCLI.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/AdminCLI.java
@@ -18,6 +18,7 @@ import org.vcell.admin.cli.sim.ResultSetCrawlerCommand;
 import org.vcell.admin.cli.sim.SimDataVerifierCommand;
 import org.vcell.admin.cli.tools.UsageCommand;
 import org.vcell.admin.cli.tools.UsersQueryCommand;
+import org.vcell.admin.cli.tools.report.ReportCommand;
 import org.vcell.db.DatabaseSyntax;
 import org.vcell.dependency.server.VCellServerModule;
 import org.vcell.util.document.KeyValue;
@@ -35,6 +36,7 @@ import picocli.CommandLine.Command;
         XmlControlCharScanCommand.class,
         UsageCommand.class,
         UsersQueryCommand.class,
+        ReportCommand.class,
         ResultSetCrawlerCommand.class,
         SimDataVerifierCommand.class,
         JobInfoCommand.class,

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/CLIDatabaseService.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/CLIDatabaseService.java
@@ -16,6 +16,7 @@ import org.vcell.util.document.*;
 
 import java.math.BigDecimal;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -95,6 +96,25 @@ public class CLIDatabaseService implements AutoCloseable {
     public AdminDBTopLevel.DbUserSimCount[] getUserSimCount(int pastTime_days) throws SQLException, DataAccessException {
         AdminDBTopLevel adminDbTopLevel = new AdminDBTopLevel(conFactory);
         return adminDbTopLevel.getUserSimCounts(pastTime_days);
+    }
+
+    // Period-bounded report primitives. See .claude/commands/admin-report.md.
+
+    public int countNewUsers(LocalDate start, LocalDate end) throws SQLException, DataAccessException {
+        return new AdminDBTopLevel(conFactory).countNewUsers(start, end);
+    }
+
+    public int countSimJobsInDb(LocalDate start, LocalDate end) throws SQLException, DataAccessException {
+        return new AdminDBTopLevel(conFactory).countSimJobsInDb(start, end);
+    }
+
+    public int countAsOf(AdminDBTopLevel.AsOfMetric metric, LocalDate asOf) throws SQLException, DataAccessException {
+        return new AdminDBTopLevel(conFactory).countAsOf(metric, asOf);
+    }
+
+    public List<AdminDBTopLevel.ActiveUser> listActiveUsersInPeriod(LocalDate start, LocalDate end)
+            throws SQLException, DataAccessException {
+        return new AdminDBTopLevel(conFactory).listActiveUsersInPeriod(start, end);
     }
 
     public MathVerifier getMathVerifier() throws DataAccessException, SQLException {

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/CountAsOfCommand.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/CountAsOfCommand.java
@@ -1,0 +1,61 @@
+package org.vcell.admin.cli.tools.report;
+
+import cbit.vcell.modeldb.AdminDBTopLevel.AsOfMetric;
+import org.vcell.admin.cli.CLIDatabaseService;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ITypeConverter;
+import picocli.CommandLine.Option;
+
+import java.time.LocalDate;
+import java.util.concurrent.Callable;
+
+/**
+ * Cumulative count for the chosen as-of metric, evaluated at the given date (inclusive).
+ *
+ * <p>Metric names are case-insensitive and may use hyphens or underscores
+ * (e.g. {@code --metric total-users} maps to {@link AsOfMetric#TOTAL_USERS}).
+ * Available metrics: {@code total-users}, {@code users-with-sims},
+ * {@code biomodels}, {@code mathmodels}, {@code total-models}, {@code simulations},
+ * {@code public-biomodels}, {@code public-mathmodels}, {@code public-models},
+ * {@code public-biomodel-sims}, {@code public-mathmodel-sims}, {@code public-sims}.
+ *
+ * <p>Output: integer on stdout, one human-readable line on stderr.
+ *
+ * <p>To add a new as-of metric next year: add an enum value to
+ * {@link AsOfMetric} plus a SQL branch in {@code AdminDBTopLevel.countAsOfImpl}.
+ * No new command class needed. See {@code .claude/commands/admin-report.md}.
+ */
+@Command(name = "count-asof",
+        description = "Cumulative count for the chosen metric as of a given date.")
+public class CountAsOfCommand implements Callable<Integer> {
+
+    @Option(names = "--metric", required = true,
+            converter = AsOfMetricConverter.class,
+            description = "Which cumulative metric to compute. "
+                    + "One of: total-users, users-with-sims, biomodels, mathmodels, "
+                    + "total-models, simulations, public-biomodels, public-mathmodels, "
+                    + "public-models, public-biomodel-sims, public-mathmodel-sims, public-sims.")
+    private AsOfMetric metric;
+
+    @Option(names = "--asof", required = true,
+            description = "Date at which to evaluate the count (yyyy-MM-dd, inclusive).")
+    private LocalDate asOf;
+
+    @Override
+    public Integer call() throws Exception {
+        try (CLIDatabaseService db = new CLIDatabaseService()) {
+            int n = db.countAsOf(metric, asOf);
+            System.err.println(metric.name() + " as of " + asOf + ":");
+            System.out.println(n);
+        }
+        return 0;
+    }
+
+    /** Accepts hyphenated or underscored, case-insensitive metric names. */
+    public static class AsOfMetricConverter implements ITypeConverter<AsOfMetric> {
+        @Override
+        public AsOfMetric convert(String value) {
+            return AsOfMetric.valueOf(value.trim().toUpperCase().replace('-', '_'));
+        }
+    }
+}

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/CountNewUsersCommand.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/CountNewUsersCommand.java
@@ -1,0 +1,40 @@
+package org.vcell.admin.cli.tools.report;
+
+import org.vcell.admin.cli.CLIDatabaseService;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.time.LocalDate;
+import java.util.concurrent.Callable;
+
+/**
+ * Count of {@code vc_userinfo} rows whose insertDate falls in {@code [start, end]} (inclusive) — i.e.,
+ * the number of new VCell users registered during the period.
+ *
+ * <p>Output: integer on stdout, one human-readable line on stderr.
+ *
+ * <p>Part of the {@code report} toolkit; see {@code .claude/commands/admin-report.md}
+ * for the full RPPR recipe.
+ */
+@Command(name = "count-new-users",
+        description = "Count of vc_userinfo rows with insertDate in [start, end].")
+public class CountNewUsersCommand implements Callable<Integer> {
+
+    @Option(names = "--start", required = true,
+            description = "Period start date (yyyy-MM-dd, inclusive).")
+    private LocalDate start;
+
+    @Option(names = "--end", required = true,
+            description = "Period end date (yyyy-MM-dd, inclusive).")
+    private LocalDate end;
+
+    @Override
+    public Integer call() throws Exception {
+        try (CLIDatabaseService db = new CLIDatabaseService()) {
+            int n = db.countNewUsers(start, end);
+            System.err.println("New users in [" + start + ", " + end + "]:");
+            System.out.println(n);
+        }
+        return 0;
+    }
+}

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/CountSimJobsInDbCommand.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/CountSimJobsInDbCommand.java
@@ -1,0 +1,47 @@
+package org.vcell.admin.cli.tools.report;
+
+import org.vcell.admin.cli.CLIDatabaseService;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.time.LocalDate;
+import java.util.concurrent.Callable;
+
+/**
+ * Count of {@code vc_simulationjob} rows whose submitDate falls in {@code [start, end]} (inclusive).
+ *
+ * <p><strong>This number undercounts the true historical job count.</strong>
+ * {@code vc_simulationjob} has ON DELETE CASCADE on its parent simulation, so jobs
+ * whose parent simulation was later deleted/replaced are gone. For total jobs ever
+ * submitted to the compute cluster, use SLURM accounting:
+ * <pre>
+ *   sacct -S &lt;start&gt; -E &lt;end&gt; --truncate -X --noheader -o JobID | wc -l
+ * </pre>
+ *
+ * <p>Output: integer on stdout, one human-readable line on stderr.
+ * See {@code .claude/commands/admin-report.md} for context.
+ */
+@Command(name = "count-sim-jobs-in-db",
+        description = "Count of vc_simulationjob rows with submitDate in [start, end] "
+                + "(undercount due to cascade-delete; SLURM accounting is the true source).")
+public class CountSimJobsInDbCommand implements Callable<Integer> {
+
+    @Option(names = "--start", required = true,
+            description = "Period start date (yyyy-MM-dd, inclusive).")
+    private LocalDate start;
+
+    @Option(names = "--end", required = true,
+            description = "Period end date (yyyy-MM-dd, inclusive).")
+    private LocalDate end;
+
+    @Override
+    public Integer call() throws Exception {
+        try (CLIDatabaseService db = new CLIDatabaseService()) {
+            int n = db.countSimJobsInDb(start, end);
+            System.err.println("Sim jobs in DB with submitDate in [" + start + ", " + end + "]:");
+            System.err.println("  (undercount; see SLURM sacct for true value)");
+            System.out.println(n);
+        }
+        return 0;
+    }
+}

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/ListActiveUsersCommand.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/ListActiveUsersCommand.java
@@ -1,0 +1,88 @@
+package org.vcell.admin.cli.tools.report;
+
+import cbit.vcell.modeldb.AdminDBTopLevel.ActiveUser;
+import org.vcell.admin.cli.CLIDatabaseService;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * CSV of distinct users who submitted at least one simulation job during {@code [start, end]}.
+ * Columns: {@code userid,email,company,country,tld_extension}.
+ *
+ * <p>{@code userid} is the VCell login id from {@code vc_userinfo.userid}. {@code company} comes
+ * from {@code vc_userinfo.companyname}, {@code country} from {@code vc_userinfo.country} (both
+ * may be blank). {@code tld_extension} is derived from the email's domain — the substring after
+ * the last {@code .}, lowercased — and is blank if the email has no dot.
+ *
+ * <p>Output: CSV with header on stdout, or to {@code -o &lt;file&gt;}.
+ *
+ * <p>Same cascade-delete caveat as {@link CountSimJobsInDbCommand}: a user whose only jobs in
+ * the period have since had their parent simulation removed will not appear here.
+ *
+ * <p>See {@code .claude/commands/admin-report.md}.
+ */
+@Command(name = "list-active-users",
+        description = "CSV of users who submitted a sim job in [start, end] "
+                + "(userid, email, company, country, tld_extension).")
+public class ListActiveUsersCommand implements Callable<Integer> {
+
+    @Option(names = "--start", required = true,
+            description = "Period start date (yyyy-MM-dd, inclusive).")
+    private LocalDate start;
+
+    @Option(names = "--end", required = true,
+            description = "Period end date (yyyy-MM-dd, inclusive).")
+    private LocalDate end;
+
+    @Option(names = {"-o", "--output-file"},
+            description = "Write CSV to this file instead of stdout.")
+    private File outputFile;
+
+    @Override
+    public Integer call() throws Exception {
+        try (CLIDatabaseService db = new CLIDatabaseService()) {
+            List<ActiveUser> users = db.listActiveUsersInPeriod(start, end);
+            try (Writer w = outputFile != null
+                    ? new FileWriter(outputFile)
+                    : new java.io.OutputStreamWriter(System.out);
+                 PrintWriter pw = new PrintWriter(w)) {
+                pw.println("userid,email,company,country,tld_extension");
+                for (ActiveUser u : users) {
+                    pw.println(csv(u.userid()) + "," + csv(u.email()) + "," + csv(u.company())
+                            + "," + csv(u.country()) + "," + csv(tldOf(u.email())));
+                }
+                pw.flush();
+            }
+            System.err.println("Active users in [" + start + ", " + end + "]: " + users.size());
+        }
+        return 0;
+    }
+
+    /** Last dot-segment of an email's domain, lowercased; empty string if none. */
+    static String tldOf(String email) {
+        if (email == null) return "";
+        int at = email.lastIndexOf('@');
+        if (at < 0 || at == email.length() - 1) return "";
+        String domain = email.substring(at + 1);
+        int dot = domain.lastIndexOf('.');
+        if (dot < 0 || dot == domain.length() - 1) return "";
+        return domain.substring(dot + 1).toLowerCase();
+    }
+
+    /** RFC-4180-ish CSV escaping: quote when the value contains comma, quote, CR, or LF. */
+    static String csv(String s) {
+        if (s == null) return "";
+        boolean needsQuote = s.indexOf(',') >= 0 || s.indexOf('"') >= 0
+                || s.indexOf('\n') >= 0 || s.indexOf('\r') >= 0;
+        if (!needsQuote) return s;
+        return "\"" + s.replace("\"", "\"\"") + "\"";
+    }
+}

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/ReportCommand.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/ReportCommand.java
@@ -1,0 +1,22 @@
+package org.vcell.admin.cli.tools.report;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/**
+ * Parent picocli command grouping the period-bounded usage-report primitives.
+ * Has no body of its own; subcommands do the work.
+ *
+ * <p>See {@code .claude/commands/admin-report.md} for the toolkit overview.
+ */
+@Command(name = "report",
+        description = "Period-bounded VCell usage report primitives (RPPR-style metrics).",
+        subcommands = {
+                CountNewUsersCommand.class,
+                CountSimJobsInDbCommand.class,
+                CountAsOfCommand.class,
+                ListActiveUsersCommand.class,
+                CommandLine.HelpCommand.class
+        })
+public class ReportCommand {
+}

--- a/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/package-info.java
+++ b/vcell-admin/src/main/java/org/vcell/admin/cli/tools/report/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Modular admincli report toolkit for period-bounded VCell usage reports
+ * (NIH RPPR and similar).
+ *
+ * <p>Each command in this package does exactly one thing and emits a single
+ * value (an integer count) or a single CSV. Compose them in shell to assemble
+ * a report for a particular period; see {@code .claude/commands/admin-report.md}
+ * for the recipe and a checklist for adding new metrics next year.
+ *
+ * <p>SQL implementations live on
+ * {@link cbit.vcell.modeldb.AdminDBTopLevel} (search for {@code countNewUsers},
+ * {@code countSimJobsInDb}, {@code countAsOf}, {@code listActiveUsersInPeriod}).
+ * They follow the convention of building queries from
+ * {@link cbit.sql.Field#getQualifiedColName Field.getQualifiedColName()} on
+ * {@code Table}-class singletons rather than from raw column-name string
+ * literals, and bind dates via {@code PreparedStatement.setDate}.
+ *
+ * <p>Caveat: the {@code count-sim-jobs-in-db} metric undercounts the true number
+ * of jobs ever submitted to the compute cluster because {@code vc_simulationjob}
+ * rows cascade-delete with their parent simulation. The full count must be
+ * obtained from SLURM accounting (e.g. {@code sacct}); see the slash-command
+ * markdown for the invocation.
+ */
+package org.vcell.admin.cli.tools.report;

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/AdminDBTopLevel.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/AdminDBTopLevel.java
@@ -11,6 +11,7 @@
 package cbit.vcell.modeldb;
 
 import cbit.vcell.messaging.db.SimulationJobDbDriver;
+import cbit.vcell.messaging.db.SimulationJobTable;
 import cbit.vcell.messaging.db.SimulationRequirements;
 import cbit.vcell.modeldb.ApiAccessToken.AccessTokenStatus;
 import cbit.vcell.mongodb.VCMongoMessage;
@@ -24,9 +25,11 @@ import org.vcell.util.UseridIDExistsException;
 import org.vcell.util.document.*;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.LocalDate;
 import java.util.*;
 
 /**
@@ -1247,6 +1250,223 @@ public class AdminDBTopLevel extends AbstractDBTopLevel {
             }
         } finally {
             conFactory.release(con, lock);
+        }
+    }
+
+    // ========================================================================
+    // Period-bounded usage report primitives.
+    //
+    // These are used by the admincli `report` toolkit to produce NIH RPPR-style
+    // metrics. Unlike getBasicStatistics() above, these queries take explicit
+    // [start, end] / asof dates as PreparedStatement parameters and reference
+    // columns through Table-class Field objects rather than embedded literals.
+    //
+    // See .claude/commands/admin-report.md for the toolkit overview and the
+    // recipe for assembling an RPPR report.
+    // ========================================================================
+
+    /**
+     * Cumulative metrics evaluated as of a given date (inclusive).
+     * Naming maps to the corresponding picocli enum value via case-insensitive
+     * conversion (e.g. {@code --metric total-users} -> {@link #TOTAL_USERS}).
+     */
+    public enum AsOfMetric {
+        TOTAL_USERS,
+        USERS_WITH_SIMS,
+        BIOMODELS,
+        MATHMODELS,
+        TOTAL_MODELS,
+        SIMULATIONS,
+        PUBLIC_BIOMODELS,
+        PUBLIC_MATHMODELS,
+        PUBLIC_MODELS,
+        PUBLIC_BIOMODEL_SIMS,
+        PUBLIC_MATHMODEL_SIMS,
+        PUBLIC_SIMS
+    }
+
+    /** One row per active user; a {@code null} field means the user record had no value for it. */
+    public record ActiveUser(String userid, String email, String company, String country) {}
+
+    /** Count of {@code vc_userinfo} rows whose insertDate falls in {@code [start, end]} inclusive. */
+    public int countNewUsers(LocalDate start, LocalDate end) throws SQLException, DataAccessException {
+        Object lock = new Object();
+        Connection con = conFactory.getConnection(lock);
+        try {
+            String sql = "select count(*) from " + UserTable.table.getTableName()
+                    + " where " + UserTable.table.insertDate.getQualifiedColName() + " >= ?"
+                    + " and " + UserTable.table.insertDate.getQualifiedColName() + " <= ?";
+            return executeCountPrepared(con, sql,
+                    java.sql.Date.valueOf(start), java.sql.Date.valueOf(end));
+        } catch (Throwable e) {
+            lg.error("failure in countNewUsers()", e);
+            handle_DataAccessException_SQLException(e);
+            return 0;
+        } finally {
+            conFactory.release(con, lock);
+        }
+    }
+
+    /**
+     * Count of {@code vc_simulationjob} rows whose submitDate falls in {@code [start, end]} inclusive.
+     * <p>
+     * NOTE: this number undercounts the true historical number of jobs that ran. {@code vc_simulationjob}
+     * has ON DELETE CASCADE on its parent simulation, so jobs whose parent simulation was later
+     * deleted/replaced are gone from the table. For total jobs ever submitted to the compute cluster,
+     * use SLURM accounting (see {@code .claude/commands/admin-report.md}).
+     */
+    public int countSimJobsInDb(LocalDate start, LocalDate end) throws SQLException, DataAccessException {
+        Object lock = new Object();
+        Connection con = conFactory.getConnection(lock);
+        try {
+            String sql = "select count(*) from " + SimulationJobTable.table.getTableName()
+                    + " where " + SimulationJobTable.table.submitDate.getQualifiedColName() + " >= ?"
+                    + " and " + SimulationJobTable.table.submitDate.getQualifiedColName() + " <= ?";
+            return executeCountPrepared(con, sql,
+                    java.sql.Date.valueOf(start), java.sql.Date.valueOf(end));
+        } catch (Throwable e) {
+            lg.error("failure in countSimJobsInDb()", e);
+            handle_DataAccessException_SQLException(e);
+            return 0;
+        } finally {
+            conFactory.release(con, lock);
+        }
+    }
+
+    /** Count for the chosen as-of metric, evaluated at {@code asOf} (inclusive). */
+    public int countAsOf(AsOfMetric metric, LocalDate asOf) throws SQLException, DataAccessException {
+        Object lock = new Object();
+        Connection con = conFactory.getConnection(lock);
+        try {
+            return countAsOfImpl(con, metric, java.sql.Date.valueOf(asOf));
+        } catch (Throwable e) {
+            lg.error("failure in countAsOf(" + metric + ")", e);
+            handle_DataAccessException_SQLException(e);
+            return 0;
+        } finally {
+            conFactory.release(con, lock);
+        }
+    }
+
+    private int countAsOfImpl(Connection con, AsOfMetric metric, java.sql.Date asOf) throws SQLException {
+        return switch (metric) {
+            case TOTAL_USERS -> executeCountPrepared(con,
+                    "select count(*) from " + UserTable.table.getTableName()
+                            + " where " + UserTable.table.insertDate.getQualifiedColName() + " <= ?",
+                    asOf);
+            case USERS_WITH_SIMS -> executeCountPrepared(con,
+                    "select count(distinct " + SimulationTable.table.ownerRef.getQualifiedColName() + ")"
+                            + " from " + SimulationTable.table.getTableName()
+                            + " where " + SimulationTable.table.versionDate.getQualifiedColName() + " <= ?",
+                    asOf);
+            case BIOMODELS -> executeCountPrepared(con, countVersionLeqSql(BioModelTable.table), asOf);
+            case MATHMODELS -> executeCountPrepared(con, countVersionLeqSql(MathModelTable.table), asOf);
+            case SIMULATIONS -> executeCountPrepared(con, countVersionLeqSql(SimulationTable.table), asOf);
+            case TOTAL_MODELS -> countAsOfImpl(con, AsOfMetric.BIOMODELS, asOf)
+                    + countAsOfImpl(con, AsOfMetric.MATHMODELS, asOf);
+            case PUBLIC_BIOMODELS -> executeCountPrepared(con, countPublicVersionLeqSql(BioModelTable.table), asOf);
+            case PUBLIC_MATHMODELS -> executeCountPrepared(con, countPublicVersionLeqSql(MathModelTable.table), asOf);
+            case PUBLIC_MODELS -> countAsOfImpl(con, AsOfMetric.PUBLIC_BIOMODELS, asOf)
+                    + countAsOfImpl(con, AsOfMetric.PUBLIC_MATHMODELS, asOf);
+            case PUBLIC_BIOMODEL_SIMS -> executeCountPrepared(con, publicBmSimsSql(), asOf);
+            case PUBLIC_MATHMODEL_SIMS -> executeCountPrepared(con, publicMmSimsSql(), asOf);
+            case PUBLIC_SIMS -> countAsOfImpl(con, AsOfMetric.PUBLIC_BIOMODEL_SIMS, asOf)
+                    + countAsOfImpl(con, AsOfMetric.PUBLIC_MATHMODEL_SIMS, asOf);
+        };
+    }
+
+    /**
+     * One row per distinct user who has at least one {@code vc_simulationjob} row whose submitDate
+     * falls in {@code [start, end]} inclusive. Userid, email, company, and country are read directly
+     * from {@code vc_userinfo}; TLD extraction (if needed) is the caller's concern.
+     * <p>
+     * Same cascade-delete caveat as {@link #countSimJobsInDb}: a user who only ran jobs whose
+     * parent simulation has since been removed will not appear here.
+     */
+    public List<ActiveUser> listActiveUsersInPeriod(LocalDate start, LocalDate end)
+            throws SQLException, DataAccessException {
+        Object lock = new Object();
+        Connection con = conFactory.getConnection(lock);
+        try {
+            String sql = "select distinct "
+                    + UserTable.table.userid.getQualifiedColName() + ", "
+                    + UserTable.table.email.getQualifiedColName() + ", "
+                    + UserTable.table.companyName.getQualifiedColName() + ", "
+                    + UserTable.table.country.getQualifiedColName()
+                    + " from " + UserTable.table.getTableName()
+                    + ", " + SimulationTable.table.getTableName()
+                    + ", " + SimulationJobTable.table.getTableName()
+                    + " where " + UserTable.table.id.getQualifiedColName() + " = " + SimulationTable.table.ownerRef.getQualifiedColName()
+                    + " and " + SimulationJobTable.table.simRef.getQualifiedColName() + " = " + SimulationTable.table.id.getQualifiedColName()
+                    + " and " + SimulationJobTable.table.submitDate.getQualifiedColName() + " >= ?"
+                    + " and " + SimulationJobTable.table.submitDate.getQualifiedColName() + " <= ?"
+                    + " order by " + UserTable.table.userid.getQualifiedColName();
+            try (PreparedStatement pstmt = con.prepareStatement(sql)) {
+                pstmt.setDate(1, java.sql.Date.valueOf(start));
+                pstmt.setDate(2, java.sql.Date.valueOf(end));
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    List<ActiveUser> out = new ArrayList<>();
+                    while (rs.next()) {
+                        out.add(new ActiveUser(rs.getString(1), rs.getString(2), rs.getString(3), rs.getString(4)));
+                    }
+                    return out;
+                }
+            }
+        } catch (Throwable e) {
+            lg.error("failure in listActiveUsersInPeriod()", e);
+            handle_DataAccessException_SQLException(e);
+            return null;
+        } finally {
+            conFactory.release(con, lock);
+        }
+    }
+
+    private static String countVersionLeqSql(VersionTable t) {
+        return "select count(*) from " + t.getTableName()
+                + " where " + t.versionDate.getQualifiedColName() + " <= ?";
+    }
+
+    private static String countPublicVersionLeqSql(VersionTable t) {
+        return "select count(*) from " + t.getTableName()
+                + " where " + t.privacy.getQualifiedColName() + " = 0"
+                + " and " + t.versionDate.getQualifiedColName() + " <= ?";
+    }
+
+    private static String publicBmSimsSql() {
+        return "select count(*) from " + SimulationTable.table.getTableName()
+                + " where " + SimulationTable.table.id.getQualifiedColName() + " in ("
+                + "select distinct " + SimulationTable.table.id.getQualifiedColName()
+                + " from " + BioModelTable.table.getTableName()
+                + ", " + SimulationTable.table.getTableName()
+                + ", " + BioModelSimulationLinkTable.table.getTableName()
+                + " where " + SimulationTable.table.id.getQualifiedColName() + " = " + BioModelSimulationLinkTable.table.simRef.getQualifiedColName()
+                + " and " + BioModelTable.table.id.getQualifiedColName() + " = " + BioModelSimulationLinkTable.table.bioModelRef.getQualifiedColName()
+                + " and " + BioModelTable.table.privacy.getQualifiedColName() + " = 0)"
+                + " and " + SimulationTable.table.versionDate.getQualifiedColName() + " <= ?";
+    }
+
+    private static String publicMmSimsSql() {
+        return "select count(*) from " + SimulationTable.table.getTableName()
+                + " where " + SimulationTable.table.id.getQualifiedColName() + " in ("
+                + "select distinct " + SimulationTable.table.id.getQualifiedColName()
+                + " from " + MathModelTable.table.getTableName()
+                + ", " + SimulationTable.table.getTableName()
+                + ", " + MathModelSimulationLinkTable.table.getTableName()
+                + " where " + SimulationTable.table.id.getQualifiedColName() + " = " + MathModelSimulationLinkTable.table.simRef.getQualifiedColName()
+                + " and " + MathModelTable.table.id.getQualifiedColName() + " = " + MathModelSimulationLinkTable.table.mathModelRef.getQualifiedColName()
+                + " and " + MathModelTable.table.privacy.getQualifiedColName() + " = 0)"
+                + " and " + SimulationTable.table.versionDate.getQualifiedColName() + " <= ?";
+    }
+
+    private static int executeCountPrepared(Connection con, String sql, java.sql.Date... dates) throws SQLException {
+        lg.info(sql);
+        try (PreparedStatement pstmt = con.prepareStatement(sql)) {
+            for (int i = 0; i < dates.length; i++) {
+                pstmt.setDate(i + 1, dates[i]);
+            }
+            try (ResultSet rs = pstmt.executeQuery()) {
+                return rs.next() ? rs.getInt(1) : 0;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- New `admincli report` subcommand kit (four single-purpose picocli commands) for NIH-RPPR-style usage metrics over arbitrary `[start, end]` windows.
- SQL primitives on `AdminDBTopLevel` use Table-class `Field.getQualifiedColName()` references and `PreparedStatement` date binding rather than embedded literals.
- Driver script `tools/report/rppr-2026.sh` runs the suite end-to-end against the `vcell_dev` role.
- `/admin-report` slash-command skill documents the toolkit, the SLURM `sacct` caveat for the true count of jobs submitted to the compute cluster, and a checklist for adding new metrics next year.
- `.gitignore` adds user-PII patterns (`users_*.txt`, `users_*.csv`, `active_users*.csv`) and `tools/report/output/` so per-user lists with emails/names/affiliations stay local.

## Why this shape

Next year's reporting request will likely have a different shape (different metrics, different groupings). Each command does one thing, so adding a new metric is one new SQL method + (for new categories) one new ~40-line command class. The `count-asof` command is enum-driven; adding a new as-of metric is one enum value plus a SQL branch — no new command class needed.

## Commands

```
admincli report count-new-users      --start <date> --end <date>
admincli report count-sim-jobs-in-db --start <date> --end <date>
admincli report count-asof --metric <m> --asof <date>
admincli report list-active-users    --start <date> --end <date> [-o <file>]
```

Each count command emits the integer on stdout with a human-readable description on stderr; `list-active-users` emits CSV (`userid,email,company,country,tld_extension`).

## Caveats documented in the code and skill

- `vc_simulationjob` cascade-deletes when its parent simulation is removed/replaced, so `count-sim-jobs-in-db` is structurally unreliable for historical reporting. The true count of jobs submitted to the compute cluster lives in SLURM accounting (`sacct`). The skill markdown documents the exact `sacct` invocation.

## Test plan
- [x] `mvn compile test-compile -pl vcell-admin,vcell-server -am` — BUILD SUCCESS
- [x] Smoke-tested against the live DB via the `vcell_dev` role for two periods (2024-04-01..2025-06-30 and 2025-07-01..2026-05-01); cumulative as-of numbers cross-check vs `/api/v1/admin/usage` snapshot
- [x] Verified user-PII files (`users_*.txt`, generated `active_users*.csv`, `tools/report/output/`) are excluded from git
- [ ] Future: SLURM `sacct` integration is intentionally out of scope; documented as a separate one-line invocation on the HTC head node

🤖 Generated with [Claude Code](https://claude.com/claude-code)