### PR TITLE
windowing: fix remaining null-parent dialogs (QuickFixSimulation P1 + table-model P2)

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/QuickFixSimulation.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/QuickFixSimulation.java
@@ -2,7 +2,6 @@ package cbit.vcell.client.desktop;
 
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
-import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -11,11 +10,12 @@ import java.util.Collection;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
-import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 
+import org.vcell.client.logicalwindow.LWContainerHandle;
+import org.vcell.client.logicalwindow.LWTitledDialog;
 import org.vcell.util.VCAssert;
 import org.vcell.util.gui.MomentoButton;
 import org.vcell.util.gui.MomentoRadioButton;
@@ -28,7 +28,7 @@ import cbit.vcell.solver.SolverDescription;
  *
  */
 @SuppressWarnings("serial")
-public class QuickFixSimulation extends JDialog {
+public class QuickFixSimulation extends LWTitledDialog {
 
 	public enum CloseAction {
 		FIX_ALL("Fix All"),
@@ -64,14 +64,14 @@ public class QuickFixSimulation extends JDialog {
 
 	/**
 	 * Create the dialog.
-	 * @param activated parent 
+	 * @param lwParent logical owner (must be non-null so the modal dialog is never orphaned)
 	 * @param useFixAll should "fix all" button appear?
 	 * @param message what to say about the situation
 	 * @param goodSolvers  options to list / select
 	 */
-	public QuickFixSimulation(Window activated, boolean useFixAll, String message, Collection<SolverDescription> goodSolvers) {
-		super(activated);
-		setModalityType(ModalityType.DOCUMENT_MODAL);
+	public QuickFixSimulation(LWContainerHandle lwParent, boolean useFixAll, String message, Collection<SolverDescription> goodSolvers) {
+		// LWTitledDialog is DOCUMENT_MODAL and owned by lwParent; no more super((Window)null) orphan path.
+		super(lwParent, "Unsupported Solver");
 		selectedSolver = null;
 		closeAction = CloseAction.CANCEL; 
 		

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/VCDocumentDecorator.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/VCDocumentDecorator.java
@@ -1,6 +1,7 @@
 package cbit.vcell.client.desktop;
 
 import java.awt.Window;
+import java.lang.ref.WeakReference;
 import java.beans.PropertyVetoException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -12,6 +13,9 @@ import java.util.Set;
 import org.vcell.util.*;
 import org.vcell.util.Issue.IssueCategory;
 import org.vcell.util.document.VCDocument;
+import org.vcell.client.logicalwindow.LWContainerHandle;
+import org.vcell.client.logicalwindow.LWNamespace;
+import org.vcell.client.logicalwindow.LWTopFrame;
 
 import cbit.vcell.biomodel.BioModel;
 import cbit.vcell.client.desktop.QuickFixSimulation.CloseAction;
@@ -283,7 +287,14 @@ public abstract class VCDocumentDecorator {
 			}
 			if (goodSolvers.size() > 0) {
 				final boolean useFixAll = siblings.size() > 1;
-				QuickFixSimulation qfs = new QuickFixSimulation(activated,useFixAll,
+				// resolve a non-null logical owner so the modal dialog is never orphaned; activated may be
+				// null (e.g. a MathModel simulation), in which case fall back to the current top-level window.
+				LWContainerHandle lwParent = LWNamespace.findLWOwner(activated);
+				if (lwParent == null) {
+					lwParent = LWTopFrame.liveWindows().map(WeakReference::get)
+							.filter(Objects::nonNull).findFirst().orElse(null);
+				}
+				QuickFixSimulation qfs = new QuickFixSimulation(lwParent,useFixAll,
 						currentSolver + " does not support current model. Please select one of the following solvers:",
 						goodSolvers);
 				qfs.setVisible(true);

--- a/vcell-client/src/main/java/cbit/vcell/export/gui/N5SettingsPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/export/gui/N5SettingsPanel.java
@@ -1,6 +1,7 @@
 package cbit.vcell.export.gui;
 
 import cbit.vcell.export.server.*;
+import org.vcell.util.gui.DialogUtils;
 
 import javax.swing.*;
 import java.awt.*;
@@ -60,7 +61,7 @@ public class N5SettingsPanel extends javax.swing.JPanel implements java.awt.even
         boolean onlySpaces = dataSetName.matches("^\\s*$");
         boolean notAllowedName = dataSetName.isEmpty() || onlySpaces || !allowedCharacters || dataSetName.length() > 100;
         if (fieldASCIISettingsPanelListenerEventMulticaster == null || notAllowedName) {
-            JOptionPane.showMessageDialog(null, "N5 File Name contains characters not allowed. A-Z, 0-9, [] , () , : , _ ,- are allowed.", "Naming Error", JOptionPane.INFORMATION_MESSAGE);
+            DialogUtils.showInfoDialog(this, "Naming Error", "N5 File Name contains characters not allowed. A-Z, 0-9, [] , () , : , _ ,- are allowed.");
             return;
         };
         fieldASCIISettingsPanelListenerEventMulticaster.JButtonOKAction_actionPerformed(newEvent);

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/LinkSpecsTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/LinkSpecsTableModel.java
@@ -8,6 +8,7 @@ import cbit.vcell.model.Structure;
 import cbit.vcell.parser.Expression;
 import org.vcell.model.rbm.*;
 import org.vcell.util.Coordinate;
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.GuiUtils;
 import org.vcell.util.gui.ScrollTable;
 import org.vcell.util.springsalad.NamedColor;
@@ -106,7 +107,7 @@ public class LinkSpecsTableModel extends VCellSortTableModel<MolecularInternalLi
                     try {
                         res = Double.parseDouble(newExpressionString);
                     } catch(NumberFormatException ex) {
-                        JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
+                        DialogUtils.showErrorDialog(ownerTable, "Number expected");
                         return;
                     }
                     // the link is a derived value, we don't store it - we just show it in the table

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/MolecularTypeSpecsTableModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/MolecularTypeSpecsTableModel.java
@@ -222,7 +222,7 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<LinkNode> 
 				try {
 					res = Double.parseDouble(newExpressionString);
 				} catch(NumberFormatException e) {
-					JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
+					DialogUtils.showErrorDialog(ownerTable, "Number expected");
 					return;
 				}
 				Coordinate c = sas.getCoordinate();
@@ -243,7 +243,7 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<LinkNode> 
 				try {
 					res = Double.parseDouble(newExpressionString);
 				} catch(NumberFormatException e) {
-					JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
+					DialogUtils.showErrorDialog(ownerTable, "Number expected");
 					return;
 				}
 				Coordinate c = sas.getCoordinate();
@@ -263,7 +263,7 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<LinkNode> 
 				try {
 					res = Double.parseDouble(newExpressionString);
 				} catch(NumberFormatException ex) {
-					JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
+					DialogUtils.showErrorDialog(ownerTable, "Number expected");
 //					DialogUtils.showErrorDialog(ownerTable.getParent(), "Number expected");
 //					SwingUtilities.invokeLater(new Runnable() {
 //						public void run() {
@@ -292,11 +292,11 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<LinkNode> 
 				try {
 					res = Double.parseDouble(newExpressionString);
 				} catch(NumberFormatException ex) {
-					JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
+					DialogUtils.showErrorDialog(ownerTable, "Number expected");
 					return;
 				}
 				if(res <= 0.0) {
-					JOptionPane.showMessageDialog(null, "Site radius must be a positive number", "Error", JOptionPane.ERROR_MESSAGE);
+					DialogUtils.showErrorDialog(ownerTable, "Site radius must be a positive number");
 					return;
 				}
 				if(sas == null) {
@@ -312,11 +312,11 @@ public class MolecularTypeSpecsTableModel extends VCellSortTableModel<LinkNode> 
 				try {
 					res = Double.parseDouble(newExpressionString);
 				} catch(NumberFormatException ex) {
-					JOptionPane.showMessageDialog(null, "Number expected", "Error", JOptionPane.ERROR_MESSAGE);
+					DialogUtils.showErrorDialog(ownerTable, "Number expected");
 					return;
 				}
 				if(res <= 0.0) {
-					JOptionPane.showMessageDialog(null, "Site diffusion coefficient must be a positive number", "Error", JOptionPane.ERROR_MESSAGE);
+					DialogUtils.showErrorDialog(ownerTable, "Site diffusion coefficient must be a positive number");
 					return;
 				}
 				if(sas == null) {


### PR DESCRIPTION
## Summary

Remaining audit fixes from `docs/windowing-design-patterns.md` §6.

### P1 — QuickFixSimulation
The unsupported-solver quick-fix dialog extended `JDialog` and did `super(activated)` where `activated` could be **null** (e.g. a MathModel simulation) → an orphaned modal dialog. Now:
- `QuickFixSimulation extends LWTitledDialog` (owned, `DOCUMENT_MODAL`, LW-tracked).
- The `VCDocumentDecorator` call site resolves a **non-null** owner: `findLWOwner(activated)`, falling back to the current top-level `LWTopFrame` when `activated` is null.
- Close-action control flow (`getCloseAction`/`getSelectedSolver`) unchanged.

### P2 — null-parent `JOptionPane` validation dialogs → `DialogUtils`
- `MolecularTypeSpecsTableModel` (×7) and `LinkSpecsTableModel` (×1): the table models already hold `ownerTable` → `DialogUtils.showErrorDialog(ownerTable, msg)` (matches the commented-out intended fix already present in `MolecularTypeSpecsTableModel`).
- `N5SettingsPanel`: `DialogUtils.showInfoDialog(this, "Naming Error", msg)`.

### Deliberately left as-is
`ClientLogin` (×3) and `VCellClientMain` (×2) run at **login/startup/fatal** time when no window exists yet — `null` parent is correct there, and threading a parent through startup adds risk with no z-order benefit (audit rated LOW).

Compiles (`vcell-client` BUILD SUCCESS). No behavior change beyond parenting.

With this, the §6 **P1 list is cleared** and the meaningful **P2** items are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)