### PR TITLE
windowing: standalone Help window → LWTopFrame (was un-owned JFrame)

### DIFF
--- a/vcell-client/src/main/java/org/vcell/documentation/VcellHelpViewer.java
+++ b/vcell-client/src/main/java/org/vcell/documentation/VcellHelpViewer.java
@@ -23,9 +23,9 @@ import javax.help.HelpSet;
 import javax.help.JHelp;
 import javax.help.Map.ID;
 import javax.swing.JButton;
-import javax.swing.JFrame;
 import javax.swing.JPanel;
 
+import org.vcell.client.logicalwindow.LWTopFrame;
 import org.vcell.util.gui.GeneralGuiUtils;
 import org.vcell.util.document.VCellSoftwareVersion;
 
@@ -54,7 +54,26 @@ public class VcellHelpViewer extends JPanel {
     /**
      * reusable reference to viewer; allows garbage (if not visible)
      */
-    private static WeakReference<JFrame> standaloneRef = null;
+    private static WeakReference<LWTopFrame> standaloneRef = null;
+
+    /**
+     * issue: window z-order. The standalone Help window is a top-level, document-independent window,
+     * so it is an {@link LWTopFrame} (a tracked LW root that appears in the "Window" menu and is
+     * brought to front on open) rather than a raw, un-owned {@code JFrame} that could hide behind the
+     * desktop. It is intentionally NOT an owned child window — global Help must outlive any single
+     * document window. See {@code docs/windowing-design-patterns.md}.
+     */
+    @SuppressWarnings("serial")
+    private static class VcellHelpWindow extends LWTopFrame {
+        private VcellHelpWindow(String title) {
+            super();
+            setTitle(title);
+        }
+        @Override
+        public String menuDescription() {
+            return getTitle();
+        }
+    }
 
     public void setCloseMyParent(ChildWindow closeableWindow) {
         this.closeableWindow = closeableWindow;
@@ -112,10 +131,10 @@ public class VcellHelpViewer extends JPanel {
     }
 
     public static void showStandaloneViewer() {
-        JFrame frame = standaloneRef != null ? standaloneRef.get() : null;
+        LWTopFrame frame = standaloneRef != null ? standaloneRef.get() : null;
         if (frame == null) {
             VcellHelpViewer helpViewer = new VcellHelpViewer(VcellHelpViewer.VCELL_DOC_URL);
-            frame = new JFrame("Virtual Cell Help");
+            frame = new VcellHelpWindow("Virtual Cell Help");
             String title = "Virtual Cell Help" + " -- VCell " + VCellSoftwareVersion.fromSystemProperty().getSoftwareVersionString();
             frame.setTitle(title);
             frame.setPreferredSize(new Dimension(VcellHelpViewer.DEFAULT_HELP_DIALOG_WIDTH, VcellHelpViewer.DEFAULT_HELP_DIALOG_HEIGHT));


### PR DESCRIPTION
## Summary

Audit **P1** fix from `docs/windowing-design-patterns.md` §6. `VcellHelpViewer.showStandaloneViewer()` built the Help window as a raw `new JFrame("Virtual Cell Help")` — an un-owned, LW-untracked top-level that could hide behind the desktop and never appeared in the "Window" menu.

## Change
- The standalone Help window is now a small `LWTopFrame` subclass (`VcellHelpWindow`): a tracked LW **root** that registers in the top-level list, shows up in the Window menu, and is brought to front on open.
- `standaloneRef` retyped `WeakReference<LWTopFrame>`; the raw `JFrame` import removed.

## Why LWTopFrame and not an owned child
Deliberate: the global Help window must **outlive any single document window**, so owning it to one `DocumentWindow` (the #1763 owned-child pattern) would be wrong. It should be a **peer** of the document windows — exactly what `LWTopFrame` provides.

Compiles (`vcell-client` BUILD SUCCESS). Callers unchanged (`DocumentWindow`, `GeometrySubVolumePanel` still call the static `showStandaloneViewer()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)