### PR TITLE
fix: GroupAccessSome REST discriminator missing (shared biomodels break /vcInfoContainer)

### DIFF
--- a/vcell-core/src/main/java/org/vcell/util/document/GroupAccessSome.java
+++ b/vcell-core/src/main/java/org/vcell/util/document/GroupAccessSome.java
@@ -28,7 +28,11 @@ public class GroupAccessSome extends GroupAccess {
 		private java.math.BigDecimal    hash			= null;
 		private User[] 					groupMembers 	= null;
 		private boolean[]				hiddenMembers	= null;
-		private final String type = "GroupAccessSome";
+		// must be public so Jackson serializes the REST discriminator, like GroupAccessAll/None.
+		// When private (no getter), shared biomodels' groupAccess is emitted without "type", and the
+		// generated REST client fails to resolve the subtype (InvalidTypeIdException) — issue seen on
+		// /api/v1/vcInfoContainer for any GroupAccessSome (shared) record.
+		public final String type = "GroupAccessSome";
 
 /**
  * Insert the method's description here.

--- a/vcell-core/src/test/java/org/vcell/core/GroupAccessSerializationTest.java
+++ b/vcell-core/src/test/java/org/vcell/core/GroupAccessSerializationTest.java
@@ -1,0 +1,49 @@
+package org.vcell.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.vcell.util.document.GroupAccess;
+import org.vcell.util.document.GroupAccessAll;
+import org.vcell.util.document.GroupAccessNone;
+import org.vcell.util.document.GroupAccessSome;
+import org.vcell.util.document.KeyValue;
+import org.vcell.util.document.User;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression guard for the REST {@code GroupAccess} polymorphic discriminator.
+ * <p>
+ * Every concrete {@code GroupAccess} subtype must serialize a {@code "type"} property so the
+ * generated REST client can resolve the subtype (used by {@code GET /api/v1/vcInfoContainer}).
+ * {@code GroupAccessSome} previously declared its {@code type} field {@code private} (no getter),
+ * so shared biomodels serialized without the discriminator and clients failed with
+ * {@code InvalidTypeIdException: missing type id property 'type'}. All three subtypes now use a
+ * {@code public final String type} field.
+ */
+@Tag("Fast")
+public class GroupAccessSerializationTest {
+
+    private final ObjectMapper mapper = new ObjectMapper()
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
+    @Test
+    public void allSubtypesSerializeTypeDiscriminator() throws Exception {
+        assertTrue(mapper.writeValueAsString(new GroupAccessAll()).contains("\"type\":\"GroupAccessAll\""),
+                "GroupAccessAll must serialize its type discriminator");
+        assertTrue(mapper.writeValueAsString(new GroupAccessNone()).contains("\"type\":\"GroupAccessNone\""),
+                "GroupAccessNone must serialize its type discriminator");
+
+        KeyValue memberKey = new KeyValue("1");
+        User[] members = new User[]{ new User("alice", memberKey) };
+        boolean[] hiddenMembers = new boolean[]{ false };
+        BigDecimal hash = GroupAccess.calculateHash(new KeyValue[]{ memberKey }, hiddenMembers);
+        GroupAccessSome some = new GroupAccessSome(new BigDecimal(100), hash, members, hiddenMembers);
+        assertTrue(mapper.writeValueAsString(some).contains("\"type\":\"GroupAccessSome\""),
+                "GroupAccessSome must serialize its type discriminator (regression: field was private)");
+    }
+}


### PR DESCRIPTION
## Summary

Hotfix for a deserialization crash on `GET /api/v1/vcInfoContainer` (from the 8.0.2.01 RPC→REST migration, #1759) hit by any client whose visible list includes a **shared** biomodel.

`GroupAccessSome` declared its discriminator field **`private`** (no getter), while `GroupAccessAll`/`GroupAccessNone` use `public final String type`. Jackson's default field visibility is public-only, so it omitted `"type"` when serializing a `GroupAccessSome` — and the generated client (which uses `@JsonTypeInfo(property="type")`) failed:

```
InvalidTypeIdException: missing type id property 'type'
  VCInfoContainerSummary["bioModelSummaries"][N] -> BioModelSummary["version"] -> Version["groupAccess"]
```

## Fix
Make `GroupAccessSome.type` `public`, matching the two sibling subtypes. **Server-only** — no client/spec regeneration (the client already expects `type`; the server now emits it).

## Test
Adds `GroupAccessSerializationTest` (`@Tag("Fast")`) asserting all three `GroupAccess` subtypes serialize their `type` discriminator. Verified: **fails** on the old `private` field (assertion: expected true, got false), **passes** after the fix.

## Why it slipped through
`VCInfoContainerApiTest` only saved a fresh biomodel (owner-private → `GroupAccessNone`), so a shared `GroupAccessSome` was never exercised.

## Deploy
This fixes the server serialization for the deployed 8.0.2.01. The desktop client needs no change; the **server** should be rebuilt and redeployed (cut `8.0.2.02`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)