### PR TITLE
windowing P4: control-flow dialogs → DialogUtils + document exceptions

### DIFF
--- a/docs/windowing-design-patterns.md
+++ b/docs/windowing-design-patterns.md
@@ -193,21 +193,43 @@ component in from the owning panel/editor.
   `LWTopFrame` so `findLWOwner` always resolves; then all children go through
   `ModelessChild`/`ParentModalChild`.
 
-### P4 — Low: bypasses LW but passes a real parent (~50 sites)
+### P4 — Low: bypasses LW but passes a real parent
 
-Not z-order bugs today, but they skip the LW/DialogUtils path; migrate gradually.
-- `new JOptionPane(...)` + `createDialog(realComponent, …)` — ~14 sites
-  (`DocumentWindow`, `NetworkConstraintsPanel`, `DatabaseWindowManager`,
-  `TestingFrameworkWindowManager`, `PDEDataViewer`, …).
-- `JOptionPane.showXxxDialog(realComponent, …)` — ~35 sites (many `…mapping.gui`,
-  `…microscopy.gui.*wizard`, `MolecularTypePropertiesPanel`, DB tree panels).
-- `setAlwaysOnTop(true)` on a **properly parented** dialog, Mac-only front hack:
-  `org/vcell/util/gui/VCFileChooser.java:159`, `ROIMultiPaintManager.java:636` —
-  acceptable, but confirm the parent is always a real LW component.
+Not z-order bugs (they already pass a real parent), just off the single DialogUtils
+path. **Done** — all `JOptionPane.showXxxDialog(realComponent, …)` are migrated to
+`DialogUtils`:
+- `showMessageDialog` (~29) → `showErrorDialog`/`showWarningDialog`/`showInfoDialog`.
+- `showConfirmDialog`/`showOptionDialog` (~13) → `showWarningDialog(component, title,
+  message, options, default)` (returns the chosen option String; `"Cancel"` on
+  X-close) or `showComponentOKCancelDialog(...)` for a component + OK/Cancel. Return
+  mappings preserved exactly (e.g. overwrite/delete confirms proceed only on `"Yes"`;
+  X-close cancels — matching or safer than the original `== YES_OPTION` checks).
+
+#### Deliberately left as documented exceptions (not violations)
+These already pass a real parent; a mechanical conversion would add a framework
+warning or risk a regression for no z-order gain. The correct fix, where any, is a
+`ChildWindowManager` refactor, tracked separately:
+- **Tier-4 modeless "view" dialogs** — `new JOptionPane(...)` + `createDialog(this,
+  title)` + `setModal(false)` (`DocumentWindow`, `NetworkConstraintsPanel`,
+  `DatabaseWindowManager`, `TestingFrameworkWindowManager`, `PDEDataViewer`,
+  `PDEPlotControlPanel`, `ParameterEstimationRunTaskPanel`). These are modeless data
+  viewers already owned by `this`; forcing them onto `DialogUtils.createDialog`
+  produces a modal `LWDialog` set modeless (the `normalizeModality` warning). Proper
+  home: `ChildWindowManager.addChildWindow(...)` (→ owned `LWChildDialog`).
+- **Tier-3 Mac `setAlwaysOnTop(true)`** on already-parented dialogs
+  (`VCFileChooser.java:159`, `ROIMultiPaintManager.java:636`). This is a macOS
+  front-order workaround — and `DialogUtils.showDialog` itself does the same on Mac
+  (see `DialogUtils` `isMac()` branch). Removing it risks a Mac regression.
+- **`ConstraintPanel.createNewBounds()`** `showInputDialog(this, …)` — already
+  parented to `this`; `DialogUtils.showInputDialog0` throws `UtilCancelException` on
+  cancel where the original returns `null`, which would change this legacy path's
+  control flow. Left as-is.
 - `new JDialog(getFrameForComponent(…)/getWindowAncestor(…), …)` — `AbstractPlotPanel`,
-  `OutputFunctionsPanel`, `ElectricalStimulusPanel`, `ROIMultiPaintManager` — OK; the
-  owner resolves to a real window. Prefer `LWDialog` if a parentless component can
-  reach them.
+  `OutputFunctionsPanel`, `ElectricalStimulusPanel`, `ROIMultiPaintManager`: owner
+  resolves to a real window; acceptable.
+
+The transitional `ChildWindowManager.JDiagAdapter` (un-owned fallback) has been
+**removed** — every child window is now an owned `LWChildDialog`/`LWTitledDialog`.
 
 ### Not violations
 

--- a/vcell-client/src/main/java/cbit/vcell/client/BNGWindowManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/BNGWindowManager.java
@@ -324,8 +324,8 @@ public void saveBNGLFile(String bngl) throws IOException {
 			selectedFile = new File(path);
 		}
 		if (selectedFile.exists()) {
-			final int answer = JOptionPane.showConfirmDialog(getComponent(), selectedFile + " exists. Overwrite?", "Confirm Replace",JOptionPane.YES_NO_OPTION);
-			if (answer != JOptionPane.YES_OPTION) {
+			final String answer = DialogUtils.showWarningDialog(getComponent(), "Confirm Replace", selectedFile + " exists. Overwrite?", new String[]{"Yes","No"}, "Yes");
+			if (!"Yes".equals(answer)) {
 				return;
 			}
 		}

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/EventPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/EventPanel.java
@@ -809,7 +809,7 @@ public class EventPanel extends DocumentEditorSubPanel {
 			// event assignment, add it to the list of event assignments in bioEvent
 			// Else, pop-up an error dialog indicating that event assignment cannot be added.
 			//
-			int ok = JOptionPane.showOptionDialog(this, eventAssignmentPanel, "New Action Event" , 0, JOptionPane.PLAIN_MESSAGE, null, new String[] {"OK", "Cancel"}, null);
+			int ok = DialogUtils.showComponentOKCancelDialog(this, eventAssignmentPanel, "New Action Event");
 			if (ok == javax.swing.JOptionPane.OK_OPTION) {
 				String varName = (String)getEventAssignVarNameComboBox().getSelectedItem();
 				EventAssignment newEventAssignment = null;

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/MolecularTypePropertiesPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/MolecularTypePropertiesPanel.java
@@ -384,7 +384,7 @@ public class MolecularTypePropertiesPanel extends DocumentEditorSubPanel {
 					errMsg += "<br>Please delete each individual State first.";
 					errMsg += "<br><br>Detailed usage information will be provided at that time to help you decide.";
 					errMsg = "<html>" + errMsg + "</html>";
-					JOptionPane.showOptionDialog(this.getParent().getParent(), errMsg, "Delete " + mc.getDisplayType(), JOptionPane.NO_OPTION, JOptionPane.WARNING_MESSAGE, null, options , options[0]);
+					DialogUtils.showWarningDialog(this.getParent().getParent(), errMsg);
 					return;
 				}
 				// we find and display component usage information to help the user decide
@@ -395,9 +395,8 @@ public class MolecularTypePropertiesPanel extends DocumentEditorSubPanel {
 					errMsg += "<br><br>Delete anyway?";
 					errMsg = "<html>" + errMsg + "</html>";
 
-			        int dialogButton = JOptionPane.YES_NO_OPTION;
-			        int returnCode = JOptionPane.showConfirmDialog(this.getParent().getParent(), errMsg, "Delete " + mc.getDisplayType(), dialogButton);
-					if (returnCode == JOptionPane.YES_OPTION) {
+			        String returnCode = DialogUtils.showWarningDialog(this.getParent().getParent(), "Delete " + mc.getDisplayType(), errMsg, new String[]{"Yes","No"}, "Yes");
+					if ("Yes".equals(returnCode)) {
 						// keep this code in sync with MolecularTypeTableModel.setValueAt
 						if(bioModel.getModel().getRbmModelContainer().delete(mt, mc) == true) {
 							mt.removeMolecularComponent(mc);
@@ -434,9 +433,8 @@ public class MolecularTypePropertiesPanel extends DocumentEditorSubPanel {
 				errMsg += "<br><br>Delete anyway?";
 				errMsg = "<html>" + errMsg + "</html>";
 
-		        int dialogButton = JOptionPane.YES_NO_OPTION;
-		        int returnCode = JOptionPane.showConfirmDialog(this.getParent().getParent(), errMsg, "Delete " + ComponentStateDefinition.typeName, dialogButton);
-				if (returnCode == JOptionPane.YES_OPTION) {
+		        String returnCode = DialogUtils.showWarningDialog(this.getParent().getParent(), "Delete " + ComponentStateDefinition.typeName, errMsg, new String[]{"Yes","No"}, "Yes");
+				if ("Yes".equals(returnCode)) {
 					// keep this code in sync with MolecularTypeTableModel.setValueAt
 					if(bioModel.getModel().getRbmModelContainer().delete(mt, mc, csd) == true) {
 						mc.deleteComponentStateDefinition(csd);		// this stays
@@ -1174,7 +1172,7 @@ public class MolecularTypePropertiesPanel extends DocumentEditorSubPanel {
 						errMsg += "<br>Please delete each individual State first.";
 						errMsg += "<br><br>Detailed usage information will be provided at that time to help you decide.";
 						errMsg = "<html>" + errMsg + "</html>";
-						JOptionPane.showOptionDialog(shapePanel, errMsg, "Delete " + mc.getDisplayType(), JOptionPane.NO_OPTION, JOptionPane.WARNING_MESSAGE, null, options , options[0]);
+						DialogUtils.showWarningDialog(shapePanel, errMsg);
 						return;
 					}
 					// we find and display component usage information to help the user decide
@@ -1184,9 +1182,8 @@ public class MolecularTypePropertiesPanel extends DocumentEditorSubPanel {
 						String errMsg = mc.dependenciesToHtml(usedHere);
 						errMsg += "<br><br>Delete anyway?";
 						errMsg = "<html>" + errMsg + "</html>";
-				        int dialogButton = JOptionPane.YES_NO_OPTION;
-				        int returnCode = JOptionPane.showConfirmDialog(shapePanel, errMsg, "Delete " + mc.getDisplayType(), dialogButton);
-						if (returnCode == JOptionPane.YES_OPTION) {
+				        String returnCode = DialogUtils.showWarningDialog(shapePanel, "Delete " + mc.getDisplayType(), errMsg, new String[]{"Yes","No"}, "Yes");
+						if ("Yes".equals(returnCode)) {
 							// keep this code in sync with MolecularTypeTableModel.setValueAt
 							if(bioModel.getModel().getRbmModelContainer().delete(molecularType, mc) == true) {
 								molecularType.removeMolecularComponent(mc);
@@ -1232,9 +1229,8 @@ public class MolecularTypePropertiesPanel extends DocumentEditorSubPanel {
 						String errMsg = csd.dependenciesToHtml(usedHere);
 						errMsg += "<br><br>Delete anyway?";
 						errMsg = "<html>" + errMsg + "</html>";
-				        int dialogButton = JOptionPane.YES_NO_OPTION;
-				        int returnCode = JOptionPane.showConfirmDialog(shapePanel, errMsg, "Delete " + ComponentStateDefinition.typeName, dialogButton);
-						if (returnCode == JOptionPane.YES_OPTION) {
+				        String returnCode = DialogUtils.showWarningDialog(shapePanel, "Delete " + ComponentStateDefinition.typeName, errMsg, new String[]{"Yes","No"}, "Yes");
+						if ("Yes".equals(returnCode)) {
 							// keep this code in sync with MolecularTypeTableModel.setValueAt
 							if(bioModel.getModel().getRbmModelContainer().delete(molecularType, mc, csd) == true) {
 								mc.deleteComponentStateDefinition(csd);

--- a/vcell-client/src/main/java/cbit/vcell/client/task/ChooseFile.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/task/ChooseFile.java
@@ -356,9 +356,8 @@ private File showBioModelXMLFileChooser(Hashtable<String, Object> hashTable) thr
 					errMsg += "<br>Some information will be lost.";
 					errMsg += "<br><br>Continue anyway?";
 					errMsg = "<html>" + errMsg + "</html>";
-					int dialogButton = JOptionPane.YES_NO_OPTION;
-					int returnCode = JOptionPane.showConfirmDialog(topLevelWindowManager.getComponent(), errMsg, "Exporting to .bngl", dialogButton);
-					if (returnCode != JOptionPane.YES_OPTION) {
+					String returnCode = DialogUtils.showWarningDialog(topLevelWindowManager.getComponent(), "Exporting to .bngl", errMsg, new String[]{"Yes","No"}, "Yes");
+					if (!"Yes".equals(returnCode)) {
 						throw UserCancelException.CANCEL_FILE_SELECTION;
 					}
 				}

--- a/vcell-client/src/main/java/cbit/vcell/graph/gui/ReactionCartoonTool.java
+++ b/vcell-client/src/main/java/cbit/vcell/graph/gui/ReactionCartoonTool.java
@@ -2982,11 +2982,8 @@ public class ReactionCartoonTool extends BioCartoonTool implements BioCartoonToo
 			java.io.File selectedFile = fileChooser.getSelectedFile();
 			if (selectedFile != null) {
 				if (selectedFile.exists()) {
-					int question = javax.swing.JOptionPane.showConfirmDialog(
-							getDialogOwner(getGraphPane()), "Overwrite file: "
-									+ selectedFile.getPath() + "?");
-					if (question == javax.swing.JOptionPane.NO_OPTION
-							|| question == javax.swing.JOptionPane.CANCEL_OPTION) {
+					String question = DialogUtils.showWarningDialog(getDialogOwner(getGraphPane()), "Overwrite?", "Overwrite file: " + selectedFile.getPath() + "?", new String[]{"Yes","No"}, "Yes");
+					if (!"Yes".equals(question)) {
 						return;
 					}
 				}

--- a/vcell-client/src/main/java/org/vcell/util/gui/exporter/BnglExtensionFilter.java
+++ b/vcell-client/src/main/java/org/vcell/util/gui/exporter/BnglExtensionFilter.java
@@ -9,6 +9,7 @@ import javax.swing.JOptionPane;
 import org.apache.commons.io.FileUtils;
 import org.vcell.model.rbm.RbmNetworkGenerator;
 import org.vcell.util.UserCancelException;
+import org.vcell.util.gui.DialogUtils;
 
 import cbit.vcell.biomodel.BioModel;
 import cbit.vcell.clientdb.DocumentManager;
@@ -35,9 +36,8 @@ public class BnglExtensionFilter extends SelectorExtensionFilter {
 			errMsg += "<br>Some information will be lost.";
 			errMsg += "<br><br>Continue anyway?";
 			errMsg = "<html>" + errMsg + "</html>";
-	        int dialogButton = JOptionPane.YES_NO_OPTION;
-	        int returnCode = JOptionPane.showConfirmDialog(ctx.topLevelWindowManager.getComponent(), errMsg, "Exporting to .bngl", dialogButton);
-			if (returnCode != JOptionPane.YES_OPTION) {
+	        String returnCode = DialogUtils.showWarningDialog(ctx.topLevelWindowManager.getComponent(), "Exporting to .bngl", errMsg, new String[]{"Yes","No"}, "Yes");
+			if (!"Yes".equals(returnCode)) {
 				throw UserCancelException.CANCEL_FILE_SELECTION;
 			}
 		}

--- a/vcell-client/src/main/java/org/vcell/util/gui/exporter/SedmlExtensionFilter.java
+++ b/vcell-client/src/main/java/org/vcell/util/gui/exporter/SedmlExtensionFilter.java
@@ -8,6 +8,7 @@ import org.vcell.sedml.ModelFormat;
 import org.vcell.sedml.SEDMLExporter;
 import org.vcell.util.FileUtils;
 import org.vcell.util.UserCancelException;
+import org.vcell.util.gui.DialogUtils;
 
 import javax.swing.*;
 import java.awt.*;
@@ -33,17 +34,8 @@ public class SedmlExtensionFilter extends SelectorExtensionFilter {
 
 	@Override
 	public void askUser(ChooseContext ctx) throws UserCancelException {
-		Object[] options = {"VCML","SBML"};
-		int choice = JOptionPane.showOptionDialog(
-				ctx.topLevelWindowManager.getComponent(),
-				"VCML or SBML?",			// message,
-				"Choose an option",			// title
-				JOptionPane.YES_NO_OPTION,	// optionType
-				JOptionPane.QUESTION_MESSAGE,	// messageType
-				null,						// Icon
-				options,
-				"SBML");					// initialValue 
-		if (choice == 0) modelFormat = ModelFormat.VCML;
+		String choice = DialogUtils.showWarningDialog(ctx.topLevelWindowManager.getComponent(), "Choose an option", "VCML or SBML?", new String[]{"VCML","SBML"}, "SBML");
+		if ("VCML".equals(choice)) modelFormat = ModelFormat.VCML;
 		System.out.println(modelFormat);
 	}
 	


### PR DESCRIPTION
## Summary

Completes the P4 dialog migration (`docs/windowing-design-patterns.md` §6): the remaining `showConfirmDialog`/`showOptionDialog` control-flow dialogs (which already passed a real parent but bypassed the LW framework) now go through `DialogUtils`, with return semantics preserved exactly. Follows PR #1768 (message dialogs + JDiagAdapter retirement).

## Converted — 12 sites, semantics preserved
- **Overwrite/export confirms** — `BNGWindowManager`, `BnglExtensionFilter`, `ChooseFile` → `showWarningDialog(component, title, message, {Yes,No}, Yes)`; proceed only on `"Yes"`. X-close returns `"Cancel"` → treated as cancel (matches the original `!= YES_OPTION`, and is *safer* for `ReactionCartoonTool`'s image overwrite, which previously overwrote on X-close).
- **`MolecularTypePropertiesPanel`** — 4 "Delete anyway?" confirms (delete only on `"Yes"`) + 2 "cannot delete" OK-only info dialogs (return was ignored → `showWarningDialog`).
- **`SedmlExtensionFilter`** VCML/SBML choice → `{VCML,SBML}` (VCML only on `"VCML"`).
- **`EventPanel`** "New Action Event" panel dialog → `showComponentOKCancelDialog(...)` — returns `JOptionPane.OK_OPTION`/`CANCEL_OPTION`, so the `== OK_OPTION` check is unchanged.

Verified against `DialogUtils.showDialog`: `showWarningDialog(...options...)` returns the chosen option String, or `SimpleUserMessage.OPTION_CANCEL` (`"Cancel"`) on X-close — so `"Yes".equals(x)` is null-safe and cancels on close.

## Deliberately left (documented exceptions in §6) — already parented, not z-order bugs
- **Tier-4** modeless "view" dialogs (`new JOptionPane` + `createDialog` + `setModal(false)`): already owned by `this`; proper home is a `ChildWindowManager` refactor (forcing `DialogUtils.createDialog` trips the `normalizeModality` warning).
- **Tier-3** Mac `setAlwaysOnTop(true)` on parented dialogs — `DialogUtils` itself does this on Mac; removing risks a regression.
- **`ConstraintPanel.createNewBounds`** `showInputDialog` — `null`-on-cancel vs `showInputDialog0`'s throw-on-cancel would change control flow.

Compiles (`vcell-client` BUILD SUCCESS).

With this, the §6 dialog-pattern migration is complete and the pattern is unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)