### PR TITLE
perf(ci): parallelize install4j client installer build (5-way matrix + parallel mac notarize)

### DIFF
--- a/.github/workflows/site_deploy.yml
+++ b/.github/workflows/site_deploy.yml
@@ -93,7 +93,7 @@ jobs:
   # Build the five install4j media (Windows 64/32, Linux 64/32, macOS) in parallel — one per runner —
   # instead of serially in a single clientgen container. Each job produces its installer plus a
   # updates_<platform>.xml fragment; the combine job fans them back into one updates.xml.
-  build_installers:
+  build_installer_other:
     name: Build installer (media ${{ matrix.build_id }})
     runs-on: ubuntu-24.04
     needs: build
@@ -101,8 +101,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # install4j build ids: 349=win64, 450=win32, 652=linux64, 547=linux32, 105=mac64
-        build_id: [349, 450, 652, 547, 105]
+        # non-mac install4j build ids: 349=win64, 450=win32, 652=linux64, 547=linux32
+        # (mac 105 is its own job so notarize can start as soon as it finishes)
+        build_id: [349, 450, 652, 547]
     steps:
     - name: checkout tag
       uses: actions/checkout@v4
@@ -150,12 +151,64 @@ jobs:
         path: docker/swarm/generated_installers
         retention-days: 1
 
-  # Fan-in: gather the five per-media installers and reconstruct the combined updates.xml.
+  # The mac installer is built on its own so notarize can start on it immediately (in parallel with
+  # the win/linux builds) rather than waiting for the fan-in.
+  build_installer_mac:
+    name: Build installer (media 105 mac)
+    runs-on: ubuntu-24.04
+    needs: build
+    if: ${{ github.event.inputs.server_only != 'true' }}
+    steps:
+    - name: checkout tag
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.vcell_version }}.${{ github.event.inputs.vcell_build }}
+    - name: setup ssh-agent
+      uses: webfactory/ssh-agent@v0.8.0
+      with:
+        ssh-private-key: ${{ secrets.VC_KEY }}
+    - name: retrieve variables
+      uses: actions/download-artifact@v4
+      with:
+        name: variables
+        path: variables
+    - name: setenv
+      run: |
+        for line in $(cat variables/variables); do echo $line >> $GITHUB_ENV; done
+    - name: get installer secrets
+      run: |
+        ssh-keyscan $VCELL_MANAGER_NODE >> ~/.ssh/known_hosts
+        sudo mkdir /usr/local/deploy
+        sudo chmod 777 /usr/local/deploy
+        cd /usr/local/deploy
+        scp ${{ secrets.CD_FULL_USER }}@${VCELL_MANAGER_NODE}:${VCELL_DEPLOY_REMOTE_DIR}/deploy_dir_2025_03_18.tar .
+        cd ..
+        sudo tar -xvf deploy/deploy_dir_2025_03_18.tar
+        sudo chmod 777 -R deploy
+    - name: retrieve deploy config
+      uses: actions/download-artifact@v4
+      with:
+        name: deploy-config
+        path: docker/swarm
+    - name: build the mac installer
+      run: |
+        cd docker/swarm
+        echo "${{ secrets.GITHUB_TOKEN }}" | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        sudo docker pull $VCELL_REPO_NAMESPACE/vcell-clientgen:${VCELL_VERSION}.${VCELL_BUILD}
+        BUILD_IDS="105" ./generate_installers.sh ./${VCELL_CONFIG_FILE_NAME}
+    - name: upload mac installer (un-notarized)
+      uses: actions/upload-artifact@v4
+      with:
+        name: mac-raw
+        path: docker/swarm/generated_installers
+        retention-days: 1
+
+  # Fan-in: gather the win/linux installers + the NOTARIZED mac installer and reconstruct updates.xml.
   combine:
     name: Combine installers + updates.xml
     runs-on: ubuntu-24.04
-    needs: build_installers
-    if: ${{ github.event.inputs.server_only != 'true' }}
+    needs: [build_installer_other, notarize]
+    if: ${{ always() && needs.build_installer_other.result == 'success' && needs.notarize.result == 'success' }}
     steps:
     - name: checkout tag
       uses: actions/checkout@v4
@@ -181,23 +234,21 @@ jobs:
   notarize:
     name: Notarize the MacOS client
     runs-on: macos-latest
-    needs: [build, combine]
-    # run for full deploys (combine succeeded) and for server_only (build_installers/combine skipped);
-    # skip only if the installer build actually failed.
-    if: ${{ always() && needs.build.result == 'success' && needs.combine.result != 'failure' && needs.combine.result != 'cancelled' }}
+    # depends ONLY on the mac build, so it runs in parallel with the win/linux builds and combine.
+    # skipped for server_only (build_installer_mac is skipped) and if the mac build failed.
+    needs: build_installer_mac
+    if: ${{ always() && needs.build_installer_mac.result == 'success' }}
     steps:
-    - name: download generated installers
-      if: ${{ github.event.inputs.server_only != 'true' }}
+    - name: download mac installer
       uses: actions/download-artifact@v4
       with:
-        name: installers
-        path: installers
+        name: mac-raw
+        path: mac
     - name: notarize mac installer
-      if: ${{ github.event.inputs.server_only != 'true' }}
       run: |
         set -x
         set +e
-        cd installers
+        cd mac
         export MAC_INSTALLER=`ls *dmg`
         xcrun notarytool submit --output-format normal --no-progress --no-wait --team-id "${{ secrets.MACTEAMID }}" --apple-id "${{ secrets.MACID }}" --password "${{ secrets.MACPW }}" $MAC_INSTALLER > submit_output
         SUBMIT_EXIT=$?
@@ -231,19 +282,20 @@ jobs:
           xcrun notarytool log --verbose --output-format normal --no-progress --team-id "${{ secrets.MACTEAMID }}" --apple-id "${{ secrets.MACID }}" --password "${{ secrets.MACPW }}" `cat UUID`
           exit 1
         fi
-    - name: update generated installers
-      if: ${{ github.event.inputs.server_only != 'true' }}
+    - name: upload notarized mac installer
       uses: actions/upload-artifact@v4
       with:
-        name: updated_installers
-        path: installers
+        name: installers-mac
+        path: mac
         retention-days: 1
 
   deploy:
     name: Deploy to site
     runs-on: ubuntu-24.04
-    needs: notarize
-    if: ${{ always() && needs.notarize.result == 'success' }}
+    # deploy last, after ALL other jobs: a server_only run (all installer jobs skipped) or a full
+    # deploy (all succeeded). Skip only if some installer job actually failed.
+    needs: [build, build_installer_other, build_installer_mac, notarize, combine]
+    if: ${{ always() && needs.build.result == 'success' && needs.build_installer_other.result != 'failure' && needs.build_installer_other.result != 'cancelled' && needs.build_installer_mac.result != 'failure' && needs.build_installer_mac.result != 'cancelled' && needs.notarize.result != 'failure' && needs.notarize.result != 'cancelled' && needs.combine.result != 'failure' && needs.combine.result != 'cancelled' }}
     steps:
     - name: checkout tag
       uses: actions/checkout@v4
@@ -253,8 +305,8 @@ jobs:
       if: ${{ github.event.inputs.server_only != 'true' }}
       uses: actions/download-artifact@v4
       with:
-          name: updated_installers
-          path: updated_installers
+          name: installers
+          path: installers
     - name: retrieve variables
       uses: actions/download-artifact@v4
       with:
@@ -266,7 +318,7 @@ jobs:
     - name: stage installers
       if: ${{ github.event.inputs.server_only != 'true' }}
       run: |
-        cd updated_installers
+        cd installers
         mkdir ../docker/swarm/generated_installers
         mv * ../docker/swarm/generated_installers
     - name: setup ssh-agent

--- a/.github/workflows/site_deploy.yml
+++ b/.github/workflows/site_deploy.yml
@@ -292,10 +292,12 @@ jobs:
   deploy:
     name: Deploy to site
     runs-on: ubuntu-24.04
-    # deploy last, after ALL other jobs: a server_only run (all installer jobs skipped) or a full
-    # deploy (all succeeded). Skip only if some installer job actually failed.
-    needs: [build, build_installer_other, build_installer_mac, notarize, combine]
-    if: ${{ always() && needs.build.result == 'success' && needs.build_installer_other.result != 'failure' && needs.build_installer_other.result != 'cancelled' && needs.build_installer_mac.result != 'failure' && needs.build_installer_mac.result != 'cancelled' && needs.notarize.result != 'failure' && needs.notarize.result != 'cancelled' && needs.combine.result != 'failure' && needs.combine.result != 'cancelled' }}
+    # deploy last. `combine` transitively depends on every installer job (mac -> notarize -> combine,
+    # and the win/linux matrix -> combine), so we only list `combine` for the full path. `build` stays
+    # because a server_only run skips `combine` (no installers) and only `build` can gate the config
+    # artifacts then. Full deploy => combine succeeded; server_only => combine skipped, build gates.
+    needs: [build, combine]
+    if: ${{ always() && needs.build.result == 'success' && (needs.combine.result == 'success' || github.event.inputs.server_only == 'true') }}
     steps:
     - name: checkout tag
       uses: actions/checkout@v4

--- a/.github/workflows/site_deploy.yml
+++ b/.github/workflows/site_deploy.yml
@@ -82,29 +82,114 @@ jobs:
         name: variables
         path: docker/swarm/variables
         retention-days: 1
-    - name: build client installers
+    - name: upload deploy config
       if: ${{ github.event.inputs.server_only != 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: deploy-config
+        path: docker/swarm/${{ env.VCELL_CONFIG_FILE_NAME }}
+        retention-days: 1
+
+  # Build the five install4j media (Windows 64/32, Linux 64/32, macOS) in parallel — one per runner —
+  # instead of serially in a single clientgen container. Each job produces its installer plus a
+  # updates_<platform>.xml fragment; the combine job fans them back into one updates.xml.
+  build_installers:
+    name: Build installer (media ${{ matrix.build_id }})
+    runs-on: ubuntu-24.04
+    needs: build
+    if: ${{ github.event.inputs.server_only != 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # install4j build ids: 349=win64, 450=win32, 652=linux64, 547=linux32, 105=mac64
+        build_id: [349, 450, 652, 547, 105]
+    steps:
+    - name: checkout tag
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.vcell_version }}.${{ github.event.inputs.vcell_build }}
+    - name: setup ssh-agent
+      uses: webfactory/ssh-agent@v0.8.0
+      with:
+        ssh-private-key: ${{ secrets.VC_KEY }}
+    - name: retrieve variables
+      uses: actions/download-artifact@v4
+      with:
+        name: variables
+        path: variables
+    - name: setenv
+      run: |
+        for line in $(cat variables/variables); do echo $line >> $GITHUB_ENV; done
+    - name: get installer secrets
+      run: |
+        ssh-keyscan $VCELL_MANAGER_NODE >> ~/.ssh/known_hosts
+        sudo mkdir /usr/local/deploy
+        sudo chmod 777 /usr/local/deploy
+        cd /usr/local/deploy
+        scp ${{ secrets.CD_FULL_USER }}@${VCELL_MANAGER_NODE}:${VCELL_DEPLOY_REMOTE_DIR}/deploy_dir_2025_03_18.tar .
+        cd ..
+        sudo tar -xvf deploy/deploy_dir_2025_03_18.tar
+        sudo chmod 777 -R deploy
+    - name: retrieve deploy config
+      uses: actions/download-artifact@v4
+      with:
+        name: deploy-config
+        path: docker/swarm
+    - name: build one installer media
       run: |
         cd docker/swarm
         echo "${{ secrets.GITHUB_TOKEN }}" | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
         sudo docker pull $VCELL_REPO_NAMESPACE/vcell-clientgen:$VCELL_TAG
-        ./generate_installers.sh ./${VCELL_CONFIG_FILE_NAME}
-    - name: upload generated installers
-      if: ${{ github.event.inputs.server_only != 'true' }}
+        BUILD_IDS="${{ matrix.build_id }}" ./generate_installers.sh ./${VCELL_CONFIG_FILE_NAME}
+    - name: upload installer media
+      uses: actions/upload-artifact@v4
+      with:
+        name: installers-${{ matrix.build_id }}
+        path: docker/swarm/generated_installers
+        retention-days: 1
+
+  # Fan-in: gather the five per-media installers and reconstruct the combined updates.xml.
+  combine:
+    name: Combine installers + updates.xml
+    runs-on: ubuntu-24.04
+    needs: build_installers
+    if: ${{ github.event.inputs.server_only != 'true' }}
+    steps:
+    - name: checkout tag
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.vcell_version }}.${{ github.event.inputs.vcell_build }}
+    - name: gather per-media installers
+      uses: actions/download-artifact@v4
+      with:
+        pattern: installers-*
+        path: generated_installers
+        merge-multiple: true
+    - name: reconstruct combined updates.xml
+      run: |
+        chmod +x docker/build/installers/combine_updates.sh
+        ./docker/build/installers/combine_updates.sh generated_installers
+    - name: upload combined installers
       uses: actions/upload-artifact@v4
       with:
         name: installers
-        path: docker/swarm/generated_installers
+        path: generated_installers
         retention-days: 1
 
   notarize:
     name: Notarize the MacOS client
     runs-on: macos-latest
-    needs: build
+    needs: [build, combine]
+    # run for full deploys (combine succeeded) and for server_only (build_installers/combine skipped);
+    # skip only if the installer build actually failed.
+    if: ${{ always() && needs.build.result == 'success' && needs.combine.result != 'failure' && needs.combine.result != 'cancelled' }}
     steps:
     - name: download generated installers
       if: ${{ github.event.inputs.server_only != 'true' }}
       uses: actions/download-artifact@v4
+      with:
+        name: installers
+        path: installers
     - name: notarize mac installer
       if: ${{ github.event.inputs.server_only != 'true' }}
       run: |
@@ -156,6 +241,7 @@ jobs:
     name: Deploy to site
     runs-on: ubuntu-24.04
     needs: notarize
+    if: ${{ always() && needs.notarize.result == 'success' }}
     steps:
     - name: checkout tag
       uses: actions/checkout@v4

--- a/.github/workflows/site_deploy.yml
+++ b/.github/workflows/site_deploy.yml
@@ -139,7 +139,9 @@ jobs:
       run: |
         cd docker/swarm
         echo "${{ secrets.GITHUB_TOKEN }}" | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
-        sudo docker pull $VCELL_REPO_NAMESPACE/vcell-clientgen:$VCELL_TAG
+        # pull clientgen by the deterministic friendly version tag (version.build), not the git short
+        # SHA (VCELL_TAG) which can abbreviate differently on the build vs deploy runners
+        sudo docker pull $VCELL_REPO_NAMESPACE/vcell-clientgen:${VCELL_VERSION}.${VCELL_BUILD}
         BUILD_IDS="${{ matrix.build_id }}" ./generate_installers.sh ./${VCELL_CONFIG_FILE_NAME}
     - name: upload installer media
       uses: actions/upload-artifact@v4

--- a/docker/build/installers/build_installers.sh
+++ b/docker/build/installers/build_installers.sh
@@ -2,17 +2,12 @@
 
 #
 # build_installers.sh must be run within Docker (see Dockerfile and docker-compose.yml in /vcell/docker/installers)
-# 
+#
 
 shopt -s -o nounset
 
 # gather classpath (filenames only), Install4J will add the correct separator
 compiler_vcellClasspathColonSep=`ls -m /vcellclient/vcell-client/target/maven-jars | tr -d '[:space:]' | tr ',' ':'`
-compiler_vcellClasspathColonSep_Win64="${compiler_vcellClasspathColonSep}"
-compiler_vcellClasspathColonSep_Win32="${compiler_vcellClasspathColonSep}"
-compiler_vcellClasspathColonSep_Linux64="${compiler_vcellClasspathColonSep}"
-compiler_vcellClasspathColonSep_Linux32="${compiler_vcellClasspathColonSep}"
-compiler_vcellClasspathColonSep_Mac64="${compiler_vcellClasspathColonSep}"
 
 cd /config
 
@@ -32,16 +27,39 @@ macCodeSignKeystore_pswd=`cat $macCodeSignKeystore_pswdfile`
 $INSTALL4JC -L $Install4J_product_key
 
 #
-# run install4jc to create installers for VCell Client on supported platforms.
+# Which install4j media (build ids) to generate. Defaults to all five supported platforms.
+# Set BUILD_IDS to a subset (e.g. "349") to build a single installer per invocation, so the
+# CD-sites workflow can fan the platforms out across parallel runners/containers. Each media is a
+# separate install4jc process — the historical reason the builds were kept separate was to avoid
+# random threading failures when building them concurrently in one install4j run.
 #
-#Separate build of win, linux and mac installers to avoid random failure due to threading
+BUILD_IDS="${BUILD_IDS:-349 450 652 547 105}"
 
-#Generate Windows 64bit installers
-$INSTALL4JC \
-	-b 349 \
-	--win-keystore-password=$winCodeSignKeystore_pswd \
-	--mac-keystore-password=$macCodeSignKeystore_pswd \
-	-D \
+# map install4j build id -> platform suffix used in the updates_<suffix>.xml fragment name
+media_suffix() {
+	case "$1" in
+		349) echo win64   ;;   # Windows 64-bit
+		450) echo win32   ;;   # Windows 32-bit
+		652) echo linux64 ;;   # Linux 64-bit
+		547) echo linux32 ;;   # Linux 32-bit
+		105) echo mac64   ;;   # macOS 64-bit
+		*)   echo "" ;;
+	esac
+}
+
+for build_id in $BUILD_IDS; do
+	suffix=$(media_suffix "$build_id")
+	if [ -z "$suffix" ]; then
+		echo "build_installers.sh: unknown install4j build id '$build_id'" >&2
+		exit 1
+	fi
+
+	echo "Generating installer for build id $build_id ($suffix)"
+	$INSTALL4JC \
+		-b "$build_id" \
+		--win-keystore-password=$winCodeSignKeystore_pswd \
+		--mac-keystore-password=$macCodeSignKeystore_pswd \
+		-D \
 vcellIcnsFile=/config/icons/vcell.icns,\
 outputDir=/outputdir,\
 mavenRootDir=/vcellclient,\
@@ -58,131 +76,20 @@ serverPrefixV0=$compiler_serverPrefixV0,\
 serverPrefixV1=$compiler_serverPrefixV1,\
 bioformatsJarFile=$compiler_bioformatsJarFile,\
 bioformatsJarDownloadURL=$compiler_bioformatsJarDownloadURL,\
-vcellClasspathColonSep=$compiler_vcellClasspathColonSep_Win64\
-	VCell.install4j
-	
-mv /outputdir/updates.xml /outputdir/updates_win64.xml
+vcellClasspathColonSep=$compiler_vcellClasspathColonSep\
+		VCell.install4j
 
-#Generate Windows 32bit installers
-$INSTALL4JC \
-	-b 450 \
-	--win-keystore-password=$winCodeSignKeystore_pswd \
-	--mac-keystore-password=$macCodeSignKeystore_pswd \
-	-D \
-vcellIcnsFile=/config/icons/vcell.icns,\
-outputDir=/outputdir,\
-mavenRootDir=/vcellclient,\
-macKeystore=$macCodeSignKeystore_p12,\
-winKeystore=$winCodeSignKeystore_pfx,\
-applicationId=$compiler_applicationId,\
-SoftwareVersionString=$compiler_softwareVersionString,\
-Site=$compiler_Site,\
-vcellVersion=$compiler_vcellVersion,\
-vcellBuild=$compiler_vcellBuild,\
-updateSiteBaseUrl=$compiler_updateSiteBaseUrl,\
-rmiHosts=$compiler_rmiHosts,\
-serverPrefixV0=$compiler_serverPrefixV0,\
-serverPrefixV1=$compiler_serverPrefixV1,\
-bioformatsJarFile=$compiler_bioformatsJarFile,\
-bioformatsJarDownloadURL=$compiler_bioformatsJarDownloadURL,\
-vcellClasspathColonSep=$compiler_vcellClasspathColonSep_Win32\
-	VCell.install4j
-	
-mv /outputdir/updates.xml /outputdir/updates_win32.xml
+	mv /outputdir/updates.xml "/outputdir/updates_${suffix}.xml"
+done
 
-#Generate linux 64bit installers
-$INSTALL4JC \
-	-b 652 \
-	--win-keystore-password=$winCodeSignKeystore_pswd \
-	--mac-keystore-password=$macCodeSignKeystore_pswd \
-	-D \
-vcellIcnsFile=/config/icons/vcell.icns,\
-outputDir=/outputdir,\
-mavenRootDir=/vcellclient,\
-macKeystore=$macCodeSignKeystore_p12,\
-winKeystore=$winCodeSignKeystore_pfx,\
-applicationId=$compiler_applicationId,\
-SoftwareVersionString=$compiler_softwareVersionString,\
-Site=$compiler_Site,\
-vcellVersion=$compiler_vcellVersion,\
-vcellBuild=$compiler_vcellBuild,\
-updateSiteBaseUrl=$compiler_updateSiteBaseUrl,\
-rmiHosts=$compiler_rmiHosts,\
-serverPrefixV0=$compiler_serverPrefixV0,\
-serverPrefixV1=$compiler_serverPrefixV1,\
-bioformatsJarFile=$compiler_bioformatsJarFile,\
-bioformatsJarDownloadURL=$compiler_bioformatsJarDownloadURL,\
-vcellClasspathColonSep=$compiler_vcellClasspathColonSep_Linux64\
-	VCell.install4j
-
-mv /outputdir/updates.xml /outputdir/updates_linux64.xml
-
-#Generate linux 32bit installers
-$INSTALL4JC \
-	-b 547 \
-	--win-keystore-password=$winCodeSignKeystore_pswd \
-	--mac-keystore-password=$macCodeSignKeystore_pswd \
-	-D \
-vcellIcnsFile=/config/icons/vcell.icns,\
-outputDir=/outputdir,\
-mavenRootDir=/vcellclient,\
-macKeystore=$macCodeSignKeystore_p12,\
-winKeystore=$winCodeSignKeystore_pfx,\
-applicationId=$compiler_applicationId,\
-SoftwareVersionString=$compiler_softwareVersionString,\
-Site=$compiler_Site,\
-vcellVersion=$compiler_vcellVersion,\
-vcellBuild=$compiler_vcellBuild,\
-updateSiteBaseUrl=$compiler_updateSiteBaseUrl,\
-rmiHosts=$compiler_rmiHosts,\
-serverPrefixV0=$compiler_serverPrefixV0,\
-serverPrefixV1=$compiler_serverPrefixV1,\
-bioformatsJarFile=$compiler_bioformatsJarFile,\
-bioformatsJarDownloadURL=$compiler_bioformatsJarDownloadURL,\
-vcellClasspathColonSep=$compiler_vcellClasspathColonSep_Linux32\
-	VCell.install4j
-
-mv /outputdir/updates.xml /outputdir/updates_linux32.xml
-
-
-#Generate mac 64bit installer
-$INSTALL4JC \
-	-b 105 \
-	--win-keystore-password=$winCodeSignKeystore_pswd \
-	--mac-keystore-password=$macCodeSignKeystore_pswd \
-	-D \
-vcellIcnsFile=/config/icons/vcell.icns,\
-outputDir=/outputdir,\
-mavenRootDir=/vcellclient,\
-macKeystore=$macCodeSignKeystore_p12,\
-winKeystore=$winCodeSignKeystore_pfx,\
-applicationId=$compiler_applicationId,\
-SoftwareVersionString=$compiler_softwareVersionString,\
-Site=$compiler_Site,\
-vcellVersion=$compiler_vcellVersion,\
-vcellBuild=$compiler_vcellBuild,\
-updateSiteBaseUrl=$compiler_updateSiteBaseUrl,\
-rmiHosts=$compiler_rmiHosts,\
-serverPrefixV0=$compiler_serverPrefixV0,\
-serverPrefixV1=$compiler_serverPrefixV1,\
-bioformatsJarFile=$compiler_bioformatsJarFile,\
-bioformatsJarDownloadURL=$compiler_bioformatsJarDownloadURL,\
-vcellClasspathColonSep=$compiler_vcellClasspathColonSep_Mac64\
-	VCell.install4j
-
-mv /outputdir/updates.xml /outputdir/updates_mac64.xml
-
-
-#reconstruct combined updates.xml from fragments (used by VCell client executable to detect if update needed)
-win64c=$(wc -l < /outputdir/updates_win64.xml)
-win32c=$(wc -l < /outputdir/updates_win32.xml)
-linux64c=$(wc -l < /outputdir/updates_linux64.xml)
-linux32c=$(wc -l < /outputdir/updates_linux32.xml)
-mac64c=$(wc -l < /outputdir/updates_mac64.xml)
-
-sed -n -e "1,$(($win64c-1))p" /outputdir/updates_win64.xml >/outputdir/updates.xml
-sed -n -e "3,$(($win32c-1))p" /outputdir/updates_win32.xml >>/outputdir/updates.xml
-sed -n -e "3,$(($linux64c-1))p" /outputdir/updates_linux64.xml >>/outputdir/updates.xml
-sed -n -e "3,$(($linux32c-1))p" /outputdir/updates_linux32.xml >>/outputdir/updates.xml
-sed -n -e "3,$(($mac64c))p" /outputdir/updates_mac64.xml >>/outputdir/updates.xml
-
+#
+# Reconstruct the combined updates.xml (used by the VCell client to detect if an update is needed)
+# only when all five per-platform fragments are present, i.e. a full single-container build. When
+# BUILD_IDS is a subset (parallel/sharded build), the fan-in CD job runs combine_updates.sh after
+# gathering every platform's fragment.
+#
+if [ -f /outputdir/updates_win64.xml ]   && [ -f /outputdir/updates_win32.xml ] && \
+   [ -f /outputdir/updates_linux64.xml ] && [ -f /outputdir/updates_linux32.xml ] && \
+   [ -f /outputdir/updates_mac64.xml ]; then
+	/config/combine_updates.sh /outputdir
+fi

--- a/docker/build/installers/combine_updates.sh
+++ b/docker/build/installers/combine_updates.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Reconstruct the combined updates.xml from the five per-platform fragments produced by
+# build_installers.sh (updates_win64.xml, updates_win32.xml, updates_linux64.xml,
+# updates_linux32.xml, updates_mac64.xml).
+#
+# Pure bash/sed — no Install4j — so it runs either inside the clientgen container (after a full
+# 5-media build) or in a fan-in CI job after the per-platform installers were built in parallel on
+# separate runners.
+#
+# usage: combine_updates.sh [dir]      (dir defaults to the current directory)
+#
+set -euo pipefail
+
+OUTDIR="${1:-.}"
+
+for f in win64 win32 linux64 linux32 mac64; do
+  if [[ ! -f "$OUTDIR/updates_${f}.xml" ]]; then
+    echo "combine_updates.sh: missing fragment $OUTDIR/updates_${f}.xml" >&2
+    exit 1
+  fi
+done
+
+win64c=$(wc -l < "$OUTDIR/updates_win64.xml")
+win32c=$(wc -l < "$OUTDIR/updates_win32.xml")
+linux64c=$(wc -l < "$OUTDIR/updates_linux64.xml")
+linux32c=$(wc -l < "$OUTDIR/updates_linux32.xml")
+mac64c=$(wc -l < "$OUTDIR/updates_mac64.xml")
+
+sed -n -e "1,$((win64c - 1))p"   "$OUTDIR/updates_win64.xml"   >"$OUTDIR/updates.xml"
+sed -n -e "3,$((win32c - 1))p"   "$OUTDIR/updates_win32.xml"   >>"$OUTDIR/updates.xml"
+sed -n -e "3,$((linux64c - 1))p" "$OUTDIR/updates_linux64.xml" >>"$OUTDIR/updates.xml"
+sed -n -e "3,$((linux32c - 1))p" "$OUTDIR/updates_linux32.xml" >>"$OUTDIR/updates.xml"
+sed -n -e "3,${mac64c}p"         "$OUTDIR/updates_mac64.xml"   >>"$OUTDIR/updates.xml"
+
+echo "combine_updates.sh: wrote $OUTDIR/updates.xml"

--- a/docker/swarm/generate_installers.sh
+++ b/docker/swarm/generate_installers.sh
@@ -74,9 +74,14 @@ VCELL_TAG=$(grep VCELL_TAG "$local_config_file" | cut -d"=" -f2)
 
 VCELL_DEPLOY_SECRETS_DIR=$(grep VCELL_DEPLOY_SECRETS_DIR "$local_config_file" | cut -d"=" -f2)
 
+# which install4j media (build ids) to generate; default = all five platforms. The CD-sites
+# workflow sets this to a single id per matrix job so each installer builds on its own runner.
+BUILD_IDS="${BUILD_IDS:-349 450 652 547 105}"
+
 echo "sudo docker run --rm ... ${VCELL_REPO_NAMESPACE}/vcell-clientgen:${VCELL_TAG}"
 
-echo "sudo docker run --rm --cpus=\"1.0\"\\"
+echo "sudo docker run --rm \\"
+echo "    -e BUILD_IDS=\"$BUILD_IDS\" \\"
 echo "    -e compiler_updateSiteBaseUrl=$VCELL_UPDATE_SITE \\"
 echo "    -e compiler_Site=$VCELL_SITE_CAMEL \\"
 echo "    -e compiler_vcellVersion=$VCELL_VERSION_NUMBER \\"
@@ -99,7 +104,8 @@ echo "    ${VCELL_REPO_NAMESPACE}/vcell-clientgen:${VCELL_TAG}"
 
 
 
-if ! sudo docker run --rm --cpus="1.0" \
+if ! sudo docker run --rm \
+    -e BUILD_IDS="$BUILD_IDS" \
     -e compiler_updateSiteBaseUrl="$VCELL_UPDATE_SITE" \
     -e compiler_Site="$VCELL_SITE_CAMEL" \
     -e compiler_vcellVersion="$VCELL_VERSION_NUMBER" \

--- a/docker/swarm/generate_installers.sh
+++ b/docker/swarm/generate_installers.sh
@@ -72,13 +72,18 @@ VCELL_CLIENT_APPID=$(grep VCELL_CLIENT_APPID "$local_config_file" | cut -d"=" -f
 VCELL_REPO_NAMESPACE=$(grep VCELL_REPO_NAMESPACE "$local_config_file" | cut -d"=" -f2)
 VCELL_TAG=$(grep VCELL_TAG "$local_config_file" | cut -d"=" -f2)
 
+# The clientgen image is pulled by its friendly version tag (version.build), which CI-full's
+# tag-and-push publishes deterministically. VCELL_TAG (a git short SHA) is NOT used here: the build
+# and deploy runners can abbreviate the SHA to different lengths, causing "manifest unknown".
+CLIENTGEN_TAG="${VCELL_VERSION_NUMBER}.${VCELL_BUILD_NUMBER}"
+
 VCELL_DEPLOY_SECRETS_DIR=$(grep VCELL_DEPLOY_SECRETS_DIR "$local_config_file" | cut -d"=" -f2)
 
 # which install4j media (build ids) to generate; default = all five platforms. The CD-sites
 # workflow sets this to a single id per matrix job so each installer builds on its own runner.
 BUILD_IDS="${BUILD_IDS:-349 450 652 547 105}"
 
-echo "sudo docker run --rm ... ${VCELL_REPO_NAMESPACE}/vcell-clientgen:${VCELL_TAG}"
+echo "sudo docker run --rm ... ${VCELL_REPO_NAMESPACE}/vcell-clientgen:${CLIENTGEN_TAG}"
 
 echo "sudo docker run --rm \\"
 echo "    -e BUILD_IDS=\"$BUILD_IDS\" \\"
@@ -100,7 +105,7 @@ echo "    -e macCodeSignKeystore_pswdfile=/buildsecrets/Apple_Dev_Id_Certificate
 echo "    -e Install4J_product_key_file=/buildsecrets/Install4J_product_key_10.txt \\"
 echo "    -v $PWD/generated_installers:/outputdir \\"
 echo "    -v ${VCELL_DEPLOY_SECRETS_DIR}:/buildsecrets \\"
-echo "    ${VCELL_REPO_NAMESPACE}/vcell-clientgen:${VCELL_TAG}"
+echo "    ${VCELL_REPO_NAMESPACE}/vcell-clientgen:${CLIENTGEN_TAG}"
 
 
 
@@ -124,7 +129,7 @@ if ! sudo docker run --rm \
     -e Install4J_product_key_file=/buildsecrets/Install4J_product_key_10.txt \
     -v "$PWD"/generated_installers:/outputdir \
     -v "${VCELL_DEPLOY_SECRETS_DIR}":/buildsecrets \
-    "${VCELL_REPO_NAMESPACE}/vcell-clientgen":"${VCELL_TAG}";
+    "${VCELL_REPO_NAMESPACE}/vcell-clientgen":"${CLIENTGEN_TAG}";
 then
     echo "docker run failed while generating clients"
     exit 1


### PR DESCRIPTION
## Summary

Parallelizes the CD-sites installer phase, which previously built all five install4j platform installers serially in a single job (~50 min critical path). Each platform now builds on its own runner, the mac installer notarizes in parallel with the win/linux builds, and a fan-in `combine` job reassembles `updates.xml`.

On the validation run the whole `build → media → notarize → combine → deploy` critical path lands in **~8 min**.

## What changed

**`docker/build/installers/build_installers.sh`** — parameterized by `BUILD_IDS` (default = all 5). Baked into the `vcell-clientgen` image; each invocation can build one media id and emit a per-platform `updates_<suffix>.xml`.

**`docker/build/installers/combine_updates.sh`** (new) — reconstructs the single `updates.xml` from the five per-platform fragments.

**`docker/swarm/generate_installers.sh`** — passes `BUILD_IDS` through to the container; pulls `vcell-clientgen` by its **friendly version tag** (`version.build`) instead of the git short SHA (the SHA gets abbreviated to different lengths on build vs deploy runners → `manifest unknown`).

**`.github/workflows/site_deploy.yml`** — restructured job graph:
- `build` — config only (uploads `variables` + `deploy-config`)
- `build_installer_other` — matrix over win64/win32/linux64/linux32, one installer per runner (skipped on `server_only`)
- `build_installer_mac` — mac installer on its own job
- `notarize` — depends **only** on `build_installer_mac`, runs in parallel with the win/linux matrix
- `combine` — fans in the notarized mac + the win/linux matrix, rebuilds `updates.xml`
- `deploy` — depends on `[build, combine]`. `combine` transitively covers all installer jobs, so the direct edges were redundant; `build` stays to gate the config artifacts on a `server_only` deploy (where `combine` is skipped)

## Validation

Full stage run: all jobs green (config, 5 media each building exactly one installer, notarize, combine, deploy). The combined mac dmg is a **valid UDIF image** (`hdiutil verify … is VALID`) — the earlier serial build produced a corrupt dmg from a filename collision that this per-media split eliminates.

Installer/CI files only — no Java changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)