### PR TITLE
SaLaD Phase 0: serve the SpringSaLaD trajectory (viewer) file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,9 +192,9 @@
 		<solvers-vcell-mac.version>v0.0.44-dev4</solvers-vcell-mac.version>
 		<solvers-vcell-windows.version>v0.0.40</solvers-vcell-windows.version>
 		<solvers-vcell-linux.version>v0.0.44-dev4</solvers-vcell-linux.version>
-		<solvers-langevin-mac.version>1.4.7</solvers-langevin-mac.version>
-		<solvers-langevin-windows.version>1.4.7</solvers-langevin-windows.version>
-		<solvers-langevin-linux.version>1.4.7</solvers-langevin-linux.version>
+		<solvers-langevin-mac.version>1.4.9</solvers-langevin-mac.version>
+		<solvers-langevin-windows.version>1.4.9</solvers-langevin-windows.version>
+		<solvers-langevin-linux.version>1.4.9</solvers-langevin-linux.version>
 	</properties>
 
 

--- a/vcell-client/src/main/java/cbit/vcell/client/LocalDataSetControllerProvider.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/LocalDataSetControllerProvider.java
@@ -91,6 +91,11 @@ public class LocalDataSetControllerProvider implements DataSetControllerProvider
 			return dataServerImpl.getLangevinBatchResultSet(user, vcdataID);
 		}
 
+		@Override
+		public cbit.vcell.simdata.SpringSaladTrajectory getLangevinTrajectory(VCDataIdentifier vcdataID) throws DataAccessException, RemoteProxyException {
+			return dataServerImpl.getLangevinTrajectory(user, vcdataID);
+		}
+
 		public ParticleDataBlock getParticleDataBlock(VCDataIdentifier vcdataID, double time) throws DataAccessException {
 			return dataServerImpl.getParticleDataBlock(user, vcdataID, time);
 		}

--- a/vcell-core/src/main/java/cbit/vcell/message/server/bootstrap/client/RpcDataServerProxy.java
+++ b/vcell-core/src/main/java/cbit/vcell/message/server/bootstrap/client/RpcDataServerProxy.java
@@ -69,6 +69,10 @@ public LangevinBatchResultSet getLangevinBatchResultSet(VCDataIdentifier vcdID) 
 	return (LangevinBatchResultSet)rpc("getLangevinBatchResultSet",new Object[]{userLoginInfo.getUser(), vcdID});
 }
 
+public cbit.vcell.simdata.SpringSaladTrajectory getLangevinTrajectory(VCDataIdentifier vcdID) throws org.vcell.util.DataAccessException {
+	return (cbit.vcell.simdata.SpringSaladTrajectory)rpc("getLangevinTrajectory",new Object[]{userLoginInfo.getUser(), vcdID});
+}
+
 public ParticleDataBlock getParticleDataBlock(VCDataIdentifier vcdID, double time) throws org.vcell.util.DataAccessException {
 	return (ParticleDataBlock)rpc("getParticleDataBlock",new Object[]{userLoginInfo.getUser(), vcdID,time});
 }

--- a/vcell-core/src/main/java/cbit/vcell/server/DataSetController.java
+++ b/vcell-core/src/main/java/cbit/vcell/server/DataSetController.java
@@ -76,6 +76,15 @@ cbit.vcell.solver.ode.ODESimData getODEData(VCDataIdentifier vcdataID) throws Da
  */
  LangevinBatchResultSet getLangevinBatchResultSet(VCDataIdentifier vcdataID) throws DataAccessException, RemoteProxyException;
 
+/**
+ * getLangevinTrajectory - per-particle SpringSaLaD trajectory ("viewer" file) for the 3D
+ * renderer. Default returns null so implementors that do not serve sim data are unaffected;
+ * the real data paths (local + RPC) override it.
+ */
+ default cbit.vcell.simdata.SpringSaladTrajectory getLangevinTrajectory(VCDataIdentifier vcdataID) throws DataAccessException, RemoteProxyException {
+ 	return null;
+ }
+
  /**
  * This method was created in VisualAge.
  * @return ParticleData

--- a/vcell-core/src/main/java/cbit/vcell/simdata/DataServerImpl.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/DataServerImpl.java
@@ -197,6 +197,16 @@ public cbit.vcell.solver.ode.ODESimData getODEData(User user, VCDataIdentifier v
 		}
 	}
 
+	public SpringSaladTrajectory getLangevinTrajectory(User user, VCDataIdentifier vcdID) throws DataAccessException {
+		checkReadAccess(user, vcdID);
+		try {
+			return dataSetControllerImpl.getLangevinTrajectory(vcdID);
+		}catch (Throwable e){
+			lg.error(e.getMessage(), e);
+			throw new DataAccessException(e.getMessage());
+		}
+	}
+
 
 /**
  * This method was created by a SmartGuide.

--- a/vcell-core/src/main/java/cbit/vcell/simdata/DataSetControllerImpl.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/DataSetControllerImpl.java
@@ -2460,6 +2460,26 @@ public LangevinBatchResultSet getLangevinBatchResultSet(VCDataIdentifier vcdID) 
 	}
 }
 
+public SpringSaladTrajectory getLangevinTrajectory(VCDataIdentifier vcdID) throws DataAccessException {
+	if (lg.isTraceEnabled()) lg.trace("DataSetControllerImpl.getLangevinTrajectory()");
+	try {
+		VCData vcData = getVCData(vcdID);
+		if (!(vcData instanceof SimulationData)) {
+			return null;
+		}
+		SimulationData simData = (SimulationData) vcData;
+		File viewerFile = simData.getLangevinFile(LangevinBatchResultSet.LangevinFileType.Viewer);
+		if (viewerFile == null || !viewerFile.exists()) {
+			return null; // no trajectory captured for this simulation
+		}
+		try (java.io.Reader reader = new java.io.BufferedReader(new java.io.FileReader(viewerFile))) {
+			return SpringSaladTrajectory.parse(reader);
+		}
+	} catch (IOException e) {
+		throw new DataAccessException(e.getMessage(), e);
+	}
+}
+
 public ParticleDataBlock getParticleDataBlock(VCDataIdentifier vcdID, double time) throws DataAccessException {
 	if (lg.isTraceEnabled()) lg.trace("DataSetControllerImpl.getParticleDataBlock(" + time + ")");
 

--- a/vcell-core/src/main/java/cbit/vcell/simdata/LangevinBatchResultSet.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/LangevinBatchResultSet.java
@@ -24,7 +24,11 @@ public class LangevinBatchResultSet implements Serializable {
         Std("_Std", ".ida"),
         ClusterCounts("_clusters_counts", ".csv"),
         ClusterMean("_clusters_mean", ".csv"),
-        ClusterOverall("_clusters_overall", ".csv");
+        ClusterOverall("_clusters_overall", ".csv"),
+        // per-particle trajectory ("viewer") file: positions/links per dt_image frame, Run 0 only.
+        // Canonicalized flat into the user dir by the solver's postprocess step. Consumed by the
+        // SaLaD 3D renderer (see SpringSaladTrajectory).
+        Viewer("_VIEW_Run0", ".txt");
 
         private final String suffix;
         private final String extension;

--- a/vcell-core/src/main/java/cbit/vcell/simdata/LocalDataSetController.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/LocalDataSetController.java
@@ -131,6 +131,11 @@ public cbit.vcell.solver.ode.ODESimData getODEData(VCDataIdentifier vcdID) throw
 		return dataServerImpl.getLangevinBatchResultSet(user, vcdataID);
 	}
 
+	@Override
+	public SpringSaladTrajectory getLangevinTrajectory(VCDataIdentifier vcdataID) throws DataAccessException, RemoteProxyException {
+		return dataServerImpl.getLangevinTrajectory(user, vcdataID);
+	}
+
 
 	/**
  * This method was created by a SmartGuide.

--- a/vcell-core/src/main/java/cbit/vcell/simdata/SpringSaladTrajectory.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/SpringSaladTrajectory.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 1999-2026 University of Connecticut Health Center
+ *
+ * Licensed under the MIT License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *  http://www.opensource.org/licenses/mit-license.php
+ */
+package cbit.vcell.simdata;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * In-memory model of a SpringSaLaD (Langevin) particle trajectory, parsed from the
+ * solver's viewer file ({@code SimID_<key>_0__VIEW_Run0.txt}).
+ * <p>
+ * The viewer file is written by the {@code LangevinNoVis01} solver every {@code dt_image}
+ * step (for Run 0 only). It is a tab-delimited text file: a small header followed by a
+ * sequence of {@code SCENE} blocks, one per time point, each listing every site's id,
+ * radius, color and xyz position plus the links/bonds present at that instant. See
+ * {@code docs/salad-3d-renderer-design.md} (&sect;5) for the format specification.
+ * <p>
+ * This is the spatiotemporal data consumed by the SaLaD 3D renderer / movie player.
+ */
+public class SpringSaladTrajectory implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/** A single site (glyph) snapshot within one frame. */
+	public static class Site implements Serializable {
+		private static final long serialVersionUID = 1L;
+		private final int id;
+		private final double radius;
+		private final String color;
+		private final double x;
+		private final double y;
+		private final double z;
+
+		public Site(int id, double radius, String color, double x, double y, double z) {
+			this.id = id;
+			this.radius = radius;
+			this.color = color;
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+		public int getId() { return id; }
+		public double getRadius() { return radius; }
+		public String getColor() { return color; }
+		public double getX() { return x; }
+		public double getY() { return y; }
+		public double getZ() { return z; }
+	}
+
+	/** One time point: the sites' positions and the links/bonds present at {@link #getTime()}. */
+	public static class Frame implements Serializable {
+		private static final long serialVersionUID = 1L;
+		private final int sceneNumber;
+		private final double time;
+		private final List<Site> sites;
+		/** Each link is an {@code int[]{idA, idB}}; includes both structural links and dynamic bonds. */
+		private final List<int[]> links;
+
+		public Frame(int sceneNumber, double time, List<Site> sites, List<int[]> links) {
+			this.sceneNumber = sceneNumber;
+			this.time = time;
+			this.sites = Collections.unmodifiableList(sites);
+			this.links = Collections.unmodifiableList(links);
+		}
+		public int getSceneNumber() { return sceneNumber; }
+		public double getTime() { return time; }
+		public List<Site> getSites() { return sites; }
+		public List<int[]> getLinks() { return links; }
+	}
+
+	// header fields
+	private final double totalTime;
+	private final double dtImage;
+	private final double xSize;
+	private final double ySize;
+	private final double zOutside;
+	private final double zInside;
+	private final List<Frame> frames;
+
+	public SpringSaladTrajectory(double totalTime, double dtImage, double xSize, double ySize,
+								 double zOutside, double zInside, List<Frame> frames) {
+		this.totalTime = totalTime;
+		this.dtImage = dtImage;
+		this.xSize = xSize;
+		this.ySize = ySize;
+		this.zOutside = zOutside;
+		this.zInside = zInside;
+		this.frames = Collections.unmodifiableList(frames);
+	}
+
+	public double getTotalTime() { return totalTime; }
+	public double getDtImage() { return dtImage; }
+	/** Bounding-box extents from the header; use these for the scene box (units are the model's). */
+	public double getXSize() { return xSize; }
+	public double getYSize() { return ySize; }
+	public double getZOutside() { return zOutside; }
+	public double getZInside() { return zInside; }
+	public List<Frame> getFrames() { return frames; }
+	public int getFrameCount() { return frames.size(); }
+
+	/**
+	 * Parse a SpringSaLaD viewer file into a {@link SpringSaladTrajectory}.
+	 *
+	 * @param reader a reader over the viewer file contents (caller closes it)
+	 * @return the parsed trajectory
+	 * @throws IOException on read error or malformed header
+	 */
+	public static SpringSaladTrajectory parse(Reader reader) throws IOException {
+		BufferedReader br = (reader instanceof BufferedReader) ? (BufferedReader) reader : new BufferedReader(reader);
+
+		double totalTime = 0, dtImage = 0, xSize = 0, ySize = 0, zOutside = 0, zInside = 0;
+		boolean sawTotalTime = false;
+
+		// ---- header: key\tvalue lines until the terminating blank line ----
+		String line;
+		while ((line = br.readLine()) != null) {
+			if (line.trim().isEmpty()) {
+				break; // blank line ends the header
+			}
+			String[] t = line.split("\t");
+			if (t.length < 2) {
+				continue;
+			}
+			String key = t[0].trim();
+			double val = parseDouble(t[1]);
+			switch (key) {
+				case "TotalTime": totalTime = val; sawTotalTime = true; break;
+				case "dtimage":   dtImage = val;   break;
+				case "xsize":     xSize = val;     break;
+				case "ysize":     ySize = val;     break;
+				case "z_outside": zOutside = val;  break;
+				case "z_inside":  zInside = val;   break;
+				default: break; // tolerate unknown header keys
+			}
+		}
+		if (!sawTotalTime) {
+			throw new IOException("Not a SpringSaLaD viewer file: missing 'TotalTime' header");
+		}
+
+		// ---- frames: repeated SCENE blocks ----
+		List<Frame> frames = new ArrayList<>();
+		int sceneNumber = -1;
+		double time = 0;
+		List<Site> sites = new ArrayList<>();
+		List<int[]> links = new ArrayList<>();
+		boolean inScene = false;
+
+		while ((line = br.readLine()) != null) {
+			if (line.trim().isEmpty()) {
+				continue; // blank lines separate frames; frame is flushed on next SCENE / EOF
+			}
+			String[] t = line.split("\t");
+			String tag = t[0].trim();
+			switch (tag) {
+				case "SCENE":
+					if (inScene) {
+						frames.add(new Frame(sceneNumber, time, sites, links));
+					}
+					inScene = true;
+					sceneNumber = -1;
+					time = 0;
+					sites = new ArrayList<>();
+					links = new ArrayList<>();
+					break;
+				case "SceneNumber":
+					// SceneNumber \t <n> \t CurrentTime \t <t>
+					if (t.length >= 2) sceneNumber = (int) parseDouble(t[1]);
+					if (t.length >= 4) time = parseDouble(t[3]);
+					break;
+				case "ID":
+					// ID \t <id> \t <radius> \t <color> \t <x> \t <y> \t <z>
+					if (t.length >= 7) {
+						sites.add(new Site(
+								(int) parseDouble(t[1]),
+								parseDouble(t[2]),
+								t[3].trim(),
+								parseDouble(t[4]),
+								parseDouble(t[5]),
+								parseDouble(t[6])));
+					}
+					break;
+				case "Link":
+					// Link \t <idA> \t : \t <idB>
+					if (t.length >= 4) {
+						links.add(new int[] { (int) parseDouble(t[1]), (int) parseDouble(t[3]) });
+					}
+					break;
+				default:
+					break; // tolerate unknown lines
+			}
+		}
+		if (inScene) {
+			frames.add(new Frame(sceneNumber, time, sites, links));
+		}
+
+		return new SpringSaladTrajectory(totalTime, dtImage, xSize, ySize, zOutside, zInside, frames);
+	}
+
+	private static double parseDouble(String s) {
+		return Double.parseDouble(s.trim());
+	}
+}

--- a/vcell-core/src/main/java/cbit/vcell/simdata/VCDataManager.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/VCDataManager.java
@@ -298,6 +298,20 @@ public synchronized LangevinBatchResultSet getLangevinBatchResultSet(VCDataIdent
 	}
 }
 
+public synchronized SpringSaladTrajectory getLangevinTrajectory(VCDataIdentifier vcdID) throws DataAccessException {
+	try {
+		return getDataSetController().getLangevinTrajectory(vcdID);
+	}catch (RemoteProxyException e){
+		handleRemoteProxyException(e);
+		try {
+			return getDataSetController().getLangevinTrajectory(vcdID);
+		}catch (RemoteProxyException e2){
+			handleRemoteProxyException(e2);
+			throw new RuntimeException(e2.getMessage());
+		}
+	}
+}
+
 public synchronized NFSimMolecularConfigurations getNFSimMolecularConfigurations(VCDataIdentifier vcdID) throws DataAccessException {
 	try {
 		return getDataSetController().getNFSimMolecularConfigurations(vcdID);

--- a/vcell-core/src/test/java/cbit/vcell/simdata/SpringSaladTrajectoryTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/simdata/SpringSaladTrajectoryTest.java
@@ -1,0 +1,96 @@
+package cbit.vcell.simdata;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("Fast")
+public class SpringSaladTrajectoryTest {
+
+	// A minimal SpringSaLaD viewer file: header + two SCENE frames. Tabs are significant.
+	private static final String VIEWER =
+			"TotalTime\t0.01\n" +
+			"dtimage\t0.005\n" +
+			"xsize\t0.1\n" +
+			"ysize\t0.1\n" +
+			"z_outside\t0.01\n" +
+			"z_inside\t0.09\n" +
+			"\n" +
+			"SCENE\n" +
+			"SceneNumber\t0\tCurrentTime\t0.0\n" +
+			"ID\t0\t2.000000\tYELLOW\t0.000000\t4.000000\t4.000000\n" +
+			"ID\t1\t1.500000\tGREEN\t1.000000\t2.000000\t3.000000\n" +
+			"Link\t0\t:\t1\n" +
+			"\n" +
+			"SCENE\n" +
+			"SceneNumber\t1\tCurrentTime\t0.005\n" +
+			"ID\t0\t2.000000\tRED\t0.100000\t4.100000\t4.100000\n" +
+			"ID\t1\t1.500000\tGREEN\t1.100000\t2.100000\t3.100000\n" +
+			"Link\t0\t:\t1\n" +
+			"\n";
+
+	@Test
+	public void parsesHeaderFramesSitesAndLinks() throws IOException {
+		SpringSaladTrajectory traj = SpringSaladTrajectory.parse(new StringReader(VIEWER));
+
+		// header
+		assertEquals(0.01, traj.getTotalTime(), 0.0);
+		assertEquals(0.005, traj.getDtImage(), 0.0);
+		assertEquals(0.1, traj.getXSize(), 0.0);
+		assertEquals(0.1, traj.getYSize(), 0.0);
+		assertEquals(0.01, traj.getZOutside(), 0.0);
+		assertEquals(0.09, traj.getZInside(), 0.0);
+
+		// two frames
+		assertEquals(2, traj.getFrameCount());
+
+		SpringSaladTrajectory.Frame f0 = traj.getFrames().get(0);
+		assertEquals(0, f0.getSceneNumber());
+		assertEquals(0.0, f0.getTime(), 0.0);
+		assertEquals(2, f0.getSites().size());
+
+		SpringSaladTrajectory.Site s0 = f0.getSites().get(0);
+		assertEquals(0, s0.getId());
+		assertEquals(2.0, s0.getRadius(), 0.0);
+		assertEquals("YELLOW", s0.getColor());
+		assertEquals(0.0, s0.getX(), 0.0);
+		assertEquals(4.0, s0.getY(), 0.0);
+		assertEquals(4.0, s0.getZ(), 0.0);
+
+		assertEquals(1, f0.getLinks().size());
+		assertArrayEquals(new int[] { 0, 1 }, f0.getLinks().get(0));
+
+		// second frame: color/position change over time (state transition -> color change)
+		SpringSaladTrajectory.Frame f1 = traj.getFrames().get(1);
+		assertEquals(1, f1.getSceneNumber());
+		assertEquals(0.005, f1.getTime(), 0.0);
+		assertEquals("RED", f1.getSites().get(0).getColor());
+		assertEquals(0.1, f1.getSites().get(0).getX(), 1e-9);
+	}
+
+	@Test
+	public void rejectsNonViewerContent() {
+		String notViewer = "some random\nfile contents\n";
+		assertThrows(IOException.class, () -> SpringSaladTrajectory.parse(new StringReader(notViewer)));
+	}
+
+	@Test
+	public void handlesTrailingSceneWithoutTrailingBlankLine() throws IOException {
+		String oneFrameNoTrailingBlank =
+				"TotalTime\t1.0\n" +
+				"dtimage\t1.0\n" +
+				"xsize\t1\nysize\t1\nz_outside\t1\nz_inside\t1\n" +
+				"\n" +
+				"SCENE\n" +
+				"SceneNumber\t0\tCurrentTime\t0.0\n" +
+				"ID\t0\t1.0\tBLUE\t0.0\t0.0\t0.0\n"; // no trailing blank line
+		SpringSaladTrajectory traj = SpringSaladTrajectory.parse(new StringReader(oneFrameNoTrailingBlank));
+		assertEquals(1, traj.getFrameCount());
+		assertEquals(1, traj.getFrames().get(0).getSites().size());
+		assertTrue(traj.getFrames().get(0).getLinks().isEmpty());
+	}
+}


### PR DESCRIPTION
Phase 0 of the SaLaD 3D renderer (`docs/salad-3d-renderer-design.md`) — the **data path only**; the desktop glyph renderer is Phase 1.

**Companion:** [cam-center/LangevinNoVis01#39](https://github.com/cam-center/LangevinNoVis01/pull/39), which canonicalizes the solver's Run-0 trajectory ("viewer") file to a flat name in the user dir. This PR makes VCell serve it.

## What & why

The `LangevinNoVis01` solver writes a per-particle trajectory (positions + links per `dt_image` frame, Run 0) that VCell previously ignored — the only SaLaD results served were the aggregate `.ida`/`.csv`. This adds a server→client path for that trajectory, the spatiotemporal data the renderer needs.

## Changes (all mirror the existing `getLangevinBatchResultSet` path)

- **`SpringSaladTrajectory`** — in-memory model + tab-delimited `SCENE` parser (header + per-frame sites/links). Unit test (`SpringSaladTrajectoryTest`, `@Tag("Fast")`, 3 tests) with an inline fixture.
- **`LangevinFileType.Viewer` (`_VIEW_Run0`, `.txt`)** — so the existing `SimulationData.getLangevinFile()` resolves the flat canonical file with no new resolution logic. (`LangevinFileType.values()` is unused, so extending the enum is safe.)
- **`getLangevinTrajectory()`** threaded down the existing chain: `DataSetControllerImpl` (parse + return, null if absent), `DataServerImpl`, `LocalDataSetController`, `RpcDataServerProxy` (reflection-dispatched RPC), `VCDataManager`, and the vcell-client provider. `DataSetController` gets a **default** returning null so the other implementors are unaffected.

## Verification

- `mvn -pl vcell-core,vcell-client -am test-compile` → success.
- `SpringSaladTrajectoryTest` → Tests run: 3, Failures: 0, Errors: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)