### PR TITLE
Fix .zenodo.json license: cc-by-4.0 → mit

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,7 @@
   "upload_type": "software",
   "title": "Virtual Cell (VCell)",
   "description": "The Virtual Cell (VCell) is a comprehensive platform for modeling and simulation in cell biology, developed since 1997 at the Center for Cell Analysis and Modeling (CCAM) at UConn Health.",
-  "license": "cc-by-4.0",
+  "license": "mit",
   "creators": [
     {
       "name": "Schaff, James C.",


### PR DESCRIPTION
VCell is **MIT**-licensed — the `LICENSE` file and `CITATION.cff` both say MIT — but `.zenodo.json` declared `cc-by-4.0`. Since release archiving uses `.zenodo.json` verbatim, releases have been published to Zenodo under the **wrong license**.

Sets it to `"mit"` — the Zenodo deposit id the other tool-managed repos (pyvcell, compose-api, SpringSaLaD) use, which publish correctly as MIT.

Surfaced by `zenodo-maint audit`.

**Note:** the already-published records also carry the wrong license (445 `cc-by-4.0` + 46 `other-open` across 492 versions). Those will be normalized to MIT separately via `zenodo-maint apply-metadata --license-only`; this PR just fixes the source so future releases are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZx7w9BexQc9wWU5JoHYaF