### PR TITLE
Fix hardcoded publication date default in webapp

### DIFF
--- a/webapp-ng/src/app/components/publication-edit/publication-edit.component.html
+++ b/webapp-ng/src/app/components/publication-edit/publication-edit.component.html
@@ -85,10 +85,10 @@
       <button mat-raised-button color="primary" (click)="addMathmodelRef(newMathmodelKey)">Add Mathmodel +</button>
     </div>
 
-    <!--    <mat-form-field class="full-width">-->
-    <!--      <mat-label>Date</mat-label>-->
-    <!--      <input matInput type="date" [(ngModel)]="publication.date" name="date">-->
-    <!--    </mat-form-field>-->
+    <mat-form-field class="full-width">
+      <mat-label>Date</mat-label>
+      <input matInput type="date" [(ngModel)]="publication.date" name="date">
+    </mat-form-field>
 
     <div *ngIf="showPublishControls" class="publish-row">
       <button mat-raised-button color="accent" type="button" (click)="publishModels()" [disabled]="selectedBiomodelKeys.size === 0 && selectedMathmodelKeys.size === 0">

--- a/webapp-ng/src/app/components/publication-new/publication-new.component.ts
+++ b/webapp-ng/src/app/components/publication-new/publication-new.component.ts
@@ -34,7 +34,7 @@ export class PublicationNewComponent {
       wittid: 0,
       biomodelRefs: [],
       mathmodelRefs: [],
-      date: "2023-12-28"
+      date: new Date().toISOString().slice(0, 10)
     };
   }
 


### PR DESCRIPTION
## Summary

New publications were defaulting `vc_publication.pubdate` to a hardcoded literal **`2023-12-28`**, and users couldn't change it.

Two webapp causes:
- `publication-new.component.ts` `onNew()` seeded the default Publication with `date: "2023-12-28"` (placeholder scaffold data).
- The Date `<input>` in `publication-edit.component.html` was **commented out**, so the placeholder propagated, unedited, all the way to the database.

The backend was innocent — `PublicationResource.add()` → `PublicationService.savePublication()` → `DbDriver` faithfully stored whatever date the webapp sent. No `2023-12-28` literal exists in the Java/DB code.

## Changes
- **`publication-new.component.ts`**: default new publications' `date` to **today** (`new Date().toISOString().slice(0, 10)` → `yyyy-MM-dd`) instead of the literal.
- **`publication-edit.component.html`**: **uncomment the Date input** so users can set/correct the date.

## Compatibility
`yyyy-MM-dd` round-trips through the OpenAPI `Publication.date` string and the backend `@JsonFormat("yyyy-MM-dd")`. No OpenAPI client regeneration or backend change required.

## Notes / follow-ups (not in this PR)
- `onNew()` still contains other placeholder defaults (`title: "title"`, `authors: ["string"]`, `doi: "doi"`, …) — out of scope here, but worth cleaning up to empty values.
- `toISOString()` is UTC, so the default date can read as "tomorrow" for users several hours behind UTC creating a publication late at night. It's only a default and now editable; can switch to a local-date computation if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)