### PR TITLE
Phase 2 (#1746): add simulation keys to BioModel/MathModel child summaries

### DIFF
--- a/python-restclient/.openapi-generator/FILES
+++ b/python-restclient/.openapi-generator/FILES
@@ -119,8 +119,6 @@ docs/VcelloptStatus.md
 docs/Version.md
 docs/VersionFlag.md
 test/__init__.py
-test/test_vc_info_container_resource_api.py
-test/test_vc_info_container_summary.py
 tox.ini
 vcell_client/__init__.py
 vcell_client/api/__init__.py

--- a/python-restclient/docs/BioModelChildSummary.md
+++ b/python-restclient/docs/BioModelChildSummary.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **app_types** | [**List[MathType]**](MathType.md) |  | [optional] 
 **sim_names** | **List[List[str]]** |  | [optional] 
 **sim_annots** | **List[List[str]]** |  | [optional] 
+**sim_keys** | **List[str]** |  | [optional] 
 **geometry_dimensions** | **List[int]** |  | [optional] 
 **geometry_names** | **List[str]** |  | [optional] 
 **simulation_context_annotations** | **List[str]** |  | [optional] 

--- a/python-restclient/docs/MathModelChildSummary.md
+++ b/python-restclient/docs/MathModelChildSummary.md
@@ -4,6 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**sim_keys** | **List[str]** |  | [optional] 
 **model_type** | [**MathType**](MathType.md) |  | [optional] 
 **geometry_dimension** | **int** |  | [optional] 
 **geometry_name** | **str** |  | [optional] 

--- a/python-restclient/vcell_client/models/bio_model_child_summary.py
+++ b/python-restclient/vcell_client/models/bio_model_child_summary.py
@@ -40,12 +40,13 @@ class BioModelChildSummary(BaseModel):
     app_types: Optional[List[MathType]] = Field(default=None, alias="appTypes")
     sim_names: Optional[List[List[StrictStr]]] = Field(default=None, alias="simNames")
     sim_annots: Optional[List[List[StrictStr]]] = Field(default=None, alias="simAnnots")
+    sim_keys: Optional[List[StrictStr]] = Field(default=None, alias="simKeys")
     geometry_dimensions: Optional[List[StrictInt]] = Field(default=None, alias="geometryDimensions")
     geometry_names: Optional[List[StrictStr]] = Field(default=None, alias="geometryNames")
     simulation_context_annotations: Optional[List[StrictStr]] = Field(default=None, alias="simulationContextAnnotations")
     simulation_context_names: Optional[List[StrictStr]] = Field(default=None, alias="simulationContextNames")
     application_info: Optional[List[ApplicationInfo]] = Field(default=None, alias="applicationInfo")
-    __properties: ClassVar[List[str]] = ["scNames", "scAnnots", "geoNames", "geoDims", "appTypes", "simNames", "simAnnots", "geometryDimensions", "geometryNames", "simulationContextAnnotations", "simulationContextNames", "applicationInfo"]
+    __properties: ClassVar[List[str]] = ["scNames", "scAnnots", "geoNames", "geoDims", "appTypes", "simNames", "simAnnots", "simKeys", "geometryDimensions", "geometryNames", "simulationContextAnnotations", "simulationContextNames", "applicationInfo"]
 
     model_config = {
         "populate_by_name": True,
@@ -114,6 +115,7 @@ class BioModelChildSummary(BaseModel):
             "appTypes": obj.get("appTypes"),
             "simNames": obj.get("simNames"),
             "simAnnots": obj.get("simAnnots"),
+            "simKeys": obj.get("simKeys"),
             "geometryDimensions": obj.get("geometryDimensions"),
             "geometryNames": obj.get("geometryNames"),
             "simulationContextAnnotations": obj.get("simulationContextAnnotations"),

--- a/python-restclient/vcell_client/models/math_model_child_summary.py
+++ b/python-restclient/vcell_client/models/math_model_child_summary.py
@@ -32,12 +32,13 @@ class MathModelChildSummary(BaseModel):
     """
     MathModelChildSummary
     """ # noqa: E501
+    sim_keys: Optional[List[StrictStr]] = Field(default=None, alias="simKeys")
     model_type: Optional[MathType] = Field(default=None, alias="modelType")
     geometry_dimension: Optional[StrictInt] = Field(default=None, alias="geometryDimension")
     geometry_name: Optional[StrictStr] = Field(default=None, alias="geometryName")
     simulation_annotations: Optional[List[StrictStr]] = Field(default=None, alias="simulationAnnotations")
     simulation_names: Optional[List[StrictStr]] = Field(default=None, alias="simulationNames")
-    __properties: ClassVar[List[str]] = ["modelType", "geometryDimension", "geometryName", "simulationAnnotations", "simulationNames"]
+    __properties: ClassVar[List[str]] = ["simKeys", "modelType", "geometryDimension", "geometryName", "simulationAnnotations", "simulationNames"]
 
     model_config = {
         "populate_by_name": True,
@@ -92,6 +93,7 @@ class MathModelChildSummary(BaseModel):
                 raise ValueError("Error due to additional fields (not defined in MathModelChildSummary) in the input: " + _key)
 
         _obj = cls.model_validate({
+            "simKeys": obj.get("simKeys"),
             "modelType": obj.get("modelType"),
             "geometryDimension": obj.get("geometryDimension"),
             "geometryName": obj.get("geometryName"),

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -2453,6 +2453,10 @@ components:
             type: array
             items:
               type: string
+        simKeys:
+          type: array
+          items:
+            type: string
         geometryDimensions:
           type: array
           items:
@@ -3137,6 +3141,10 @@ components:
     MathModelChildSummary:
       type: object
       properties:
+        simKeys:
+          type: array
+          items:
+            type: string
         modelType:
           $ref: '#/components/schemas/MathType'
         geometryDimension:

--- a/vcell-core/src/main/java/cbit/vcell/biomodel/BioModel.java
+++ b/vcell-core/src/main/java/cbit/vcell/biomodel/BioModel.java
@@ -434,6 +434,11 @@ public class BioModel implements VCDocument, Matchable, VetoableChangeListener, 
         int[] geoDims = new int[simContexts.length];
         String[][] simNames = new String[simContexts.length][];
         String[][] simAnnots = new String[simContexts.length][];
+        // issue #1746 Phase 2: flat list of this BioModel's saved simulation keys. Sim keys are NOT part of the
+        // serialization (the REST/dev getInfo path re-joins them from vc_biomodelsim), but when the summary is built
+        // from a live, saved BioModel the Simulation objects already carry their keys — populate them so an
+        // in-memory summary is self-consistent without a DB round-trip. Unsaved sims have a null key and are skipped.
+        java.util.List<String> simKeysList = new java.util.ArrayList<String>();
 
         for(int i = 0; i < simContexts.length; i += 1){
             scNames[i] = simContexts[i].getName();
@@ -448,9 +453,12 @@ public class BioModel implements VCDocument, Matchable, VetoableChangeListener, 
             for(int j = 0; j < sims.length; j += 1){
                 simNames[i][j] = sims[j].getName();
                 simAnnots[i][j] = sims[j].getDescription();
+                if(sims[j].getKey() != null){
+                    simKeysList.add(sims[j].getKey().toString());
+                }
             }
         }
-        return new BioModelChildSummary(scNames, appTypes, scAnnots, simNames, simAnnots, geoNames, geoDims);
+        return new BioModelChildSummary(scNames, appTypes, scAnnots, simNames, simAnnots, simKeysList.toArray(new String[0]), geoNames, geoDims);
     }
 
     /**

--- a/vcell-core/src/main/java/cbit/vcell/mathmodel/MathModel.java
+++ b/vcell-core/src/main/java/cbit/vcell/mathmodel/MathModel.java
@@ -253,12 +253,20 @@ public class MathModel implements VCDocument, SimulationOwner, Matchable, Vetoab
         Simulation[] sims = getSimulations();
         String[] simNames = new String[sims.length];
         String[] simAnnots = new String[sims.length];
+        // issue #1746 Phase 2: flat list of this MathModel's saved simulation keys. Sim keys are NOT part of the
+        // serialization (the REST/dev getInfo path re-joins them from vc_mathmodelsim), but when the summary is built
+        // from a live, saved MathModel the Simulation objects already carry their keys — populate them so an
+        // in-memory summary is self-consistent without a DB round-trip. Unsaved sims have a null key and are skipped.
+        java.util.List<String> simKeysList = new java.util.ArrayList<String>();
         for(int i = 0; i < sims.length; i += 1){
             simNames[i] = sims[i].getName();
             simAnnots[i] = sims[i].getDescription();
+            if(sims[i].getKey() != null){
+                simKeysList.add(sims[i].getKey().toString());
+            }
         }
 
-        return new MathModelChildSummary(modelType, geoName, geoDim, simNames, simAnnots);
+        return new MathModelChildSummary(modelType, geoName, geoDim, simNames, simAnnots, simKeysList.toArray(new String[0]));
 
     }
 

--- a/vcell-core/src/main/java/org/vcell/util/document/BioModelChildSummary.java
+++ b/vcell-core/src/main/java/org/vcell/util/document/BioModelChildSummary.java
@@ -34,6 +34,9 @@ public class BioModelChildSummary implements java.io.Serializable {
 
 	private String simNames[][] = new String[0][];
 	private String simAnnots[][] = new String[0][];
+	// issue #1746 Phase 2: flat list of this BioModel version's simulation database keys, sourced at
+	// read time from vc_biomodelsim in the DB layer (NOT part of the DB serialization).
+	private String simKeys[] = new String[0];
 
 	private final static String NOCHILDREN = "NOCHILDREN";
 	public final static String COMPARTMENTAL_GEO_STR = "Compartmental";
@@ -61,7 +64,7 @@ public class BioModelChildSummary implements java.io.Serializable {
  */
 private BioModelChildSummary() {}
 
-public BioModelChildSummary(String[] arg_scNames, MathType[] arg_appType, String[] arg_scAnnots, String[][] arg_simNames, String[][] arg_simAnnots, String[] arg_geoNames, int[] arg_geoDims){
+public BioModelChildSummary(String[] arg_scNames, MathType[] arg_appType, String[] arg_scAnnots, String[][] arg_simNames, String[][] arg_simAnnots, String[] arg_simKeys, String[] arg_geoNames, int[] arg_geoDims){
 	this.scNames = arg_scNames;
 	this.appTypes = arg_appType;
 	this.scAnnots = arg_scAnnots;
@@ -69,6 +72,17 @@ public BioModelChildSummary(String[] arg_scNames, MathType[] arg_appType, String
 	this.geoDims = arg_geoDims;
 	this.simNames = arg_simNames;
 	this.simAnnots = arg_simAnnots;
+	this.simKeys = arg_simKeys;
+}
+
+/** issue #1746 Phase 2: flat list of this BioModel version's simulation database keys (read-time,
+ *  from vc_biomodelsim; empty when none). */
+public String[] getSimKeys() {
+	return simKeys;
+}
+
+public void setSimKeys(String[] simKeys) {
+	this.simKeys = simKeys;
 }
 
 /**

--- a/vcell-core/src/main/java/org/vcell/util/document/BioModelInfo.java
+++ b/vcell-core/src/main/java/org/vcell/util/document/BioModelInfo.java
@@ -26,6 +26,7 @@ public class BioModelInfo implements org.vcell.util.document.VCDocumentInfo {
 	private Version version = null;
 	private BioModelChildSummary bioModelChildSummary = null; // Used for caching on server side
 	private BigString bioModelChildSummaryString = null; // String Required
+	private String[] simKeys = null; // issue #1746 Phase 2: sim keys joined from vc_biomodelsim, injected into the child summary on parse
 
 	private VCellSoftwareVersion softwareVersion = null;
 	private final ArrayList<PublicationInfo> publicationInfos = new ArrayList<>();
@@ -77,7 +78,15 @@ public BioModelChildSummary getBioModelChildSummary() {
 		bioModelChildSummary = BioModelChildSummary.fromDatabaseSerialization(bioModelChildSummaryString.toString());
 		bioModelChildSummaryString = null;
 	}
+	if (bioModelChildSummary != null && simKeys != null) {
+		bioModelChildSummary.setSimKeys(simKeys); // issue #1746 Phase 2: inject DB-joined sim keys
+	}
 	return bioModelChildSummary;
+}
+
+/** issue #1746 Phase 2: sim keys joined from vc_biomodelsim (set by BioModelTable.getInfo). */
+public void setSimKeys(String[] simKeys) {
+	this.simKeys = simKeys;
 }
 /**
  * This method was created in VisualAge.

--- a/vcell-core/src/main/java/org/vcell/util/document/MathModelChildSummary.java
+++ b/vcell-core/src/main/java/org/vcell/util/document/MathModelChildSummary.java
@@ -35,6 +35,10 @@ public class MathModelChildSummary implements java.io.Serializable {
 	private String simNames[] = null;
 	@JsonIgnore
 	private String simAnnots[] = null;
+	// issue #1746 Phase 2: flat list of this MathModel version's simulation database keys, sourced at
+	// read time from vc_mathmodelsim (NOT part of the DB serialization). NOT @JsonIgnore — it is
+	// serialized via getSimKeys() (same property name as the field, so @JsonIgnore would suppress it).
+	private String simKeys[] = new String[0];
 	//math model type deterministic or stochastic
 	private MathType modelType = null;
 /**
@@ -43,12 +47,23 @@ public class MathModelChildSummary implements java.io.Serializable {
  */
 private MathModelChildSummary() {}
 
-public MathModelChildSummary(MathType arg_modelType, String arg_geoName, int arg_geoDim, String[] arg_simNames, String[] arg_simAnnots){
+public MathModelChildSummary(MathType arg_modelType, String arg_geoName, int arg_geoDim, String[] arg_simNames, String[] arg_simAnnots, String[] arg_simKeys){
 	this.modelType = arg_modelType;
 	this.geoName = arg_geoName;
 	this.geoDim = arg_geoDim;
 	this.simNames = arg_simNames;
 	this.simAnnots = arg_simAnnots;
+	this.simKeys = arg_simKeys;
+}
+
+/** issue #1746 Phase 2: flat list of this MathModel version's simulation database keys (read-time,
+ *  from vc_mathmodelsim; empty when none). */
+public String[] getSimKeys() {
+	return simKeys;
+}
+
+public void setSimKeys(String[] simKeys) {
+	this.simKeys = simKeys;
 }
 /**
  * Insert the method's description here.

--- a/vcell-core/src/main/java/org/vcell/util/document/MathModelInfo.java
+++ b/vcell-core/src/main/java/org/vcell/util/document/MathModelInfo.java
@@ -33,6 +33,7 @@ public class MathModelInfo implements VCDocumentInfo {
 	private KeyValue mathKey = null;
 	private MathModelChildSummary mathModelChildSummary = null;
 	private BigString mathModelChildSummaryString = null;
+	private String[] simKeys = null; // issue #1746 Phase 2: sim keys joined from vc_mathmodelsim, injected into the child summary on parse
 	private VCellSoftwareVersion softwareVersion = null;
 	private ArrayList<PublicationInfo> publicationInfos = new ArrayList<>();
 	private String annotatedFunctionsStr = null;
@@ -106,7 +107,15 @@ public MathModelChildSummary getMathModelChildSummary() {
 		mathModelChildSummary = MathModelChildSummary.fromDatabaseSerialization(mathModelChildSummaryString.toString());
 		mathModelChildSummaryString = null;
 	}
+	if (mathModelChildSummary != null && simKeys != null) {
+		mathModelChildSummary.setSimKeys(simKeys); // issue #1746 Phase 2: inject DB-joined sim keys
+	}
 	return mathModelChildSummary;
+}
+
+/** issue #1746 Phase 2: sim keys joined from vc_mathmodelsim (set by MathModelTable.getInfo). */
+public void setSimKeys(String[] simKeys) {
+	this.simKeys = simKeys;
 }
 /**
  * This method was created in VisualAge.

--- a/vcell-rest/src/test/java/org/vcell/restq/apiclient/VCInfoContainerApiTest.java
+++ b/vcell-rest/src/test/java/org/vcell/restq/apiclient/VCInfoContainerApiTest.java
@@ -71,6 +71,14 @@ public class VCInfoContainerApiTest {
         // the freshly saved biomodel must be visible in the owner's bulk container
         Assertions.assertFalse(container.getBioModelSummaries().isEmpty(),
                 "expected the saved BioModel to appear in the vcInfoContainer");
+
+        // issue #1746 Phase 2: each biomodel summary carries its (possibly empty) sim keys from vc_biomodelsim
+        for (org.vcell.restclient.model.BioModelSummary bm : container.getBioModelSummaries()) {
+            if (bm.getSummary() != null) {
+                Assertions.assertNotNull(bm.getSummary().getSimKeys(),
+                        "vcInfoContainer must populate simKeys on each biomodel child summary");
+            }
+        }
     }
 
     @Test

--- a/vcell-restclient/.openapi-generator/FILES
+++ b/vcell-restclient/.openapi-generator/FILES
@@ -246,5 +246,3 @@ src/main/java/org/vcell/restclient/model/Vcellopt.java
 src/main/java/org/vcell/restclient/model/VcelloptStatus.java
 src/main/java/org/vcell/restclient/model/Version.java
 src/main/java/org/vcell/restclient/model/VersionFlag.java
-src/test/java/org/vcell/restclient/api/VcInfoContainerResourceApiTest.java
-src/test/java/org/vcell/restclient/model/VCInfoContainerSummaryTest.java

--- a/vcell-restclient/api/openapi.yaml
+++ b/vcell-restclient/api/openapi.yaml
@@ -2588,9 +2588,6 @@ components:
         scAnnots:
         - scAnnots
         - scAnnots
-        simulationContextNames:
-        - simulationContextNames
-        - simulationContextNames
         geoNames:
         - geoNames
         - geoNames
@@ -2608,12 +2605,18 @@ components:
         geoDims:
         - 5
         - 5
-        appTypes:
-        - null
-        - null
         scNames:
         - scNames
         - scNames
+        simulationContextNames:
+        - simulationContextNames
+        - simulationContextNames
+        simKeys:
+        - simKeys
+        - simKeys
+        appTypes:
+        - null
+        - null
         applicationInfo:
         - geometryName: geometryName
           name: name
@@ -2662,6 +2665,10 @@ components:
               type: string
             type: array
           type: array
+        simKeys:
+          items:
+            type: string
+          type: array
         geometryDimensions:
           items:
             format: int32
@@ -2693,9 +2700,6 @@ components:
           scAnnots:
           - scAnnots
           - scAnnots
-          simulationContextNames:
-          - simulationContextNames
-          - simulationContextNames
           geoNames:
           - geoNames
           - geoNames
@@ -2713,12 +2717,18 @@ components:
           geoDims:
           - 5
           - 5
-          appTypes:
-          - null
-          - null
           scNames:
           - scNames
           - scNames
+          simulationContextNames:
+          - simulationContextNames
+          - simulationContextNames
+          simKeys:
+          - simKeys
+          - simKeys
+          appTypes:
+          - null
+          - null
           applicationInfo:
           - geometryName: geometryName
             name: name
@@ -3916,9 +3926,16 @@ components:
         - simulationNames
         - simulationNames
         geometryName: geometryName
+        simKeys:
+        - simKeys
+        - simKeys
         geometryDimension: 0
         modelType: null
       properties:
+        simKeys:
+          items:
+            type: string
+          type: array
         modelType:
           $ref: '#/components/schemas/MathType'
         geometryDimension:
@@ -3945,6 +3962,9 @@ components:
           - simulationNames
           - simulationNames
           geometryName: geometryName
+          simKeys:
+          - simKeys
+          - simKeys
           geometryDimension: 0
           modelType: null
         keyValue: keyValue
@@ -5445,6 +5465,9 @@ components:
             - simulationNames
             - simulationNames
             geometryName: geometryName
+            simKeys:
+            - simKeys
+            - simKeys
             geometryDimension: 0
             modelType: null
           keyValue: keyValue
@@ -5528,6 +5551,9 @@ components:
             - simulationNames
             - simulationNames
             geometryName: geometryName
+            simKeys:
+            - simKeys
+            - simKeys
             geometryDimension: 0
             modelType: null
           keyValue: keyValue
@@ -5696,9 +5722,6 @@ components:
             scAnnots:
             - scAnnots
             - scAnnots
-            simulationContextNames:
-            - simulationContextNames
-            - simulationContextNames
             geoNames:
             - geoNames
             - geoNames
@@ -5716,12 +5739,18 @@ components:
             geoDims:
             - 5
             - 5
-            appTypes:
-            - null
-            - null
             scNames:
             - scNames
             - scNames
+            simulationContextNames:
+            - simulationContextNames
+            - simulationContextNames
+            simKeys:
+            - simKeys
+            - simKeys
+            appTypes:
+            - null
+            - null
             applicationInfo:
             - geometryName: geometryName
               name: name
@@ -5814,9 +5843,6 @@ components:
             scAnnots:
             - scAnnots
             - scAnnots
-            simulationContextNames:
-            - simulationContextNames
-            - simulationContextNames
             geoNames:
             - geoNames
             - geoNames
@@ -5834,12 +5860,18 @@ components:
             geoDims:
             - 5
             - 5
-            appTypes:
-            - null
-            - null
             scNames:
             - scNames
             - scNames
+            simulationContextNames:
+            - simulationContextNames
+            - simulationContextNames
+            simKeys:
+            - simKeys
+            - simKeys
+            appTypes:
+            - null
+            - null
             applicationInfo:
             - geometryName: geometryName
               name: name

--- a/vcell-restclient/docs/BioModelChildSummary.md
+++ b/vcell-restclient/docs/BioModelChildSummary.md
@@ -14,6 +14,7 @@
 |**appTypes** | **List&lt;MathType&gt;** |  |  [optional] |
 |**simNames** | **List&lt;List&lt;String&gt;&gt;** |  |  [optional] |
 |**simAnnots** | **List&lt;List&lt;String&gt;&gt;** |  |  [optional] |
+|**simKeys** | **List&lt;String&gt;** |  |  [optional] |
 |**geometryDimensions** | **List&lt;Integer&gt;** |  |  [optional] |
 |**geometryNames** | **List&lt;String&gt;** |  |  [optional] |
 |**simulationContextAnnotations** | **List&lt;String&gt;** |  |  [optional] |

--- a/vcell-restclient/docs/MathModelChildSummary.md
+++ b/vcell-restclient/docs/MathModelChildSummary.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**simKeys** | **List&lt;String&gt;** |  |  [optional] |
 |**modelType** | **MathType** |  |  [optional] |
 |**geometryDimension** | **Integer** |  |  [optional] |
 |**geometryName** | **String** |  |  [optional] |

--- a/vcell-restclient/src/main/java/org/vcell/restclient/model/BioModelChildSummary.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/model/BioModelChildSummary.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   BioModelChildSummary.JSON_PROPERTY_APP_TYPES,
   BioModelChildSummary.JSON_PROPERTY_SIM_NAMES,
   BioModelChildSummary.JSON_PROPERTY_SIM_ANNOTS,
+  BioModelChildSummary.JSON_PROPERTY_SIM_KEYS,
   BioModelChildSummary.JSON_PROPERTY_GEOMETRY_DIMENSIONS,
   BioModelChildSummary.JSON_PROPERTY_GEOMETRY_NAMES,
   BioModelChildSummary.JSON_PROPERTY_SIMULATION_CONTEXT_ANNOTATIONS,
@@ -71,6 +72,9 @@ public class BioModelChildSummary {
 
   public static final String JSON_PROPERTY_SIM_ANNOTS = "simAnnots";
   private List<List<String>> simAnnots;
+
+  public static final String JSON_PROPERTY_SIM_KEYS = "simKeys";
+  private List<String> simKeys;
 
   public static final String JSON_PROPERTY_GEOMETRY_DIMENSIONS = "geometryDimensions";
   private List<Integer> geometryDimensions;
@@ -321,6 +325,39 @@ public class BioModelChildSummary {
   }
 
 
+  public BioModelChildSummary simKeys(List<String> simKeys) {
+    this.simKeys = simKeys;
+    return this;
+  }
+
+  public BioModelChildSummary addSimKeysItem(String simKeysItem) {
+    if (this.simKeys == null) {
+      this.simKeys = new ArrayList<>();
+    }
+    this.simKeys.add(simKeysItem);
+    return this;
+  }
+
+   /**
+   * Get simKeys
+   * @return simKeys
+  **/
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_SIM_KEYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public List<String> getSimKeys() {
+    return simKeys;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_SIM_KEYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setSimKeys(List<String> simKeys) {
+    this.simKeys = simKeys;
+  }
+
+
   public BioModelChildSummary geometryDimensions(List<Integer> geometryDimensions) {
     this.geometryDimensions = geometryDimensions;
     return this;
@@ -505,6 +542,7 @@ public class BioModelChildSummary {
         Objects.equals(this.appTypes, bioModelChildSummary.appTypes) &&
         Objects.equals(this.simNames, bioModelChildSummary.simNames) &&
         Objects.equals(this.simAnnots, bioModelChildSummary.simAnnots) &&
+        Objects.equals(this.simKeys, bioModelChildSummary.simKeys) &&
         Objects.equals(this.geometryDimensions, bioModelChildSummary.geometryDimensions) &&
         Objects.equals(this.geometryNames, bioModelChildSummary.geometryNames) &&
         Objects.equals(this.simulationContextAnnotations, bioModelChildSummary.simulationContextAnnotations) &&
@@ -514,7 +552,7 @@ public class BioModelChildSummary {
 
   @Override
   public int hashCode() {
-    return Objects.hash(scNames, scAnnots, geoNames, geoDims, appTypes, simNames, simAnnots, geometryDimensions, geometryNames, simulationContextAnnotations, simulationContextNames, applicationInfo);
+    return Objects.hash(scNames, scAnnots, geoNames, geoDims, appTypes, simNames, simAnnots, simKeys, geometryDimensions, geometryNames, simulationContextAnnotations, simulationContextNames, applicationInfo);
   }
 
   @Override
@@ -528,6 +566,7 @@ public class BioModelChildSummary {
     sb.append("    appTypes: ").append(toIndentedString(appTypes)).append("\n");
     sb.append("    simNames: ").append(toIndentedString(simNames)).append("\n");
     sb.append("    simAnnots: ").append(toIndentedString(simAnnots)).append("\n");
+    sb.append("    simKeys: ").append(toIndentedString(simKeys)).append("\n");
     sb.append("    geometryDimensions: ").append(toIndentedString(geometryDimensions)).append("\n");
     sb.append("    geometryNames: ").append(toIndentedString(geometryNames)).append("\n");
     sb.append("    simulationContextAnnotations: ").append(toIndentedString(simulationContextAnnotations)).append("\n");
@@ -642,6 +681,15 @@ public class BioModelChildSummary {
         joiner.add(String.format("%ssimAnnots%s%s=%s", prefix, suffix,
             "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
             URLEncoder.encode(String.valueOf(getSimAnnots().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+      }
+    }
+
+    // add `simKeys` to the URL query string
+    if (getSimKeys() != null) {
+      for (int i = 0; i < getSimKeys().size(); i++) {
+        joiner.add(String.format("%ssimKeys%s%s=%s", prefix, suffix,
+            "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+            URLEncoder.encode(String.valueOf(getSimKeys().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
       }
     }
 

--- a/vcell-restclient/src/main/java/org/vcell/restclient/model/MathModelChildSummary.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/model/MathModelChildSummary.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * MathModelChildSummary
  */
 @JsonPropertyOrder({
+  MathModelChildSummary.JSON_PROPERTY_SIM_KEYS,
   MathModelChildSummary.JSON_PROPERTY_MODEL_TYPE,
   MathModelChildSummary.JSON_PROPERTY_GEOMETRY_DIMENSION,
   MathModelChildSummary.JSON_PROPERTY_GEOMETRY_NAME,
@@ -43,6 +44,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class MathModelChildSummary {
+  public static final String JSON_PROPERTY_SIM_KEYS = "simKeys";
+  private List<String> simKeys;
+
   public static final String JSON_PROPERTY_MODEL_TYPE = "modelType";
   private MathType modelType;
 
@@ -60,6 +64,39 @@ public class MathModelChildSummary {
 
   public MathModelChildSummary() { 
   }
+
+  public MathModelChildSummary simKeys(List<String> simKeys) {
+    this.simKeys = simKeys;
+    return this;
+  }
+
+  public MathModelChildSummary addSimKeysItem(String simKeysItem) {
+    if (this.simKeys == null) {
+      this.simKeys = new ArrayList<>();
+    }
+    this.simKeys.add(simKeysItem);
+    return this;
+  }
+
+   /**
+   * Get simKeys
+   * @return simKeys
+  **/
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_SIM_KEYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public List<String> getSimKeys() {
+    return simKeys;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_SIM_KEYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setSimKeys(List<String> simKeys) {
+    this.simKeys = simKeys;
+  }
+
 
   public MathModelChildSummary modelType(MathType modelType) {
     this.modelType = modelType;
@@ -214,7 +251,8 @@ public class MathModelChildSummary {
       return false;
     }
     MathModelChildSummary mathModelChildSummary = (MathModelChildSummary) o;
-    return Objects.equals(this.modelType, mathModelChildSummary.modelType) &&
+    return Objects.equals(this.simKeys, mathModelChildSummary.simKeys) &&
+        Objects.equals(this.modelType, mathModelChildSummary.modelType) &&
         Objects.equals(this.geometryDimension, mathModelChildSummary.geometryDimension) &&
         Objects.equals(this.geometryName, mathModelChildSummary.geometryName) &&
         Objects.equals(this.simulationAnnotations, mathModelChildSummary.simulationAnnotations) &&
@@ -223,13 +261,14 @@ public class MathModelChildSummary {
 
   @Override
   public int hashCode() {
-    return Objects.hash(modelType, geometryDimension, geometryName, simulationAnnotations, simulationNames);
+    return Objects.hash(simKeys, modelType, geometryDimension, geometryName, simulationAnnotations, simulationNames);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class MathModelChildSummary {\n");
+    sb.append("    simKeys: ").append(toIndentedString(simKeys)).append("\n");
     sb.append("    modelType: ").append(toIndentedString(modelType)).append("\n");
     sb.append("    geometryDimension: ").append(toIndentedString(geometryDimension)).append("\n");
     sb.append("    geometryName: ").append(toIndentedString(geometryName)).append("\n");
@@ -281,6 +320,15 @@ public class MathModelChildSummary {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `simKeys` to the URL query string
+    if (getSimKeys() != null) {
+      for (int i = 0; i < getSimKeys().size(); i++) {
+        joiner.add(String.format("%ssimKeys%s%s=%s", prefix, suffix,
+            "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+            URLEncoder.encode(String.valueOf(getSimKeys().get(i)), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+      }
+    }
 
     // add `modelType` to the URL query string
     if (getModelType() != null) {

--- a/vcell-restclient/src/main/java/org/vcell/restclient/utils/DtoModelTransforms.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/utils/DtoModelTransforms.java
@@ -247,8 +247,9 @@ public class DtoModelTransforms {
         String[] scAnnotations = dto.getScAnnots() == null ? null : dto.getScAnnots().toArray(new String[0]);
         String[] geoNames = dto.getGeoNames() == null ? null : dto.getGeoNames().toArray(new String[0]);
         int[] geoDims = dto.getGeoDims() == null ? null : dto.getGeoDims().stream().mapToInt(Integer::intValue).toArray();
+        String[] simKeys = dto.getSimKeys() == null ? new String[0] : dto.getSimKeys().toArray(new String[0]);
         return new BioModelChildSummary(dto.getSimulationContextNames().toArray(new String[0]),
-                mathTypes, scAnnotations, simNames, simAnnots, geoNames,
+                mathTypes, scAnnotations, simNames, simAnnots, simKeys, geoNames,
                 geoDims);
     }
 
@@ -279,9 +280,10 @@ public class DtoModelTransforms {
     }
 
     public static MathModelChildSummary mathModelChildSummary(org.vcell.restclient.model.MathModelChildSummary dto){
+        String[] simKeys = dto.getSimKeys() == null ? new String[0] : dto.getSimKeys().toArray(new String[0]);
         return new MathModelChildSummary(BioModelChildSummary.MathType.valueOf(dto.getModelType().getValue()),
                 dto.getGeometryName(), dto.getGeometryDimension(), dto.getSimulationNames().toArray(new String[0]),
-                dto.getSimulationAnnotations().toArray(new String[0]));
+                dto.getSimulationAnnotations().toArray(new String[0]), simKeys);
     }
 
     public static MathModelInfo mathModelContextToMathModel(MathModelSummary summary){

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/BioModelTable.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/BioModelTable.java
@@ -119,8 +119,23 @@ public VersionInfo getInfo(ResultSet rset,Connection con,DatabaseSyntax dbSyntax
 	String softwareVersion = rset.getString(SoftwareVersionTable.table.softwareVersion.toString());
 	VCellSoftwareVersion vcSoftwareVersion = VCellSoftwareVersion.fromString(softwareVersion);
 	String serialDbChildSummary = DbDriver.varchar2_CLOB_get(rset,BioModelTable.table.childSummarySmall,BioModelTable.table.childSummaryLarge,dbSyntax);
-	
-	return new org.vcell.util.document.BioModelInfo(version, serialDbChildSummary, vcSoftwareVersion);
+
+	org.vcell.util.document.BioModelInfo bioModelInfo = new org.vcell.util.document.BioModelInfo(version, serialDbChildSummary, vcSoftwareVersion);
+	// issue #1746 Phase 2: attach the flat sim keys aggregated by the "simKeys" subquery column
+	bioModelInfo.setSimKeys(parseSimKeysCsv(rset.getString("simKeys")));
+	return bioModelInfo;
+}
+
+/** issue #1746 Phase 2: parse a '[k1,k2,...]' aggregated simKeys column into a flat String[] (empty when none). */
+private static String[] parseSimKeysCsv(String csv){
+	if (csv == null){
+		return new String[0];
+	}
+	String stripped = csv.replace("[","").replace("]","").trim();
+	if (stripped.isEmpty()){
+		return new String[0];
+	}
+	return stripped.split(",");
 }
 
 public String getInfoSQL(User user,String extraConditions,String special, DatabaseSyntax dbSyntax) {
@@ -129,7 +144,20 @@ public String getInfoSQL(User user,String extraConditions,String special, Databa
 	BioModelTable vTable = BioModelTable.table;
 	SoftwareVersionTable swvTable = SoftwareVersionTable.table;
 	String sql;
-	Field[] f = {userTable.userid,new cbit.sql.StarField(vTable),swvTable.softwareVersion};
+	// issue #1746 Phase 2: a correlated subquery column that aggregates this BioModel's simulation keys
+	// from vc_biomodelsim into a '[k1,k2,...]' string aliased "simKeys" (same listagg pattern as
+	// getPreparedStatement_BioModelReps). Emitted as an expression Field (like StarField).
+	final BioModelSimulationLinkTable bmsimTable = BioModelSimulationLinkTable.table;
+	final String concatFn = (dbSyntax==DatabaseSyntax.ORACLE) ? "listagg" : "string_agg";
+	final String cast = (dbSyntax==DatabaseSyntax.ORACLE) ? "" : "::varchar(255)";
+	final String simKeysSubquery =
+		"(select '['||"+concatFn+"(SQ1_"+bmsimTable.simRef.getQualifiedColName()+cast+", ',')||']' " +
+		"   from "+bmsimTable.getTableName()+" SQ1_"+bmsimTable.getTableName()+
+		"   where SQ1_"+bmsimTable.bioModelRef.getQualifiedColName()+" = "+vTable.id.getQualifiedColName()+") simKeys";
+	Field simKeysField = new Field("simKeys", null, null){
+		@Override public String getQualifiedColName(){ return simKeysSubquery; }
+	};
+	Field[] f = {userTable.userid,new cbit.sql.StarField(vTable),swvTable.softwareVersion,simKeysField};
 	Table[] t = {vTable,userTable,swvTable};
 	
 	switch (dbSyntax){

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/MathModelTable.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/MathModelTable.java
@@ -63,7 +63,22 @@ public VersionInfo getInfo(ResultSet rset,Connection con,DatabaseSyntax dbSyntax
 
 	String softwareVersion = rset.getString(SoftwareVersionTable.table.softwareVersion.toString());
 	
-	return new MathModelInfo(version, mathRef, serialDbChildSummary, VCellSoftwareVersion.fromString(softwareVersion));
+	MathModelInfo mathModelInfo = new MathModelInfo(version, mathRef, serialDbChildSummary, VCellSoftwareVersion.fromString(softwareVersion));
+	// issue #1746 Phase 2: attach the flat sim keys aggregated by the "simKeys" subquery column
+	mathModelInfo.setSimKeys(parseSimKeysCsv(rset.getString("simKeys")));
+	return mathModelInfo;
+}
+
+/** issue #1746 Phase 2: parse a '[k1,k2,...]' aggregated simKeys column into a flat String[] (empty when none). */
+private static String[] parseSimKeysCsv(String csv){
+	if (csv == null){
+		return new String[0];
+	}
+	String stripped = csv.replace("[","").replace("]","").trim();
+	if (stripped.isEmpty()){
+		return new String[0];
+	}
+	return stripped.split(",");
 }
 
 
@@ -77,7 +92,19 @@ public String getInfoSQL(User user,String extraConditions,String special,Databas
 	MathModelTable vTable = MathModelTable.table;
 	SoftwareVersionTable swvTable = SoftwareVersionTable.table;
 	String sql;
-	Field[] f = {userTable.userid,new cbit.sql.StarField(vTable),swvTable.softwareVersion};
+	// issue #1746 Phase 2: correlated subquery aggregating this MathModel's simulation keys from
+	// vc_mathmodelsim into a '[k1,k2,...]' string aliased "simKeys" (same pattern as BioModelTable).
+	final MathModelSimulationLinkTable mmsimTable = MathModelSimulationLinkTable.table;
+	final String concatFn = (dbSyntax==DatabaseSyntax.ORACLE) ? "listagg" : "string_agg";
+	final String cast = (dbSyntax==DatabaseSyntax.ORACLE) ? "" : "::varchar(255)";
+	final String simKeysSubquery =
+		"(select '['||"+concatFn+"(SQ1_"+mmsimTable.simRef.getQualifiedColName()+cast+", ',')||']' " +
+		"   from "+mmsimTable.getTableName()+" SQ1_"+mmsimTable.getTableName()+
+		"   where SQ1_"+mmsimTable.mathModelRef.getQualifiedColName()+" = "+vTable.id.getQualifiedColName()+") simKeys";
+	Field simKeysField = new Field("simKeys", null, null){
+		@Override public String getQualifiedColName(){ return simKeysSubquery; }
+	};
+	Field[] f = {userTable.userid,new cbit.sql.StarField(vTable),swvTable.softwareVersion,simKeysField};
 	Table[] t = {vTable,userTable,swvTable};
 	
 	switch (dbSyntax){

--- a/webapp-ng/src/app/core/modules/openapi/model/bio-model-child-summary.ts
+++ b/webapp-ng/src/app/core/modules/openapi/model/bio-model-child-summary.ts
@@ -21,6 +21,7 @@ export interface BioModelChildSummary {
     appTypes?: Array<MathType>;
     simNames?: Array<Array<string>>;
     simAnnots?: Array<Array<string>>;
+    simKeys?: Array<string>;
     geometryDimensions?: Array<number>;
     geometryNames?: Array<string>;
     simulationContextAnnotations?: Array<string>;

--- a/webapp-ng/src/app/core/modules/openapi/model/math-model-child-summary.ts
+++ b/webapp-ng/src/app/core/modules/openapi/model/math-model-child-summary.ts
@@ -13,6 +13,7 @@ import { MathType } from './math-type';
 
 
 export interface MathModelChildSummary { 
+    simKeys?: Array<string>;
     modelType?: MathType;
     geometryDimension?: number;
     geometryName?: string;


### PR DESCRIPTION
## Summary

Phase 2 of issue #1746. Adds each model version's **simulation database keys** (`simKeys`) to `BioModelChildSummary` and `MathModelChildSummary`, so a simulation being viewed in a results viewer can be resolved to its owning model across versions.

Supersedes #1760 (that PR was on the abandoned `phase2-biomodel-simkeys` branch, which used an earlier holder + `String[][]` design). This branch is the reworked, simpler implementation.

## Design

- **Flat `String[]`** shape on both summaries — unconditional field, no opt-in query flag, no `@JsonInclude`.
- **Single user-scoped query.** Keys are aggregated in the primary `getInfoSQL`/`getInfo` path via a correlated `listagg` (Oracle) / `string_agg` (Postgres) subquery over `vc_biomodelsim` / `vc_mathmodelsim` — the same pattern as `getPreparedStatement_BioModelReps`. No IN-list of thousands of keys, no second round-trip.
- **Shared DB/domain layer**, so dev-mode (`VCellClientDevMain` → `LocalUserMetaDbServer` → `DatabaseServerImpl`) populates identically to REST. `BioModelInfo`/`MathModelInfo` carry the joined keys and inject them into the lazily-parsed child summary.
- **In-memory summaries are self-consistent too.** `BioModel.createBioModelChildSummary()` / `MathModel.createMathModelChildSummary()` now populate `simKeys` from each saved `Simulation`'s key (skipping `null` keys of unsaved sims), so a summary built from a live model without a DB round-trip agrees with the read-time-joined one.
- **Read-time only** — `simKeys` are NOT part of `to/fromDatabaseSerialization`. Keys join live from existing link tables, so **no migration / no stored-format change**: all historical models are covered and prod/dev deploy independently.

## Client regeneration

Regenerated the OpenAPI spec + Java/Python/TS clients (additive: `simKeys` on both summaries). `DtoModelTransforms` carries `simKeys` into the domain objects so the desktop consumes them.

## Tests

`VCInfoContainerApiTest` asserts `/vcInfoContainer` populates `simKeys` on each biomodel child summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
