### PR TITLE
windowing: route six orphan-JDialog+alwaysOnTop dialogs through DialogUtils

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/ClientRequestManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ClientRequestManager.java
@@ -355,21 +355,18 @@ public class ClientRequestManager
 		}
 		// warn if necessary
 		if (isChanged) {
-			JDialog dialog = new JDialog();
-			dialog.setAlwaysOnTop(true);
-			final String[] warnCloseArr = new String[] { UserMessage.OPTION_YES, "No", UserMessage.OPTION_CANCEL };
-			int confirm = JOptionPane.showOptionDialog(dialog, UserMessage.warn_close.getMessage(null),
-					"Save warning...", JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, warnCloseArr,
-					warnCloseArr[0]);
-
-//		String choice = PopupGenerator.showWarningDialog(windowManager, getUserPreferences(), UserMessage.warn_close,null);
-			if (confirm != 0 && confirm != 1/* choice.equals(UserMessage.OPTION_CANCEL) */) {
-				// user canceled
-				return CloseOption.CANCEL_CLOSE;
-			}
-			if (confirm == 0/* choice.equals(UserMessage.OPTION_YES) */) {
+			// logical-window-owned warning dialog (restores the original PopupGenerator path; the interim
+			// throw-away always-on-top JDialog could hide behind the document window). warn_close options
+			// are [Yes, No, Cancel], default Yes.
+			String confirm = PopupGenerator.showWarningDialog(windowManager, getUserPreferences(), UserMessage.warn_close, null);
+			if (UserMessage.OPTION_YES.equals(confirm)) {
 				return CloseOption.SAVE_AND_CLOSE;
 			}
+			if (!UserMessage.OPTION_NO.equals(confirm)) {
+				// Cancel, or dialog dismissed → do not close
+				return CloseOption.CANCEL_CLOSE;
+			}
+			// OPTION_NO → close without saving (falls through to CLOSE_IN_ANY_CASE)
 		}
 		// nothing changed, or user confirmed, close it
 		return CloseOption.CLOSE_IN_ANY_CASE;
@@ -481,10 +478,7 @@ public class ClientRequestManager
 
 				if (((DocumentWindowManager) windowManager).getUser() == null
 						|| User.isGuest(((DocumentWindowManager) windowManager).getUser().getName())) {
-					JDialog dialog = new JDialog();
-					dialog.setAlwaysOnTop(true);
-					JOptionPane.showMessageDialog(dialog, User.createGuestErrorMessage("saveDocument"), "Error...",
-							JOptionPane.ERROR_MESSAGE, null);
+					DialogUtils.showErrorDialog(windowManager.getComponent(), User.createGuestErrorMessage("saveDocument"));
 					return false;
 				}
 
@@ -658,8 +652,6 @@ public class ClientRequestManager
 
 
 	public void logOut(final TopLevelWindowManager requester){
-		JDialog dialog = new JDialog();
-		dialog.setAlwaysOnTop(true);
 		StringBuilder dialogMessage = new StringBuilder();
 		dialogMessage.append("You are about to log out of the VCell client.\n\n");
 		if (requester instanceof DocumentWindowManager documentWindowManager){
@@ -674,10 +666,10 @@ public class ClientRequestManager
 		}
 		dialogMessage.append("Do you wish to continue?");
 
-		int confirm = JOptionPane.showOptionDialog(dialog, dialogMessage.toString(),
-				"Logout", JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
+		// logical-window-owned confirm dialog instead of a throw-away always-on-top JDialog
+		String confirm = DialogUtils.showWarningDialog(requester.getComponent(), "Logout", dialogMessage.toString(),
 				new String[] { "Continue", "Cancel" }, "Continue");
-		if (confirm == JOptionPane.OK_OPTION)  {
+		if ("Continue".equals(confirm))  {
 			closeAllWindows(false);
 			getClientServerManager().cleanup(); //set VCell connection to null
 			getClientServerManager().getAsynchMessageManager().stopPolling();

--- a/vcell-client/src/main/java/cbit/vcell/client/VCellGuiInteractiveContext.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/VCellGuiInteractiveContext.java
@@ -1,7 +1,6 @@
 package cbit.vcell.client;
 
-import javax.swing.JDialog;
-import javax.swing.JOptionPane;
+import org.vcell.util.gui.DialogUtils;
 
 import cbit.vcell.client.server.InteractiveClientServerContext;
 
@@ -17,16 +16,14 @@ public class VCellGuiInteractiveContext implements InteractiveClientServerContex
 
 	@Override
 	public void showErrorDialog(String errorMessage) {
-		JDialog dialog = new JDialog();
-		dialog.setAlwaysOnTop(true);
-		JOptionPane.showMessageDialog(dialog, errorMessage, "Error...", JOptionPane.ERROR_MESSAGE, null);
+		// route through DialogUtils so the dialog is owned by the logical window (see showConnectWarning
+		// below, which already does this) instead of a throw-away always-on-top JDialog.
+		DialogUtils.showErrorDialog(topLevelWindowManager.getComponent(), errorMessage);
 	}
 
 	@Override
 	public void showWarningDialog(String warningMessage) {
-		JDialog dialog = new JDialog();
-		dialog.setAlwaysOnTop(true);
-		JOptionPane.showMessageDialog(dialog, warningMessage, "Warning...", JOptionPane.WARNING_MESSAGE, null);
+		DialogUtils.showWarningDialog(topLevelWindowManager.getComponent(), warningMessage);
 	}
 
 	@Override

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SolverTaskDescriptionAdvancedPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SolverTaskDescriptionAdvancedPanel.java
@@ -107,14 +107,14 @@ public class SolverTaskDescriptionAdvancedPanel extends javax.swing.JPanel {
 			} else if (e.getSource() == sensitivityAnalysisHelpButton) {
 				showSensitivityAnalysisHelp();
 			} else if (e.getSource() == timeoutDisabledHelpButton) {
-				JDialog dialog = new JDialog();
-				dialog.setAlwaysOnTop(true);
-				JOptionPane.showMessageDialog(dialog, "By default, Simulations running for 21 days are automatically terminated.\nThe reason for "
+				DialogUtils.showInfoDialog(SolverTaskDescriptionAdvancedPanel.this,
+						"Disable forced timeout for very long Simulations",
+						"By default, Simulations running for 21 days are automatically terminated.\nThe reason for "
 						+ "this is to free hardware resources locked by long forgotten / crashed simulations in a "
 						+ "consistent manner.\n"
 						+ "However, we are allowing our power users to bypass this rule and allow very long simulations "
 						+ "to run indefinitely.\nIf you need to run such a simulation, please contact us at vcell_support@uchc.edu "
-						+ "to be added to the power user list.", "Disable forced timeout for very long Simulations", JOptionPane.PLAIN_MESSAGE, null);
+						+ "to be added to the power user list.");
 			}
 		}
 


### PR DESCRIPTION
## Summary

Audit **P1** fix from `docs/windowing-design-patterns.md` §6. Six dialogs were built on a throw-away `new JDialog()` + `setAlwaysOnTop(true)` used only as a `JOptionPane` owner — the highest-signal anti-pattern (mis-parented *and* always-on-top over every app). Each now routes through the logical-window-aware `DialogUtils`/`PopupGenerator` path, parented to the real component.

## Sites
- **`VCellGuiInteractiveContext`** `showErrorDialog` / `showWarningDialog` → `DialogUtils.showErrorDialog/showWarningDialog(topLevelWindowManager.getComponent(), …)` — mirrors the sibling `showConnectWarning`, which already resolved the LW owner.
- **`SolverTaskDescriptionAdvancedPanel`** timeout-help → `DialogUtils.showInfoDialog(this, …)`.
- **`ClientRequestManager`** guest-save error → `DialogUtils.showErrorDialog(windowManager.getComponent(), …)`.
- **`ClientRequestManager`** close/save warning → restores the original `PopupGenerator.showWarningDialog(windowManager, prefs, UserMessage.warn_close, null)` (still present commented-out). **Return mapping preserved exactly:** Yes→`SAVE_AND_CLOSE`, No→`CLOSE_IN_ANY_CASE`, Cancel/dismissed→`CANCEL_CLOSE` (defaults to *not* closing on any ambiguity — no risk of losing unsaved changes).
- **`ClientRequestManager`** logout confirm → `DialogUtils.showWarningDialog(requester.getComponent(), "Logout", …, {Continue,Cancel}, Continue)`; proceeds only on `"Continue"`.

## Safety
No behavior change beyond parenting. The two control-flow dialogs (close-with-unsaved-changes, logout) preserve exact semantics via null-safe string comparisons. `vcell-client` BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)