### PR TITLE
fix: GIFImage.getSize() NPE aborts /vcInfoContainer for undecodable preview gifs

### DIFF
--- a/vcell-core/src/main/java/cbit/image/GIFImage.java
+++ b/vcell-core/src/main/java/cbit/image/GIFImage.java
@@ -72,8 +72,15 @@ public ISize getSize() {
 		return size;
 	}
 	BufferedImage javaImage = getJavaImage();
+	if (javaImage == null) {
+		// ImageIO.read() returns null when no reader can decode this gif (e.g. an unusual/blank
+		// thumbnail). Don't dereference it — returning null lets JSON serialization of the preview
+		// finish (size -> null) instead of throwing an NPE that aborts the entire streamed
+		// /api/v1/vcInfoContainer response mid-way (leaving the client with truncated JSON).
+		return null;
+	}
+	int width = javaImage.getWidth();
 	int height = javaImage.getHeight();
-	int width = javaImage.getHeight();
 	this.size = new ISize(width,height,1);
 	return this.size;
 }

--- a/vcell-core/src/test/java/org/vcell/core/GIFImageSerializationTest.java
+++ b/vcell-core/src/test/java/org/vcell/core/GIFImageSerializationTest.java
@@ -1,0 +1,35 @@
+package org.vcell.core;
+
+import cbit.image.GIFImage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression guard for a serialization NPE in the REST /api/v1/vcInfoContainer response.
+ * <p>
+ * {@link GIFImage#getSize()} lazily decoded the gif via {@code ImageIO.read()} on every call and
+ * dereferenced the result. {@code ImageIO.read()} returns {@code null} when no reader can decode the
+ * bytes (an unusual/blank thumbnail), so {@code getSize()} threw an NPE. Because Jackson serializes
+ * the {@code preview} (GIFImage) as part of a large streamed response, that NPE aborted the whole
+ * vcInfoContainer body mid-stream, and the desktop client saw truncated/garbled JSON. getSize() now
+ * returns {@code null} for an undecodable gif instead of throwing.
+ */
+@Tag("Fast")
+public class GIFImageSerializationTest {
+
+    @Test
+    public void undecodableGifSizeSerializesWithoutNpe() throws Exception {
+        // bytes that no ImageIO reader can decode -> getJavaImage() returns null
+        GIFImage gif = new GIFImage("this-is-not-a-real-gif".getBytes());
+
+        assertNull(gif.getSize(), "getSize() must return null for an undecodable gif rather than NPE");
+
+        String json = new ObjectMapper().writeValueAsString(gif);
+        assertTrue(json.contains("\"size\":null"),
+                "GIFImage must serialize with size:null for an undecodable gif (regression: NPE aborted the stream): " + json);
+    }
+}


### PR DESCRIPTION
## Root cause (confirmed in the dev `rest` pod logs)

```
NullPointerException: Cannot invoke "BufferedImage.getHeight()" because "javaImage" is null
  at cbit.image.GIFImage.getSize(GIFImage.java:75)
  ...VCInfoContainerSummary["vcImageSummaries"][18] -> VCImageSummary["preview"] -> GIFImage["size"]
```

`GIFImage.getSize()` lazily decodes the gif with `ImageIO.read()` and dereferences the result. `ImageIO.read()` returns **null** when no reader can decode the bytes (an unusual/blank thumbnail), so `getSize()` NPE'd. Because `getVCInfoContainer` (#1759) serializes each VCImage's `preview` GIFImage via Jackson in one large **streamed** response, that NPE aborted the whole body mid-stream — the desktop client then hit `JsonParseException: Unexpected character ('e')` on the truncated JSON. Public models were fine (their previews decode); the user's private image #18 didn't.

## Fix
`getSize()` returns `null` for an undecodable gif instead of dereferencing → serializes as `size: null`, response completes. Also fixes a latent bug (width was computed from `getHeight()`). **Server-only** — no client/spec change.

## Test
`GIFImageSerializationTest` (`@Tag("Fast")`) builds a GIFImage from undecodable bytes and asserts `getSize()` is null and it serializes to `size:null` rather than throwing. Passes with the fix; the production stack trace shows it NPE'd without it.

## Follow-up (architectural)
This is the **second** core-domain-object-via-Jackson serialization bug on `getVCInfoContainer` (after `GroupAccessSome`). Per VCell's convention of **dedicated JSON DTOs**, the endpoint should serialize purpose-built DTOs rather than core objects (`GIFImage`, `VCellSoftwareVersion`, `Version`, `GroupAccess`) directly — which also lets us drop the ~8 MB of base64 preview gifs from the bulk list. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)