### PR TITLE
Revert "ci: split CodeQL Java build-mode" (#1789 made PR scans slower)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,10 +40,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Only needed for the Java autobuild path (push/schedule). PR Java scans use
-    # build-mode 'none' (source extraction, no compile), and JS/Python never build.
     - name: setup java 17 with maven cache
-      if: ${{ matrix.language == 'java' && github.event_name != 'pull_request' }}
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
@@ -51,21 +48,30 @@ jobs:
         cache: 'maven'
 
     # Initializes the CodeQL tools for scanning.
-    #
-    # build-mode split (matters for Java only; JS/Python are interpreted, so always 'none'):
-    #   * pull_request  -> 'none'      extract the CodeQL DB straight from source, no Maven
-    #                                  compile. Fast (~2-3 min vs ~9) for quick PR feedback.
-    #   * push/schedule -> 'autobuild' full compile of the monorepo for maximum dataflow
-    #                                  depth (build-time generated code + library bytecode),
-    #                                  on master and the weekly deep scan where 9 min is fine.
-    # With build-mode set here, init drives the build itself - no separate Autobuild step.
-    # Trade-off on PRs: source-only extraction can miss findings that flow through generated
-    # code or unmodeled third-party bytecode; the push/schedule autobuild run backstops those.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.language == 'java' && github.event_name != 'pull_request' && 'autobuild' || 'none' }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Reverts #1789.

**Measured result contradicted the premise.** `build-mode: none` on the Java PR scan took **11m 55s** — *slower* than the autobuild baseline (**9m 24s**). General guidance says `none` is faster, but this monorepo has a large volume of **committed generated code** (`vcell-restclient` OpenAPI Java) plus test sources. `none` extracts *every* `.java` file → larger CodeQL DB → the query/analysis phase (identical in both modes) runs longer, outweighing the compile time `none` saves.

Reverting to restore the ~9 min autobuild baseline on all events. A real speedup needs to target the analysis phase (paths-ignore generated/test dirs, trimmed query suite), which is being investigated separately.

CI-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)