### PR TITLE
Bump langevin solver to 1.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,9 +192,9 @@
 		<solvers-vcell-mac.version>v0.0.44-dev4</solvers-vcell-mac.version>
 		<solvers-vcell-windows.version>v0.0.40</solvers-vcell-windows.version>
 		<solvers-vcell-linux.version>v0.0.44-dev4</solvers-vcell-linux.version>
-		<solvers-langevin-mac.version>1.4.6</solvers-langevin-mac.version>
-		<solvers-langevin-windows.version>1.4.6</solvers-langevin-windows.version>
-		<solvers-langevin-linux.version>1.4.6</solvers-langevin-linux.version>
+		<solvers-langevin-mac.version>1.4.7</solvers-langevin-mac.version>
+		<solvers-langevin-windows.version>1.4.7</solvers-langevin-windows.version>
+		<solvers-langevin-linux.version>1.4.7</solvers-langevin-linux.version>
 	</properties>
 
 


### PR DESCRIPTION
Updates the Langevin (SpringSaLaD) solver from **1.4.6 → 1.4.7**.

### What 1.4.7 fixes
Release [1.4.7](https://github.com/cam-center/LangevinNoVis01/releases/tag/1.4.7) fixes a `NullPointerException` that crashed the solver when a bound site transitioned to a `(state, partner-state)` signature with no associated binding reaction (cam-center/LangevinNoVis01#36). The bond now retains its existing reaction identity/length and stops spontaneously dissociating in that state (off-rate `0.0`) instead of crashing.

### Change
Bumps the three solver version properties in `pom.xml`:
- `solvers-langevin-mac.version`
- `solvers-langevin-windows.version`
- `solvers-langevin-linux.version`

### How this propagates
- `vcell-core/pom.xml` downloads the per-platform binaries from the GitHub release using these properties (`langevin-windows-latest`, `langevin-macos-universal`, `langevin-ubuntu-latest`) into `localsolvers/`.
- `docker/build/Dockerfile-batch-dev` `COPY`s the downloaded `localsolvers/linux64/langevin_x64` into the vcell-batch image (and onward to the singularity image) — no Dockerfile change required.

Per request, `vcell-fluxcd` is intentionally **not** changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)