### PR TITLE
windowing: owned modeless child windows (LWChildDialog) — fixes child-window z-order

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/ChildWindowManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ChildWindowManager.java
@@ -19,6 +19,7 @@ import javax.swing.JMenuBar;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.vcell.client.logicalwindow.LWChildDialog;
 import org.vcell.client.logicalwindow.LWChildFrame;
 import org.vcell.client.logicalwindow.LWContainerHandle;
 import org.vcell.client.logicalwindow.LWFrameOrDialog;
@@ -51,14 +52,24 @@ public class ChildWindowManager {
 		ChildWindowManager getChildWindowManager(); 
 	}
 	
+	/**
+	 * issue: window z-order. Modeless child windows are now OWNED windows ({@link LWChildDialog},
+	 * an owned modeless JDialog) rather than un-owned {@link LWChildFrame}s. An un-owned JFrame could
+	 * only be kept above its parent by a best-effort {@code Window.toFront()}, which modern macOS
+	 * (13.3+/Sonoma cooperative activation) and Windows (foreground lock) refuse for a non-foreground
+	 * app — the "child window hides behind the document window" bug. A natively-owned window is kept
+	 * above its owner by the OS itself. Trade-off (accepted): no independent taskbar button; the child
+	 * travels with its owner. Mirrors the already-owned {@link ParentModalChild} (modal) sibling.
+	 * See {@code docs/windowing-design-patterns.md} §7.
+	 */
 	@SuppressWarnings("serial")
-	private static class ModelessChild extends LWChildFrame implements ManagedChild {
+	private static class ModelessChild extends LWChildDialog implements ManagedChild {
 		private final ChildWindowManager childWindowManager;
 		private ModelessChild(ChildWindowManager cwm,LWContainerHandle parent, String title, LWTraits tr) throws HeadlessException {
 			super(parent, title);
 			Objects.requireNonNull(cwm);
 			childWindowManager = cwm;
-			traits = tr; 
+			traits = tr;
 		}
 
 		@Override

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/annotations/AddAnnotationsPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/annotations/AddAnnotationsPanel.java
@@ -2,6 +2,8 @@ package cbit.vcell.client.desktop.biomodel.annotations;
 
 import cbit.vcell.biomodel.meta.VCMetaDataMiriamManager;
 import cbit.vcell.client.desktop.biomodel.AnnotationsPanel;
+import org.vcell.client.logicalwindow.LWChildDialog;
+import org.vcell.client.logicalwindow.LWNamespace;
 import org.xml.sax.SAXException;
 
 import javax.swing.*;
@@ -22,7 +24,17 @@ import java.util.StringTokenizer;
 
 import static cbit.vcell.biomodel.meta.VCMetaDataMiriamManager.VCMetaDataDataType.DataType_UNIPROT;
 
-public class AddAnnotationsPanel extends JFrame implements ActionListener {
+/**
+ * Search-online-databases child window of {@link AnnotationsPanel}.
+ * <p>
+ * Prototype (issue: window z-order): converted from a raw, un-owned {@code JFrame} — which relied
+ * on {@link java.awt.Window#toFront()} to stay above its parent and could slip behind the document
+ * window on modern macOS/Windows — to an <b>owned modeless</b> {@link LWChildDialog}. The logical
+ * (and native) parent is resolved from the triggering {@code annotationsPanel} via
+ * {@link LWNamespace#findLWOwner(java.awt.Component)}, so the OS keeps this window above its owner.
+ * See {@code docs/windowing-design-patterns.md} §7.
+ */
+public class AddAnnotationsPanel extends LWChildDialog implements ActionListener {
 
     public static final int MAX_DESCRIPTION_LENGTH = 160;
 
@@ -43,14 +55,16 @@ public class AddAnnotationsPanel extends JFrame implements ActionListener {
     private JPanel searchComponentsPanel = null;
 
     public AddAnnotationsPanel (AnnotationsPanel annotationsPanel, JComboBox JComboBoxURI, JComboBox JComboBoxQualifier) {
+        // owned modeless child: native+logical owner resolved from the annotations panel, so the OS
+        // keeps this window above its owner (replaces the old un-owned JFrame + toFront/alwaysOnTop).
+        super(LWNamespace.findLWOwner(annotationsPanel), "Add Annotations");
         this.annotationsPanel = annotationsPanel;
         this.jComboBoxURI = JComboBoxURI;
         this.jComboBoxQualifier = (JComboBoxQualifier==null) ? new JComboBox<>(): JComboBoxQualifier;
 
-        setTitle("Add Annotations");
         setResizable(false);
-        setLocationRelativeTo(annotationsPanel);
-//        setAlwaysOnTop(true);
+        // positioning is handled by the LW framework (staggered on parent); no setLocationRelativeTo,
+        // no setAlwaysOnTop — the owned-window relationship enforces z-order.
 
         JPanel mainPanel = new JPanel(new GridBagLayout());
 

--- a/vcell-client/src/main/java/org/vcell/client/logicalwindow/LWChildDialog.java
+++ b/vcell-client/src/main/java/org/vcell/client/logicalwindow/LWChildDialog.java
@@ -1,0 +1,120 @@
+package org.vcell.client.logicalwindow;
+
+import java.awt.Window;
+import java.util.Iterator;
+
+import javax.swing.JDialog;
+import javax.swing.JMenuItem;
+
+import org.vcell.client.logicalwindow.LWTraits.InitialPosition;
+
+/**
+ * Base class for logical <b>modeless child</b> windows of an {@link LWContainerHandle}.
+ * <p>
+ * This is the <i>owned-window</i> counterpart to {@link LWChildFrame}. Where {@code LWChildFrame}
+ * extends {@link javax.swing.JFrame} — which in AWT is always a top-level root and therefore has
+ * <b>no native owner</b> — this class extends {@link JDialog} constructed <b>with the logical
+ * parent's window as its native owner</b> and {@link ModalityType#MODELESS} modality.
+ * <p>
+ * The practical difference is z-order robustness. {@code LWChildFrame} can only be kept above its
+ * logical parent by a best-effort {@link Window#toFront()}, which modern macOS (13.3+/Sonoma
+ * cooperative activation) and Windows (foreground lock) refuse to honor for a non-foreground
+ * application — the "window appears behind its parent" bug. A natively-<b>owned</b> window is kept
+ * above its owner <b>by the OS itself</b>, regardless of which application is active, so it does not
+ * depend on {@code toFront()} at all.
+ * <p>
+ * Trade-off (deliberate): an owned window does not get its own taskbar button / independent
+ * minimize on Windows, and travels with its owner under Spaces / Stage Manager / Snap / virtual
+ * desktops. For a child editor/viewer that logically belongs to a document window, that is the
+ * desired behavior.
+ * <p>
+ * See {@code docs/windowing-design-patterns.md} §7 for the platform analysis motivating this class.
+ *
+ * @see LWChildFrame the un-owned {@code JFrame} counterpart (fragile z-order)
+ */
+@SuppressWarnings("serial")
+public abstract class LWChildDialog extends JDialog implements LWFrameOrDialog, LWContainerHandle {
+
+	private final LWManager lwManager;
+	protected LWTraits traits;
+
+	/**
+	 * @param parent logical owner; also becomes the native AWT owner so the OS enforces z-order.
+	 *               Null is tolerated (for WindowBuilder / transition), but a non-null parent is the
+	 *               whole point — pass one.
+	 * @param title  window title (also the default menu description)
+	 */
+	public LWChildDialog(LWContainerHandle parent, String title) {
+		super(parent != null ? parent.getWindow() : null, title, ModalityType.MODELESS);
+		lwManager = new LWManager(parent, this);
+		traits = new LWTraits(InitialPosition.STAGGERED_ON_PARENT);
+		if (parent != null) {
+			parent.manage(this);
+			LWContainerHandle.stagger(parent.getWindow(), this);
+		}
+		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+	}
+
+	public LWChildDialog(LWContainerHandle parent) {
+		this(parent, null);
+	}
+
+	@Override
+	public Window getWindow() {
+		return this;
+	}
+
+	@Override
+	public Iterator<LWHandle> iterator() {
+		return lwManager.visible();
+	}
+
+	@Override
+	public void manage(LWHandle child) {
+		lwManager.manage(this, child);
+	}
+
+	@Override
+	public LWModality getLWModality() {
+		return LWModality.MODELESS;
+	}
+
+	@Override
+	public LWContainerHandle getlwParent() {
+		return lwManager.getLwParent();
+	}
+
+	@Override
+	public void closeRecursively() {
+		lwManager.closeRecursively();
+	}
+
+	@Override
+	public void unIconify() {
+		// a JDialog cannot be iconified; no-op (mirrors LWDialog)
+	}
+
+	@Override
+	public JMenuItem menuItem(int level) {
+		return LWMenuItemFactory.menuFor(level, this);
+	}
+
+	@Override
+	public LWTraits getTraits() {
+		return traits;
+	}
+
+	/**
+	 * Default menu description is the window title. Subclasses may override.
+	 */
+	@Override
+	public String menuDescription() {
+		String t = getTitle();
+		return (t != null) ? t : "";
+	}
+
+	@Override
+	public Window self() {
+		return this;
+	}
+}


### PR DESCRIPTION
## Owned modeless child windows — systemic z-order fix

Implements `docs/windowing-design-patterns.md` §7.4 (merged in #1762): move modeless child windows off the fragile **un-owned `JFrame` + `Window.toFront()`** path onto a **native owned-window** relationship the OS enforces.

### Why
A `JFrame` cannot have an owner in AWT, so `LWChildFrame` could only be kept above its parent by a best-effort `toFront()` — which modern **macOS** (13.3+/Sonoma cooperative activation) and **Windows** (foreground lock) refuse for a non-foreground app. An owned window is kept above its owner **by the OS itself**. (Full platform analysis + JDK bug IDs in §7.)

### What
1. **`LWChildDialog`** (new) — the owned counterpart to `LWChildFrame`: an owned modeless `JDialog` (parent's window as native owner + `MODELESS`), implementing `LWContainerHandle`/`LWFrameOrDialog` and registering with `LWManager` identically. No `toFront()` dependence.
2. **`ChildWindowManager.ModelessChild` → `LWChildDialog`** — the systemic fix. Every `MODELESS` child created via `addChildWindow(...)` is now owned. This is the high-leverage change: it covers the general child-window path, not a single window.
3. **`AddAnnotationsPanel`** — a specific P1 audit violation (raw un-owned `JFrame` with a tell-tale commented-out `setAlwaysOnTop`) converted to extend `LWChildDialog` as a concrete example.

### Why it's safe
- `ChildWindow` drives `impl` purely through the `LWFrameOrDialog` interface — no `Frame` cast.
- The **modal** sibling `ParentModalChild` already extends an owned `JDialog` (`LWTitledDialog`) and works in this exact machinery — this just extends the proven pattern to the modeless case.
- Close/re-open is handled by the `windowClosing` listener (`closeChildWindow` → dispose + remove), independent of the default close operation.
- `vcell-client` compiles (BUILD SUCCESS).

### Trade-off (ratified by maintainer)
Owned windows have **no independent taskbar button** and travel with their owner under Spaces / Stage Manager / Snap / virtual desktops. For child editors/viewers that logically belong to a document window, that is the desired behavior.

### Verification note
Runtime z-order can only be confirmed interactively on macOS/Windows (the initiative's headless-observation crux). Compilation + the structural argument above are what CI can check.

### Follow-ups (not in this PR)
- `VcellHelpViewer` (P1) is a *global* help window, a poor fit for owned-child — it should become an `LWTopFrame` (LW-tracked top-level) instead. Separate change.
- The six orphan-`JDialog`+`alwaysOnTop` dialogs and null-parent `JOptionPane` sites (§6 P1/P2) are `DialogUtils`-routing fixes, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
