### PR TITLE
Add dev-only Swing debug bridge for live UI introspection and control

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/VCellClient.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/VCellClient.java
@@ -201,7 +201,9 @@ public void startClient(final VCDocument startupDoc, final ClientServerInfo clie
 		    if (currWindowManager != null) {
 		    	hashTable.put("currWindowManager", currWindowManager);
 		    }
-		    
+
+		    // dev-only introspection surface; no-op unless -Dvcell.debugBridge=true
+		    org.vcell.client.debug.SwingDebugBridge.startIfEnabled();
 		}
 	};
 	

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/DocumentWindow.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/DocumentWindow.java
@@ -1612,7 +1612,10 @@ public class DocumentWindow extends LWTopFrame implements TopLevelWindow, Reconn
                 ClientServerInfo.createRemoteServerInfo(host, Integer.parseInt(port), pathPrefix, null));
 
         AsynchClientTask[] taskArray = new AsynchClientTask[]{task1a, task1b, task2};
-        ClientTaskDispatcher.dispatch(null, hash, taskArray);
+        // pass this window as the requester so a login failure (e.g. server
+        // unreachable) surfaces an error dialog parented to it, instead of a
+        // silent no-op with an unparented dialog
+        ClientTaskDispatcher.dispatch(this, hash, taskArray);
     }
 
 

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -1,0 +1,76 @@
+# Swing Debug Bridge
+
+A dev-only introspection + control surface for the running VCell desktop client —
+the Swing analog of a browser's DOM inspector + Playwright. It lets a developer
+(or an automated coding agent) **see the live UI as text and pixels** and
+**drive it**, without attaching a debugger.
+
+- `SwingInspector` — EDT-safe primitives: serialize every showing window to JSON,
+  find/click a component by path, screenshot a window to PNG.
+- `SwingDebugBridge` — a loopback-only HTTP server exposing those primitives.
+
+## Why
+
+Java Swing has no built-in text serialization of the widget tree the way the web
+has the DOM. This bridge manufactures one: every node carries a stable `path`
+selector (e.g. `0/3/2` = window 0 → child 3 → child 2) that you hand back to
+`/click` or `findByPath(...)`. That closes the observe→act→observe loop that web
+tooling gets for free.
+
+## Safety
+
+- **Off by default.** Nothing starts unless `-Dvcell.debugBridge=true` (or env
+  `VCELL_DEBUG_BRIDGE=true`). A normal production launch is completely unaffected.
+- **Loopback only.** Binds to `127.0.0.1`, never reachable off the machine.
+- **Never fatal.** Startup/handler failures are logged, never propagated.
+
+## Enable
+
+Add JVM args to your launch (IDE run config, or install4j vmoptions):
+
+```
+-Dvcell.debugBridge=true
+-Dvcell.debugBridge.port=9123          # optional, default 9123
+-Dvcell.debugBridge.dir=/tmp/vcell-debug   # optional screenshot dir
+```
+
+On startup you'll see a `WARN` log line: `Swing debug bridge listening on http://127.0.0.1:9123`.
+
+## Endpoints
+
+| Endpoint | Returns |
+|---|---|
+| `GET /health` | `ok` |
+| `GET /windows` | JSON: showing top-level windows only (depth 0) |
+| `GET /tree[?maxDepth=N]` | JSON: full component tree of every showing window |
+| `GET /screenshot[?window=N]` | JSON `{"path": "...png"}`; omit `window` for the active window |
+| `GET /click?path=0/3/2` | JSON `{"clicked": true\|false}` |
+
+Buttons/checkboxes are clicked via `doClick()` (no cursor movement); other
+components get a synthetic `Robot` click at their center.
+
+## Typical loop
+
+```bash
+curl -s localhost:9123/tree?maxDepth=8 | jq          # read the UI as text
+curl -s localhost:9123/screenshot | jq -r .path       # -> PNG to open/inspect
+curl -s "localhost:9123/click?path=0/0/1/0/0/0"       # act
+curl -s localhost:9123/tree | jq                       # observe the result
+```
+
+## Node fields
+
+`path`, `class`, `name` (from `Component.getName()`), `text`, `tooltip`,
+`visible`, `showing`, `enabled`, `selected` (buttons only), `bounds{x,y,w,h}`,
+`children[]`.
+
+> Tip: components with a `name` (~28% of client files call `setName`) are the
+> most reliable to target and to reason about. When adding UI, `setName(...)`
+> on interactive widgets makes them addressable here and in future AssertJ-Swing
+> tests.
+
+## Smoke test
+
+A standalone demo (no VCell server / login needed) lives in the scratchpad during
+development; the pattern: set `vcell.debugBridge=true`, show a `JFrame` with named
+widgets, call `SwingDebugBridge.startIfEnabled()`, then curl the endpoints.

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -26,7 +26,14 @@ tooling gets for free.
 
 ## Enable
 
-Add JVM args to your launch (IDE run config, or install4j vmoptions):
+Easiest, from a source build:
+
+```bash
+./vcell.sh --debug-bridge            # bridge on :9123
+./vcell.sh --debug-bridge=9200       # bridge on a custom port
+```
+
+Or add JVM args to any launch (IDE run config, or install4j vmoptions):
 
 ```
 -Dvcell.debugBridge=true

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -50,11 +50,12 @@ On startup you'll see a `WARN` log line: `Swing debug bridge listening on http:/
 | `GET /health` | `ok` |
 | `GET /windows` | JSON: showing top-level windows only (depth 0) |
 | `GET /tree[?maxDepth=N]` | JSON: full component tree of every showing window |
-| `GET /screenshot[?window=N]` | JSON `{"path": "...png"}`; omit `window` for the active window |
+| `GET /screenshot[?window=N]` | JSON `{"path": "...png"}`; omit `window` for the active window. Rendered off-screen via `printAll`, so overlapping applications never bleed into the capture |
 | `GET /click?path=0/3/2` | JSON `{"clicked": true\|false}` |
 | `GET /setText?path=&text=&enter=` | JSON `{"set": true\|false}` |
 | `GET /selectTab?path=&index=` | JSON `{"selected": true\|false}` |
 | `GET /listeners?path=0/3/2` | JSON: registered `ActionListener` classes, action command, mouse-listener count — "is this control actually wired up?" |
+| `GET /log[?lines=N]` | text/plain tail (default 200 lines) of the client's real log — VCell redirects System.out/err to `<vcellHome>/logs/vcellrun_<site>.log`, so exceptions never appear on the launcher's stdout |
 
 Buttons/checkboxes are clicked via `doClick()` posted with `invokeLater` (no
 cursor movement, and the request returns immediately even if the action opens a

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -52,9 +52,13 @@ On startup you'll see a `WARN` log line: `Swing debug bridge listening on http:/
 | `GET /tree[?maxDepth=N]` | JSON: full component tree of every showing window |
 | `GET /screenshot[?window=N]` | JSON `{"path": "...png"}`; omit `window` for the active window |
 | `GET /click?path=0/3/2` | JSON `{"clicked": true\|false}` |
+| `GET /setText?path=&text=&enter=` | JSON `{"set": true\|false}` |
+| `GET /selectTab?path=&index=` | JSON `{"selected": true\|false}` |
+| `GET /listeners?path=0/3/2` | JSON: registered `ActionListener` classes, action command, mouse-listener count — "is this control actually wired up?" |
 
-Buttons/checkboxes are clicked via `doClick()` (no cursor movement); other
-components get a synthetic `Robot` click at their center.
+Buttons/checkboxes are clicked via `doClick()` posted with `invokeLater` (no
+cursor movement, and the request returns immediately even if the action opens a
+modal dialog); other components get a synthetic `Robot` click at their center.
 
 ## Typical loop
 

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 1999-2011 University of Connecticut Health Center
+ *
+ * Licensed under the MIT License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *  http://www.opensource.org/licenses/mit-license.php
+ */
+
+package org.vcell.client.debug;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Loopback-only HTTP control surface over {@link SwingInspector} that lets a
+ * developer or an automated agent observe and drive the running Swing UI the
+ * way a browser's DevTools / Playwright drive a web page.
+ *
+ * <p><b>Opt-in only.</b> Started only when {@code -Dvcell.debugBridge=true}
+ * (or env {@code VCELL_DEBUG_BRIDGE=true}). In a normal production launch
+ * {@link #startIfEnabled()} is a no-op, so this has zero runtime footprint.
+ *
+ * <p>Binds exclusively to the loopback interface (127.0.0.1) so it is never
+ * reachable off the machine.
+ *
+ * <pre>
+ *   GET /health                 -&gt; "ok"
+ *   GET /windows                -&gt; JSON, showing top-level windows (depth 0)
+ *   GET /tree[?maxDepth=N]      -&gt; JSON, full component tree of every window
+ *   GET /screenshot[?window=N]  -&gt; JSON {"path": "...png"}; N omitted = active window
+ *   GET /click?path=0/3/2       -&gt; JSON {"clicked": true|false}
+ *   GET /setText?path=..&amp;text=..[&amp;enter=true]  -&gt; JSON {"set": true|false}
+ *   GET /selectTab?path=..&amp;index=N            -&gt; JSON {"selected": true|false}
+ * </pre>
+ *
+ * Example: {@code curl -s localhost:9123/tree?maxDepth=6 | jq}
+ */
+public final class SwingDebugBridge {
+
+	private static final Logger LG = LogManager.getLogger(SwingDebugBridge.class);
+
+	private static final String ENABLE_PROP = "vcell.debugBridge";
+	private static final String ENABLE_ENV = "VCELL_DEBUG_BRIDGE";
+	private static final String PORT_PROP = "vcell.debugBridge.port";
+	private static final String DIR_PROP = "vcell.debugBridge.dir";
+	private static final int DEFAULT_PORT = 9123;
+
+	private static HttpServer server;
+
+	private SwingDebugBridge() {
+	}
+
+	/** @return true if the bridge is switched on via system property or environment variable. */
+	public static boolean isEnabled() {
+		if (Boolean.parseBoolean(System.getProperty(ENABLE_PROP, "false"))) {
+			return true;
+		}
+		return Boolean.parseBoolean(System.getenv(ENABLE_ENV));
+	}
+
+	/** Screenshot output directory ({@code -Dvcell.debugBridge.dir}, else {@code <tmp>/vcell-debug}). */
+	public static File outputDir() {
+		String configured = System.getProperty(DIR_PROP);
+		if (configured != null && !configured.isEmpty()) {
+			return new File(configured);
+		}
+		return new File(System.getProperty("java.io.tmpdir"), "vcell-debug");
+	}
+
+	/**
+	 * Start the bridge if enabled. Safe to call more than once (subsequent calls
+	 * are no-ops). Never throws; failures are logged so a debug facility can
+	 * never take down the client.
+	 */
+	public static synchronized void startIfEnabled() {
+		if (!isEnabled()) {
+			return;
+		}
+		if (server != null) {
+			return;
+		}
+		int port = Integer.getInteger(PORT_PROP, DEFAULT_PORT);
+		try {
+			HttpServer s = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), port), 0);
+			s.createContext("/health", ex -> respond(ex, 200, "text/plain", "ok".getBytes(StandardCharsets.UTF_8)));
+			s.createContext("/windows", wrap(SwingDebugBridge::handleWindows));
+			s.createContext("/tree", wrap(SwingDebugBridge::handleTree));
+			s.createContext("/screenshot", wrap(SwingDebugBridge::handleScreenshot));
+			s.createContext("/click", wrap(SwingDebugBridge::handleClick));
+			s.createContext("/setText", wrap(SwingDebugBridge::handleSetText));
+			s.createContext("/selectTab", wrap(SwingDebugBridge::handleSelectTab));
+			s.setExecutor(null); // default single-threaded executor is fine for a debug surface
+			s.start();
+			server = s;
+			LG.warn("Swing debug bridge listening on http://127.0.0.1:{} (screenshots -> {})", port, outputDir());
+		} catch (Exception e) {
+			LG.error("failed to start Swing debug bridge on port " + port, e);
+		}
+	}
+
+	/** Stop the bridge if running. */
+	public static synchronized void stop() {
+		if (server != null) {
+			server.stop(0);
+			server = null;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// Handlers
+	// ---------------------------------------------------------------------
+
+	private interface ThrowingHandler {
+		String handle(HttpExchange ex) throws Exception;
+	}
+
+	private static com.sun.net.httpserver.HttpHandler wrap(ThrowingHandler h) {
+		return ex -> {
+			try {
+				String json = h.handle(ex);
+				respond(ex, 200, "application/json", json.getBytes(StandardCharsets.UTF_8));
+			} catch (Exception e) {
+				LG.error("debug bridge handler error for " + ex.getRequestURI(), e);
+				String msg = e.getClass().getSimpleName() + ": " + String.valueOf(e.getMessage());
+				respond(ex, 500, "application/json", ("{\"error\":\"" + jsonEscape(msg) + "\"}").getBytes(StandardCharsets.UTF_8));
+			}
+		};
+	}
+
+	private static String handleWindows(HttpExchange ex) {
+		return SwingInspector.dumpWindowsJson(0);
+	}
+
+	private static String handleTree(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		int maxDepth = q.containsKey("maxDepth") ? Integer.parseInt(q.get("maxDepth")) : Integer.MAX_VALUE;
+		return SwingInspector.dumpWindowsJson(maxDepth);
+	}
+
+	private static String handleScreenshot(HttpExchange ex) throws Exception {
+		Map<String, String> q = query(ex);
+		int windowIndex = q.containsKey("window") ? Integer.parseInt(q.get("window")) : -1;
+		File png = SwingInspector.screenshot(windowIndex, outputDir());
+		return "{\"path\":\"" + jsonEscape(png.getAbsolutePath()) + "\"}";
+	}
+
+	private static String handleClick(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty()) {
+			return "{\"error\":\"missing 'path' query parameter\"}";
+		}
+		boolean clicked = SwingInspector.click(path);
+		return "{\"clicked\":" + clicked + ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	private static String handleSetText(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty()) {
+			return "{\"error\":\"missing 'path' query parameter\"}";
+		}
+		String text = q.getOrDefault("text", "");
+		boolean commit = Boolean.parseBoolean(q.getOrDefault("enter", "false"));
+		boolean ok = SwingInspector.setText(path, text, commit);
+		return "{\"set\":" + ok + ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	private static String handleSelectTab(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty() || !q.containsKey("index")) {
+			return "{\"error\":\"require 'path' and 'index' query parameters\"}";
+		}
+		boolean ok = SwingInspector.selectTab(path, Integer.parseInt(q.get("index")));
+		return "{\"selected\":" + ok + ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	// ---------------------------------------------------------------------
+	// HTTP helpers
+	// ---------------------------------------------------------------------
+
+	private static void respond(HttpExchange ex, int status, String contentType, byte[] body) throws IOException {
+		ex.getResponseHeaders().set("Content-Type", contentType);
+		ex.sendResponseHeaders(status, body.length);
+		try (OutputStream os = ex.getResponseBody()) {
+			os.write(body);
+		}
+	}
+
+	private static Map<String, String> query(HttpExchange ex) {
+		Map<String, String> map = new HashMap<>();
+		URI uri = ex.getRequestURI();
+		String raw = uri.getRawQuery();
+		if (raw == null || raw.isEmpty()) {
+			return map;
+		}
+		for (String pair : raw.split("&")) {
+			int eq = pair.indexOf('=');
+			if (eq < 0) {
+				map.put(urlDecode(pair), "");
+			} else {
+				map.put(urlDecode(pair.substring(0, eq)), urlDecode(pair.substring(eq + 1)));
+			}
+		}
+		return map;
+	}
+
+	private static String urlDecode(String s) {
+		return java.net.URLDecoder.decode(s, StandardCharsets.UTF_8);
+	}
+
+	private static String jsonEscape(String s) {
+		return s.replace("\\", "\\\\").replace("\"", "\\\"");
+	}
+}

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
@@ -46,6 +46,7 @@ import com.sun.net.httpserver.HttpServer;
  *   GET /click?path=0/3/2       -&gt; JSON {"clicked": true|false}
  *   GET /setText?path=..&amp;text=..[&amp;enter=true]  -&gt; JSON {"set": true|false}
  *   GET /selectTab?path=..&amp;index=N            -&gt; JSON {"selected": true|false}
+ *   GET /listeners?path=0/3/2   -&gt; JSON, registered listeners of the component
  * </pre>
  *
  * Example: {@code curl -s localhost:9123/tree?maxDepth=6 | jq}
@@ -104,7 +105,13 @@ public final class SwingDebugBridge {
 			s.createContext("/click", wrap(SwingDebugBridge::handleClick));
 			s.createContext("/setText", wrap(SwingDebugBridge::handleSetText));
 			s.createContext("/selectTab", wrap(SwingDebugBridge::handleSelectTab));
-			s.setExecutor(null); // default single-threaded executor is fine for a debug surface
+			s.createContext("/listeners", wrap(SwingDebugBridge::handleListeners));
+			// small pool: a request that blocks on a modal dialog must not wedge /health and /screenshot
+			s.setExecutor(java.util.concurrent.Executors.newFixedThreadPool(4, r -> {
+				Thread t = new Thread(r, "swing-debug-bridge");
+				t.setDaemon(true);
+				return t;
+			}));
 			s.start();
 			server = s;
 			LG.warn("Swing debug bridge listening on http://127.0.0.1:{} (screenshots -> {})", port, outputDir());
@@ -179,6 +186,15 @@ public final class SwingDebugBridge {
 		boolean commit = Boolean.parseBoolean(q.getOrDefault("enter", "false"));
 		boolean ok = SwingInspector.setText(path, text, commit);
 		return "{\"set\":" + ok + ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	private static String handleListeners(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty()) {
+			return "{\"error\":\"missing 'path' query parameter\"}";
+		}
+		return SwingInspector.dumpListenersJson(path);
 	}
 
 	private static String handleSelectTab(HttpExchange ex) {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.vcell.util.logging.ConsoleCapture;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
@@ -47,6 +48,7 @@ import com.sun.net.httpserver.HttpServer;
  *   GET /setText?path=..&amp;text=..[&amp;enter=true]  -&gt; JSON {"set": true|false}
  *   GET /selectTab?path=..&amp;index=N            -&gt; JSON {"selected": true|false}
  *   GET /listeners?path=0/3/2   -&gt; JSON, registered listeners of the component
+ *   GET /log[?lines=N]          -&gt; text/plain tail of the client's real log
  * </pre>
  *
  * Example: {@code curl -s localhost:9123/tree?maxDepth=6 | jq}
@@ -106,6 +108,14 @@ public final class SwingDebugBridge {
 			s.createContext("/setText", wrap(SwingDebugBridge::handleSetText));
 			s.createContext("/selectTab", wrap(SwingDebugBridge::handleSelectTab));
 			s.createContext("/listeners", wrap(SwingDebugBridge::handleListeners));
+			s.createContext("/log", ex -> {
+				try {
+					respond(ex, 200, "text/plain; charset=utf-8", handleLog(ex).getBytes(StandardCharsets.UTF_8));
+				} catch (Exception e) {
+					LG.error("debug bridge /log error", e);
+					respond(ex, 500, "text/plain", String.valueOf(e.getMessage()).getBytes(StandardCharsets.UTF_8));
+				}
+			});
 			// small pool: a request that blocks on a modal dialog must not wedge /health and /screenshot
 			s.setExecutor(java.util.concurrent.Executors.newFixedThreadPool(4, r -> {
 				Thread t = new Thread(r, "swing-debug-bridge");
@@ -186,6 +196,24 @@ public final class SwingDebugBridge {
 		boolean commit = Boolean.parseBoolean(q.getOrDefault("enter", "false"));
 		boolean ok = SwingInspector.setText(path, text, commit);
 		return "{\"set\":" + ok + ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	/**
+	 * Tail of the client's real log. VCellClientMain redirects System.out/err
+	 * to {@code <vcellHome>/logs/vcellrun_<site>.log} via {@link ConsoleCapture},
+	 * so a launcher that captures the process's stdout only sees pre-redirect
+	 * lines — exceptions, login-flow progress, and UNCAUGHT EXCEPTION dumps all
+	 * land in the redirected file this endpoint serves.
+	 */
+	private static String handleLog(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		int lines = q.containsKey("lines") ? Integer.parseInt(q.get("lines")) : 200;
+		ConsoleCapture cc = ConsoleCapture.getInstance();
+		if (!cc.isRedirectedStandardOutErr()) {
+			return "(stdout/stderr not redirected; nothing captured)";
+		}
+		ConsoleCapture.CurrentContent content = cc.getLastLines(lines);
+		return content.isAvailable ? content.content : "(log content unavailable)";
 	}
 
 	private static String handleListeners(HttpExchange ex) {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -1,0 +1,569 @@
+/*
+ * Copyright (C) 1999-2011 University of Connecticut Health Center
+ *
+ * Licensed under the MIT License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *  http://www.opensource.org/licenses/mit-license.php
+ */
+
+package org.vcell.client.debug;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.GraphicsEnvironment;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Window;
+import java.awt.event.InputEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import javax.imageio.ImageIO;
+import javax.swing.AbstractButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JTabbedPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.text.JTextComponent;
+
+/**
+ * Read-only (mostly) introspection of the live Swing UI, intended to give an
+ * automated agent / developer a text and pixel view of the running application
+ * without a running debugger.
+ *
+ * <p>This is the Swing analog of a browser's DOM + accessibility tree. Every
+ * node in {@link #dumpWindowsJson()} carries a stable {@code path} selector
+ * (e.g. {@code "0/3/2"} = window 0, child 3, child 2) that can be handed back to
+ * {@link #findByPath(String)} / {@link #click(String)} to drive the component.
+ *
+ * <p>All AWT/Swing state is read on the Event Dispatch Thread; callers may be on
+ * any thread. Enabled only via {@link SwingDebugBridge}; has no effect in a
+ * normal production launch.
+ */
+public final class SwingInspector {
+
+	private static final int MAX_TEXT = 200;
+	private static final int MAX_TABLE_ROWS = 25;
+	private static final int MAX_TABLE_COLS = 15;
+	private static final int MAX_LIST_ITEMS = 50;
+
+	private SwingInspector() {
+	}
+
+	// ---------------------------------------------------------------------
+	// Window enumeration
+	// ---------------------------------------------------------------------
+
+	/**
+	 * @return the showing top-level windows, in a stable order (AWT creation
+	 *         order). Index into this list is the first segment of a node path.
+	 */
+	public static List<Window> showingWindows() {
+		return onEdt(() -> {
+			List<Window> out = new ArrayList<>();
+			for (Window w : Window.getWindows()) {
+				if (w.isShowing()) {
+					out.add(w);
+				}
+			}
+			return out;
+		});
+	}
+
+	// ---------------------------------------------------------------------
+	// Tree serialization
+	// ---------------------------------------------------------------------
+
+	/** @return a JSON array of the full component tree of every showing window. */
+	public static String dumpWindowsJson() {
+		return dumpWindowsJson(Integer.MAX_VALUE);
+	}
+
+	/**
+	 * @param maxDepth maximum component nesting depth to emit (root window = depth 0)
+	 * @return a JSON array of the component tree of every showing window
+	 */
+	public static String dumpWindowsJson(final int maxDepth) {
+		return onEdt(() -> {
+			List<Window> windows = new ArrayList<>();
+			for (Window w : Window.getWindows()) {
+				if (w.isShowing()) {
+					windows.add(w);
+				}
+			}
+			StringBuilder sb = new StringBuilder(4096);
+			sb.append('[');
+			for (int i = 0; i < windows.size(); i++) {
+				if (i > 0) {
+					sb.append(',');
+				}
+				appendNode(sb, windows.get(i), Integer.toString(i), 0, maxDepth);
+			}
+			sb.append(']');
+			return sb.toString();
+		});
+	}
+
+	private static void appendNode(StringBuilder sb, Component c, String path, int depth, int maxDepth) {
+		sb.append('{');
+		kv(sb, "path", path);
+		comma(sb);
+		kv(sb, "class", c.getClass().getName());
+
+		String name = c.getName();
+		if (name != null && !name.isEmpty()) {
+			comma(sb);
+			kv(sb, "name", name);
+		}
+		String text = textOf(c);
+		if (text != null && !text.isEmpty()) {
+			comma(sb);
+			kv(sb, "text", truncate(text));
+		}
+		if (c instanceof JComponent) {
+			String tip = ((JComponent) c).getToolTipText();
+			if (tip != null && !tip.isEmpty()) {
+				comma(sb);
+				kv(sb, "tooltip", tip);
+			}
+		}
+		comma(sb);
+		raw(sb, "visible", c.isVisible());
+		comma(sb);
+		raw(sb, "showing", c.isShowing());
+		comma(sb);
+		raw(sb, "enabled", c.isEnabled());
+		if (c instanceof AbstractButton) {
+			comma(sb);
+			raw(sb, "selected", ((AbstractButton) c).isSelected());
+		}
+
+		Rectangle b = c.getBounds();
+		sb.append(",\"bounds\":{\"x\":").append(b.x)
+				.append(",\"y\":").append(b.y)
+				.append(",\"w\":").append(b.width)
+				.append(",\"h\":").append(b.height).append('}');
+
+		appendTypeSpecific(sb, c);
+
+		if (c instanceof Container && depth < maxDepth) {
+			Component[] kids = ((Container) c).getComponents();
+			if (kids.length > 0) {
+				sb.append(",\"children\":[");
+				for (int i = 0; i < kids.length; i++) {
+					if (i > 0) {
+						sb.append(',');
+					}
+					appendNode(sb, kids[i], path + '/' + i, depth + 1, maxDepth);
+				}
+				sb.append(']');
+			}
+		}
+		sb.append('}');
+	}
+
+	private static String textOf(Component c) {
+		if (c instanceof AbstractButton) {
+			return ((AbstractButton) c).getText();
+		}
+		if (c instanceof JLabel) {
+			return ((JLabel) c).getText();
+		}
+		if (c instanceof JTextComponent) {
+			return ((JTextComponent) c).getText();
+		}
+		if (c instanceof JFrame) {
+			return ((JFrame) c).getTitle();
+		}
+		if (c instanceof JDialog) {
+			return ((JDialog) c).getTitle();
+		}
+		return null;
+	}
+
+	/**
+	 * Emit compact structural detail for content-bearing widgets that the plain
+	 * component hierarchy does not otherwise reveal: tabbed-pane tab titles,
+	 * combo/list selection, and table cell values (capped).
+	 */
+	private static void appendTypeSpecific(StringBuilder sb, Component c) {
+		if (c instanceof JTabbedPane) {
+			JTabbedPane tp = (JTabbedPane) c;
+			sb.append(",\"tabs\":{\"selected\":").append(tp.getSelectedIndex()).append(",\"titles\":[");
+			for (int i = 0; i < tp.getTabCount(); i++) {
+				if (i > 0) {
+					sb.append(',');
+				}
+				sb.append('"').append(escape(nz(tp.getTitleAt(i)))).append('"');
+			}
+			sb.append("]}");
+		} else if (c instanceof JComboBox) {
+			JComboBox<?> cb = (JComboBox<?>) c;
+			sb.append(",\"combo\":{\"selectedIndex\":").append(cb.getSelectedIndex());
+			sb.append(",\"selectedItem\":\"").append(escape(truncate(String.valueOf(cb.getSelectedItem())))).append('"');
+			sb.append(",\"itemCount\":").append(cb.getItemCount()).append('}');
+		} else if (c instanceof JList) {
+			JList<?> jl = (JList<?>) c;
+			int size = jl.getModel().getSize();
+			sb.append(",\"list\":{\"size\":").append(size).append(",\"selectedIndices\":[");
+			int[] sel = jl.getSelectedIndices();
+			for (int i = 0; i < sel.length; i++) {
+				if (i > 0) {
+					sb.append(',');
+				}
+				sb.append(sel[i]);
+			}
+			sb.append("],\"items\":[");
+			int shown = Math.min(size, MAX_LIST_ITEMS);
+			for (int i = 0; i < shown; i++) {
+				if (i > 0) {
+					sb.append(',');
+				}
+				sb.append('"').append(escape(truncate(String.valueOf(jl.getModel().getElementAt(i))))).append('"');
+			}
+			sb.append("],\"truncated\":").append(size > shown).append('}');
+		} else if (c instanceof JTable) {
+			appendTable(sb, (JTable) c);
+		}
+	}
+
+	private static void appendTable(StringBuilder sb, JTable t) {
+		int rows = t.getRowCount();
+		int cols = t.getColumnCount();
+		int maxR = Math.min(rows, MAX_TABLE_ROWS);
+		int maxC = Math.min(cols, MAX_TABLE_COLS);
+		sb.append(",\"table\":{\"rowCount\":").append(rows).append(",\"columnCount\":").append(cols);
+		sb.append(",\"selectedRow\":").append(t.getSelectedRow());
+		sb.append(",\"columns\":[");
+		for (int col = 0; col < maxC; col++) {
+			if (col > 0) {
+				sb.append(',');
+			}
+			sb.append('"').append(escape(nz(t.getColumnName(col)))).append('"');
+		}
+		sb.append("],\"cells\":[");
+		for (int r = 0; r < maxR; r++) {
+			if (r > 0) {
+				sb.append(',');
+			}
+			sb.append('[');
+			for (int col = 0; col < maxC; col++) {
+				if (col > 0) {
+					sb.append(',');
+				}
+				String cell;
+				try {
+					cell = String.valueOf(t.getValueAt(r, col));
+				} catch (Exception e) {
+					cell = "?";
+				}
+				sb.append('"').append(escape(truncate(cell))).append('"');
+			}
+			sb.append(']');
+		}
+		sb.append("],\"truncated\":").append(rows > maxR || cols > maxC).append('}');
+	}
+
+	// ---------------------------------------------------------------------
+	// Lookup + interaction
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Resolve a node path (as emitted by {@link #dumpWindowsJson()}) to a live
+	 * component. First segment indexes {@link #showingWindows()}; remaining
+	 * segments index {@link Container#getComponents()}.
+	 *
+	 * @return the component, or {@code null} if the path does not resolve
+	 */
+	public static Component findByPath(final String path) {
+		return onEdt(() -> {
+			String[] segs = path.split("/");
+			List<Window> windows = new ArrayList<>();
+			for (Window w : Window.getWindows()) {
+				if (w.isShowing()) {
+					windows.add(w);
+				}
+			}
+			int wi = Integer.parseInt(segs[0]);
+			if (wi < 0 || wi >= windows.size()) {
+				return null;
+			}
+			Component cur = windows.get(wi);
+			for (int s = 1; s < segs.length; s++) {
+				if (!(cur instanceof Container)) {
+					return null;
+				}
+				Component[] kids = ((Container) cur).getComponents();
+				int ci = Integer.parseInt(segs[s]);
+				if (ci < 0 || ci >= kids.length) {
+					return null;
+				}
+				cur = kids[ci];
+			}
+			return cur;
+		});
+	}
+
+	/** Depth-first search for the first component whose {@link Component#getName()} matches. */
+	public static Component findByName(final String targetName) {
+		return onEdt(() -> {
+			for (Window w : Window.getWindows()) {
+				if (w.isShowing()) {
+					Component hit = searchByName(w, targetName);
+					if (hit != null) {
+						return hit;
+					}
+				}
+			}
+			return null;
+		});
+	}
+
+	private static Component searchByName(Component c, String targetName) {
+		if (targetName.equals(c.getName())) {
+			return c;
+		}
+		if (c instanceof Container) {
+			for (Component kid : ((Container) c).getComponents()) {
+				Component hit = searchByName(kid, targetName);
+				if (hit != null) {
+					return hit;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Click a component identified by node path. Buttons/checkboxes use
+	 * {@link AbstractButton#doClick()} (EDT-safe, no native cursor movement);
+	 * anything else gets a synthetic {@link Robot} mouse click at its center.
+	 *
+	 * @return true if a component resolved and was clicked
+	 */
+	public static boolean click(String path) {
+		Component c = findByPath(path);
+		if (c == null) {
+			return false;
+		}
+		if (c instanceof AbstractButton) {
+			onEdt(() -> {
+				((AbstractButton) c).doClick();
+				return null;
+			});
+			return true;
+		}
+		// non-button: synthesize a real mouse click at the component center
+		Point screenPt = onEdt(() -> {
+			if (!c.isShowing()) {
+				return null;
+			}
+			Point loc = c.getLocationOnScreen();
+			Dimension d = c.getSize();
+			return new Point(loc.x + d.width / 2, loc.y + d.height / 2);
+		});
+		if (screenPt == null) {
+			return false;
+		}
+		try {
+			Robot robot = new Robot();
+			robot.mouseMove(screenPt.x, screenPt.y);
+			robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+			robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+			return true;
+		} catch (Exception e) {
+			throw new RuntimeException("robot click failed at " + screenPt, e);
+		}
+	}
+
+	/**
+	 * Set the text of a {@link JTextComponent} at the given path. This drives the
+	 * document model directly (firing document listeners); it does not simulate
+	 * per-key events.
+	 *
+	 * @param commit if true and the target is a {@link JTextField}, also fire its
+	 *               action event (equivalent to pressing Enter), which is how many
+	 *               VCell fields commit their value
+	 * @return true if a text component resolved and was updated
+	 */
+	public static boolean setText(String path, String text, boolean commit) {
+		Component c = findByPath(path);
+		if (!(c instanceof JTextComponent)) {
+			return false;
+		}
+		onEdt(() -> {
+			JTextComponent tc = (JTextComponent) c;
+			tc.setText(text);
+			if (commit && tc instanceof JTextField) {
+				((JTextField) tc).postActionEvent();
+			}
+			return null;
+		});
+		return true;
+	}
+
+	/**
+	 * Select a tab by index on a {@link JTabbedPane} at the given path.
+	 *
+	 * @return true if the pane resolved and the index was valid
+	 */
+	public static boolean selectTab(String path, int index) {
+		Component c = findByPath(path);
+		if (!(c instanceof JTabbedPane)) {
+			return false;
+		}
+		return Boolean.TRUE.equals(onEdt(() -> {
+			JTabbedPane tp = (JTabbedPane) c;
+			if (index < 0 || index >= tp.getTabCount()) {
+				return false;
+			}
+			tp.setSelectedIndex(index);
+			return true;
+		}));
+	}
+
+	// ---------------------------------------------------------------------
+	// Screenshots
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Capture the on-screen pixels of a window to a PNG.
+	 *
+	 * @param windowIndex index into {@link #showingWindows()}, or -1 for the
+	 *                    active/focused window
+	 * @param outDir      directory to write into (created if needed)
+	 * @return the written file
+	 */
+	public static File screenshot(int windowIndex, File outDir) throws Exception {
+		if (GraphicsEnvironment.isHeadless()) {
+			throw new IllegalStateException("cannot screenshot in a headless environment");
+		}
+		final Rectangle bounds = onEdt(() -> {
+			List<Window> windows = new ArrayList<>();
+			for (Window w : Window.getWindows()) {
+				if (w.isShowing()) {
+					windows.add(w);
+				}
+			}
+			Window target = null;
+			if (windowIndex >= 0 && windowIndex < windows.size()) {
+				target = windows.get(windowIndex);
+			} else {
+				for (Window w : windows) {
+					if (w.isActive()) {
+						target = w;
+						break;
+					}
+				}
+				if (target == null && !windows.isEmpty()) {
+					target = windows.get(windows.size() - 1);
+				}
+			}
+			return target == null ? null : target.getBounds();
+		});
+		if (bounds == null) {
+			throw new IllegalStateException("no showing window to capture (index=" + windowIndex + ")");
+		}
+		outDir.mkdirs();
+		BufferedImage img = new Robot().createScreenCapture(bounds);
+		File out = new File(outDir, "vcell-window-" + (windowIndex < 0 ? "active" : windowIndex) + ".png");
+		ImageIO.write(img, "png", out);
+		return out;
+	}
+
+	// ---------------------------------------------------------------------
+	// EDT + JSON helpers
+	// ---------------------------------------------------------------------
+
+	private static <T> T onEdt(Supplier<T> supplier) {
+		if (SwingUtilities.isEventDispatchThread()) {
+			return supplier.get();
+		}
+		final AtomicReference<T> result = new AtomicReference<>();
+		final AtomicReference<Throwable> error = new AtomicReference<>();
+		try {
+			SwingUtilities.invokeAndWait(() -> {
+				try {
+					result.set(supplier.get());
+				} catch (Throwable t) {
+					error.set(t);
+				}
+			});
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("interrupted waiting on EDT", e);
+		} catch (InvocationTargetException e) {
+			throw new RuntimeException(e.getCause());
+		}
+		if (error.get() != null) {
+			throw new RuntimeException(error.get());
+		}
+		return result.get();
+	}
+
+	private static void comma(StringBuilder sb) {
+		sb.append(',');
+	}
+
+	private static void kv(StringBuilder sb, String key, String value) {
+		sb.append('"').append(key).append("\":\"").append(escape(value)).append('"');
+	}
+
+	private static void raw(StringBuilder sb, String key, boolean value) {
+		sb.append('"').append(key).append("\":").append(value);
+	}
+
+	private static String truncate(String s) {
+		return s.length() <= MAX_TEXT ? s : s.substring(0, MAX_TEXT) + "…";
+	}
+
+	private static String nz(String s) {
+		return s == null ? "" : s;
+	}
+
+	private static String escape(String s) {
+		StringBuilder sb = new StringBuilder(s.length() + 8);
+		for (int i = 0; i < s.length(); i++) {
+			char ch = s.charAt(i);
+			switch (ch) {
+				case '"':
+					sb.append("\\\"");
+					break;
+				case '\\':
+					sb.append("\\\\");
+					break;
+				case '\n':
+					sb.append("\\n");
+					break;
+				case '\r':
+					sb.append("\\r");
+					break;
+				case '\t':
+					sb.append("\\t");
+					break;
+				default:
+					if (ch < 0x20) {
+						sb.append(String.format("\\u%04x", (int) ch));
+					} else {
+						sb.append(ch);
+					}
+			}
+		}
+		return sb.toString();
+	}
+}

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -37,6 +37,7 @@ import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JTabbedPane;
 import javax.swing.JTable;
+import javax.swing.JTree;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.text.JTextComponent;
@@ -61,6 +62,7 @@ public final class SwingInspector {
 	private static final int MAX_TABLE_ROWS = 25;
 	private static final int MAX_TABLE_COLS = 15;
 	private static final int MAX_LIST_ITEMS = 50;
+	private static final int MAX_TREE_ROWS = 100;
 
 	private SwingInspector() {
 	}
@@ -239,7 +241,34 @@ public final class SwingInspector {
 			sb.append("],\"truncated\":").append(size > shown).append('}');
 		} else if (c instanceof JTable) {
 			appendTable(sb, (JTable) c);
+		} else if (c instanceof JTree) {
+			appendTree(sb, (JTree) c);
 		}
+	}
+
+	private static void appendTree(StringBuilder sb, JTree t) {
+		int rows = t.getRowCount();
+		int maxR = Math.min(rows, MAX_TREE_ROWS);
+		sb.append(",\"tree\":{\"rowCount\":").append(rows);
+		sb.append(",\"selectedRow\":").append(t.getMinSelectionRow());
+		sb.append(",\"rows\":[");
+		for (int r = 0; r < maxR; r++) {
+			if (r > 0) {
+				sb.append(',');
+			}
+			javax.swing.tree.TreePath path = t.getPathForRow(r);
+			String text;
+			try {
+				text = String.valueOf(path.getLastPathComponent());
+			} catch (Exception e) {
+				text = "?";
+			}
+			sb.append("{\"row\":").append(r);
+			sb.append(",\"depth\":").append(path.getPathCount() - 1);
+			sb.append(",\"expanded\":").append(t.isExpanded(r));
+			sb.append(",\"text\":\"").append(escape(truncate(text))).append("\"}");
+		}
+		sb.append("],\"truncated\":").append(rows > maxR).append('}');
 	}
 
 	private static void appendTable(StringBuilder sb, JTable t) {
@@ -476,7 +505,10 @@ public final class SwingInspector {
 	// ---------------------------------------------------------------------
 
 	/**
-	 * Capture the on-screen pixels of a window to a PNG.
+	 * Render a window to a PNG by asking Swing to paint it into an off-screen
+	 * buffer ({@link Component#printAll}). Unlike a Robot screen grab this shows
+	 * the window's own content even when other applications overlap it, and it
+	 * does not require the window to be front-most.
 	 *
 	 * @param windowIndex index into {@link #showingWindows()}, or -1 for the
 	 *                    active/focused window
@@ -487,7 +519,7 @@ public final class SwingInspector {
 		if (GraphicsEnvironment.isHeadless()) {
 			throw new IllegalStateException("cannot screenshot in a headless environment");
 		}
-		final Rectangle bounds = onEdt(() -> {
+		final BufferedImage img = onEdt(() -> {
 			List<Window> windows = new ArrayList<>();
 			for (Window w : Window.getWindows()) {
 				if (w.isShowing()) {
@@ -508,13 +540,22 @@ public final class SwingInspector {
 					target = windows.get(windows.size() - 1);
 				}
 			}
-			return target == null ? null : target.getBounds();
+			if (target == null || target.getWidth() <= 0 || target.getHeight() <= 0) {
+				return null;
+			}
+			BufferedImage buf = new BufferedImage(target.getWidth(), target.getHeight(), BufferedImage.TYPE_INT_ARGB);
+			java.awt.Graphics2D g = buf.createGraphics();
+			try {
+				target.printAll(g);
+			} finally {
+				g.dispose();
+			}
+			return buf;
 		});
-		if (bounds == null) {
+		if (img == null) {
 			throw new IllegalStateException("no showing window to capture (index=" + windowIndex + ")");
 		}
 		outDir.mkdirs();
-		BufferedImage img = new Robot().createScreenCapture(bounds);
 		File out = new File(outDir, "vcell-window-" + (windowIndex < 0 ? "active" : windowIndex) + ".png");
 		ImageIO.write(img, "png", out);
 		return out;

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -319,6 +319,41 @@ public final class SwingInspector {
 		});
 	}
 
+	/**
+	 * Dump the listeners registered on the component at the given path as JSON:
+	 * action listeners (with their class names) plus counts of the generic
+	 * component/mouse listeners. Answers "is this control actually wired up?".
+	 */
+	public static String dumpListenersJson(final String path) {
+		return onEdt(() -> {
+			Component c = findByPath(path);
+			if (c == null) {
+				return "{\"error\":\"path did not resolve\"}";
+			}
+			StringBuilder sb = new StringBuilder(256);
+			sb.append('{');
+			kv(sb, "class", c.getClass().getName());
+			sb.append(',');
+			kv(sb, "name", String.valueOf(c.getName()));
+			if (c instanceof AbstractButton) {
+				sb.append(",\"actionListeners\":[");
+				java.awt.event.ActionListener[] als = ((AbstractButton) c).getActionListeners();
+				for (int i = 0; i < als.length; i++) {
+					if (i > 0) {
+						sb.append(',');
+					}
+					sb.append('"').append(escape(als[i].getClass().getName())).append('"');
+				}
+				sb.append(']');
+				sb.append(",\"actionCommand\":\"")
+						.append(escape(String.valueOf(((AbstractButton) c).getActionCommand()))).append('"');
+			}
+			sb.append(",\"mouseListeners\":").append(c.getMouseListeners().length);
+			sb.append('}');
+			return sb.toString();
+		});
+	}
+
 	/** Depth-first search for the first component whose {@link Component#getName()} matches. */
 	public static Component findByName(final String targetName) {
 		return onEdt(() -> {
@@ -362,10 +397,9 @@ public final class SwingInspector {
 			return false;
 		}
 		if (c instanceof AbstractButton) {
-			onEdt(() -> {
-				((AbstractButton) c).doClick();
-				return null;
-			});
+			// fire-and-forget: the action may open a modal dialog, which would
+			// block invokeAndWait (and with it the whole bridge) until dismissed
+			SwingUtilities.invokeLater(((AbstractButton) c)::doClick);
 			return true;
 		}
 		// non-button: synthesize a real mouse click at the component center

--- a/vcell-client/src/main/java/org/vcell/client/logicalwindow/LWNamespace.java
+++ b/vcell-client/src/main/java/org/vcell/client/logicalwindow/LWNamespace.java
@@ -117,6 +117,9 @@ public interface LWNamespace {
      * @return or null
      */
     public static <T> T findOwnerOfType(Class<? extends T> clzz, Component swingParent) {
+        if (swingParent == null) {
+            return null;
+        }
         final Logger lg = LGHolder.LG;
         T t = CastingUtils.downcast(clzz, swingParent);
         if (t != null) {

--- a/vcell.sh
+++ b/vcell.sh
@@ -1,12 +1,85 @@
 #!/usr/bin/env bash
+#
+# Dev launcher for the VCell desktop client from a source build.
+#
+# Mirrors the JVM options used by the install4j installer
+# (docker/build/installers/VCell.install4j) so the from-source client behaves
+# like a shipped one — in particular the `--add-exports` that Java 17 needs for
+# image handling, and the server host / prefix / bioformats properties.
+#
+# Usage:
+#   ./vcell.sh [--debug-bridge[=PORT]] [extra VCellClientMain args...]
+#
+# Options:
+#   --debug-bridge[=PORT]  Enable the dev-only Swing debug bridge (loopback HTTP,
+#                          default port 9123). See
+#                          vcell-client/src/main/java/org/vcell/client/debug/README.md
+#
+# Environment overrides:
+#   VCELL_API_HOST          api server host[:port]  (default vcellapi.cam.uchc.edu:443)
+#   VCELL_SOFTWARE_VERSION  version string          (default Rel_Version_8.0.0_build_00)
+#
+# Examples:
+#   ./vcell.sh                                            # connect to production
+#   VCELL_API_HOST=vcell-dev.cam.uchc.edu:443 ./vcell.sh  # connect to dev
+#   ./vcell.sh --debug-bridge                             # bridge on :9123
+#   ./vcell.sh --debug-bridge=9200 model.vcml            # bridge on :9200, open model
 
-CLASSPATH=./vcell-client/target/maven-jars/*:./vcell-client/target/*
+set -eo pipefail
+
+VCELL_API_HOST="${VCELL_API_HOST:-vcellapi.cam.uchc.edu:443}"
+VCELL_SOFTWARE_VERSION="${VCELL_SOFTWARE_VERSION:-Rel_Version_8.0.0_build_00}"
+
 MAIN_CLASS=cbit.vcell.client.VCellClientMain
+CLASSPATH="./vcell-client/target/maven-jars/*:./vcell-client/target/*"
 
-props="-Dvcell.installDir=$PWD"
-props="${props} -Dvcell.softwareVersion=standalone_VCell_7.0"
-props="${props} -Dvcell.bioformatsJarFileName=vcell-bioformats-0.0.9-jar-with-dependencies.jar"
-props="${props} -Dvcell.bioformatsJarDownloadURL=http://vcell.org/webstart/vcell-bioformats-0.0.9-jar-with-dependencies.jar"
+# Separate our own flags from arguments passed through to the client.
+bridge_props=()
+passthrough=()
+bridge_note=""
+for arg in "$@"; do
+  case "$arg" in
+    --debug-bridge)
+      bridge_props=(-Dvcell.debugBridge=true)
+      bridge_note=" debug-bridge=on(:9123)"
+      ;;
+    --debug-bridge=*)
+      port="${arg#*=}"
+      bridge_props=(-Dvcell.debugBridge=true "-Dvcell.debugBridge.port=${port}")
+      bridge_note=" debug-bridge=on(:${port})"
+      ;;
+    *)
+      passthrough+=("$arg")
+      ;;
+  esac
+done
 
-echo java ${props} -cp $CLASSPATH $MAIN_CLASS --api-host=vcellapi.cam.uchc.edu:443
-java ${props} -cp $CLASSPATH $MAIN_CLASS --api-host=vcellapi.cam.uchc.edu:443
+# Fail early with a helpful message if the source build hasn't produced jars.
+if ! ls ./vcell-client/target/*.jar >/dev/null 2>&1 \
+   && ! ls ./vcell-client/target/maven-jars/*.jar >/dev/null 2>&1; then
+  echo "ERROR: no build artifacts under vcell-client/target/." >&2
+  echo "Build the project first, e.g.:  mvn clean install -DskipTests" >&2
+  exit 1
+fi
+
+# JVM options mirrored from the install4j launcher vmOptions.
+vmopts=(
+  --add-exports java.desktop/sun.awt.image=ALL-UNNAMED
+  "-Dvcell.installDir=$PWD"
+  -Dvcell.autoflushlog=true
+  -Dvcell.thirdPartyLicense=thirdpartylicenses.txt
+  "-Dvcell.softwareVersion=${VCELL_SOFTWARE_VERSION}"
+  "-Dvcell.serverHost=${VCELL_API_HOST}"
+  -Dvcell.serverPrefix.v0=/api/v0
+  -Dvcell.serverPrefix.v1=/api/v1
+  -Dvcell.onlineResourcesURL=http://vcell.org
+  -Dvcell.bioformatsJarFileName=vcell-bioformats-0.0.9-jar-with-dependencies.jar
+  -Dvcell.bioformatsJarDownloadURL=http://vcell.org/webstart/vcell-bioformats-0.0.9-jar-with-dependencies.jar
+  -Dvcell.imagej.plugin.url=http://vcell.org/webstart
+)
+
+echo "VCell client (dev): host=${VCELL_API_HOST} version=${VCELL_SOFTWARE_VERSION}${bridge_note}" >&2
+
+exec java "${vmopts[@]}" ${bridge_props[@]+"${bridge_props[@]}"} \
+  -cp "$CLASSPATH" "$MAIN_CLASS" \
+  --api-host="$VCELL_API_HOST" ${passthrough[@]+"${passthrough[@]}"}


### PR DESCRIPTION
## What

A **dev-only, opt-in** HTTP surface over the running desktop client that lets a developer or an automated coding agent **observe the Swing UI as text and pixels and drive it** — the Swing analog of a browser's DOM inspector + Playwright.

Motivation: unlike the web (DOM + accessibility tree + Playwright), Swing has no built-in text serialization of the widget tree, so an agent can't easily "see" or drive the live UI. This manufactures that: every tree node carries a stable `path` selector (e.g. `0/3/2` = window 0 → child 3 → child 2) that you hand back to `/click`, `/setText`, etc. — closing the observe→act→observe loop.

> **Note:** this branch grew past the original bridge. It now also includes a `vcell.sh` launcher rework and a genuine **product bugfix** (silent login failure) that was found *using* the bridge — see the last two sections. Commits are logically grouped if you'd rather review them one at a time.

## Components

- **`SwingInspector`** — EDT-safe primitives:
  - serialize every *showing* window to JSON (path, class, name, text, tooltip, visible/showing/enabled, selected, bounds)
  - content-bearing widgets expanded inline: **JTabbedPane** tab titles/selection, **JTable** cell values (capped 25×15), **JComboBox**/**JList** selection/items (capped), **JTree** visible rows (depth, expanded, text; capped 100)
  - `findByPath` / `findByName`, `click`, `setText` (optional Enter-commit), `selectTab`, `screenshot` → PNG, listener introspection
- **`SwingDebugBridge`** — JDK `HttpServer` bound to `127.0.0.1`, on a small daemon thread pool:

  | Endpoint | Returns |
  |---|---|
  | `GET /health` | `ok` |
  | `GET /windows` | showing top-level windows (depth 0) |
  | `GET /tree[?maxDepth=N]` | full component tree of every window |
  | `GET /screenshot[?window=N]` | `{"path": "...png"}` (active window if omitted) |
  | `GET /click?path=..` | `{"clicked": bool}` |
  | `GET /setText?path=..&text=..[&enter=true]` | `{"set": bool}` |
  | `GET /selectTab?path=..&index=N` | `{"selected": bool}` |
  | `GET /listeners?path=..` | registered `ActionListener` classes, action command, mouse-listener count — "is this control wired up?" |
  | `GET /log[?lines=N]` | text/plain tail of the client's real log |

- **`VCellClient`** — one guarded `SwingDebugBridge.startIfEnabled()` after GUI creation.
- **`vcell.sh`** — reworked dev launcher: mirrors the install4j vmoptions (the `--add-exports` Java 17 needs), adds a `--debug-bridge[=PORT]` flag, `VCELL_API_HOST`/`VCELL_SOFTWARE_VERSION` overrides, and passthrough args.
- **README** in the package documents enablement, endpoints, and the workflow.

## Robustness (hardening from real use)

- **Screenshots render off-screen** via `Component.printAll` instead of a `Robot` screen grab — overlapping windows no longer bleed into the capture, and the target need not be front-most.
- **Clicks are modal-safe**: button clicks post via `invokeLater` (fire-and-forget), so a click that opens a modal dialog returns immediately instead of wedging the request.
- **Server won't self-wedge**: a small daemon thread pool replaces the default single-threaded executor, so one blocked request can't stall `/health` and the rest.
- **`/log`** surfaces the client's real log (`<vcellHome>/logs/vcellrun_<site>.log`), which `ConsoleCapture` redirects `System.out/err` into — so exceptions that never reach the launcher's stdout are still visible to an agent.

## Product bugfix: silent login failure

Found while debugging with the bridge. Clicking **Account → Login** against an unreachable server produced **no visible feedback**: the connect task threw an `ApiException` (nginx 503), and the error-reporting path then crashed the EDT with its *own* `NullPointerException` — so the user saw nothing and assumed login was broken. (This is exactly what masked a server outage as an "Auth0 is broken" report.)

Two causes, two fixes:
- `DocumentWindow.login()` dispatched with a `null` requester → error dialog had no parent. Pass the window (`this`).
- `LWNamespace.findOwnerOfType` dereferenced a null `Component` → NPE inside `showErrorDialog`. Guard the null case (defense-in-depth for every null-requester caller).

Verified against a scaled-to-zero dev `rest` deployment: **Login now raises an error dialog instead of failing silently, and no NPE reaches the EDT.**

## Safety

- **Off by default.** Nothing starts unless `-Dvcell.debugBridge=true` (or env `VCELL_DEBUG_BRIDGE=true`). A normal production launch is completely unaffected — zero runtime footprint. (The login bugfix is the one change that is always live; it is a strict correctness improvement.)
- **Loopback only** (`127.0.0.1`), never reachable off the machine.
- **Never fatal** — startup/handler failures are logged, never propagated into the client.
- **Dependency-free** — JDK + log4j only.

## Verification

`mvn compile -pl vcell-client -am` → BUILD SUCCESS. Exercised end-to-end against live windows:
- tree / windows / screenshot render correctly; screenshot PNG matches the tree
- `click` fires real `ActionListener`s; checkbox `selected` flips in the re-dump
- `setText ...&enter=true` updates the field **and** fires its commit action
- `selectTab` switches tabs; tabs/table/combo/list/tree serialize accurately
- `/listeners` and `/log` confirmed against the running client
- silent-login fix verified against a down backend (see above)
- bad targets degrade gracefully (`{"clicked":false}` / `{"set":false}`), never crash

## Enable

```
-Dvcell.debugBridge=true
-Dvcell.debugBridge.port=9123          # optional, default 9123
-Dvcell.debugBridge.dir=/tmp/vcell-debug   # optional screenshot dir
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
