### PR TITLE
fix(client): null-guard vcInfoContainer DTO reconstruction (3 real-data NPEs)

### DIFF
--- a/vcell-rest/src/test/java/org/vcell/restq/serialization/LiveVCInfoContainerRoundTripTest.java
+++ b/vcell-rest/src/test/java/org/vcell/restq/serialization/LiveVCInfoContainerRoundTripTest.java
@@ -1,0 +1,117 @@
+package org.vcell.restq.serialization;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.vcell.restclient.ApiClient;
+import org.vcell.restclient.api.VcInfoContainerResourceApi;
+import org.vcell.restclient.model.VCInfoContainerSummary;
+import org.vcell.restclient.utils.DtoModelTransforms;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * END-TO-END round-trip against a LIVE, already-running vcInfoContainer service (e.g. a local
+ * vcell-rest started in prod mode against Oracle). Unlike the unit round-trip test, this hits the
+ * real HTTP endpoint, so it exercises the actual server serialization AND the generated client's
+ * deserialization, then reconstructs every model via {@link DtoModelTransforms} — the exact path
+ * the desktop client (VCellClientMain) follows.
+ *
+ * <p>Each model that fails reconstruction is collected (not fatal mid-run) and reported with its
+ * name/key, so one run surfaces every data-dependent problem at once (a null child summary, a shared
+ * GroupAccessSome, an undecodable preview, ...). This is the check that reproduces the client-side
+ * NPE against real production data.
+ *
+ * <p><b>Disabled unless {@code VCELL_API_LIVE} is set</b> (and tagged {@code live-service}), so it
+ * never runs in the normal CI groups. Run it against a locally-running prod-mode service:
+ * <pre>
+ *   # anonymous (public records only)
+ *   VCELL_API_LIVE=1 mvn test -pl vcell-rest -am -Dtest=LiveVCInfoContainerRoundTripTest \
+ *        -Dgroups=live-service -Dmdep.analyze.skip=true
+ *
+ *   # authenticated (the user's own + shared records; measures the slow subquery path)
+ *   VCELL_API_LIVE=1 VCELL_API_TOKEN='<auth0 access token>' mvn test -pl vcell-rest -am ...
+ * </pre>
+ * {@code VCELL_API_BASE_URL} defaults to {@code http://localhost:9000}.
+ */
+@Tag("live-service")
+public class LiveVCInfoContainerRoundTripTest {
+
+    private record Failure(String kind, String label, Throwable error) {
+        @Override public String toString() {
+            Throwable root = error;
+            while (root.getCause() != null && root.getCause() != root) root = root.getCause();
+            return String.format("%-9s %s: %s: %s", kind, label, root.getClass().getSimpleName(), root.getMessage());
+        }
+    }
+
+    private static String env(String name, String dflt) {
+        String v = System.getenv(name);
+        return (v == null || v.isBlank()) ? dflt : v.trim();
+    }
+
+    @Test
+    public void everyModelFromLiveEndpointRoundTrips() throws Exception {
+        Assumptions.assumeTrue(System.getenv("VCELL_API_LIVE") != null,
+                "live-service round-trip skipped: set VCELL_API_LIVE=1 (service must be running)");
+        String baseUri = env("VCELL_API_BASE_URL", "http://localhost:9000");
+        String token = env("VCELL_API_TOKEN", null);
+
+        ApiClient client = new ApiClient();
+        client.updateBaseUri(baseUri);
+        if (token != null) {
+            client.setRequestInterceptor(request -> request.header("Authorization", "Bearer " + token));
+        }
+
+        long t0 = System.nanoTime();
+        VCInfoContainerSummary vcic = new VcInfoContainerResourceApi(client).getVCInfoContainer();
+        long fetchMs = (System.nanoTime() - t0) / 1_000_000;
+
+        List<Failure> failures = new ArrayList<>();
+        int total = 0;
+
+        total += roundTrip("BioModel", vcic.getBioModelSummaries(),
+                s -> s.getVersion() == null ? "?" : s.getVersion().getName() + " (key=" + s.getVersion().getVersionKey() + ")",
+                DtoModelTransforms::bioModelContextToBioModelInfo, failures);
+        total += roundTrip("MathModel", vcic.getMathModelSummaries(),
+                s -> s.getVersion() == null ? "?" : s.getVersion().getName() + " (key=" + s.getVersion().getVersionKey() + ")",
+                DtoModelTransforms::mathModelContextToMathModel, failures);
+        total += roundTrip("Geometry", vcic.getGeometrySummaries(),
+                s -> s.getVersion() == null ? "?" : s.getVersion().getName() + " (key=" + s.getVersion().getVersionKey() + ")",
+                DtoModelTransforms::geometrySummaryToGeometryInfo, failures);
+        total += roundTrip("VCImage", vcic.getVcImageSummaries(),
+                s -> s.getVersion() == null ? "?" : s.getVersion().getName() + " (key=" + s.getVersion().getVersionKey() + ")",
+                DtoModelTransforms::imageSummaryToVCImageInfo, failures);
+
+        System.out.printf("live round-trip @ %s (%s): %d models in %d ms fetch, %d failures%n",
+                baseUri, token == null ? "anonymous" : "authenticated", total, fetchMs, failures.size());
+        if (!failures.isEmpty()) {
+            StringBuilder sb = new StringBuilder(failures.size() + " of " + total
+                    + " models failed the vcInfoContainer DTO round-trip:\n");
+            for (Failure f : failures) sb.append("  - ").append(f).append('\n');
+            fail(sb.toString());
+        }
+    }
+
+    private static <T> int roundTrip(String kind, List<T> summaries, Function<T, String> label,
+                                     Consumer<T> reconstruct, List<Failure> failures) {
+        if (summaries == null) return 0;
+        for (T s : summaries) {
+            try {
+                reconstruct.accept(s);
+            } catch (Throwable t) {
+                failures.add(new Failure(kind, safe(label, s), t));
+            }
+        }
+        return summaries.size();
+    }
+
+    private static <T> String safe(Function<T, String> label, T s) {
+        try { return label.apply(s); } catch (Throwable t) { return "?"; }
+    }
+}

--- a/vcell-restclient/src/main/java/org/vcell/restclient/utils/DtoModelTransforms.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/utils/DtoModelTransforms.java
@@ -240,6 +240,9 @@ public class DtoModelTransforms {
     }
 
     public static BioModelChildSummary dtoToBioModelChildSummary(org.vcell.restclient.model.BioModelChildSummary dto){
+        if (dto == null) {
+            return null; // a BioModel can legitimately have no child summary (matches the native DB path)
+        }
         BioModelChildSummary.MathType[] mathTypes = new BioModelChildSummary.MathType[dto.getAppTypes().size()];
         for (int i = 0; i < mathTypes.length; i++){
             mathTypes[i] = dtoToBioModelMathType(dto.getAppTypes().get(i));
@@ -291,6 +294,9 @@ public class DtoModelTransforms {
     }
 
     public static MathModelChildSummary mathModelChildSummary(org.vcell.restclient.model.MathModelChildSummary dto){
+        if (dto == null) {
+            return null; // a MathModel can legitimately have no model-info summary (matches the native DB path)
+        }
         String[] simKeys = dto.getSimKeys() == null ? new String[0] : dto.getSimKeys().toArray(new String[0]);
         return new MathModelChildSummary(BioModelChildSummary.MathType.valueOf(dto.getModelType().getValue()),
                 dto.getGeometryName(), dto.getGeometryDimension(), dto.getSimulationNames().toArray(new String[0]),
@@ -307,7 +313,9 @@ public class DtoModelTransforms {
     public static GeometryInfo geometrySummaryToGeometryInfo(org.vcell.restclient.model.GeometrySummary summary){
         return new GeometryInfo(DtoModelTransforms.versionDTOToVersion(summary.getVersion()),
                 summary.getDimension(), DtoModelTransforms.dtoToExtent(summary.getExtent()),
-                DtoModelTransforms.dtoToOrigin(summary.getOrigin()), new KeyValue(summary.getImageRef()),
+                DtoModelTransforms.dtoToOrigin(summary.getOrigin()),
+                // analytic geometries have no image reference -> null KeyValue (matches the native DB path)
+                summary.getImageRef() == null ? null : new KeyValue(summary.getImageRef()),
                 DtoModelTransforms.dtoToVCellSoftwareVersion(summary.getSoftwareVersion()));
     }
 


### PR DESCRIPTION
Fixes the desktop-client `NullPointerException` reconstructing native POJOs from `/api/v1/vcInfoContainer` summaries. With the earlier GroupAccess fix in place, reconstruction proceeds further and hits three more null gaps in `DtoModelTransforms`, all for fields the DB legitimately leaves null:

- **1457 Geometries** — no `imageRef` (analytic geometry) → `new KeyValue(null)`
- **13 BioModels** — no child summary → `dtoToBioModelChildSummary(null)`
- **11 MathModels** — no `modelInfo` → `mathModelChildSummary(null)`

Each is guarded to rebuild the native object with the same null the DB path produces.

**Verified against the production database** (via a local prod-mode vcell-rest): anonymous **1615/1615** and authenticated **6073/6073** models now round-trip with **0 failures** (was 72 / 1481).

Adds `LiveVCInfoContainerRoundTripTest` — a gated, opt-in fixture (`VCELL_API_LIVE`, optional `VCELL_API_TOKEN`) that drives a running service through the generated client + `DtoModelTransforms` for every model, surfacing data-dependent reconstruction bugs in one run. It caught all three.

Note: a separate perf investigation (the bulk endpoint's per-row LOB loading — image previews + child-summary CLOBs) is tracked separately; the `simKeys` subquery was ruled out as the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)