### PR TITLE
Dan ss bug fixes

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorApplicationsPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorApplicationsPanel.java
@@ -73,7 +73,8 @@ public class BioModelEditorApplicationsPanel extends BioModelEditorRightSidePane
 	private JMenu menuAppSpatialCopyAsSpatial = null;
 	private JMenuItem menuItemAppSpatialCopyAsSpatialStochastic = null;
 	private JMenuItem menuItemAppSpatialCopyAsSpatialDeterministic = null;
-	
+	private JMenuItem menuItemAppSpatialCopyAsSpatialSpringSaLaD = null;
+
 	private JMenuItem appNewStochApp = null;
 	private JMenuItem appNewDeterministicApp = null;
 	private JMenuItem appNewRulebasedApp = null;
@@ -99,8 +100,9 @@ public class BioModelEditorApplicationsPanel extends BioModelEditorRightSidePane
 					|| e.getSource() == menuItemAppSpatialCopyAsNonSpatialDeterministic
 					|| e.getSource() == menuItemAppSpatialCopyAsNonSpatialStochastic
 					|| e.getSource() == menuItemAppSpatialCopyAsSpatialDeterministic
-					|| e.getSource() == menuItemAppSpatialCopyAsSpatialStochastic) {
-				applicationMenuItem_ActionPerformed(e)	;	
+					|| e.getSource() == menuItemAppSpatialCopyAsSpatialStochastic
+					|| e.getSource() == menuItemAppSpatialCopyAsSpatialSpringSaLaD) {
+				applicationMenuItem_ActionPerformed(e)	;
 			} 
 		}
 	}
@@ -410,9 +412,12 @@ public class BioModelEditorApplicationsPanel extends BioModelEditorRightSidePane
 				menuItemAppSpatialCopyAsSpatialStochastic = new JMenuItem(GuiConstants.MENU_TEXT_STOCHASTIC_APPLICATION);
 				menuItemAppSpatialCopyAsSpatialStochastic.setActionCommand(GuiConstants.ACTIONCMD_SPATIAL_COPY_TO_SPATIAL_STOCHASTIC_APPLICATION);
 				menuItemAppSpatialCopyAsSpatialStochastic.addActionListener(eventHandler);
+				menuItemAppSpatialCopyAsSpatialSpringSaLaD = new JMenuItem(GuiConstants.MENU_TEXT_SPRINGSALAD_APPLICATION);
+				menuItemAppSpatialCopyAsSpatialSpringSaLaD.setActionCommand(GuiConstants.ACTIONCMD_SPATIAL_COPY_TO_SPATIAL_SPRINGSALAD_APPLICATION);
+				menuItemAppSpatialCopyAsSpatialSpringSaLaD.addActionListener(eventHandler);
 				menuAppSpatialCopyAsSpatial.add(menuItemAppSpatialCopyAsSpatialDeterministic);
 				menuAppSpatialCopyAsSpatial.add(menuItemAppSpatialCopyAsSpatialStochastic);
-	
+//				menuAppSpatialCopyAsSpatial.add(menuItemAppSpatialCopyAsSpatialSpringSaLaD);
 			} catch (java.lang.Throwable ivjExc) {
 				handleException(ivjExc);
 			}

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/DocumentEditor.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/DocumentEditor.java
@@ -162,7 +162,8 @@ public abstract class DocumentEditor extends JPanel {
 	private JMenuItem menuItemSpatialCopyAsSpatialDeterministic = null;
 	private ProblemSignalling problemSignalling = null;
 	private JMenuItem menuItemSpatialCopyAsSpatialRulebased = null;
-	
+	private JMenuItem menuItemSpatialCopyAsSpatialSpringSaLaD = null;
+
 	private class ProblemSignalling {
 		private javax.swing.Timer timer = null;
 		private int counter = 0;
@@ -270,8 +271,9 @@ public abstract class DocumentEditor extends JPanel {
 						|| e.getSource() == menuItemSpatialCopyAsNonSpatialRulebased
 						|| e.getSource() == menuItemSpatialCopyAsSpatialDeterministic
 						|| e.getSource() == menuItemSpatialCopyAsSpatialStochastic
-						|| e.getSource() == menuItemSpatialCopyAsSpatialRulebased ) {
-				popupMenuActionPerformed(DocumentEditorPopupMenuAction.copy_app, e.getActionCommand());	
+						|| e.getSource() == menuItemSpatialCopyAsSpatialRulebased
+						|| e.getSource() == menuItemSpatialCopyAsSpatialSpringSaLaD ) {
+				popupMenuActionPerformed(DocumentEditorPopupMenuAction.copy_app, e.getActionCommand());
 			} else if (e.getSource() == menuItemNewBiomodelFromApp){
 				popupMenuActionPerformed(DocumentEditorPopupMenuAction.app_new_biomodel, e.getActionCommand());
 			} else if((problemSignalling != null) && (e.getSource() == problemSignalling.getTimer())) {
@@ -833,9 +835,14 @@ private void construcutPopupMenu() {
 					menuItemSpatialCopyAsSpatialRulebased = new JMenuItem(GuiConstants.MENU_TEXT_RULEBASED_APPLICATION);
 					menuItemSpatialCopyAsSpatialRulebased.setActionCommand(GuiConstants.ACTIONCMD_SPATIAL_COPY_TO_SPATIAL_RULEBASED_APPLICATION);
 					menuItemSpatialCopyAsSpatialRulebased.addActionListener(eventHandler);
+					menuItemSpatialCopyAsSpatialSpringSaLaD = new JMenuItem(GuiConstants.MENU_TEXT_SPRINGSALAD_APPLICATION);
+					menuItemSpatialCopyAsSpatialSpringSaLaD.setActionCommand(GuiConstants.ACTIONCMD_SPATIAL_COPY_TO_SPATIAL_SPRINGSALAD_APPLICATION);
+					menuItemSpatialCopyAsSpatialSpringSaLaD.addActionListener(eventHandler);
+
 					menuSpatialCopyAsSpatial.add(menuItemSpatialCopyAsSpatialDeterministic);
 					menuSpatialCopyAsSpatial.add(menuItemSpatialCopyAsSpatialStochastic);
 					//menuSpatialCopyAsSpatial.add(menuItemSpatialCopyAsSpatialRulebased);		// not supported yet, uncomment when time comes
+					//menuSpatialCopyAsSpatial.add(menuItemSpatialCopyAsSpatialSpringSaLaD);
 				}
 				menuAppCopyAs.add(menuSpatialCopyAsNonSpatial);
 				menuAppCopyAs.add(menuSpatialCopyAsSpatial);

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/simulation/SimulationWorkspace.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/simulation/SimulationWorkspace.java
@@ -321,7 +321,7 @@ private static boolean checkSimulationParameters(Simulation simulation, Componen
 		
 		MeshSpecification meshSpecification = simulation.getMeshSpecification();
 		boolean bCellCentered = simulation.hasCellCenteredMesh();
-		if (meshSpecification != null && !meshSpecification.isAspectRatioOK(bCellCentered)) {
+		if (meshSpecification != null && !meshSpecification.isAspectRatioOK(bCellCentered) && !solverDescription.isLangevinSolver()) {
 			warningMessage =  (warningMessage == null? "" : warningMessage + "\n\n") 
 				+ "Non uniform spatial step is detected. This might affect the accuracy of the solution.\n\n"
 				+ "\u0394x=" + meshSpecification.getDx(bCellCentered) + "\n" 

--- a/vcell-client/src/main/java/cbit/vcell/client/task/RunSims.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/task/RunSims.java
@@ -164,7 +164,7 @@ public void run(Hashtable<String, Object> hashTable) throws java.lang.Exception 
 					DialogUtils.showErrorDialog(documentWindowManager.getComponent(), "Problem found in simulation '" + sim.getName() + "':\n" + ex.getMessage());
 					continue;
 				}
-				if (dimension > 0) {
+				if (dimension > 0 && !sim.getSolverTaskDescription().getSolverDescription().isLangevinSolver()) {
 					MeshSpecification meshSpecification = sim.getMeshSpecification();
 					boolean bCellCentered = sim.hasCellCenteredMesh();
 					if (meshSpecification != null && !meshSpecification.isAspectRatioOK(bCellCentered)) {

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/MathOverridesTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/MathOverridesTableModel.java
@@ -13,6 +13,8 @@ import java.util.Arrays;
 
 import javax.swing.JTable;
 
+import cbit.vcell.math.MathDescription;
+import cbit.vcell.solver.*;
 import org.vcell.util.gui.DialogUtils;
 
 import cbit.gui.ScopedExpression;
@@ -26,11 +28,7 @@ import cbit.vcell.parser.DivideByZeroException;
 import cbit.vcell.parser.Expression;
 import cbit.vcell.parser.ExpressionException;
 import cbit.vcell.parser.SymbolTableEntry;
-import cbit.vcell.solver.ConstantArraySpec;
-import cbit.vcell.solver.MathOverrides;
-import cbit.vcell.solver.MathOverridesEvent;
-import cbit.vcell.solver.MathOverridesListener;
-import cbit.vcell.solver.SimulationSymbolTable;
+
 /**
  * Insert the type's description here.
  * Creation date: (10/22/2000 11:46:26 AM)
@@ -260,7 +258,7 @@ public Object getValueAt(int row, int column) {
 				}
 			}
 			case COLUMN_SCAN: {
-				return new Boolean(getMathOverrides().isScan(fieldKeys[row]));
+				return getMathOverrides().isScan(fieldKeys[row]);
 			}
 			default: {
 				throw new Exception();
@@ -309,6 +307,13 @@ public boolean isCellEditable(int r, int c) {
 			return true;
 		}
 	} else if (c == COLUMN_SCAN) {
+		MathOverrides mo = getMathOverrides();
+		Simulation sim = mo.getSimulation();
+		MathDescription md = sim.getMathDescription();
+		boolean isLangevin = md.isLangevin();
+		if(isLangevin) {
+			return false;
+		}
 		return true;
 	} else {
 		return false;
@@ -348,7 +353,7 @@ public synchronized void removePropertyChangeListener(java.beans.PropertyChangeL
 public void setEditable(boolean editable) {
 	boolean oldValue = fieldEditable;
 	fieldEditable = editable;
-	firePropertyChange("editable", new Boolean(oldValue), new Boolean(editable));
+	firePropertyChange("editable", oldValue, editable);
 }
 
 
@@ -395,12 +400,11 @@ private void updateKeys(MathOverrides mathOverrides) {
 /**
  * Sets the modified property (boolean) value.
  * @param modified The new value for the property.
- * @see #getModified
  */
 public void setModified(boolean modified) {
 	boolean oldValue = fieldModified;
 	fieldModified = modified;
-	firePropertyChange("modified", new Boolean(oldValue), new Boolean(modified));
+	firePropertyChange("modified", oldValue, modified);
 }
 
 

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/MoleculeSpecificationPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/MoleculeSpecificationPanel.java
@@ -342,6 +342,7 @@ public class MoleculeSpecificationPanel extends AbstractSpecificationPanel {
                 throw new IllegalArgumentException("Invalid qualifier NONE for column: " + columnName);
             }
             boolean include = false;
+                                                        // TODO: add reactions !!!!!!!
             switch (mode) {
                 case MOLECULES:
                     include = (lr.site == null || lr.site.isEmpty());   // Molecules = entries with no site
@@ -357,7 +358,12 @@ public class MoleculeSpecificationPanel extends AbstractSpecificationPanel {
                     break;
             }
             if (include) {
-                ColumnDescription cd = langevinSolverResultSet.getColumnDescriptionByName(columnName);
+                if(langevinSolverResultSet.getAvg() == null) {
+                    lg.warn("langevinSolverResultSet.getAvg() is null for column: {}", columnName);
+                    continue;
+                }
+                int index = langevinSolverResultSet.getAvg().findColumn(columnName);
+                ColumnDescription cd = langevinSolverResultSet.getAvg().getColumnDescriptions(index);
                 if (cd != null) {
                     list.add(cd);
                 }

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SimulationSummaryPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SimulationSummaryPanel.java
@@ -18,12 +18,16 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.beans.PropertyVetoException;
 
+import org.apache.commons.lang3.time.DurationFormatUtils;
+
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 
+import cbit.vcell.resource.PropertyLoader;
+import cbit.vcell.solver.*;
 import org.vcell.chombo.ChomboSolverSpec;
 import org.vcell.model.rbm.MolecularType;
 import org.vcell.util.Compare;
@@ -35,17 +39,7 @@ import org.vcell.util.gui.GuiUtils;
 import cbit.vcell.client.constants.GuiConstants;
 import cbit.vcell.client.desktop.biomodel.DocumentEditorSubPanel;
 import cbit.vcell.math.Constant;
-import cbit.vcell.solver.DefaultOutputTimeSpec;
-import cbit.vcell.solver.ErrorTolerance;
-import cbit.vcell.solver.MeshSpecification;
-import cbit.vcell.solver.NFsimSimulationOptions;
-import cbit.vcell.solver.NonspatialStochSimOptions;
-import cbit.vcell.solver.Simulation;
-import cbit.vcell.solver.SolverDescription;
-import cbit.vcell.solver.SolverTaskDescription;
-import cbit.vcell.solver.TimeBounds;
-import cbit.vcell.solver.TimeStep;
-import cbit.vcell.solver.UniformOutputTimeSpec;
+
 /**
  * Insert the type's description here.
  * Creation date: (5/2/2001 12:17:49 PM)
@@ -53,6 +47,9 @@ import cbit.vcell.solver.UniformOutputTimeSpec;
  */
 @SuppressWarnings("serial")
 public class SimulationSummaryPanel extends DocumentEditorSubPanel {
+	private final static String MeshLabel = "Mesh:";
+	private final static String PartitionsNumberLabel = "Partitions:";
+
 	private Simulation fieldSimulation = null;
 	private IvjEventHandler ivjEventHandler = new IvjEventHandler();
 //	private JLabel labelSimKey = null;
@@ -82,6 +79,8 @@ public class SimulationSummaryPanel extends DocumentEditorSubPanel {
 	private JLabel labelViewLevelMesh;
 	private JLabel jlabelNumProcessors;
 	private JLabel jlabelTitleNumProcessors;
+	private JLabel ivjJLabel20 = null;
+	private JLabel ivjJLabel21 = null;
 	
 	private class IvjEventHandler implements java.beans.PropertyChangeListener, FocusListener {
 		public void propertyChange(java.beans.PropertyChangeEvent event) {
@@ -167,6 +166,7 @@ private void displayMesh() {
 			
       if (getSimulation()!=null && getSimulation().getMeshSpecification() != null) {
 				ISize samplingSize = getSimulation().getMeshSpecification().getSamplingSize();
+				String labelName = MeshLabel;
 				String labelText = "";
 				int dimension = getSimulation().getMeshSpecification().getGeometry().getDimension();
 				switch (dimension) {
@@ -177,10 +177,19 @@ private void displayMesh() {
 					}
 					default :
 					{
-				    labelText = GuiUtils.getMeshSizeText(dimension, samplingSize, true) + " elements";
+						// for Langevin we don't use the mesh (although it exists), instead we have "Partitions"
+						if(getSimulation().getSolverTaskDescription().getSolverDescription().isLangevinSolver()) {
+							SolverTaskDescription std = getSimulation().getSolverTaskDescription();
+							LangevinSimulationOptions lso = std.getLangevinSimulationOptions();
+							int [] nPart = lso.getNPart();
+							labelText = nPart[0] + "," + nPart[1] + "," + nPart[2];
+							labelName = PartitionsNumberLabel;
+						} else {
+							labelText = GuiUtils.getMeshSizeText(dimension, samplingSize, true) + " elements";
+						}
 				    break;
 					}
-				}
+				}getJLabel11().setText(labelName);
 				getJLabelMesh().setText(labelText);
 
         ChomboSolverSpec chomboSolverSpec = getSimulation().getSolverTaskDescription().getChomboSolverSpec();
@@ -330,9 +339,47 @@ private void displayTask() {
 		getJLabel12().setEnabled(false);
 		getJLabel10().setText("Sensitivity Analysis");
 		getJLabel10().setEnabled(true);
+		getJLabel20().setEnabled(false);
+		getJLabel21().setEnabled(false);
+		getJLabel20().setVisible(false);
+		getJLabel21().setVisible(false);
 		if (solverDescription.equals(SolverDescription.StochGibson)) {
 			getJLabel12().setEnabled(false);
 			getJLabelTimestep().setText("");
+		} else if(solverDescription.equals(SolverDescription.Langevin)) {
+			LangevinSimulationOptions lso = solverTaskDescription.getLangevinSimulationOptions();
+			getJLabel12().setEnabled(true);
+			getJLabel12().setText("Timestep");
+			getJLabelTimestep().setText(timeStep.getDefaultTimeStep() + "s");
+			getJLabelRelTol().setText("Spring Interval");
+			getJLabelRelTol().setEnabled(true);
+			getJLabelRelTolValue().setText(lso.getIntervalSpring() + "s");
+			getJLabelAbsTol().setText("Image Interval");
+			getJLabelAbsTol().setEnabled(true);
+			getJLabelAbsTolValue().setText(lso.getIntervalImage() + "s");
+			// default task timeout to 7 days, old default was 86400 s (1 day), but that is too short for some of the larger models
+			String sTimeoutPerTaskSeconds = PropertyLoader.getProperty(PropertyLoader.slurm_langevin_timeoutPerTaskSeconds, "604800");
+			long value = Long.parseLong(sTimeoutPerTaskSeconds);
+			String str = DurationFormatUtils.formatDuration(value * 1000, "d'd' H'h' m'm' s's'");
+			getJLabel10().setText("Timeout per task ");
+			getJLabel10().setEnabled(true);
+			getJLabelSensitivity().setText(str);
+			int tot = lso.getTotalNumberOfJobs();
+			int conc = lso.getNumberOfConcurrentJobs();
+			if(tot == 1) {
+				getJLabel20().setText("Single run.");
+				getJLabel21().setText("");
+				getJLabel21().setEnabled(false);
+				getJLabel21().setVisible(false);
+			} else {
+				getJLabel20().setText("Batch run:");
+				getJLabel21().setText(conc + " concurrent runs / " + tot + " total runs");
+				getJLabel21().setEnabled(true);
+				getJLabel21().setVisible(true);
+			}
+			getJLabel20().setEnabled(true);
+			getJLabel20().setVisible(true);
+
 		} else if (solverDescription.equals(SolverDescription.NFSim)) {
 			TimeBounds tb = solverTaskDescription.getTimeBounds();
 			double dtime = tb.getEndingTime() - tb.getStartingTime();
@@ -424,7 +471,10 @@ private void displayTask() {
 		if (bChomboSolver) {
 			getJLabelNumProcessors().setText(String.valueOf(solverTaskDescription.getNumProcessors()));
 		}
-		if (getSimulation().isSpatial() || solverDescription.isNonSpatialStochasticSolver()) {
+		if(solverDescription.equals(SolverDescription.Langevin)) {
+			getJLabelSensitivity().setVisible(true);		// for Langevin is Timeout per task
+			getJLabel10().setVisible(true);
+		} else if (getSimulation().isSpatial() || solverDescription.isNonSpatialStochasticSolver()) {
 			getJLabelSensitivity().setVisible(false);
 			getJLabel10().setVisible(false);
 		} else if(solverDescription.equals(SolverDescription.NFSim)) {
@@ -563,7 +613,7 @@ private javax.swing.JLabel getJLabelAbsTol() {
 private javax.swing.JLabel getJLabel11() {
 	if (ivjJLabel11 == null) {
 		try {
-			ivjJLabel11 = new javax.swing.JLabel("Mesh:");
+			ivjJLabel11 = new javax.swing.JLabel(MeshLabel);
 			ivjJLabel11.setName("JLabel11");
 			ivjJLabel11.setVisible(false);
 		} catch (java.lang.Throwable ivjExc) {
@@ -725,6 +775,33 @@ private javax.swing.JLabel getJLabelTimestep() {
 	}
 	return ivjJLabelTimestep;
 }
+
+	private javax.swing.JLabel getJLabel20() {		// Single Run / Batch Run
+		if (ivjJLabel20 == null) {
+			try {
+				ivjJLabel20 = new javax.swing.JLabel("");
+				ivjJLabel20.setName("JLabel20");
+				ivjJLabel20.setVisible(false);
+			} catch (java.lang.Throwable ivjExc) {
+				handleException(ivjExc);
+			}
+		}
+		return ivjJLabel20;
+	}
+	private javax.swing.JLabel getJLabel21() {		// concurrent runs / total runs
+		if (ivjJLabel21 == null) {
+			try {
+				ivjJLabel21 = new javax.swing.JLabel("");
+				ivjJLabel21.setName("JLabel21");
+				ivjJLabel21.setForeground(java.awt.Color.blue);
+				ivjJLabel21.setVisible(false);
+			} catch (java.lang.Throwable ivjExc) {
+				handleException(ivjExc);
+			}
+		}
+		return ivjJLabel21;
+	}
+
 
 /**
  * Return the JTextArea1 property value.
@@ -972,11 +1049,28 @@ private void initialize() {
 		gbc.gridy = gridy;
 		gbc.fill = GridBagConstraints.HORIZONTAL;
 		gbc.weightx = 1.0;
-		gbc.gridwidth = 3;
+		gbc.gridwidth = 2;
 		gbc.anchor = GridBagConstraints.LINE_START;
 		gbc.insets = new Insets(4, 4, 4, 4);
-		add(getSettingsPanel(), gbc); 	
-		
+		add(getSettingsPanel(), gbc);
+
+		GridBagConstraints constraintsJLabel20 = new GridBagConstraints();
+		constraintsJLabel20.gridx = 3;
+		constraintsJLabel20.gridy = gridy;
+		constraintsJLabel20.anchor = GridBagConstraints.EAST;
+		constraintsJLabel20.insets = new Insets(4, 4, 4, 4);
+		add(getJLabel20(), constraintsJLabel20); // Geometry Size
+
+		GridBagConstraints constraintsJLabel21 = new GridBagConstraints();
+		constraintsJLabel21.gridx = 4;
+		constraintsJLabel21.gridy = gridy;
+		constraintsJLabel21.weightx = 1.0;
+		constraintsJLabel21.fill = GridBagConstraints.HORIZONTAL;
+		constraintsJLabel21.insets = new Insets(4, 4, 4, 4);
+		add(getJLabel21(), constraintsJLabel21);
+
+// ---------------------------------------------------------------------------------------------------------------
+
 		gridy ++;
 		GridBagConstraints constraintsJLabel11 = new GridBagConstraints();
 		constraintsJLabel11.gridx = 0; 
@@ -995,19 +1089,20 @@ private void initialize() {
 		add(getJLabelMesh(), constraintsJLabelMesh);
 
 		GridBagConstraints constraintsJLabel8 = new GridBagConstraints();
-		constraintsJLabel8.gridx = 3; 
+		constraintsJLabel8.gridx = 3;
 		constraintsJLabel8.gridy = gridy;
 		constraintsJLabel8.anchor = GridBagConstraints.EAST;
 		constraintsJLabel8.insets = new Insets(4, 4, 4, 4);
 		add(getJLabel8(), constraintsJLabel8); // Geometry Size
 
 		GridBagConstraints constraintsJLabelGeometrySize = new GridBagConstraints();
-		constraintsJLabelGeometrySize.gridx = 4; 
+		constraintsJLabelGeometrySize.gridx = 4;
 		constraintsJLabelGeometrySize.gridy = gridy;
 		constraintsJLabelGeometrySize.weightx = 1.0;
 		constraintsJLabelGeometrySize.fill = GridBagConstraints.HORIZONTAL;
 		constraintsJLabelGeometrySize.insets = new Insets(4, 4, 4, 4);
 		add(getJLabelGeometrySize(), constraintsJLabelGeometrySize);
+
 
 		gridy ++;
 		GridBagConstraints constraints = new GridBagConstraints();

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SimulationSummaryPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SimulationSummaryPanel.java
@@ -358,7 +358,7 @@ private void displayTask() {
 			getJLabelAbsTol().setEnabled(true);
 			getJLabelAbsTolValue().setText(lso.getIntervalImage() + "s");
 			// default task timeout to 7 days, old default was 86400 s (1 day), but that is too short for some of the larger models
-			String sTimeoutPerTaskSeconds = PropertyLoader.getProperty(PropertyLoader.slurm_langevin_timeoutPerTaskSeconds, "604800");
+			String sTimeoutPerTaskSeconds = PropertyLoader.getProperty(PropertyLoader.slurm_langevin_timeoutPerTaskSeconds, "345600");
 			long value = Long.parseLong(sTimeoutPerTaskSeconds);
 			String str = DurationFormatUtils.formatDuration(value * 1000, "d'd' H'h' m'm' s's'");
 			getJLabel10().setText("Timeout per task ");

--- a/vcell-core/src/main/java/cbit/vcell/client/constants/GuiConstants.java
+++ b/vcell-core/src/main/java/cbit/vcell/client/constants/GuiConstants.java
@@ -100,9 +100,11 @@ public class GuiConstants {
 			new ApplicationActionCommand.CopyChange("Spatial Copy To Spatial Deterministic Application",true,true,Application.NETWORK_DETERMINISTIC).getLabel();
 	public static final String ACTIONCMD_SPATIAL_COPY_TO_SPATIAL_STOCHASTIC_APPLICATION = 
 			new ApplicationActionCommand.CopyChange("Spatial Copy To Spatial Stochastic Application",true,true,Application.NETWORK_STOCHASTIC).getLabel();
-	public static final String ACTIONCMD_SPATIAL_COPY_TO_SPATIAL_RULEBASED_APPLICATION = 
+	public static final String ACTIONCMD_SPATIAL_COPY_TO_SPATIAL_RULEBASED_APPLICATION =
 			new ApplicationActionCommand.CopyChange("Spatial Copy To Spatial Rulebased Application",true,true,Application.RULE_BASED_STOCHASTIC).getLabel();
-	
+	public static final String ACTIONCMD_SPATIAL_COPY_TO_SPATIAL_SPRINGSALAD_APPLICATION =
+			new ApplicationActionCommand.CopyChange("Spatial Copy To Spatial SpringSalaD Application",true,true,Application.SPRINGSALAD).getLabel();
+
 	public static final String ACTIONCMD_CHANGE_GEOMETRY = "Change Geometry...";
 //	public static final String ACTIONCMD_VIEW_CHANGE_GEOMETRY = "View / Change Geometry";
 	public static final String ACTIONCMD_CREATE_MATH_MODEL = "Create Math Model";

--- a/vcell-core/src/main/java/cbit/vcell/mapping/MolecularInternalLinkSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/MolecularInternalLinkSpec.java
@@ -31,6 +31,25 @@ public class MolecularInternalLinkSpec implements Identifiable, IssueSource, Mat
 	private LinkNode fieldLinkNodeTwo = null;
 //	private double linkLength = 0;		// it's a derived value which we don't store, we just compute it at need
 
+	public MolecularInternalLinkSpec(SpeciesContextSpec ourScs, MolecularInternalLinkSpec thatMils) {
+		fieldSpeciesContextSpec = ourScs;
+		LinkNode thatLinkNodeOne = thatMils.fieldLinkNodeOne;
+		LinkNode thatLinkNodeTwo = thatMils.fieldLinkNodeTwo;
+		if(thatLinkNodeOne instanceof MolecularComponentPattern) {
+			fieldLinkNodeOne = thatLinkNodeOne;
+		} else if(thatLinkNodeOne instanceof StructuralSite) {
+			fieldLinkNodeOne = findStructuralSiteByName(ourScs, thatLinkNodeOne.getName());
+		} else {
+			throw new IllegalArgumentException("Unknown LinkNode type for linkNodeOne");
+		}
+		if(thatLinkNodeTwo instanceof MolecularComponentPattern) {
+			fieldLinkNodeTwo = thatLinkNodeTwo;
+		} else if(thatLinkNodeTwo instanceof StructuralSite) {
+			fieldLinkNodeTwo = findStructuralSiteByName(ourScs, thatLinkNodeTwo.getName());
+		} else {
+			throw new IllegalArgumentException("Unknown LinkNode type for linkNodeTwo");
+		}
+	}
 	public MolecularInternalLinkSpec(SpeciesContextSpec scs, LinkNode linkOne, LinkNode linkTwo) throws IllegalArgumentException {
 		fieldSpeciesContextSpec = scs;
 		SpeciesContext sc = scs.getSpeciesContext();
@@ -203,7 +222,6 @@ public class MolecularInternalLinkSpec implements Identifiable, IssueSource, Mat
 		return in;
 	}
 
-	
 	public Pair<LinkNode, LinkNode> getLink() {
 		return new Pair<LinkNode, LinkNode>(fieldLinkNodeOne, fieldLinkNodeTwo);
 	}
@@ -221,6 +239,16 @@ public class MolecularInternalLinkSpec implements Identifiable, IssueSource, Mat
 			fieldLinkNodeTwo = link.one;
 		}
 	}
+
+	public static StructuralSite findStructuralSiteByName(SpeciesContextSpec scs, String ssName) {
+		for (StructuralSite ss : scs.getStructuralSiteAttributesMap().keySet()) {
+			if (ss.getName().equals(ssName)) {
+				return ss;
+			}
+		}
+		throw new IllegalArgumentException("Unknown StructuralSite name: " + ssName);
+	}
+
 
 	@Override
 	public boolean compareEqual(Matchable obj) {

--- a/vcell-core/src/main/java/cbit/vcell/mapping/ReactionRuleSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/ReactionRuleSpec.java
@@ -1302,29 +1302,33 @@ public void gatherIssues(IssueContext issueContext, List<Issue> issueList, React
 				issueList.add(new Issue(r, issueContext, IssueCategory.Identifiers, msg, tip, Issue.Severity.ERROR));
 				return;
 			}
-			if(sasOne != null && sasTwo != null) {
-				for(Map.Entry<MolecularComponentPattern, SiteAttributesSpec> entry : siteAttributesMapTwo.entrySet()) {
-					MolecularComponentPattern mcpCandidate = entry.getKey();
-					if(MolecularComponentPattern.BondType.None != mcpCandidate.getBondType()) {
-						continue;
-					}
-					MolecularComponent mcCandidate = mcpCandidate.getMolecularComponent();
-					if(mcOursOne == mcCandidate) {
-						sasOne = entry.getValue();
-					} else if(mcOursTwo == mcCandidate) {
-						sasTwo = entry.getValue();
-					}
+			for(Map.Entry<MolecularComponentPattern, SiteAttributesSpec> entry : siteAttributesMapTwo.entrySet()) {
+				MolecularComponentPattern mcpCandidate = entry.getKey();
+				if(MolecularComponentPattern.BondType.None != mcpCandidate.getBondType()) {
+					continue;
 				}
+				MolecularComponent mcCandidate = mcpCandidate.getMolecularComponent();
+				if(mcOursOne == mcCandidate) {
+					sasOne = entry.getValue();
+				} else if(mcOursTwo == mcCandidate) {
+					sasTwo = entry.getValue();
+				}
+			}
+			if(sasOne != null && sasTwo != null) {
 				if(sasOne.getLocation() != sasTwo.getLocation()) {
 					String msg = SpringSaLaDMsgTransmembraneBinding;
 					String tip = "Both binding reactant Sites need to be in the same compartment.";
 					issueList.add(new Issue(r, issueContext, IssueCategory.Identifiers, msg, tip, Issue.Severity.ERROR));
 					return;
 				}
-				if(checkOnRate(sasOne, sasTwo) == false) {	// rate doesn't check as acceptable
+				double factor = 1.0;
+				if(mtOursOne == mtOursTwo) {
+					factor = 2.0;	// A + A -> A.A
+				}
+				if(checkOnRate(sasOne, sasTwo, factor) == false) {	// Kon is too large, leading to non-physical negative intrinsic on-rate
 					String msg = "The forward rate Kf is too large (i.e. exceeds the diffusion limited rate) for this reaction rule.";
 					String tip = "Please consider reducing Kon or increasing the Radius or D of the participating Site Types.";
-					issueList.add(new Issue(r, issueContext, IssueCategory.Identifiers, msg, tip, Issue.Severity.WARNING));
+					issueList.add(new Issue(r, issueContext, IssueCategory.Identifiers, msg, tip, Issue.Severity.ERROR));
 					return;
 				}
 			}
@@ -1390,7 +1394,7 @@ public void gatherIssues(IssueContext issueContext, List<Issue> issueList, React
 	 * The maximum possible on-rate is given by kon_max = 4*pi*R*D, so we'd
 	 * better have kon < 4*pi*R*D . If that isn't satisfied then nothing else will work.
 	 */
-	public boolean checkOnRate(SiteAttributesSpec sasOne, SiteAttributesSpec sasTwo) {
+	public boolean checkOnRate(SiteAttributesSpec sasOne, SiteAttributesSpec sasTwo, double factor) {
 
 		// set of acceptable numbers (marginally) for A + A -> A.A are:
 		// Kon = 40 s-1uM-1
@@ -1398,18 +1402,23 @@ public void gatherIssues(IssueContext issueContext, List<Issue> issueList, React
 		// site diffusion rate 1 um2s-1
 
 		double R = sasOne.computeReactionRadius() + sasTwo.computeReactionRadius();	// nm
-		double D = sasOne.getDiffusionRate() + sasTwo.getDiffusionRate();
+		double D = sasOne.getDiffusionRate() + sasTwo.getDiffusionRate();			// um^2/s
 
-		LocalParameter lp = getModelProcess().getKineticLaw().getLocalParameter(RbmKineticLaw.RbmKineticLawParameterType.MassActionForwardRate);
-		String doubleRegex = "[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?";
-		if(!lp.getExpression().infix().matches(doubleRegex)) {
-			return false;
+		RbmKineticLaw kineticLaw = reactionRule.getKineticLaw();
+		RbmKineticLaw kineticLaw2 = getModelProcess().getKineticLaw();
+
+		LocalParameter lp = kineticLaw.getLocalParameter(RbmKineticLaw.RbmKineticLawParameterType.MassActionForwardRate);
+		Expression konExpr = lp.getExpression();
+		Expression kon_new = new Expression(konExpr);
+		double kon = 0;
+		try {
+			kon_new = kon_new.flatten();
+			kon = StochasticTransformer.substituteParameters(kon_new, true).evaluateConstant();
+		} catch (ExpressionException e) {
+			throw new RuntimeException("writeBindingData(): kon or koff is not a constant expression: " + e.getMessage());
 		}
-		double kon = Double.parseDouble(lp.getExpression().infix());
-// TODO: check all scaling
-		double kon_scale = 1660000.0 * kon;			// Kon also needs some conversion (micromolar -> particles)
-		double D_scale = D * 1000000.0;				// D is in um^2/s, convert to nm^2/s
-
+		double kon_scale = 1660000.0 * kon * factor;	// Kon also needs some conversion (micromolar -> particles)
+		double D_scale = D * 1000000.0;					// D is in um^2/s, convert to nm^2/s
 		double kD = 4.0*Math.PI*R*D_scale;
 
 		// double kOnIntrinsic = (rescalekon * kD) / (kD - rescalekon); cannot be negative,

--- a/vcell-core/src/main/java/cbit/vcell/mapping/ReactionRuleSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/ReactionRuleSpec.java
@@ -1411,7 +1411,6 @@ public void gatherIssues(IssueContext issueContext, List<Issue> issueList, React
 		double D = sasOne.getDiffusionRate() + sasTwo.getDiffusionRate();			// um^2/s
 
 		RbmKineticLaw kineticLaw = reactionRule.getKineticLaw();
-		RbmKineticLaw kineticLaw2 = getModelProcess().getKineticLaw();
 
 		LocalParameter lp = kineticLaw.getLocalParameter(RbmKineticLaw.RbmKineticLawParameterType.MassActionForwardRate);
 		Expression konExpr = lp.getExpression();

--- a/vcell-core/src/main/java/cbit/vcell/mapping/ReactionRuleSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/ReactionRuleSpec.java
@@ -1315,16 +1315,22 @@ public void gatherIssues(IssueContext issueContext, List<Issue> issueList, React
 				}
 			}
 			if(sasOne != null && sasTwo != null) {
-				if(sasOne.getLocation() != sasTwo.getLocation()) {
+				if (sasOne.getLocation() != sasTwo.getLocation()) {
 					String msg = SpringSaLaDMsgTransmembraneBinding;
 					String tip = "Both binding reactant Sites need to be in the same compartment.";
 					issueList.add(new Issue(r, issueContext, IssueCategory.Identifiers, msg, tip, Issue.Severity.ERROR));
 					return;
 				}
-				double factor = 1.0;
-				if(mtOursOne == mtOursTwo) {
-					factor = 2.0;	// A + A -> A.A
+			}
+			// check for rate validity - we need to do this for binding reactions only
+			double factor = 1.0;
+			if(mtOursOne == mtOursTwo) {	// both reactants have the same molecular type
+				factor = 2.0;				// A + A -> A.A
+				if(sasTwo == null) {    	// this may happen if the same site is being bound
+					sasTwo = sasOne;
 				}
+			}
+			if(sasOne != null && sasTwo != null) {
 				if(checkOnRate(sasOne, sasTwo, factor) == false) {	// Kon is too large, leading to non-physical negative intrinsic on-rate
 					String msg = "The forward rate Kf is too large (i.e. exceeds the diffusion limited rate) for this reaction rule.";
 					String tip = "Please consider reducing Kon or increasing the Radius or D of the participating Site Types.";

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SimulationContext.java
@@ -758,6 +758,14 @@ public class SimulationContext implements SimulationOwner, Versionable, Matchabl
             initializeForSpatial();
         }
 
+        if(applicationType != Application.SPRINGSALAD) {
+            for(SpeciesContextSpec scs : reactionContext.getSpeciesContextSpecs()) {
+                scs.getInternalLinkSet().clear();
+                scs.getStructuralSiteAttributesMap().clear();
+                scs.getSiteAttributesMap().clear();
+            }
+        }
+
         boolean isAllowedMicroscopeMeasurements = this.getGeometry().getDimension() > 0 && this.getApplicationType() == Application.NETWORK_DETERMINISTIC;
         if(isAllowedMicroscopeMeasurements){
             MicroscopeMeasurement oldMM = oldSimulationContext.getMicroscopeMeasurement();

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SiteAttributesSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SiteAttributesSpec.java
@@ -53,8 +53,26 @@ public class SiteAttributesSpec implements Serializable, Identifiable, Displayab
 		this(scs, ln, structure);
 		setRadius(radius);
 		setDiffusionRate(diffusion);
-		setCoordinate(coordinate);
 		setColor(color);
+		setCoordinate(coordinate);
+	}
+	public SiteAttributesSpec(SpeciesContextSpec thisScs, SiteAttributesSpec thatSas) {
+		fieldSpeciesContextSpec = thisScs;
+		if(thatSas.getLinkNode() instanceof MolecularComponentPattern) {
+			// MolecularComponentPattern is physiology defined, we use the same instance
+			setLinkNode(thatSas.getLinkNode());
+		} else if(thatSas.getLinkNode() instanceof StructuralSite) {
+			// StructuralSite is application dependent, so we create a new instance with the same name
+			setLinkNode(new StructuralSite(thatSas.getLinkNode().getName()));
+		} else {
+			throw new RuntimeException("SiteAttributesSpec copy constructor: unknown LinkNode type");
+		}
+		setLocation(thatSas.getLocation());
+		setRadius(thatSas.getRadius());
+		setDiffusionRate(thatSas.getDiffusionRate());
+		setColor(thatSas.getColor());
+		Coordinate c = new Coordinate(thatSas.getCoordinate().getX(), thatSas.getCoordinate().getY(), thatSas.getCoordinate().getZ());
+		setCoordinate(c);	// we make a new instance for coordinates
 	}
 
 	public SpeciesContextSpec getSpeciesContextSpec() {

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
@@ -568,6 +568,34 @@ public class SpeciesContextSpec implements Matchable, ScopedSymbolTable, Seriali
             Expression otherParmExp = (otherParm.getExpression() == null) ? (null) : (new Expression(otherParm.getExpression()));
             fieldParameters[i] = new SpeciesContextSpecParameter(otherParm.getName(), otherParmExp, otherParm.getRole(), otherParm.getUnitDefinition(), otherParm.getDescription());
         }
+        // if the source application type is springsalad, then we copy the site attributes and internal links, if any
+        // regardless of the destination application type, which we do not know at this time
+        // later on, once we know the destination application type, we will decide whether to keep or discard the
+        // site attributes and internal links
+        SimulationContext thatSimulationContext = speciesContextSpec.getSimulationContext();
+        boolean isThatSpringSaLaDApp = (thatSimulationContext != null && thatSimulationContext.getApplicationType() == Application.SPRINGSALAD);
+        if(isThatSpringSaLaDApp && speciesContextSpec.siteAttributesMap != null){
+            for (Map.Entry<MolecularComponentPattern, SiteAttributesSpec> entry : speciesContextSpec.siteAttributesMap.entrySet()) {
+                MolecularComponentPattern mcp = entry.getKey();
+                SiteAttributesSpec thatSas = entry.getValue();
+                SiteAttributesSpec newSiteAttributesSpec = new SiteAttributesSpec(this, thatSas);
+                siteAttributesMap.put(mcp, newSiteAttributesSpec);
+            }
+        }
+        if(isThatSpringSaLaDApp && speciesContextSpec.structuralSiteAttributesMap != null){
+            for (Map.Entry<StructuralSite, SiteAttributesSpec> entry : speciesContextSpec.structuralSiteAttributesMap.entrySet()) {
+                StructuralSite ss = entry.getKey();
+                SiteAttributesSpec thatSas = entry.getValue();
+                SiteAttributesSpec newSiteAttributesSpec = new SiteAttributesSpec(this, thatSas);
+                structuralSiteAttributesMap.put(ss, newSiteAttributesSpec);
+            }
+        }
+        if(isThatSpringSaLaDApp && speciesContextSpec.internalLinkSet != null){
+            for (MolecularInternalLinkSpec mils : speciesContextSpec.internalLinkSet) {
+                MolecularInternalLinkSpec newMils = new MolecularInternalLinkSpec(this, mils);
+                internalLinkSet.add(newMils);
+            }
+        }
         refreshDependencies();
     }
 

--- a/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/mapping/SpeciesContextSpec.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.*;
 
+import cbit.vcell.mapping.stoch.StochasticTransformer;
 import cbit.vcell.model.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -2640,19 +2641,21 @@ public class SpeciesContextSpec implements Matchable, ScopedSymbolTable, Seriali
 
         // compare the next few lines with LangevinLngvWriter.writeSpeciesInfo() where we have a math
         // here we must assume that the expression is numeric
-        Expression count = initialCountParameter.getExpression();
-        String scount;
+        Expression count = new Expression(initialCountParameter.getExpression());
+        double dcount;
+        int icount;
         try {
-            double ddd = count.evaluateConstant();
-            scount = Integer.toString((int)ddd);
-        } catch (Exception e) {
-            throw new RuntimeException("Initial concentration must be a number");
+            count = count.flatten();
+            dcount = StochasticTransformer.substituteParameters(count, true).evaluateConstant();
+            icount = (int) Math.round(dcount);
+        } catch (ExpressionException e) {
+            throw new RuntimeException("Initial concentration is not a constant expression");
         }
 
         int siteTypes = componentList.size() + structuralSiteAttributesMap.size();
         int totalSites = siteAttributesMap.size() + structuralSiteAttributesMap.size();
         sb.append("MOLECULE: \"" + getSpeciesContext().getName() + "\" " + getSpeciesContext().getStructure().getName() +
-                " Number " + scount +
+                " Number " + icount +
                 " Site_Types " + siteTypes + " Total" + "_Sites " + totalSites +
                 " Total_Links " + getInternalLinkSet().size() + " is2D " + (dimension == 2 ? true : false));    // TODO: molecule is flat, unrelated to geometry
         sb.append("\n");

--- a/vcell-core/src/main/java/cbit/vcell/simdata/LangevinSolverResultSet.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/LangevinSolverResultSet.java
@@ -78,15 +78,6 @@ public class LangevinSolverResultSet implements Serializable {
         return maxClusterCountOverall;
     }
 
-    public ColumnDescription getColumnDescriptionByName(String columnName) {
-        if(raw == null || raw.getOdeSimDataAvg() == null) {
-            return null;
-        }
-        int index = raw.getOdeSimDataAvg().findColumn(columnName);
-        ColumnDescription cd = raw.getOdeSimDataAvg().getColumnDescriptions(index);
-        return cd;
-    }
-
     // helper functions
     public boolean isAverageDataAvailable() {
         return getAvg() != null &&
@@ -134,15 +125,10 @@ public class LangevinSolverResultSet implements Serializable {
             ODESimData co = getAvg();
             populateMetadata(co);
             checkTrivial(co);
-            // if avg is trivial, then min, max and std will be trivial too
-//            co = getMin();
-//            checkTrivial(co);
-//            co = getMax();
-//            checkTrivial(co);
-//            co = getStd();
-//            checkTrivial(co);
+            // we don't care if min, max and std are trivial or not
         }
     }
+                                                                            // TODO: add reactions   !!!!!!!!!
     private void populateMetadata(ODESimData co) {
         // from solver-generated observable (ColumnDescription.name) extract molecule, site and state names
         ColumnDescription[] cds = co.getColumnDescriptions();

--- a/vcell-core/src/main/java/cbit/vcell/simdata/ODEDataManager.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/ODEDataManager.java
@@ -179,17 +179,24 @@ private void setVcDataManager(VCDataManager newVcDataManager) {
 	vcDataManager = newVcDataManager;
 }
 
+// some profiling info, to get an idea of how long it takes to get the data from the server
+//   RPC: getODEData + NFSimConfig    ~ 328 ms      single run, single result set
+//   RPC: getLangevinBatchResultSet   ~ 1016 ms     bath run, multiple result sets (avg, min, max, std, cluster count, cluster statistics)
+//   postProcess()                    ~ 25 ms		duplicating cluster count result set, multiple checks for triviality, etc
 private void connect() throws DataAccessException {
-	// clone, so we can operate safely on it (adding/removing user-defined functions) - real remote data is being cached...
-	odeSolverResultSet = new ODESimData(getVCDataIdentifier(),getVCDataManager().getODEData(getVCDataIdentifier()));
-	nFSimMolecularConfigurations = getVCDataManager().getNFSimMolecularConfigurations(getVCDataIdentifier());
 	LangevinBatchResultSet raw = getVCDataManager().getLangevinBatchResultSet(getVCDataIdentifier());
 	langevinSolverResultSet = new LangevinSolverResultSet(raw);		// may be null
-	if(langevinSolverResultSet != null) {
-		langevinSolverResultSet.postProcess();
-	}
-	if( langevinSolverResultSet != null && langevinSolverResultSet.isAverageDataAvailable()) {
+	if(raw != null && langevinSolverResultSet.isAverageDataAvailable() && langevinSolverResultSet.isClusterDataAvailable()) {
+		// it's langevin batch run, we have all that we need
 		odeSolverResultSet = langevinSolverResultSet.getAvg();
+		langevinSolverResultSet.postProcess();
+		lg.debug("ODEDataManager: Langevin batch run detected, using average data for odeSolverResultSet");
+	} else {
+		// it's some single run (langevin, nfsim, something else), get single run results the old way
+		// clone, so we can operate safely on it (adding/removing user-defined functions) - real remote data is being cached...
+		odeSolverResultSet = new ODESimData(getVCDataIdentifier(),getVCDataManager().getODEData(getVCDataIdentifier()));
+		nFSimMolecularConfigurations = getVCDataManager().getNFSimMolecularConfigurations(getVCDataIdentifier());
+		lg.debug("ODEDataManager: Single run detected, using ODEDataManager.getVCDataManager().getODEData() for odeSolverResultSet");
 	}
 }
 

--- a/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
@@ -724,7 +724,10 @@ private static final String REQUIRED_SERVICE_PROPERTIES[] = {
 		PropertyLoader.htcMinMemoryMB,
 		PropertyLoader.htcMaxMemoryMB,
 		PropertyLoader.htcPowerUserMemoryFloorMB,
-		PropertyLoader.htcPowerUserMemoryMaxMB
+		PropertyLoader.htcPowerUserMemoryMaxMB,
+		PropertyLoader.slurm_langevin_timeoutPerTaskSeconds,
+		PropertyLoader.slurm_langevin_batchMemoryLimitPerTaskMB,
+		PropertyLoader.slurm_langevin_memoryBlockSizeMB
 	};
 
 

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
@@ -489,9 +489,7 @@ public class SlurmProxy extends HtcProxy {
 		int perTaskMinutes = (timeoutSeconds + 59) / 60; // ceiling(timeoutSeconds/60)
 		int batches = (totalNumberOfJobs + numberOfConcurrentTasks - 1) / numberOfConcurrentTasks;
 		long workMinutes = (long) batches * perTaskMinutes;
-		long extraMinutes = 3L * perTaskMinutes;
-		long totalMinutes = workMinutes + extraMinutes;
-		long cushionedMinutes = (long) Math.ceil(totalMinutes * 1.10);
+		long cushionedMinutes = (long) Math.ceil(workMinutes * 1.20);
 
 		long totalHours = cushionedMinutes / 60;
 		long minutes = cushionedMinutes % 60;
@@ -500,6 +498,9 @@ public class SlurmProxy extends HtcProxy {
 			return String.format("%02d:%02d:00", totalHours, minutes);
 		} else {
 			long days = totalHours / 24;
+			if(days >= 21) {
+				return("20-23:59:00");	// maxwall for vcell is 21-00:00:00
+			}
 			long hours = totalHours % 24;
 			return String.format("%d-%02d:%02d:00", days, hours, minutes);
 		}
@@ -665,9 +666,10 @@ public class SlurmProxy extends HtcProxy {
 		SolverDescription solverDescription = std.getSolverDescription();
 		MemLimitResults memoryMBAllowed = HtcProxy.getMemoryLimit(vcellUserid, simID, solverDescription, memSizeMB, simTask.isPowerUser());
 
-		String sTimeoutPerTaskSeconds = PropertyLoader.getProperty(PropertyLoader.slurm_langevin_timeoutPerTaskSeconds, "604800");	// seconds. 7 days
-		String sHardbBtchMemoryLimitPerTask = PropertyLoader.getProperty(PropertyLoader.slurm_langevin_batchMemoryLimitPerTaskMB, "1024");
-		String sBlockSizeMB =  PropertyLoader.getProperty(PropertyLoader.slurm_langevin_memoryBlockSizeMB, "256");
+		// next 3 will fire exception if prop not set
+		String sTimeoutPerTaskSeconds = PropertyLoader.getRequiredProperty(PropertyLoader.slurm_langevin_timeoutPerTaskSeconds);	// seconds. 7 days
+		String sHardbBtchMemoryLimitPerTask = PropertyLoader.getRequiredProperty(PropertyLoader.slurm_langevin_batchMemoryLimitPerTaskMB);
+		String sBlockSizeMB =  PropertyLoader.getRequiredProperty(PropertyLoader.slurm_langevin_memoryBlockSizeMB);
 		int timeoutPerTaskSeconds = Integer.parseInt(sTimeoutPerTaskSeconds);				// seconds. 24 hours
 		long hardbBtchMemoryLimitPerTask = Long.parseLong(sHardbBtchMemoryLimitPerTask);	// MB. we hard limit mem to 2G for langevin batch jobs
 		int blockSizeMB = Integer.parseInt(sBlockSizeMB); 						// MB. SLURM memory allocation granularity

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
@@ -665,7 +665,7 @@ public class SlurmProxy extends HtcProxy {
 		SolverDescription solverDescription = std.getSolverDescription();
 		MemLimitResults memoryMBAllowed = HtcProxy.getMemoryLimit(vcellUserid, simID, solverDescription, memSizeMB, simTask.isPowerUser());
 
-		String sTimeoutPerTaskSeconds = PropertyLoader.getProperty(PropertyLoader.slurm_langevin_timeoutPerTaskSeconds, "86400");
+		String sTimeoutPerTaskSeconds = PropertyLoader.getProperty(PropertyLoader.slurm_langevin_timeoutPerTaskSeconds, "604800");	// seconds. 7 days
 		String sHardbBtchMemoryLimitPerTask = PropertyLoader.getProperty(PropertyLoader.slurm_langevin_batchMemoryLimitPerTaskMB, "1024");
 		String sBlockSizeMB =  PropertyLoader.getProperty(PropertyLoader.slurm_langevin_memoryBlockSizeMB, "256");
 		int timeoutPerTaskSeconds = Integer.parseInt(sTimeoutPerTaskSeconds);				// seconds. 24 hours

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
@@ -499,7 +499,7 @@ public class SlurmProxy extends HtcProxy {
 		} else {
 			long days = totalHours / 24;
 			if(days >= 21) {
-				return("20-23:59:00");	// maxwall for vcell is 21-00:00:00
+				return String.format("%d-%02d:%02d:00", 20, 23, 59); // maxwall for vcell is 21-00:00:00
 			}
 			long hours = totalHours % 24;
 			return String.format("%d-%02d:%02d:00", days, hours, minutes);

--- a/vcell-server/src/test/java/cbit/vcell/message/server/htc/slurm/SlurmProxyTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/htc/slurm/SlurmProxyTest.java
@@ -90,6 +90,10 @@ public class SlurmProxyTest {
 		setProperty(PropertyLoader.htcPowerUserMemoryFloorMB, "51200");
 		setProperty(PropertyLoader.htcMinMemoryMB, "4096");
 		setProperty(PropertyLoader.htcMaxMemoryMB, "81920");
+
+		setProperty(PropertyLoader.slurm_langevin_timeoutPerTaskSeconds, "345600");
+		setProperty(PropertyLoader.slurm_langevin_batchMemoryLimitPerTaskMB, "1024");
+		setProperty(PropertyLoader.slurm_langevin_memoryBlockSizeMB, "256");
 	}
 
 	@AfterEach

--- a/vcell-server/src/test/resources/slurm_fixtures/langevin/V_TEST2_999999999_0_0.slurm.sub
+++ b/vcell-server/src/test/resources/slurm_fixtures/langevin/V_TEST2_999999999_0_0.slurm.sub
@@ -9,7 +9,7 @@
 #SBATCH --cpus-per-task=1
 #SBATCH --mem-per-cpu=4096M
 #SBATCH --nodes=1
-#SBATCH --time=6-14:24:00		# timeout for the entire job
+#SBATCH --time=14-09:36:00		# timeout for the entire job
 #SBATCH --nodelist=mantis-040
 #SBATCH --no-kill
 #SBATCH --no-requeue
@@ -23,7 +23,7 @@ set +e
 USERID=danv
 SIM_ID=999999999
 TOTAL_JOBS=8            # to be set by generator to lso.getTotalNumberOfJobs()
-JOB_TIMEOUT_SECONDS=86400  # per-job timeout (seconds), adjust per generator
+JOB_TIMEOUT_SECONDS=345600  # per-job timeout (seconds), adjust per generator
 LOG_FILE="/share/apps/vcell3/htclogs/V_TEST2_999999999_0_.submit.log"
 MESSAGING_CONFIG_FILE="/share/apps/vcell3/users/danv/SimID_999999999_0_.langevinMessagingConfig"
 


### PR DESCRIPTION
Implementing copy springsalad application
Some mesh-related issue warnings are irrelevant for springsalad application
mirroring some slurm batch langevin properties on client and server, make them required
simulation summary panel now displays meaningful (and useful) langevin simulation options
disable parameter scans for langevin simulations
optimization for RPC transfer of results for langevin batch runs
code fix when both reactants are the same molecule type
raise issue when Kon is too large