### PR TITLE
windowing P4: migrate showMessageDialog to DialogUtils + retire JDiagAdapter

### DIFF
--- a/vcell-client/src/main/java/cbit/plot/gui/ClusterDataPanel.java
+++ b/vcell-client/src/main/java/cbit/plot/gui/ClusterDataPanel.java
@@ -12,6 +12,7 @@ import cbit.vcell.solver.ode.gui.ClusterSpecificationPanel;
 import cbit.vcell.util.ColumnDescription;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.NonEditableDefaultTableModel;
 import org.vcell.util.gui.ScrollTable;
 import org.vcell.util.gui.SpecialtyTableRenderer;
@@ -230,12 +231,7 @@ public class ClusterDataPanel extends AbstractDataPanel {
 
         } catch (Exception ex) {
             lg.error("Error copying cluster data", ex);
-            JOptionPane.showMessageDialog(
-                    this,
-                    "Error copying cluster data: " + ex.getMessage(),
-                    "Copy Error",
-                    JOptionPane.ERROR_MESSAGE
-            );
+            DialogUtils.showErrorDialog(this, "Error copying cluster data: " + ex.getMessage());
         }
     }
 

--- a/vcell-client/src/main/java/cbit/plot/gui/MoleculeDataPanel.java
+++ b/vcell-client/src/main/java/cbit/plot/gui/MoleculeDataPanel.java
@@ -17,6 +17,7 @@ import cbit.vcell.solver.ode.gui.MoleculeVisualizationPanel;
 import cbit.vcell.util.ColumnDescription;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.NonEditableDefaultTableModel;
 import org.vcell.util.gui.ScrollTable;
 
@@ -359,12 +360,7 @@ public class MoleculeDataPanel extends AbstractDataPanel {
 
         } catch (Exception ex) {
             lg.error("Error copying cluster data", ex);
-            JOptionPane.showMessageDialog(
-                    this,
-                    "Error copying cluster data: " + ex.getMessage(),
-                    "Copy Error",
-                    JOptionPane.ERROR_MESSAGE
-            );
+            DialogUtils.showErrorDialog(this, "Error copying cluster data: " + ex.getMessage());
         }
     }
 

--- a/vcell-client/src/main/java/cbit/vcell/client/ChildWindowManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ChildWindowManager.java
@@ -100,72 +100,26 @@ public class ChildWindowManager {
 	}
 	
 	/**
-	 * transition dialog for hierarchies without logicalwindow parents 
-	 */
-	@SuppressWarnings("serial")
-	private static class JDiagAdapter extends JDialog implements LWFrameOrDialog {
-		private final LWTraits traits;
-
-		private JDiagAdapter(Window owner, String title, ModalityType modalityType, LWTraits tr) {
-			super(owner, title, modalityType);
-			traits = tr; 
-		}
-		
-
-		@Override
-		public LWTraits getTraits() {
-			return traits;
-		}
-
-
-		@Override
-		public LWModality getLWModality() {
-			ModalityType smt = getModalityType( );
-			switch (smt) {
-			case MODELESS:
-				return LWModality.MODELESS;
-			case DOCUMENT_MODAL:
-				return LWModality.PARENT_ONLY;
-			default:
-				if (LG.isDebugEnabled()) {
-					LG.warn(ExecutionTrace.justClassName(this) + " titled " + getTitle() + 
-							" using unsupported modality "  + smt);
-				}
-				return LWModality.PARENT_ONLY;
-			}
-		}
-
-		@Override
-		public Window self() {
-			return this;
-		}
-	}
-	
-	/**
 	 * @param title not null
 	 * @param modality not null
 	 * @return implementing class
 	 */
 	private LWFrameOrDialog createContainerImplementation(String title,LWModality modality, boolean parentCentered) {
 		LWTraits traits = parentCentered ? new LWTraits(InitialPosition.CENTERED_ON_PARENT) : new LWTraits(InitialPosition.STAGGERED_ON_PARENT);
-		if (owner != null) {
-			switch (modality) {
-			case MODELESS:
-				return new ModelessChild(this,owner, title,traits);
-			case PARENT_ONLY:
-				return new ParentModalChild(this,owner, title,traits);
-			}
+		if (owner == null) {
+			// every ChildWindowManager host is an LWTopFrame, so findLWOwner(parent) always resolves an
+			// owner. A null owner would mean a non-LW host was introduced — fail loudly rather than fall
+			// back to an un-owned dialog (the retired JDiagAdapter transition path).
+			throw new IllegalStateException("ChildWindowManager has no logical-window owner for parent " + parent
+					+ "; the host frame must extend LWTopFrame");
 		}
-		else { //remove eventually
-			switch (modality) {
-			case MODELESS:
-				return new JDiagAdapter(parent, title, ModalityType.MODELESS,traits);
-			case PARENT_ONLY:
-				return new JDiagAdapter(parent, title, ModalityType.DOCUMENT_MODAL,traits);
-			}
-		}		
-		//this shouldn't happen
-		throw new UnsupportedOperationException("Modality " + modality + " no supported");
+		switch (modality) {
+		case MODELESS:
+			return new ModelessChild(this,owner, title,traits);
+		case PARENT_ONLY:
+			return new ParentModalChild(this,owner, title,traits);
+		}
+		throw new UnsupportedOperationException("Modality " + modality + " not supported");
 	}
 
 	public class ChildWindow {

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/simulation/SimulationEditor.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/simulation/SimulationEditor.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
+import org.vcell.util.gui.DialogUtils;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 
@@ -291,7 +292,7 @@ public void prepareToEdit(Simulation simulation, Component parent) throws Chombo
 		throw exc;
 	} catch (Throwable exc) {
 		exc.printStackTrace(System.out);
-		JOptionPane.showMessageDialog(this, "Could not initialize simulation editor\n"+exc.getMessage(), "Error:", JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this, "Could not initialize simulation editor\n"+exc.getMessage());
 	}
 }
 

--- a/vcell-client/src/main/java/cbit/vcell/desktop/BioModelDbTreePanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/desktop/BioModelDbTreePanel.java
@@ -19,6 +19,7 @@ import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
+import org.vcell.util.gui.DialogUtils;
 import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.JTree;
@@ -368,7 +369,7 @@ private BioModelInfo[] getBioModelVersionDates(BioModelInfo thisBioModelInfo) th
  	}
 
  	if (bioModelBranchList.size() == 0) {
-		JOptionPane.showMessageDialog(this,"No Versions in biomodel","Error comparing BioModels",JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this,"No Versions in biomodel");
 	 	throw new NullPointerException("No Versions in biomodel!");
  	}
 

--- a/vcell-client/src/main/java/cbit/vcell/desktop/MathModelDbTreePanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/desktop/MathModelDbTreePanel.java
@@ -17,6 +17,7 @@ import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
+import org.vcell.util.gui.DialogUtils;
 import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.JTree;
@@ -614,7 +615,7 @@ private MathModelInfo[] getMathModelVersionDates(MathModelInfo thisMathModelInfo
  	}
 
  	if (mathModelBranchList.size() == 0) {
-		JOptionPane.showMessageDialog(this,"No Versions in Mathmodel","Error comparing MathModels",JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this,"No Versions in Mathmodel");
 	 	throw new NullPointerException("No Versions in Mathmodel!");
  	}
 

--- a/vcell-client/src/main/java/cbit/vcell/geometry/gui/GeometrySizeDialog.java
+++ b/vcell-client/src/main/java/cbit/vcell/geometry/gui/GeometrySizeDialog.java
@@ -22,6 +22,7 @@ import javax.swing.JPanel;
 
 import org.vcell.util.Extent;
 import org.vcell.util.Origin;
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.GuiUtils;
 
 import cbit.vcell.client.PopupGenerator;
@@ -657,7 +658,7 @@ private void handleException(Throwable exception) {
 	System.out.println("--------- UNCAUGHT EXCEPTION in GeometrySizeDialog ---------");
 	exception.printStackTrace(System.out);
 	if (exception instanceof PropertyVetoException){
-		javax.swing.JOptionPane.showMessageDialog(this, exception.getMessage(), "input error", javax.swing.JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this, exception.getMessage());
 	}
 }
 /**

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/DataSymbolsPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/DataSymbolsPanel.java
@@ -239,7 +239,7 @@ private void addVFrapOriginalImages() {		// add dataset (normal images) from vFr
 			
 			String initialFieldDataName = (String)hashTable.get("initialFieldDataName");
 			if(initialFieldDataName.equals("")) {
-				JOptionPane.showMessageDialog(DataSymbolsPanel.this, "Field Data name " + initialFieldDataName + " already in use."); 					
+				DialogUtils.showInfoDialog(DataSymbolsPanel.this, "Field Data name " + initialFieldDataName + " already in use."); 					
 				// prevents the rest of tasks below from running
 				throw UserCancelException.CANCEL_GENERIC;
 			}
@@ -446,7 +446,7 @@ private void addVFrapDerivedImages() {		// add special (computed) images from vF
 			
 			String mixedFieldDataName = (String)hashTable.get("mixedFieldDataName");
 			if(mixedFieldDataName.equals("")) {
-				JOptionPane.showMessageDialog(DataSymbolsPanel.this, "Field Data name " + mixedFieldDataName + " already in use."); 					
+				DialogUtils.showInfoDialog(DataSymbolsPanel.this, "Field Data name " + mixedFieldDataName + " already in use."); 					
 				// prevents the rest of tasks below from running
 				throw UserCancelException.CANCEL_GENERIC;
 			}

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/DataSymbolsSpecPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/DataSymbolsSpecPanel.java
@@ -30,6 +30,7 @@ import cbit.vcell.data.DataSymbol;
 import cbit.vcell.data.DataSymbol.DataSymbolType;
 import cbit.vcell.export.gui.ExportMonitorPanel;
 import cbit.vcell.parser.ExpressionException;
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.GeneralGuiUtils;
 
 @SuppressWarnings("serial")
@@ -111,7 +112,7 @@ private ImagePlaneManagerPanel getImagePlaneManagerPanel() {
 private void handleException(Throwable exception) {
 	/* Uncomment the following lines to print uncaught exceptions to stdout */
 	if (exception instanceof ExpressionException){
-		javax.swing.JOptionPane.showMessageDialog(this, exception.getMessage(), "Error", javax.swing.JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this, exception.getMessage());
 	}
 	System.out.println("--------- UNCAUGHT EXCEPTION --------- in DataSymbolsSpecPanel");
 	exception.printStackTrace(System.out);

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/MolecularStructuresPropertiesPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/MolecularStructuresPropertiesPanel.java
@@ -16,6 +16,7 @@ import cbit.vcell.parser.ExpressionException;
 import org.vcell.model.rbm.LinkNode;
 import org.vcell.model.rbm.MolecularComponentPattern;
 import org.vcell.model.rbm.MolecularTypePattern;
+import org.vcell.util.gui.DialogUtils;
 
 import javax.swing.*;
 import java.awt.*;
@@ -118,7 +119,7 @@ public class MolecularStructuresPropertiesPanel extends DocumentEditorSubPanel {
     private void handleException(Throwable exception) {
         /* Uncomment the following lines to print uncaught exceptions to stdout */
         if (exception instanceof ExpressionException){
-            javax.swing.JOptionPane.showMessageDialog(this, exception.getMessage(), "Error", javax.swing.JOptionPane.ERROR_MESSAGE);
+            DialogUtils.showErrorDialog(this, exception.getMessage());
         }
         System.out.println("--------- UNCAUGHT EXCEPTION --------- in SpeciesContextSpecPanel");
         exception.printStackTrace(System.out);

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/ReactionRuleSpecPropertiesPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/ReactionRuleSpecPropertiesPanel.java
@@ -36,6 +36,7 @@ import javax.swing.JSplitPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.ScrollTable;
 
 import cbit.vcell.biomodel.BioModel;
@@ -101,7 +102,7 @@ private void handleException(Throwable exception) {
 
 	/* Uncomment the following lines to print uncaught exceptions to stdout */
 	if (exception instanceof ExpressionException){
-		javax.swing.JOptionPane.showMessageDialog(this, exception.getMessage(), "Error", javax.swing.JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this, exception.getMessage());
 	}
 	System.out.println("--------- UNCAUGHT EXCEPTION --------- in SpeciesContextSpecPanel");
 	exception.printStackTrace(System.out);

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/SpatialObjectPropertyPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/SpatialObjectPropertyPanel.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import javax.swing.JCheckBox;
 import javax.swing.JPanel;
 
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.sorttable.JSortTable;
 
 import cbit.vcell.client.desktop.biomodel.DocumentEditorSubPanel;
@@ -77,7 +78,7 @@ private void handleException(Throwable exception) {
 
 	/* Uncomment the following lines to print uncaught exceptions to stdout */
 	if (exception instanceof ExpressionException){
-		javax.swing.JOptionPane.showMessageDialog(this, exception.getMessage(), "Error", javax.swing.JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this, exception.getMessage());
 	}
 	System.out.println("--------- UNCAUGHT EXCEPTION --------- in SpatialObjectPropertyPanel");
 	exception.printStackTrace(System.out);

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/SpatialProcessPropertyPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/SpatialProcessPropertyPanel.java
@@ -15,6 +15,7 @@ import java.awt.Color;
 
 import javax.swing.JPanel;
 
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.sorttable.JSortTable;
 
 import cbit.vcell.client.desktop.biomodel.DocumentEditorSubPanel;
@@ -52,7 +53,7 @@ private void handleException(Throwable exception) {
 
 	/* Uncomment the following lines to print uncaught exceptions to stdout */
 	if (exception instanceof ExpressionException){
-		javax.swing.JOptionPane.showMessageDialog(this, exception.getMessage(), "Error", javax.swing.JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this, exception.getMessage());
 	}
 	System.out.println("--------- UNCAUGHT EXCEPTION --------- in SpatialObjectPropertyPanel");
 	exception.printStackTrace(System.out);

--- a/vcell-client/src/main/java/cbit/vcell/mapping/gui/SpeciesContextSpecPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/mapping/gui/SpeciesContextSpecPanel.java
@@ -32,6 +32,7 @@ import cbit.vcell.mapping.SimulationContext;
 import org.vcell.model.rbm.MolecularComponentPattern;
 import org.vcell.model.rbm.MolecularTypePattern;
 import org.vcell.model.rbm.SpeciesPattern;
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.sorttable.JSortTable;
 
 import cbit.vcell.biomodel.BioModel;
@@ -115,7 +116,7 @@ private void handleException(Throwable exception) {
 
 	/* Uncomment the following lines to print uncaught exceptions to stdout */
 	if (exception instanceof ExpressionException){
-		javax.swing.JOptionPane.showMessageDialog(this, exception.getMessage(), "Error", javax.swing.JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this, exception.getMessage());
 	}
 	System.out.println("--------- UNCAUGHT EXCEPTION --------- in SpeciesContextSpecPanel");
 	exception.printStackTrace(System.out);

--- a/vcell-client/src/main/java/cbit/vcell/math/gui/MathDescEditor.java
+++ b/vcell-client/src/main/java/cbit/vcell/math/gui/MathDescEditor.java
@@ -31,6 +31,7 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JOptionPane;
+import org.vcell.util.gui.DialogUtils;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTextPane;
@@ -96,7 +97,7 @@ public void itemStateChanged(ItemEvent e) {
  * Comment
  */
 private void apply_ExceptionOccurred(java.lang.Throwable e) throws javax.swing.text.BadLocationException {
-	JOptionPane.showMessageDialog(this, e.getMessage(), "Error While Saving", JOptionPane.ERROR_MESSAGE);
+	DialogUtils.showErrorDialog(this, e.getMessage());
 	if (e instanceof MathFormatException){
 		int lineNumber = ((MathFormatException)e).getLineNumber();
 		if (lineNumber>=0){

--- a/vcell-client/src/main/java/cbit/vcell/microscopy/batchrun/gui/addFRAPdocWizard/CropDescriptor.java
+++ b/vcell-client/src/main/java/cbit/vcell/microscopy/batchrun/gui/addFRAPdocWizard/CropDescriptor.java
@@ -17,6 +17,8 @@ import java.util.Hashtable;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import org.vcell.util.gui.DialogUtils;
+
 import org.vcell.wizard.WizardPanelDescriptor;
 
 import cbit.vcell.client.task.AsynchClientTask;
@@ -93,7 +95,7 @@ public class CropDescriptor extends WizardPanelDescriptor {
 				if(VCellConfiguration.getValue(VFRAPPreference.ROI_ASSIST_REQUIREMENT_TYPE, VFRAPPreference.ROI_ASSIST_PREF_NOT_SET).equals(VFRAPPreference.ROI_ASSIST_PREF_NOT_SET))
 				{
 					DefineROI_RequireAssistPanel assistPanel = new DefineROI_RequireAssistPanel();
-					JOptionPane.showMessageDialog(imgPanel, assistPanel);
+					DialogUtils.showInfoDialog(imgPanel, assistPanel, "");
 					VCellConfiguration.putValue(VFRAPPreference.ROI_ASSIST_REQUIREMENT_TYPE, assistPanel.getRequireAssistType());
 					if(VCellConfiguration.getValue(VFRAPPreference.ROI_ASSIST_REQUIREMENT_TYPE, VFRAPPreference.ROI_ASSIST_REQUIRE_ALWAYS).equals(VFRAPPreference.ROI_ASSIST_REQUIRE_ALWAYS) &&
 						((BatchRunROIImgPanel)imgPanel).getBatchRunWorkspace().getWorkingFrapStudy().getFrapData().getRoi(FRAPData.VFRAP_ROI_ENUM.ROI_CELL.name()).getNonzeroPixelsCount()<1)

--- a/vcell-client/src/main/java/cbit/vcell/microscopy/gui/defineROIwizard/DefineROI_CropDescriptor.java
+++ b/vcell-client/src/main/java/cbit/vcell/microscopy/gui/defineROIwizard/DefineROI_CropDescriptor.java
@@ -17,6 +17,8 @@ import java.util.Hashtable;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import org.vcell.util.gui.DialogUtils;
+
 import org.vcell.wizard.WizardPanelDescriptor;
 
 import cbit.vcell.client.task.AsynchClientTask;
@@ -89,7 +91,7 @@ public class DefineROI_CropDescriptor extends WizardPanelDescriptor {
 				if(VCellConfiguration.getValue(VFRAPPreference.ROI_ASSIST_REQUIREMENT_TYPE, VFRAPPreference.ROI_ASSIST_PREF_NOT_SET).equals(VFRAPPreference.ROI_ASSIST_PREF_NOT_SET))
 				{
 					DefineROI_RequireAssistPanel assistPanel = new DefineROI_RequireAssistPanel();
-					JOptionPane.showMessageDialog(imgPanel, assistPanel);
+					DialogUtils.showInfoDialog(imgPanel, assistPanel, "");
 					VCellConfiguration.putValue(VFRAPPreference.ROI_ASSIST_REQUIREMENT_TYPE, assistPanel.getRequireAssistType());
 //					if(VFRAPPreference.getValue(VFRAPPreference.ROI_ASSIST_REQUIREMENT_TYPE, VFRAPPreference.ROI_ASSIST_REQUIRE_ALWAYS).equals(VFRAPPreference.ROI_ASSIST_REQUIRE_ALWAYS) &&
 //						((DefineROI_Panel)imgPanel).getFrapWorkspace().getWorkingFrapStudy().getFrapData().getRoi(FRAPData.VFRAP_ROI_ENUM.ROI_CELL.name()).getNonzeroPixelsCount()<1)

--- a/vcell-client/src/main/java/cbit/vcell/microscopy/gui/estparamwizard/EstParams_OneDiffComponentPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/microscopy/gui/estparamwizard/EstParams_OneDiffComponentPanel.java
@@ -148,7 +148,7 @@ public class EstParams_OneDiffComponentPanel extends JPanel {
 					getROIPanel().setCheckboxesForDisplay(frapWorkspace.getWorkingFrapStudy().getSelectedROIsForErrorCalculation());
 					getROIPanel().refreshROIImageForDisplay();
 				}
-				JOptionPane.showMessageDialog(EstParams_OneDiffComponentPanel.this, getROIPanel());
+				DialogUtils.showInfoDialog(EstParams_OneDiffComponentPanel.this, getROIPanel(), "");
 			}
 		});
 		showRoisButton.setFont(new Font("", Font.PLAIN, 11));

--- a/vcell-client/src/main/java/cbit/vcell/microscopy/gui/estparamwizard/EstParams_ReacBindingPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/microscopy/gui/estparamwizard/EstParams_ReacBindingPanel.java
@@ -145,7 +145,7 @@ public class EstParams_ReacBindingPanel extends JPanel {
 					getROIPanel().setCheckboxesForDisplay(frapWorkspace.getWorkingFrapStudy().getSelectedROIsForErrorCalculation());
 					getROIPanel().refreshROIImageForDisplay();
 				}
-				JOptionPane.showMessageDialog(EstParams_ReacBindingPanel.this, getROIPanel());
+				DialogUtils.showInfoDialog(EstParams_ReacBindingPanel.this, getROIPanel(), "");
 			}
 		});
 		showRoisButton.setText("Show ROIs");

--- a/vcell-client/src/main/java/cbit/vcell/microscopy/gui/estparamwizard/EstParams_ReactionOffRatePanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/microscopy/gui/estparamwizard/EstParams_ReactionOffRatePanel.java
@@ -150,7 +150,7 @@ public class EstParams_ReactionOffRatePanel extends JPanel
 					getROIPanel().setCheckboxesForDisplay(FRAPStudy.createSelectedROIsForReactionOffRateModel());
 					getROIPanel().refreshROIImageForDisplay();
 				}
-				JOptionPane.showMessageDialog(EstParams_ReactionOffRatePanel.this, getROIPanel());
+				DialogUtils.showInfoDialog(EstParams_ReactionOffRatePanel.this, getROIPanel(), "");
 			}
 		});
 		showRoisButton.setFont(new Font("", Font.PLAIN, 11));

--- a/vcell-client/src/main/java/cbit/vcell/microscopy/gui/estparamwizard/EstParams_TwoDiffComponentPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/microscopy/gui/estparamwizard/EstParams_TwoDiffComponentPanel.java
@@ -153,7 +153,7 @@ public class EstParams_TwoDiffComponentPanel extends JPanel {
 					getROIPanel().setCheckboxesForDisplay(frapWorkspace.getWorkingFrapStudy().getSelectedROIsForErrorCalculation());
 					getROIPanel().refreshROIImageForDisplay();
 				}
-				JOptionPane.showMessageDialog(EstParams_TwoDiffComponentPanel.this, getROIPanel());
+				DialogUtils.showInfoDialog(EstParams_TwoDiffComponentPanel.this, getROIPanel(), "");
 			}
 		});
 		showRoisButton.setFont(new Font("Tahoma", Font.PLAIN, 11));

--- a/vcell-client/src/main/java/cbit/vcell/model/gui/SimpleReactionPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/model/gui/SimpleReactionPanel.java
@@ -23,6 +23,7 @@ import cbit.vcell.client.PopupGenerator;
 import cbit.vcell.model.Membrane;
 import cbit.vcell.model.ReactionCanvas;
 import cbit.vcell.model.SimpleReaction;
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.util.gui.GeneralGuiUtils;
 
 /**
@@ -552,9 +553,9 @@ public static void main(java.lang.String[] args) {
  */
 public void setChargeCarrierValence_Exception(java.lang.Throwable e) {
 	if (e instanceof NumberFormatException){
-		javax.swing.JOptionPane.showMessageDialog(this, "Number format error '"+e.getMessage()+"'", "Error changing charge valence", javax.swing.JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this, "Number format error '"+e.getMessage()+"'");
 	}else{
-		javax.swing.JOptionPane.showMessageDialog(this, e.getMessage(), "Error changing charge valence", javax.swing.JOptionPane.ERROR_MESSAGE);
+		DialogUtils.showErrorDialog(this, e.getMessage());
 	}
 }
 


### PR DESCRIPTION
## Summary

Two steps toward one unambiguous VCell dialog/window pattern (`docs/windowing-design-patterns.md`).

### 1. `showMessageDialog` → `DialogUtils` (23 sites)
Mechanical migration of `JOptionPane.showMessageDialog(realComponent, …)` calls (which already passed a real parent but bypassed the LW framework) to `DialogUtils.showErrorDialog` / `showWarningDialog` / `showInfoDialog` (+ `showInfoDialog(component, panel, title)` for the 6 panel-as-message sites in the microscopy wizards). Across `mapping.gui`, `model/gui`, geometry, simulation, DB tree panels, plot panels, and the estparam/ROI wizards. Void calls — no control-flow change.

### 2. Retire `ChildWindowManager.JDiagAdapter`
The transitional un-owned-`JDialog` fallback ("hierarchies without logicalwindow parents", marked *remove eventually*). All six `ChildWindowManager` hosts (`DocumentWindow`, `BNGWindow`, `TestingFrameworkWindow`, `FieldDataWindow`, `VirtualFrapMainFrame`, `VirtualFrapBatchRunFrame`) extend `LWTopFrame`, so `findLWOwner(parent)` **always** resolves a non-null owner and the fallback was unreachable dead code. `createContainerImplementation` now throws `IllegalStateException` if `owner` is ever null (a non-LW host would be a bug) instead of silently producing an un-owned dialog. **Every child window is now an owned `LWChildDialog`/`LWTitledDialog`** — the last ambiguous child-window path is gone.

Compiles (`vcell-client` BUILD SUCCESS).

## Not in this PR (delicate / deferred — see PR description discussion)
- **Control-flow dialogs** (14 `showConfirmDialog`/`showInputDialog`/`showOptionDialog` — delete/overwrite/logout prompts): return-value semantics, done as a separate focused pass.
- **Tier-4** `new JOptionPane`+`createDialog` modeless viewers and **Tier-3** Mac `setAlwaysOnTop` dialogs: already pass a real parent (not z-order bugs); proper conversion is a `ChildWindowManager` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)