### PR TITLE
ci: speed up Java CodeQL on PRs (build-mode split: none on PRs, autobuild on push/schedule)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    # Only needed for the Java autobuild path (push/schedule). PR Java scans use
+    # build-mode 'none' (source extraction, no compile), and JS/Python never build.
     - name: setup java 17 with maven cache
+      if: ${{ matrix.language == 'java' && github.event_name != 'pull_request' }}
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
@@ -48,30 +51,21 @@ jobs:
         cache: 'maven'
 
     # Initializes the CodeQL tools for scanning.
+    #
+    # build-mode split (matters for Java only; JS/Python are interpreted, so always 'none'):
+    #   * pull_request  -> 'none'      extract the CodeQL DB straight from source, no Maven
+    #                                  compile. Fast (~2-3 min vs ~9) for quick PR feedback.
+    #   * push/schedule -> 'autobuild' full compile of the monorepo for maximum dataflow
+    #                                  depth (build-time generated code + library bytecode),
+    #                                  on master and the weekly deep scan where 9 min is fine.
+    # With build-mode set here, init drives the build itself - no separate Autobuild step.
+    # Trade-off on PRs: source-only extraction can miss findings that flow through generated
+    # code or unmodeled third-party bytecode; the push/schedule autobuild run backstops those.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+        build-mode: ${{ matrix.language == 'java' && github.event_name != 'pull_request' && 'autobuild' || 'none' }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Problem

The Java CodeQL job takes ~9 min because Autobuild compiles the entire monorepo before analysis. JS/Python are interpreted (no build) and finish in ~1 min — that gap is the whole cost.

## Fix

Set `build-mode` on the `init` action per-language + per-event, and drop the standalone `Autobuild` step (with `build-mode` set, `init` drives the build itself):

| event | Java | JS/Python |
|-------|------|-----------|
| `pull_request` | **`none`** — extract DB from source, no Maven compile (~2–3 min) | `none` |
| `push` (master) / `schedule` (weekly) | **`autobuild`** — full compile, maximum dataflow depth | `none` |

`setup-java` (+ maven cache) is now guarded to the Java autobuild path only, since PR `none` scans and JS/Python don't need a JDK.

## Why this is safe

CodeQL is **advisory** here — it's not in the `master` ruleset's required checks (`build` / `CI-Test-group-Fast` / `CI-Test-group-Quarkus` / `regression-gate`), so it never gates a merge. Trading a little PR-time depth for speed costs nothing on the critical path.

**Trade-off:** source-only extraction on PRs can miss findings that flow through build-time *generated* code or *unmodeled third-party bytecode*. The push-to-master and weekly scheduled runs keep full `autobuild` depth and backstop exactly those cases — so nothing is permanently unscanned, PRs just get a faster (slightly shallower) first pass.

CI-config only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)