### PR TITLE
Fast lane under 5 min: parallel Fast + core/other split + setup caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,14 @@ jobs:
       - name: Install Dependencies
         run: pip install -r requirements.txt
 
+      # Cache the poetry virtualenvs so the per-package `poetry install` calls
+      # below are near-instant no-ops on a hit (keyed on the lockfiles).
+      - name: Cache poetry virtualenvs
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: poetry-venvs-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
       - name: build vcell-cli-utils package
         run: |
           cd vcell-cli-utils
@@ -112,32 +120,24 @@ jobs:
   # Fast unit tests (self-compiling). Some Fast tests shell out to the poetry
   # Python envs (OMEX validation, VTK, CoPaSi opt) and the HDF5 CLI, so those
   # must be set up here just as the long-proven combined job did.
+  #
+  # (A per-module split was tried and reverted: `-pl <modules> -am` re-runs the
+  # dependency modules' tests, so every shard still ran vcell-core's tests, and
+  # vcell-core dominates the Fast time regardless - the split made it slower.)
   # ---------------------------------------------------------------------------
-  # Fast unit tests, split across two runners by module so the fast lane stays
-  # under ~5-6 min. Scoped with -pl <modules> -am so each shard compiles only
-  # what it needs; test time (not compile) is the bulk, and the split halves it.
-  # The fast-gate job below aggregates both shards under the stable required
-  # check name "CI-Test-group-Fast".
   fast-tests:
-    name: CI-Test-group-Fast-${{ matrix.name }}
+    name: CI-Test-group-Fast
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # vcell-core holds ~60% of the Fast tests; give it its own shard.
-          - name: core
-            modules: vcell-core
-          - name: other
-            modules: vcell-util,vcell-math,vcell-server,vcell-cli,vcell-client,vcell-admin,vcell-apiclient
     steps:
       - uses: actions/checkout@v4
 
       - name: Set Docker API version workaround
         run: echo "api.version=1.44" >> ~/.docker-java.properties
 
+      # No `apt update` - the runner's package lists are fresh enough for this,
+      # and the update refresh is the slow part.
       - name: Install hdf5 tools needed for testing
-        run: sudo apt -y update && sudo apt -y install hdf5-tools
+        run: sudo apt-get -y install hdf5-tools
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -147,6 +147,12 @@ jobs:
 
       - name: Install Dependencies
         run: pip install -r requirements.txt
+
+      - name: Cache poetry virtualenvs
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: poetry-venvs-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       # poetry envs invoked by Fast tests at runtime (via `poetry run ...`).
       - name: Install python package envs
@@ -166,34 +172,12 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
-      - name: Maven build and run Fast tests (${{ matrix.name }})
+      - name: Maven build and run Fast tests
         shell: bash
         run: |
           mvn -version
           java -version
-          mvn --batch-mode clean install dependency:copy-dependencies \
-            -pl ${{ matrix.modules }} -am -Dmaven.dependency.analyze.skip=true \
-            -Dgroups="Fast"
-
-  # Aggregate gate: one stable required check ("CI-Test-group-Fast") that passes
-  # only if both Fast shards passed, so the shard split can change without
-  # touching branch-protection rules.
-  fast-gate:
-    name: CI-Test-group-Fast
-    runs-on: ubuntu-22.04
-    needs: fast-tests
-    if: ${{ always() }}
-    steps:
-      - name: Verify all Fast shards passed
-        shell: bash
-        run: |
-          result="${{ needs.fast-tests.result }}"
-          echo "fast-tests result: $result"
-          if [ "$result" != "success" ]; then
-            echo "One or more Fast shards did not succeed."
-            exit 1
-          fi
-          echo "All Fast shards passed."
+          mvn --batch-mode clean install dependency:copy-dependencies -Dgroups="Fast"
 
   # ---------------------------------------------------------------------------
   # Quarkus / vcell-rest tests + OpenAPI spec validation (self-compiling).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,11 @@ jobs:
           cache: 'maven'
 
       # Run the Fast tests with JUnit class-level parallelism (methods within a
-      # class stay on one thread - safest). Enabled via -D system properties so
-      # it applies ONLY to this Fast run; the regression suites run a separate
-      # command and stay sequential.
+      # class stay on one thread). Enabled via -D system properties so it applies
+      # ONLY to this Fast run; the regression suites run a separate command and
+      # stay sequential. Tests that mutate global config (PropertyLoader / system
+      # properties) carry @ResourceLock("vcellGlobalConfig") so they serialize
+      # among themselves while everything else parallelizes.
       - name: Maven build and run Fast tests
         shell: bash
         run: |
@@ -186,6 +188,17 @@ jobs:
             -Djunit.jupiter.execution.parallel.mode.default=same_thread \
             -Djunit.jupiter.execution.parallel.mode.classes.default=concurrent \
             -Djunit.jupiter.execution.parallel.config.strategy=dynamic
+
+      # Record per-test timing so the slowest Fast tests can be identified if a
+      # further speedup is wanted. Uploaded even on failure.
+      - name: Upload surefire timing reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports-fast
+          path: '**/target/surefire-reports/*.xml'
+          retention-days: 14
+          if-no-files-found: warn
 
   # ---------------------------------------------------------------------------
   # Quarkus / vcell-rest tests + OpenAPI spec validation (self-compiling).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,12 +172,20 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
+      # Run the Fast tests with JUnit class-level parallelism (methods within a
+      # class stay on one thread - safest). Enabled via -D system properties so
+      # it applies ONLY to this Fast run; the regression suites run a separate
+      # command and stay sequential.
       - name: Maven build and run Fast tests
         shell: bash
         run: |
           mvn -version
           java -version
-          mvn --batch-mode clean install dependency:copy-dependencies -Dgroups="Fast"
+          mvn --batch-mode clean install dependency:copy-dependencies -Dgroups="Fast" \
+            -Djunit.jupiter.execution.parallel.enabled=true \
+            -Djunit.jupiter.execution.parallel.mode.default=same_thread \
+            -Djunit.jupiter.execution.parallel.mode.classes.default=concurrent \
+            -Djunit.jupiter.execution.parallel.config.strategy=dynamic
 
   # ---------------------------------------------------------------------------
   # Quarkus / vcell-rest tests + OpenAPI spec validation (self-compiling).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,23 @@ jobs:
   # Python envs (OMEX validation, VTK, CoPaSi opt) and the HDF5 CLI, so those
   # must be set up here just as the long-proven combined job did.
   # ---------------------------------------------------------------------------
+  # Fast unit tests, split across two runners by module so the fast lane stays
+  # under ~5-6 min. Scoped with -pl <modules> -am so each shard compiles only
+  # what it needs; test time (not compile) is the bulk, and the split halves it.
+  # The fast-gate job below aggregates both shards under the stable required
+  # check name "CI-Test-group-Fast".
   fast-tests:
-    name: CI-Test-group-Fast
+    name: CI-Test-group-Fast-${{ matrix.name }}
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # vcell-core holds ~60% of the Fast tests; give it its own shard.
+          - name: core
+            modules: vcell-core
+          - name: other
+            modules: vcell-util,vcell-math,vcell-server,vcell-cli,vcell-client,vcell-admin,vcell-apiclient
     steps:
       - uses: actions/checkout@v4
 
@@ -152,12 +166,34 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
-      - name: Maven build and run Fast tests
+      - name: Maven build and run Fast tests (${{ matrix.name }})
         shell: bash
         run: |
           mvn -version
           java -version
-          mvn --batch-mode clean install dependency:copy-dependencies -Dgroups="Fast"
+          mvn --batch-mode clean install dependency:copy-dependencies \
+            -pl ${{ matrix.modules }} -am -Dmaven.dependency.analyze.skip=true \
+            -Dgroups="Fast"
+
+  # Aggregate gate: one stable required check ("CI-Test-group-Fast") that passes
+  # only if both Fast shards passed, so the shard split can change without
+  # touching branch-protection rules.
+  fast-gate:
+    name: CI-Test-group-Fast
+    runs-on: ubuntu-22.04
+    needs: fast-tests
+    if: ${{ always() }}
+    steps:
+      - name: Verify all Fast shards passed
+        shell: bash
+        run: |
+          result="${{ needs.fast-tests.result }}"
+          echo "fast-tests result: $result"
+          if [ "$result" != "success" ]; then
+            echo "One or more Fast shards did not succeed."
+            exit 1
+          fi
+          echo "All Fast shards passed."
 
   # ---------------------------------------------------------------------------
   # Quarkus / vcell-rest tests + OpenAPI spec validation (self-compiling).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,17 +117,28 @@ jobs:
             .
 
   # ---------------------------------------------------------------------------
-  # Fast unit tests (self-compiling). Some Fast tests shell out to the poetry
-  # Python envs (OMEX validation, VTK, CoPaSi opt) and the HDF5 CLI, so those
-  # must be set up here just as the long-proven combined job did.
+  # Fast unit tests, split across two runners (vcell-core, which dominates, on
+  # its own; every other module on the second) and run with JUnit class-level
+  # parallelism. Some Fast tests shell out to the poetry Python envs (OMEX/VTK/
+  # CoPaSi) and the HDF5 CLI, so those are set up here.
   #
-  # (A per-module split was tried and reverted: `-pl <modules> -am` re-runs the
-  # dependency modules' tests, so every shard still ran vcell-core's tests, and
-  # vcell-core dominates the Fast time regardless - the split made it slower.)
+  # The split uses a TWO-STEP Maven invocation to avoid the earlier trap where
+  # `-pl <modules> -am` re-ran the dependency modules' tests: first compile the
+  # whole reactor once (install -DskipTests), then run ONLY this shard's
+  # modules' tests (test -pl <modules>, no -am). The fast-gate job aggregates
+  # both shards under the stable required check name "CI-Test-group-Fast".
   # ---------------------------------------------------------------------------
   fast-tests:
-    name: CI-Test-group-Fast
+    name: CI-Test-group-Fast-${{ matrix.name }}
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: core
+            modules: vcell-core
+          - name: other
+            modules: vcell-util,vcell-math,vcell-server,vcell-cli,vcell-client,vcell-admin,vcell-apiclient
     steps:
       - uses: actions/checkout@v4
 
@@ -172,18 +183,18 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
-      # Run the Fast tests with JUnit class-level parallelism (methods within a
-      # class stay on one thread). Enabled via -D system properties so it applies
-      # ONLY to this Fast run; the regression suites run a separate command and
-      # stay sequential. Tests that mutate global config (PropertyLoader / system
-      # properties) carry @ResourceLock("vcellGlobalConfig") so they serialize
-      # among themselves while everything else parallelizes.
-      - name: Maven build and run Fast tests
+      # Step 1: compile the whole reactor once (no tests). Step 2: run ONLY this
+      # shard's modules' Fast tests, with JUnit class-level parallelism (enabled
+      # via -D so it applies to the Fast run only; regression stays sequential).
+      # Tests that mutate global config carry @ResourceLock("vcellGlobalConfig")
+      # so they serialize among themselves while everything else parallelizes.
+      - name: Maven build and run Fast tests (${{ matrix.name }})
         shell: bash
         run: |
           mvn -version
           java -version
-          mvn --batch-mode clean install dependency:copy-dependencies -Dgroups="Fast" \
+          mvn --batch-mode clean install -DskipTests dependency:copy-dependencies
+          mvn --batch-mode test -pl ${{ matrix.modules }} -Dgroups="Fast" \
             -Djunit.jupiter.execution.parallel.enabled=true \
             -Djunit.jupiter.execution.parallel.mode.default=same_thread \
             -Djunit.jupiter.execution.parallel.mode.classes.default=concurrent \
@@ -195,10 +206,30 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: surefire-reports-fast
+          name: surefire-reports-fast-${{ matrix.name }}
           path: '**/target/surefire-reports/*.xml'
           retention-days: 14
           if-no-files-found: warn
+
+  # Aggregate gate: one stable required check ("CI-Test-group-Fast") that passes
+  # only if both Fast shards passed, so the split can change without touching
+  # branch-protection rules.
+  fast-gate:
+    name: CI-Test-group-Fast
+    runs-on: ubuntu-22.04
+    needs: fast-tests
+    if: ${{ always() }}
+    steps:
+      - name: Verify all Fast shards passed
+        shell: bash
+        run: |
+          result="${{ needs.fast-tests.result }}"
+          echo "fast-tests result: $result"
+          if [ "$result" != "success" ]; then
+            echo "One or more Fast shards did not succeed."
+            exit 1
+          fi
+          echo "All Fast shards passed."
 
   # ---------------------------------------------------------------------------
   # Quarkus / vcell-rest tests + OpenAPI spec validation (self-compiling).

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -133,8 +133,10 @@ jobs:
       - name: Set Docker API version workaround
         run: echo "api.version=1.44" >> ~/.docker-java.properties
 
+      # No `apt update` - the runner's package lists are fresh enough for this,
+      # and the update refresh is the slow part.
       - name: Install hdf5 tools needed for testing
-        run: sudo apt -y update && sudo apt -y install hdf5-tools
+        run: sudo apt-get -y install hdf5-tools
 
       # Several IT groups (SED-ML, BSTS) shell out to the Python CLI utils.
       - name: Set up Python
@@ -145,6 +147,12 @@ jobs:
 
       - name: Install Dependencies
         run: pip install -r requirements.txt
+
+      - name: Cache poetry virtualenvs
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: poetry-venvs-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: build vcell-cli-utils package
         run: |

--- a/vcell-server/src/test/java/cbit/vcell/message/server/dispatcher/BatchSchedulerTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/dispatcher/BatchSchedulerTest.java
@@ -1,4 +1,5 @@
 package cbit.vcell.message.server.dispatcher;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import cbit.vcell.message.server.dispatcher.BatchScheduler.ActiveJob;
 import cbit.vcell.message.server.dispatcher.BatchScheduler.SchedulerDecisions;
@@ -24,6 +25,7 @@ import static cbit.vcell.message.server.dispatcher.BatchScheduler.SchedulerDecis
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("Fast")
+@ResourceLock("vcellGlobalConfig")
 public class BatchSchedulerTest {
 
 	VCellServerID relSite = VCellServerID.getServerID("REL");

--- a/vcell-server/src/test/java/cbit/vcell/message/server/dispatcher/SimulationDispatcherTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/dispatcher/SimulationDispatcherTest.java
@@ -1,4 +1,5 @@
 package cbit.vcell.message.server.dispatcher;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import cbit.vcell.math.MathException;
 import cbit.vcell.message.VCMessagingConstants;
@@ -27,6 +28,7 @@ import java.io.StringWriter;
 import java.sql.SQLException;
 
 @Tag("Fast")
+@ResourceLock("vcellGlobalConfig")
 public class SimulationDispatcherTest {
     public static ExtendedLogger lg = LoggerContext.getContext().getLogger(SimulationDispatcher.class);
     private final static User testUser = DispatcherTestUtils.alice;

--- a/vcell-server/src/test/java/cbit/vcell/message/server/dispatcher/SimulationStateMachineTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/dispatcher/SimulationStateMachineTest.java
@@ -1,4 +1,5 @@
 package cbit.vcell.message.server.dispatcher;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import cbit.rmi.event.WorkerEvent;
 import cbit.vcell.math.MathException;
@@ -21,6 +22,7 @@ import java.util.ArrayList;
 import java.util.NoSuchElementException;
 
 @Tag("Fast")
+@ResourceLock("vcellGlobalConfig")
 public class SimulationStateMachineTest {
     private static final User testUser = DispatcherTestUtils.alice;
     private static final MockVCMessageSession testMessageSession = new MockVCMessageSession();

--- a/vcell-server/src/test/java/cbit/vcell/message/server/htc/HtcProxyTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/htc/HtcProxyTest.java
@@ -1,4 +1,5 @@
 package cbit.vcell.message.server.htc;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import cbit.vcell.message.server.htc.HtcProxy.HtcJobInfo;
 import cbit.vcell.message.server.htc.HtcProxy.SimTaskInfo;
@@ -15,6 +16,7 @@ import static cbit.vcell.server.HtcJobID.BatchSystemType.SLURM;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("Fast")
+@ResourceLock("vcellGlobalConfig")
 public class HtcProxyTest {
 
 	@Test

--- a/vcell-server/src/test/java/cbit/vcell/message/server/htc/JobIdTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/htc/JobIdTest.java
@@ -1,4 +1,5 @@
 package cbit.vcell.message.server.htc;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import cbit.vcell.messaging.db.SimulationJobTable;
 import cbit.vcell.server.HtcJobID;
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  * {@link HtcJobID#equals(Object)} and {@link HtcJobID#hashCode()}
  */
 @Tag("Fast")
+@ResourceLock("vcellGlobalConfig")
 public class JobIdTest {
 
 	Random r = new Random( );

--- a/vcell-server/src/test/java/cbit/vcell/message/server/htc/slurm/SlurmProxyTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/htc/slurm/SlurmProxyTest.java
@@ -1,4 +1,5 @@
 package cbit.vcell.message.server.htc.slurm;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import cbit.vcell.messaging.server.SimulationTask;
 import cbit.vcell.parser.ExpressionException;
@@ -25,6 +26,7 @@ import static cbit.vcell.message.server.htc.HtcProxy.toUnixStyleText;
 
 
 @Tag("Fast")
+@ResourceLock("vcellGlobalConfig")
 public class SlurmProxyTest {
 
 	private final HashMap<String,String> originalProperties = new LinkedHashMap<>();

--- a/vcell-server/src/test/java/cbit/vcell/modeldb/PublicationTableTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/modeldb/PublicationTableTest.java
@@ -1,4 +1,5 @@
 package cbit.vcell.modeldb;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -6,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("Fast")
+@ResourceLock("vcellGlobalConfig")
 public class PublicationTableTest {
 
     @Test


### PR DESCRIPTION
Cuts the fast lane (build + Fast + Quarkus) from **7.9 min to ~4 min**, all jobs under 5.

## Changes

- **JUnit class-level parallelism** for the Fast tests (via `-D` props, scoped to the Fast run only; regression stays sequential). Exposed and fixed real thread-safety bugs: seven vcell-server tests mutate global `PropertyLoader`/system-property state and now carry `@ResourceLock("vcellGlobalConfig")` so they serialize among themselves while everything else parallelizes. Found by running the suite in parallel locally on 16 cores (more races surfaced than on CI's 2).
- **Split Fast across two runners** — vcell-core (the bulk) on one, all other modules on the other — using a two-step Maven invocation (`install -DskipTests` once, then `test -pl <modules>` with no `-am`) so dependency modules' tests aren't re-run. A `fast-gate` aggregates both under the stable required check `CI-Test-group-Fast`.
- **Setup caching** (helps every job): cache the poetry virtualenvs so the seven `poetry install` calls are near-instant; drop `apt update` before `hdf5-tools` (the update was the slow part). `build` dropped 4.8→4.0, and these apply to regression.yml too.

## Result (measured)

| job | before | after |
|---|---|---|
| build | 4.8 | 4.0 |
| Fast | 7.9 | 3.9 (core) / 2.9 (other) |
| Quarkus | 2.8 | 3.6 |
| **wall-clock** | **7.9** | **~4.0** |

Required check names unchanged (`fast-gate` keeps `CI-Test-group-Fast`), so branch protection is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMxhE4gyPPRncpMPrRxnBW