### PR TITLE
ci: make regression a merge-queue-only gate (fix PRs blocked on regression-gate)

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -4,16 +4,20 @@ name: Regression
 # ordinary pushes - that is what keeps the fast lane (ci.yml) fast.
 #
 # Runs when:
-#   * a PR is marked ready-for-review (early signal that the full suite passes),
 #   * in the merge queue (the authoritative gate before landing on master),
 #   * nightly on master (drift backstop),
-#   * on demand via "Run workflow" (all groups or a single one).
+#   * on demand via "Run workflow" (all groups or a single one, any ref).
 #
-# Note: pushing new commits to an already-ready PR does NOT re-run this (only
-# the ready_for_review transition does). The merge queue re-runs the full suite
-# on the actual merge commit, so that is the real gate; use "Run workflow" or
-# re-open-as-draft/ready if you want an interim run. This keeps ready PRs from
-# paying the full time on every commit.
+# Deliberately does NOT run on pull_request events. "regression-gate" is a
+# required status check enforced by the merge queue on its temporary merge
+# commit (the merge_group event below). Because no pull_request trigger produces
+# it, GitHub does not "expect" it on the PR itself, so a PR can enter the queue
+# as soon as the fast lane (build / CI-Test-group-Fast / CI-Test-group-Quarkus)
+# and review pass; the queue then runs this suite and blocks the merge if it
+# fails. (Previously a `pull_request: [ready_for_review]` trigger made GitHub
+# expect the gate on every PR, but it only fired on a draft->ready transition -
+# so PRs opened directly as ready were blocked forever with no way to run it.)
+# For an ad-hoc pre-queue check, use "Run workflow" on the PR branch.
 #
 # The slow groups are single parameterized tests iterating over the whole VCML
 # model suite, so they are SHARDED across parallel runners: each shard runs a
@@ -29,9 +33,6 @@ name: Regression
 # the merge queue.
 
 on:
-  pull_request:
-    types: [ready_for_review]
-    branches: [master]
   merge_group:
   schedule:
     # nightly full regression on master (07:00 UTC)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ npm run build_prod # Production build
 GitHub Actions, split by concern:
 
 - **`ci.yml`** (fast lane, ~4 min) — every push + merge queue: `build` (compile + Docker image test + Python package tests), `CI-Test-group-Fast` (JUnit class-level parallel, sharded core/other), `CI-Test-group-Quarkus`.
-- **`regression.yml`** (~9 min) — heavy integration suites (MathGen/SBML/SEDML_*/BSTS), sharded, gated by `regression-gate`. Runs on: a PR marked **ready-for-review**, the **merge queue** (`merge_group`), the **nightly** schedule, and manual **`workflow_dispatch`** (with an `include-slow` option for the slow cases the merge gate skips). NOT on ordinary pushes.
+- **`regression.yml`** (~9 min) — heavy integration suites (MathGen/SBML/SEDML_*/BSTS), sharded, gated by `regression-gate`. Runs on: the **merge queue** (`merge_group`) — the authoritative gate before landing — the **nightly** schedule, and manual **`workflow_dispatch`** (any ref; with an `include-slow` option for the slow cases the merge gate skips). Deliberately **NOT** on `pull_request` events: because no PR trigger produces `regression-gate`, GitHub doesn't expect it on the PR, so a PR enters the queue once the fast lane + review pass and the queue runs regression on the merge commit. For an ad-hoc pre-queue run, `gh workflow run regression.yml --ref <pr-branch>`.
 - **`cd.yml`** — Docker push to `ghcr.io` on release.
 - **`codeql-analysis.yml`** — security scan on push/PR to `master`.
 


### PR DESCRIPTION
## Problem

`regression-gate` is a **required status check** on `master`, but `regression.yml` only produced it via a `pull_request: types: [ready_for_review]` trigger. That event fires **only** on a draft→ready transition — never when a PR is opened directly as ready, and never on subsequent pushes.

Result: GitHub *expects* `regression-gate` on every PR (because a `pull_request` trigger declares it) but has **no way to run it**, so those PRs are blocked from the merge queue indefinitely with no self-service way to satisfy the gate. Observed on #1784 (approved, all fast-lane checks green, stuck).

## Fix

Remove the `pull_request` trigger. `regression.yml` now runs only on:
- `merge_group` — the merge queue, the authoritative gate before landing
- `schedule` — nightly drift backstop
- `workflow_dispatch` — ad-hoc, any ref

With **no** `pull_request` trigger producing `regression-gate`, GitHub no longer expects it on the PR itself. A PR enters the queue as soon as `build` / `CI-Test-group-Fast` / `CI-Test-group-Quarkus` + review pass; the **queue** then runs the full regression suite on the temporary merge commit and blocks the merge if it fails. Master stays fully protected — this just stops double-requiring the gate *before* the queue.

## Trade-off

No pre-queue "early signal": a PR carrying a regression now fails **in** the queue and is ejected, rather than failing before you queue it. For an ad-hoc pre-check, run `gh workflow run regression.yml --ref <pr-branch>`.

## Notes

- CI-config only (`regression.yml` + CLAUDE.md doc). No code, no Java.
- This is the canonical GitHub merge-queue pattern for expensive suites (run in the queue, not per-PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)