### PR TITLE
Phase 2 (#1746): add simulation keys to BioModelChildSummary via /vcInfoContainer

### DIFF
--- a/python-restclient/.openapi-generator/FILES
+++ b/python-restclient/.openapi-generator/FILES
@@ -119,8 +119,6 @@ docs/VcelloptStatus.md
 docs/Version.md
 docs/VersionFlag.md
 test/__init__.py
-test/test_vc_info_container_resource_api.py
-test/test_vc_info_container_summary.py
 tox.ini
 vcell_client/__init__.py
 vcell_client/api/__init__.py

--- a/python-restclient/docs/BioModelChildSummary.md
+++ b/python-restclient/docs/BioModelChildSummary.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **app_types** | [**List[MathType]**](MathType.md) |  | [optional] 
 **sim_names** | **List[List[str]]** |  | [optional] 
 **sim_annots** | **List[List[str]]** |  | [optional] 
+**sim_keys** | **List[str]** |  | [optional] 
 **geometry_dimensions** | **List[int]** |  | [optional] 
 **geometry_names** | **List[str]** |  | [optional] 
 **simulation_context_annotations** | **List[str]** |  | [optional] 

--- a/python-restclient/vcell_client/models/bio_model_child_summary.py
+++ b/python-restclient/vcell_client/models/bio_model_child_summary.py
@@ -40,12 +40,13 @@ class BioModelChildSummary(BaseModel):
     app_types: Optional[List[MathType]] = Field(default=None, alias="appTypes")
     sim_names: Optional[List[List[StrictStr]]] = Field(default=None, alias="simNames")
     sim_annots: Optional[List[List[StrictStr]]] = Field(default=None, alias="simAnnots")
+    sim_keys: Optional[List[StrictStr]] = Field(default=None, alias="simKeys")
     geometry_dimensions: Optional[List[StrictInt]] = Field(default=None, alias="geometryDimensions")
     geometry_names: Optional[List[StrictStr]] = Field(default=None, alias="geometryNames")
     simulation_context_annotations: Optional[List[StrictStr]] = Field(default=None, alias="simulationContextAnnotations")
     simulation_context_names: Optional[List[StrictStr]] = Field(default=None, alias="simulationContextNames")
     application_info: Optional[List[ApplicationInfo]] = Field(default=None, alias="applicationInfo")
-    __properties: ClassVar[List[str]] = ["scNames", "scAnnots", "geoNames", "geoDims", "appTypes", "simNames", "simAnnots", "geometryDimensions", "geometryNames", "simulationContextAnnotations", "simulationContextNames", "applicationInfo"]
+    __properties: ClassVar[List[str]] = ["scNames", "scAnnots", "geoNames", "geoDims", "appTypes", "simNames", "simAnnots", "simKeys", "geometryDimensions", "geometryNames", "simulationContextAnnotations", "simulationContextNames", "applicationInfo"]
 
     model_config = {
         "populate_by_name": True,
@@ -114,6 +115,7 @@ class BioModelChildSummary(BaseModel):
             "appTypes": obj.get("appTypes"),
             "simNames": obj.get("simNames"),
             "simAnnots": obj.get("simAnnots"),
+            "simKeys": obj.get("simKeys"),
             "geometryDimensions": obj.get("geometryDimensions"),
             "geometryNames": obj.get("geometryNames"),
             "simulationContextAnnotations": obj.get("simulationContextAnnotations"),

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -2453,6 +2453,10 @@ components:
             type: array
             items:
               type: string
+        simKeys:
+          type: array
+          items:
+            type: string
         geometryDimensions:
           type: array
           items:

--- a/vcell-core/src/main/java/org/vcell/util/document/BioModelChildSummary.java
+++ b/vcell-core/src/main/java/org/vcell/util/document/BioModelChildSummary.java
@@ -35,6 +35,13 @@ public class BioModelChildSummary implements java.io.Serializable {
 	private String simNames[][] = new String[0][];
 	private String simAnnots[][] = new String[0][];
 
+	// issue #1746 Phase 2: all simulation database keys owned by this BioModel version, sourced from
+	// vc_biomodelsim at read time (NOT part of the DB serialization). Populated only on the
+	// /api/v1/vcInfoContainer endpoint; @JsonInclude(NON_NULL) keeps it absent from the other summary
+	// endpoints' responses so their existing (strict) clients are unaffected without an opt-in flag.
+	@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+	private String simKeys[] = null;
+
 	private final static String NOCHILDREN = "NOCHILDREN";
 	public final static String COMPARTMENTAL_GEO_STR = "Compartmental";
 	public final static String TYPE_TOKEN = "__TYPE__:";
@@ -244,6 +251,16 @@ public String[] getSimulationNames(String simulationContextName) {
 		}
 	}
 	throw new RuntimeException("application '"+simulationContextName+"' not found");
+}
+
+/** issue #1746 Phase 2: the simulation database keys owned by this BioModel version (read-time only,
+ *  populated from vc_biomodelsim; null when not populated). */
+public String[] getSimKeys() {
+	return simKeys;
+}
+
+public void setSimKeys(String[] simKeys) {
+	this.simKeys = simKeys;
 }
 
 

--- a/vcell-rest/src/main/java/org/vcell/restq/services/VCInfoContainerService.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/services/VCInfoContainerService.java
@@ -4,8 +4,13 @@ import cbit.vcell.modeldb.DatabaseServerImpl;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.vcell.restq.db.AgroalConnectionFactory;
 import org.vcell.util.DataAccessException;
+import org.vcell.util.document.BioModelChildSummary;
+import org.vcell.util.document.BioModelInfo;
+import org.vcell.util.document.KeyValue;
 import org.vcell.util.document.User;
 import org.vcell.util.document.VCInfoContainer;
+
+import java.util.Map;
 
 @ApplicationScoped
 public class VCInfoContainerService {
@@ -22,6 +27,30 @@ public class VCInfoContainerService {
      * the REST replacement for the legacy RPC {@code UserMetaDbServer.getVCInfoContainer}.
      */
     public VCInfoContainer getVCInfoContainer(User user) throws DataAccessException {
-        return databaseServerImpl.getVCInfoContainer(user);
+        VCInfoContainer vcInfoContainer = databaseServerImpl.getVCInfoContainer(user);
+
+        // issue #1746 Phase 2: attach each BioModel's simulation database keys (bulk, one query) to its
+        // child summary so a viewed simulation can be resolved to an owning BioModel across versions.
+        BioModelInfo[] bioModelInfos = vcInfoContainer.getBioModelInfos();
+        if (bioModelInfos != null && bioModelInfos.length > 0) {
+            KeyValue[] bioModelKeys = new KeyValue[bioModelInfos.length];
+            for (int i = 0; i < bioModelInfos.length; i++) {
+                bioModelKeys[i] = bioModelInfos[i].getVersion().getVersionKey();
+            }
+            Map<KeyValue, KeyValue[]> simKeysByBioModel = databaseServerImpl.getSimulationKeysForBioModels(bioModelKeys);
+            for (BioModelInfo info : bioModelInfos) {
+                BioModelChildSummary childSummary = info.getBioModelChildSummary();
+                if (childSummary == null) {
+                    continue;
+                }
+                KeyValue[] simKeys = simKeysByBioModel.get(info.getVersion().getVersionKey());
+                String[] simKeyStrings = new String[simKeys == null ? 0 : simKeys.length];
+                for (int i = 0; i < simKeyStrings.length; i++) {
+                    simKeyStrings[i] = simKeys[i].toString();
+                }
+                childSummary.setSimKeys(simKeyStrings);
+            }
+        }
+        return vcInfoContainer;
     }
 }

--- a/vcell-rest/src/test/java/org/vcell/restq/apiclient/VCInfoContainerApiTest.java
+++ b/vcell-rest/src/test/java/org/vcell/restq/apiclient/VCInfoContainerApiTest.java
@@ -71,6 +71,17 @@ public class VCInfoContainerApiTest {
         // the freshly saved biomodel must be visible in the owner's bulk container
         Assertions.assertFalse(container.getBioModelSummaries().isEmpty(),
                 "expected the saved BioModel to appear in the vcInfoContainer");
+
+        // issue #1746 Phase 2: vcInfoContainer populates each biomodel's sim keys (possibly empty, never null)
+        boolean anySummary = false;
+        for (org.vcell.restclient.model.BioModelSummary bm : container.getBioModelSummaries()) {
+            if (bm.getSummary() != null) {
+                anySummary = true;
+                Assertions.assertNotNull(bm.getSummary().getSimKeys(),
+                        "vcInfoContainer must populate simKeys on each biomodel child summary");
+            }
+        }
+        Assertions.assertTrue(anySummary, "expected at least one biomodel summary in the container");
     }
 
     @Test

--- a/vcell-restclient/.openapi-generator/FILES
+++ b/vcell-restclient/.openapi-generator/FILES
@@ -246,5 +246,3 @@ src/main/java/org/vcell/restclient/model/Vcellopt.java
 src/main/java/org/vcell/restclient/model/VcelloptStatus.java
 src/main/java/org/vcell/restclient/model/Version.java
 src/main/java/org/vcell/restclient/model/VersionFlag.java
-src/test/java/org/vcell/restclient/api/VcInfoContainerResourceApiTest.java
-src/test/java/org/vcell/restclient/model/VCInfoContainerSummaryTest.java

--- a/vcell-restclient/api/openapi.yaml
+++ b/vcell-restclient/api/openapi.yaml
@@ -2588,9 +2588,6 @@ components:
         scAnnots:
         - scAnnots
         - scAnnots
-        simulationContextNames:
-        - simulationContextNames
-        - simulationContextNames
         geoNames:
         - geoNames
         - geoNames
@@ -2608,12 +2605,18 @@ components:
         geoDims:
         - 5
         - 5
-        appTypes:
-        - null
-        - null
         scNames:
         - scNames
         - scNames
+        simulationContextNames:
+        - simulationContextNames
+        - simulationContextNames
+        simKeys:
+        - simKeys
+        - simKeys
+        appTypes:
+        - null
+        - null
         applicationInfo:
         - geometryName: geometryName
           name: name
@@ -2662,6 +2665,10 @@ components:
               type: string
             type: array
           type: array
+        simKeys:
+          items:
+            type: string
+          type: array
         geometryDimensions:
           items:
             format: int32
@@ -2693,9 +2700,6 @@ components:
           scAnnots:
           - scAnnots
           - scAnnots
-          simulationContextNames:
-          - simulationContextNames
-          - simulationContextNames
           geoNames:
           - geoNames
           - geoNames
@@ -2713,12 +2717,18 @@ components:
           geoDims:
           - 5
           - 5
-          appTypes:
-          - null
-          - null
           scNames:
           - scNames
           - scNames
+          simulationContextNames:
+          - simulationContextNames
+          - simulationContextNames
+          simKeys:
+          - simKeys
+          - simKeys
+          appTypes:
+          - null
+          - null
           applicationInfo:
           - geometryName: geometryName
             name: name
@@ -5696,9 +5706,6 @@ components:
             scAnnots:
             - scAnnots
             - scAnnots
-            simulationContextNames:
-            - simulationContextNames
-            - simulationContextNames
             geoNames:
             - geoNames
             - geoNames
@@ -5716,12 +5723,18 @@ components:
             geoDims:
             - 5
             - 5
-            appTypes:
-            - null
-            - null
             scNames:
             - scNames
             - scNames
+            simulationContextNames:
+            - simulationContextNames
+            - simulationContextNames
+            simKeys:
+            - simKeys
+            - simKeys
+            appTypes:
+            - null
+            - null
             applicationInfo:
             - geometryName: geometryName
               name: name
@@ -5814,9 +5827,6 @@ components:
             scAnnots:
             - scAnnots
             - scAnnots
-            simulationContextNames:
-            - simulationContextNames
-            - simulationContextNames
             geoNames:
             - geoNames
             - geoNames
@@ -5834,12 +5844,18 @@ components:
             geoDims:
             - 5
             - 5
-            appTypes:
-            - null
-            - null
             scNames:
             - scNames
             - scNames
+            simulationContextNames:
+            - simulationContextNames
+            - simulationContextNames
+            simKeys:
+            - simKeys
+            - simKeys
+            appTypes:
+            - null
+            - null
             applicationInfo:
             - geometryName: geometryName
               name: name

--- a/vcell-restclient/docs/BioModelChildSummary.md
+++ b/vcell-restclient/docs/BioModelChildSummary.md
@@ -14,6 +14,7 @@
 |**appTypes** | **List&lt;MathType&gt;** |  |  [optional] |
 |**simNames** | **List&lt;List&lt;String&gt;&gt;** |  |  [optional] |
 |**simAnnots** | **List&lt;List&lt;String&gt;&gt;** |  |  [optional] |
+|**simKeys** | **List&lt;String&gt;** |  |  [optional] |
 |**geometryDimensions** | **List&lt;Integer&gt;** |  |  [optional] |
 |**geometryNames** | **List&lt;String&gt;** |  |  [optional] |
 |**simulationContextAnnotations** | **List&lt;String&gt;** |  |  [optional] |

--- a/vcell-restclient/src/main/java/org/vcell/restclient/model/BioModelChildSummary.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/model/BioModelChildSummary.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   BioModelChildSummary.JSON_PROPERTY_APP_TYPES,
   BioModelChildSummary.JSON_PROPERTY_SIM_NAMES,
   BioModelChildSummary.JSON_PROPERTY_SIM_ANNOTS,
+  BioModelChildSummary.JSON_PROPERTY_SIM_KEYS,
   BioModelChildSummary.JSON_PROPERTY_GEOMETRY_DIMENSIONS,
   BioModelChildSummary.JSON_PROPERTY_GEOMETRY_NAMES,
   BioModelChildSummary.JSON_PROPERTY_SIMULATION_CONTEXT_ANNOTATIONS,
@@ -71,6 +72,9 @@ public class BioModelChildSummary {
 
   public static final String JSON_PROPERTY_SIM_ANNOTS = "simAnnots";
   private List<List<String>> simAnnots;
+
+  public static final String JSON_PROPERTY_SIM_KEYS = "simKeys";
+  private List<String> simKeys;
 
   public static final String JSON_PROPERTY_GEOMETRY_DIMENSIONS = "geometryDimensions";
   private List<Integer> geometryDimensions;
@@ -321,6 +325,39 @@ public class BioModelChildSummary {
   }
 
 
+  public BioModelChildSummary simKeys(List<String> simKeys) {
+    this.simKeys = simKeys;
+    return this;
+  }
+
+  public BioModelChildSummary addSimKeysItem(String simKeysItem) {
+    if (this.simKeys == null) {
+      this.simKeys = new ArrayList<>();
+    }
+    this.simKeys.add(simKeysItem);
+    return this;
+  }
+
+   /**
+   * Get simKeys
+   * @return simKeys
+  **/
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_SIM_KEYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public List<String> getSimKeys() {
+    return simKeys;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_SIM_KEYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setSimKeys(List<String> simKeys) {
+    this.simKeys = simKeys;
+  }
+
+
   public BioModelChildSummary geometryDimensions(List<Integer> geometryDimensions) {
     this.geometryDimensions = geometryDimensions;
     return this;
@@ -505,6 +542,7 @@ public class BioModelChildSummary {
         Objects.equals(this.appTypes, bioModelChildSummary.appTypes) &&
         Objects.equals(this.simNames, bioModelChildSummary.simNames) &&
         Objects.equals(this.simAnnots, bioModelChildSummary.simAnnots) &&
+        Objects.equals(this.simKeys, bioModelChildSummary.simKeys) &&
         Objects.equals(this.geometryDimensions, bioModelChildSummary.geometryDimensions) &&
         Objects.equals(this.geometryNames, bioModelChildSummary.geometryNames) &&
         Objects.equals(this.simulationContextAnnotations, bioModelChildSummary.simulationContextAnnotations) &&
@@ -514,7 +552,7 @@ public class BioModelChildSummary {
 
   @Override
   public int hashCode() {
-    return Objects.hash(scNames, scAnnots, geoNames, geoDims, appTypes, simNames, simAnnots, geometryDimensions, geometryNames, simulationContextAnnotations, simulationContextNames, applicationInfo);
+    return Objects.hash(scNames, scAnnots, geoNames, geoDims, appTypes, simNames, simAnnots, simKeys, geometryDimensions, geometryNames, simulationContextAnnotations, simulationContextNames, applicationInfo);
   }
 
   @Override
@@ -528,6 +566,7 @@ public class BioModelChildSummary {
     sb.append("    appTypes: ").append(toIndentedString(appTypes)).append("\n");
     sb.append("    simNames: ").append(toIndentedString(simNames)).append("\n");
     sb.append("    simAnnots: ").append(toIndentedString(simAnnots)).append("\n");
+    sb.append("    simKeys: ").append(toIndentedString(simKeys)).append("\n");
     sb.append("    geometryDimensions: ").append(toIndentedString(geometryDimensions)).append("\n");
     sb.append("    geometryNames: ").append(toIndentedString(geometryNames)).append("\n");
     sb.append("    simulationContextAnnotations: ").append(toIndentedString(simulationContextAnnotations)).append("\n");
@@ -642,6 +681,15 @@ public class BioModelChildSummary {
         joiner.add(String.format("%ssimAnnots%s%s=%s", prefix, suffix,
             "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
             URLEncoder.encode(String.valueOf(getSimAnnots().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+      }
+    }
+
+    // add `simKeys` to the URL query string
+    if (getSimKeys() != null) {
+      for (int i = 0; i < getSimKeys().size(); i++) {
+        joiner.add(String.format("%ssimKeys%s%s=%s", prefix, suffix,
+            "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+            URLEncoder.encode(String.valueOf(getSimKeys().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
       }
     }
 

--- a/vcell-restclient/src/main/java/org/vcell/restclient/utils/DtoModelTransforms.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/utils/DtoModelTransforms.java
@@ -247,9 +247,14 @@ public class DtoModelTransforms {
         String[] scAnnotations = dto.getScAnnots() == null ? null : dto.getScAnnots().toArray(new String[0]);
         String[] geoNames = dto.getGeoNames() == null ? null : dto.getGeoNames().toArray(new String[0]);
         int[] geoDims = dto.getGeoDims() == null ? null : dto.getGeoDims().stream().mapToInt(Integer::intValue).toArray();
-        return new BioModelChildSummary(dto.getSimulationContextNames().toArray(new String[0]),
+        BioModelChildSummary result = new BioModelChildSummary(dto.getSimulationContextNames().toArray(new String[0]),
                 mathTypes, scAnnotations, simNames, simAnnots, geoNames,
                 geoDims);
+        // issue #1746 Phase 2: simulation keys are populated only by the /vcInfoContainer endpoint
+        if (dto.getSimKeys() != null) {
+            result.setSimKeys(dto.getSimKeys().toArray(new String[0]));
+        }
+        return result;
     }
 
     public static VCellSoftwareVersion dtoToVCellSoftwareVersion(org.vcell.restclient.model.VCellSoftwareVersion dto){

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/BioModelDbDriver.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/BioModelDbDriver.java
@@ -418,6 +418,48 @@ KeyValue[] getSimulationEntriesFromBioModel(Connection con,KeyValue bioModelKey)
 }
 
 
+/**
+ * issue #1746 Phase 2: bulk-fetch the simulation database keys owned by each of the given BioModel
+ * versions from vc_biomodelsim, in batched IN-list queries (Oracle IN limit is 1000) rather than one
+ * query per BioModel. Returns a map from BioModel key -> its simulation keys (BioModels with no
+ * simulations are simply absent from the map).
+ */
+java.util.Map<KeyValue, KeyValue[]> getSimulationKeysForBioModels(Connection con, KeyValue[] bioModelKeys) throws SQLException {
+	java.util.Map<KeyValue, java.util.List<KeyValue>> grouped = new java.util.LinkedHashMap<KeyValue, java.util.List<KeyValue>>();
+	if (bioModelKeys == null || bioModelKeys.length == 0) {
+		return new java.util.LinkedHashMap<KeyValue, KeyValue[]>();
+	}
+	final int BATCH = 1000; // Oracle IN-list limit
+	for (int start = 0; start < bioModelKeys.length; start += BATCH) {
+		int end = Math.min(start + BATCH, bioModelKeys.length);
+		StringBuilder inList = new StringBuilder();
+		for (int i = start; i < end; i++) {
+			if (i > start) { inList.append(","); }
+			inList.append(bioModelKeys[i]);
+		}
+		String sql = " SELECT " + bioModelSimLinkTable.bioModelRef + ", " + bioModelSimLinkTable.simRef +
+				" FROM " + bioModelSimLinkTable.getTableName() +
+				" WHERE " + bioModelSimLinkTable.bioModelRef + " IN (" + inList + ")";
+		Statement stmt = con.createStatement();
+		try {
+			ResultSet rset = stmt.executeQuery(sql);
+			while (rset.next()) {
+				KeyValue bmKey = new KeyValue(rset.getBigDecimal(bioModelSimLinkTable.bioModelRef.getUnqualifiedColName()));
+				KeyValue simKey = new KeyValue(rset.getBigDecimal(bioModelSimLinkTable.simRef.getUnqualifiedColName()));
+				grouped.computeIfAbsent(bmKey, k -> new java.util.ArrayList<KeyValue>()).add(simKey);
+			}
+		} finally {
+			stmt.close();
+		}
+	}
+	java.util.Map<KeyValue, KeyValue[]> result = new java.util.LinkedHashMap<KeyValue, KeyValue[]>();
+	for (java.util.Map.Entry<KeyValue, java.util.List<KeyValue>> e : grouped.entrySet()) {
+		result.put(e.getKey(), e.getValue().toArray(new KeyValue[0]));
+	}
+	return result;
+}
+
+
 public Versionable getVersionable(QueryHashtable dbc, Connection con, User user, VersionableType vType, KeyValue vKey)
 			throws ObjectNotFoundException, SQLException, DataAccessException {
 				

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/DBTopLevel.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/DBTopLevel.java
@@ -1019,6 +1019,26 @@ VCInfoContainer getVCInfoContainer(User user, boolean bEnableRetry,boolean bIncl
 	}
 }
 
+java.util.Map<KeyValue, KeyValue[]> getSimulationKeysForBioModels(KeyValue[] bioModelKeys, boolean bEnableRetry) throws DataAccessException, java.sql.SQLException{
+
+	Object lock = new Object();
+	Connection con = conFactory.getConnection(lock);
+	try {
+		return bioModelDB.getSimulationKeysForBioModels(con, bioModelKeys);
+	} catch (Throwable e) {
+		lg.error(e.getMessage(),e);
+		if (bEnableRetry && isBadConnection(con)) {
+			conFactory.failed(con,lock);
+			return getSimulationKeysForBioModels(bioModelKeys,false);
+		}else{
+			handle_DataAccessException_SQLException(e);
+			return null; // never gets here;
+		}
+	}finally{
+		conFactory.release(con,lock);
+	}
+}
+
 
 /**
  * This method was created in VisualAge.

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/DatabaseServerImpl.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/DatabaseServerImpl.java
@@ -930,6 +930,22 @@ public VCInfoContainer getVCInfoContainer(User user) throws DataAccessException 
 
 }
 
+/**
+ * issue #1746 Phase 2: bulk-fetch the simulation database keys owned by each of the given BioModel
+ * versions (from vc_biomodelsim), in one batched query rather than one per BioModel.
+ */
+public java.util.Map<KeyValue, KeyValue[]> getSimulationKeysForBioModels(KeyValue[] bioModelKeys) throws DataAccessException {
+	try {
+		return dbTop.getSimulationKeysForBioModels(bioModelKeys, true);
+	} catch (SQLException e) {
+		lg.error(e.getMessage(),e);
+		throw new DataAccessException(e.getMessage(),e);
+	} catch (Throwable e) {
+		lg.error(e.getMessage(),e);
+		throw new DataAccessException(e.getMessage(),e);
+	}
+}
+
 
 /**
  * This method was created in VisualAge.

--- a/webapp-ng/src/app/core/modules/openapi/model/bio-model-child-summary.ts
+++ b/webapp-ng/src/app/core/modules/openapi/model/bio-model-child-summary.ts
@@ -21,6 +21,7 @@ export interface BioModelChildSummary {
     appTypes?: Array<MathType>;
     simNames?: Array<Array<string>>;
     simAnnots?: Array<Array<string>>;
+    simKeys?: Array<string>;
     geometryDimensions?: Array<number>;
     geometryNames?: Array<string>;
     simulationContextAnnotations?: Array<string>;


### PR DESCRIPTION
## Why

Prerequisite consumption step for #1746 metadata correctness. To resolve a viewed simulation back to an owning BioModel *across versions* (an incremental-save simulation leaf is non-unique), the cached BioModel metadata needs the simulation database keys. Builds directly on #1759 (the `getVCInfoContainer` RPC→REST migration), which is why adding this field is now `serialVersionUID`-safe.

## What

- **Domain**: `BioModelChildSummary` gains `simKeys` (`String[]`) + `getSimKeys`/`setSimKeys`. **Read-time only** — not part of `toDatabaseSerialization`. `@JsonInclude(NON_NULL)` keeps it **absent from the other summary endpoints'** responses, so their existing (strict Python) clients are unaffected **without an opt-in flag** — the field is only ever populated on the freshly-added `GET /api/v1/vcInfoContainer` endpoint (which has no legacy clients).
- **Bulk source**: `BioModelDbDriver.getSimulationKeysForBioModels` joins `vc_biomodelsim` in batched IN-list queries (Oracle 1000-element limit), grouped by BioModel — **one bulk fetch for the whole container, never N+1**. Threaded through `DBTopLevel` and `DatabaseServerImpl`.
- **`VCInfoContainerService`** sets each biomodel's `simKeys` from that single bulk query.
- **Client mapping**: `DtoModelTransforms.dtoToBioModelChildSummary` carries `simKeys` into the domain object so the desktop can consume them.
- **Regenerated** OpenAPI spec + Java/Python/TS clients (additive: `simKeys` only, `openapi.yaml` +4 lines).
- **Test**: the API-client test asserts `vcInfoContainer` populates `simKeys` on each biomodel summary.

## No migration, no stored-format change

Keys are sourced live from the existing `vc_biomodelsim` link table, so **all historical BioModels are covered immediately** and prod/dev can deploy on independent schedules (no shared-DB coupling).

## Follow-up

The `#1746` resolver enhancement — `ClientSimManager.resolvePristineMetadataOwner` gaining a sim-key ownership scan (using these keys) as an additional resolution layer beyond the Phase 1 version-key reload — is a small follow-up on the #1758 branch, now unblocked.

## Verification
- `mvn compile test-compile -pl vcell-rest -am` and `mvn compile -pl vcell-client -am`: BUILD SUCCESS. Tests run in CI's Keycloak environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMxhE4gyPPRncpMPrRxnBW