### PR TITLE
SaLaD viewer: box + membrane, and fixes for local/single runs

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataViewer.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/ODEDataViewer.java
@@ -558,7 +558,10 @@ public void setOdeDataContext() {
 	// present but merely disabled for other dataset types, which was a bug (confusing dead tabs).
 	// JTabbedPane has no per-tab visibility, so we add/remove them instead.
 	setTabVisible(LANGEVIN_CLUSTER_RESULTS_TABNAME, langevin ? getViewMultiClusters() : null, langevin);
-	setTabVisible(TRAJECTORY_TABNAME, langevin ? getTrajectoryViewerPanel() : null, langevin);
+	// The 3D Trajectory tab is driven by whether a trajectory was actually captured (any SpringSaLaD
+	// run - single or batch), not by hasLangevinBatchResults (which requires cluster data).
+	boolean hasTrajectory = fieldSpringSaladTrajectory != null;
+	setTabVisible(TRAJECTORY_TABNAME, hasTrajectory ? getTrajectoryViewerPanel() : null, hasTrajectory);
 	setTabVisible(OUTPUT_SPECIES_TABNAME, nfsim ? outputSpeciesResultsPanel : null, nfsim);
 }
 

--- a/vcell-client/src/main/java/cbit/vcell/client/data/SimResultsViewer.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/SimResultsViewer.java
@@ -85,11 +85,13 @@ private DataViewer createODEDataViewer() throws DataAccessException {
 			odeDataViewer.setLangevinSolverResultSet(langevinSolverResultSet);
 			odeDataViewer.hasLangevinBatchResults = true;
 			odeDataViewer.replaceViewDataTab();
-			// trajectory was loaded on the non-Swing data thread in ODEDataManager.connect(); this is a
-			// cached read (may be null if no viewer file was captured -> the 3D tab shows "no data").
-			odeDataViewer.setSpringSaladTrajectory(((ODEDataManager)dataManager).getLangevinTrajectory());
 		}
 	}
+	// The per-particle trajectory ("viewer" file) exists for ANY SpringSaLaD run - single or batch,
+	// with or without cluster data - not only the langevin-batch case above. It was loaded off-EDT in
+	// ODEDataManager.connect(); this is a cached read. Null (non-langevin / no viewer file) -> the "3D
+	// Trajectory" tab simply won't appear.
+	odeDataViewer.setSpringSaladTrajectory(((ODEDataManager)dataManager).getLangevinTrajectory());
 	odeDataViewer.setOdeSolverResultSet(odesrs);
 	odeDataViewer.setNFSimMolecularConfigurations(((ODEDataManager)dataManager).getNFSimMolecularConfigurations());
 	odeDataViewer.setVcDataIdentifier(dataManager.getVCDataIdentifier());

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SpringSaladViewerCanvas.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SpringSaladViewerCanvas.java
@@ -16,6 +16,7 @@ import cbit.vcell.render.Vect3d;
 import cbit.vcell.simdata.SpringSaladTrajectory;
 
 import javax.swing.JPanel;
+import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -24,12 +25,14 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Java2D "impostor-sphere" renderer for one frame of a {@link SpringSaladTrajectory}.
@@ -55,6 +58,13 @@ public class SpringSaladViewerCanvas extends JPanel {
 	private double zoom = 1.0;
 	private double panX = 0, panY = 0;
 	private boolean showLinks = true;
+	private boolean showBox = true;
+	private boolean showMembrane = true;
+
+	private static final Color MEMBRANE_GREEN = new Color(45, 175, 70);
+	private static final int MEMBRANE_GRID = 12;      // NxN quad subdivision — only to depth-sort vs glyphs
+	// light direction (upper-left, toward viewer), shared with the sphere sprite, for membrane lighting
+	private static final double LIGHT_X = -0.5014, LIGHT_Y = -0.6017, LIGHT_Z = 0.6217;
 
 	// world framing (computed from all frames so the box doesn't jitter during playback)
 	private boolean boundsValid = false;
@@ -122,6 +132,8 @@ public class SpringSaladViewerCanvas extends JPanel {
 	public int getFrameIndex() { return frameIndex; }
 
 	public void setShowLinks(boolean b) { showLinks = b; repaint(); }
+	public void setShowBox(boolean b) { showBox = b; repaint(); }
+	public void setShowMembrane(boolean b) { showMembrane = b; repaint(); }
 
 	public void resetView() {
 		trackball.getCamera().resetView();
@@ -164,6 +176,17 @@ public class SpringSaladViewerCanvas extends JPanel {
 				}
 			}
 		}
+		if (trajectory != null) {
+			// include the simulation box so the whole box (and membrane) is framed, not just the glyphs
+			double xs = trajectory.getXSize(), ys = trajectory.getYSize();
+			double zo = trajectory.getZOutside(), zi = trajectory.getZInside();
+			if (xs > 0 && ys > 0) {
+				any = true;
+				minX = Math.min(minX, -xs); maxX = Math.max(maxX, xs);
+				minY = Math.min(minY, -ys); maxY = Math.max(maxY, ys);
+				minZ = Math.min(minZ, -zo); maxZ = Math.max(maxZ, zi);
+			}
+		}
 		if (!any) { cx = cy = cz = 0; halfExtent = 1; }
 		else {
 			cx = (minX + maxX) / 2; cy = (minY + maxY) / 2; cz = (minZ + maxZ) / 2;
@@ -199,41 +222,133 @@ public class SpringSaladViewerCanvas extends JPanel {
 		double minD = Double.POSITIVE_INFINITY, maxD = Double.NEGATIVE_INFINITY;
 		Map<Integer, Glyph> byId = new HashMap<>();
 		for (SpringSaladTrajectory.Site s : frame.getSites()) {
-			Vect3d v = rot.mult(new Vect3d(s.getX() - cx, s.getY() - cy, s.getZ() - cz));
+			double[] p = project(rot, s.getX(), s.getY(), s.getZ(), pixelScale, ox, oy);
 			Glyph gl = new Glyph();
 			gl.id = s.getId();
-			gl.sx = ox + v.getX() * pixelScale;
-			gl.sy = oy - v.getY() * pixelScale;
-			gl.depth = v.getZ();
+			gl.sx = p[0]; gl.sy = p[1]; gl.depth = p[2];
 			gl.screenR = Math.max(1.0, s.getRadius() * pixelScale);
 			gl.color = colorForName(s.getColor());
 			glyphs.add(gl);
 			byId.put(gl.id, gl);
 			minD = Math.min(minD, gl.depth); maxD = Math.max(maxD, gl.depth);
 		}
+		double span = (maxD - minD) < 1e-12 ? 1 : (maxD - minD);
 
-		// links behind the spheres (nearer sphere then overpaints)
+		// unified depth-sorted draw list (painter's algorithm): membrane quads + links + glyph sprites,
+		// so the membrane composites correctly with glyphs on either side of it.
+		List<Drawable> drawables = new ArrayList<>();
+		if (showMembrane) addMembrane(rot, pixelScale, ox, oy, drawables);
 		if (showLinks) {
-			g2.setColor(new Color(120, 120, 120));
 			for (int[] link : frame.getLinks()) {
 				Glyph a = byId.get(link[0]), b = byId.get(link[1]);
-				if (a != null && b != null) g2.draw(new Line2D.Double(a.sx, a.sy, b.sx, b.sy));
+				if (a == null || b == null) continue;
+				Line2D ln = new Line2D.Double(a.sx, a.sy, b.sx, b.sy);
+				drawables.add(new Drawable((a.depth + b.depth) / 2, gg -> {
+					gg.setColor(new Color(150, 150, 150));
+					gg.setStroke(new BasicStroke(1f));
+					gg.draw(ln);
+				}));
 			}
 		}
-
-		// painter's algorithm: far (smaller depth) first
-		glyphs.sort((p, q) -> Double.compare(p.depth, q.depth));
-		double span = (maxD - minD) < 1e-12 ? 1 : (maxD - minD);
 		for (Glyph gl : glyphs) {
 			double bright = MIN_BRIGHT + (1 - MIN_BRIGHT) * ((gl.depth - minD) / span); // nearer = brighter
 			BufferedImage sprite = getSprite(gl.color, bright);
 			int d = (int) Math.round(gl.screenR * 2);
-			g2.drawImage(sprite, (int) Math.round(gl.sx - gl.screenR), (int) Math.round(gl.sy - gl.screenR), d, d, null);
+			int px = (int) Math.round(gl.sx - gl.screenR), py = (int) Math.round(gl.sy - gl.screenR);
+			drawables.add(new Drawable(gl.depth, gg -> gg.drawImage(sprite, px, py, d, d, null)));
+		}
+
+		drawables.sort((p, q) -> Double.compare(p.depth, q.depth)); // far first
+		for (Drawable d : drawables) d.paint.accept(g2);
+
+		// simulation-box wireframe as a reference overlay, on top
+		if (showBox) drawBox(g2, rot, pixelScale, ox, oy);
+	}
+
+	/** Project a world point to {screenX, screenY, cameraDepth} using the current rotation/zoom/pan. */
+	private double[] project(Affine rot, double wx, double wy, double wz, double pixelScale, double ox, double oy) {
+		Vect3d v = rot.mult(new Vect3d(wx - cx, wy - cy, wz - cz));
+		return new double[] { ox + v.getX() * pixelScale, oy - v.getY() * pixelScale, v.getZ() };
+	}
+
+	/**
+	 * Membrane = the z=0 plane across the box's x,y extent, as an OPAQUE green surface. It is diced into
+	 * a grid only so each cell can be depth-sorted against the glyphs (so molecules composite correctly
+	 * on either side of it). The fill is a single uniform shade computed from the plane's rotated normal
+	 * vs the light — flat planes are uniformly lit — which avoids per-quad depth banding and, because all
+	 * cells share one color, avoids anti-alias seams between them.
+	 */
+	private void addMembrane(Affine rot, double pixelScale, double ox, double oy, List<Drawable> out) {
+		double xs = trajectory.getXSize(), ys = trajectory.getYSize();
+		if (xs <= 0 || ys <= 0) return;
+		Vect3d n = rot.mult(new Vect3d(0, 0, 1));
+		double len = Math.sqrt(n.getX() * n.getX() + n.getY() * n.getY() + n.getZ() * n.getZ());
+		double dot = len > 0 ? (n.getX() * LIGHT_X + n.getY() * LIGHT_Y + n.getZ() * LIGHT_Z) / len : 0;
+		double shade = 0.35 + 0.65 * Math.abs(dot);   // face-on = bright, edge-on = dark
+		final Color fill = new Color(
+				clamp255(MEMBRANE_GREEN.getRed() * shade),
+				clamp255(MEMBRANE_GREEN.getGreen() * shade),
+				clamp255(MEMBRANE_GREEN.getBlue() * shade));   // opaque
+		int G = MEMBRANE_GRID;
+		for (int i = 0; i < G; i++) {
+			double x0 = -xs + 2 * xs * i / G, x1 = -xs + 2 * xs * (i + 1) / G;
+			for (int j = 0; j < G; j++) {
+				double y0 = -ys + 2 * ys * j / G, y1 = -ys + 2 * ys * (j + 1) / G;
+				double[] a = project(rot, x0, y0, 0, pixelScale, ox, oy);
+				double[] b = project(rot, x1, y0, 0, pixelScale, ox, oy);
+				double[] c = project(rot, x1, y1, 0, pixelScale, ox, oy);
+				double[] d = project(rot, x0, y1, 0, pixelScale, ox, oy);
+				double depth = (a[2] + b[2] + c[2] + d[2]) / 4;
+				// grow each cell ~1px outward from its centroid so adjacent (same-color) cells overlap,
+				// hiding the anti-alias seams that would otherwise show the grid.
+				double gx = (a[0] + b[0] + c[0] + d[0]) / 4, gy = (a[1] + b[1] + c[1] + d[1]) / 4;
+				Path2D.Double quad = new Path2D.Double();
+				double[][] pts = { a, b, c, d };
+				for (int p = 0; p < 4; p++) {
+					double dx = pts[p][0] - gx, dy = pts[p][1] - gy, dl = Math.sqrt(dx * dx + dy * dy);
+					double ex = pts[p][0], ey = pts[p][1];
+					if (dl > 1e-6) { ex += dx / dl * 1.0; ey += dy / dl * 1.0; }
+					if (p == 0) quad.moveTo(ex, ey); else quad.lineTo(ex, ey);
+				}
+				quad.closePath();
+				out.add(new Drawable(depth, gg -> { gg.setColor(fill); gg.fill(quad); }));
+			}
 		}
 	}
 
+	/** Simulation box: the 12 edges of [-xSize,xSize] x [-ySize,ySize] x [-zOutside,zInside]. */
+	private void drawBox(Graphics2D g2, Affine rot, double pixelScale, double ox, double oy) {
+		double xs = trajectory.getXSize(), ys = trajectory.getYSize();
+		double zo = trajectory.getZOutside(), zi = trajectory.getZInside();
+		if (xs <= 0 || ys <= 0) return;
+		double[] X = { -xs, xs }, Y = { -ys, ys }, Z = { -zo, zi };
+		double[][] c = new double[8][];
+		int k = 0;
+		for (int a = 0; a < 2; a++)
+			for (int b = 0; b < 2; b++)
+				for (int cc = 0; cc < 2; cc++)
+					c[k++] = project(rot, X[a], Y[b], Z[cc], pixelScale, ox, oy);
+		int[][] edges = {
+			{ 0, 1 }, { 2, 3 }, { 4, 5 }, { 6, 7 },   // along z
+			{ 0, 2 }, { 1, 3 }, { 4, 6 }, { 5, 7 },   // along y
+			{ 0, 4 }, { 1, 5 }, { 2, 6 }, { 3, 7 }    // along x
+		};
+		g2.setColor(new Color(150, 150, 175));
+		g2.setStroke(new BasicStroke(1f));
+		for (int[] e : edges) g2.draw(new Line2D.Double(c[e[0]][0], c[e[0]][1], c[e[1]][0], c[e[1]][1]));
+	}
+
+	private static double clamp01(double v) { return v < 0 ? 0 : (v > 1 ? 1 : v); }
+
 	private static final class Glyph {
 		int id; double sx, sy, depth, screenR; Color color;
+	}
+
+	/** A depth-sorted paint action (glyph sprite, membrane quad, or link). */
+	private static final class Drawable {
+		final double depth;
+		final Consumer<Graphics2D> paint;
+		Drawable(double depth, Consumer<Graphics2D> paint) { this.depth = depth; this.paint = paint; }
 	}
 
 	// ---- impostor sprite generation / cache ----

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SpringSaladViewerPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SpringSaladViewerPanel.java
@@ -72,6 +72,14 @@ public class SpringSaladViewerPanel extends JPanel {
 		links.addActionListener(e -> canvas.setShowLinks(links.isSelected()));
 		controls.add(links);
 
+		JCheckBox box = new JCheckBox("Box", true);
+		box.addActionListener(e -> canvas.setShowBox(box.isSelected()));
+		controls.add(box);
+
+		JCheckBox membrane = new JCheckBox("Membrane", true);
+		membrane.addActionListener(e -> canvas.setShowMembrane(membrane.isSelected()));
+		controls.add(membrane);
+
 		JButton reset = new JButton("Reset view");
 		reset.addActionListener(e -> canvas.resetView());
 		controls.add(reset);

--- a/vcell-core/src/main/java/cbit/vcell/simdata/DataSetControllerImpl.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/DataSetControllerImpl.java
@@ -2468,7 +2468,7 @@ public SpringSaladTrajectory getLangevinTrajectory(VCDataIdentifier vcdID) throw
 			return null;
 		}
 		SimulationData simData = (SimulationData) vcData;
-		File viewerFile = simData.getLangevinFile(LangevinBatchResultSet.LangevinFileType.Viewer);
+		File viewerFile = simData.getLangevinViewerFile();	// flat canonical (server) or _FOLDER subfolder (local)
 		if (viewerFile == null || !viewerFile.exists()) {
 			return null; // no trajectory captured for this simulation
 		}

--- a/vcell-core/src/main/java/cbit/vcell/simdata/ODEDataManager.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/ODEDataManager.java
@@ -200,21 +200,22 @@ private void connect() throws DataAccessException {
 		odeSolverResultSet = langevinSolverResultSet.getAvg();
 		langevinSolverResultSet.postProcess();
 		lg.debug("ODEDataManager: Langevin batch run detected, using average data for odeSolverResultSet");
-		// load the per-particle trajectory ("viewer" file) here, on this non-Swing data thread, so
-		// the results viewer can read it as a cached field without blocking the EDT. May be null
-		// (no viewer file captured); a fetch error must not abort loading the aggregate results.
-		try {
-			springSaladTrajectory = getVCDataManager().getLangevinTrajectory(getVCDataIdentifier());
-		} catch (Exception e) {
-			lg.warn("failed to load SpringSaLaD trajectory (viewer file): " + e.getMessage(), e);
-			springSaladTrajectory = null;
-		}
 	} else {
 		// it's some single run (langevin, nfsim, something else), get single run results the old way
 		// clone, so we can operate safely on it (adding/removing user-defined functions) - real remote data is being cached...
 		odeSolverResultSet = new ODESimData(getVCDataIdentifier(),getVCDataManager().getODEData(getVCDataIdentifier()));
 		nFSimMolecularConfigurations = getVCDataManager().getNFSimMolecularConfigurations(getVCDataIdentifier());
 		lg.debug("ODEDataManager: Single run detected, using ODEDataManager.getVCDataManager().getODEData() for odeSolverResultSet");
+	}
+	// Load the per-particle trajectory ("viewer" file) for ANY run that produced one - single or
+	// batch SpringSaLaD; null for non-langevin. Done here on the non-Swing data thread so the results
+	// viewer reads it as a cached field without blocking the EDT. A fetch error must not abort the
+	// aggregate-results load.
+	try {
+		springSaladTrajectory = getVCDataManager().getLangevinTrajectory(getVCDataIdentifier());
+	} catch (Exception e) {
+		lg.warn("failed to load SpringSaLaD trajectory (viewer file): " + e.getMessage(), e);
+		springSaladTrajectory = null;
 	}
 }
 

--- a/vcell-core/src/main/java/cbit/vcell/simdata/SimulationData.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/SimulationData.java
@@ -832,6 +832,32 @@ public synchronized ODEDataBlock getODEDataBlock() throws DataAccessException, I
 		return odeFile;
 	}
 
+	/**
+	 * Resolve the SpringSaLaD trajectory ("viewer") file. Tries the flat canonical name first
+	 * (server runs: the solver's postprocess step canonicalizes it into the user dir, archival-safe),
+	 * then falls back to the solver's {@code <base>_FOLDER/viewer_files/} subfolder (local runs, which
+	 * invoke only the solver's 'simulate' step and never canonicalize). Returns null if neither exists.
+	 */
+	public synchronized File getLangevinViewerFile() throws DataAccessException {
+		File flat = getLangevinFile(LangevinBatchResultSet.LangevinFileType.Viewer);
+		if (flat != null && flat.exists()) {
+			return flat;
+		}
+		refreshLogFile();
+		if (dataFilenames == null) {
+			return null;
+		}
+		String baseFilename = dataFilenames[0];
+		int dotIndex = baseFilename.lastIndexOf('.');
+		if (dotIndex <= 0) {
+			return null;
+		}
+		String base = baseFilename.substring(0, dotIndex);
+		File sub = amplistorHelper.getFile(
+				base + "_FOLDER" + File.separator + "viewer_files" + File.separator + base + "_VIEW_Run0.txt");
+		return (sub != null && sub.exists()) ? sub : null;
+	}
+
 
 private synchronized File getODEDataFile() throws DataAccessException {
 	refreshLogFile();


### PR DESCRIPTION
Follow-up to the SaLaD 3D trajectory viewer (#1795 Phase 0, #1796 Phase 1). Two parts:

## Fixes (make it work for local / single runs)

- **Show the trajectory for any langevin run**, not only batch-with-cluster runs. The "3D Trajectory" tab was gated on `hasLangevinBatchResults`; now the trajectory is loaded (off-EDT in `ODEDataManager.connect()`) and the tab shown whenever a viewer file exists — single or batch.
- **Local runs now find the viewer file.** The desktop `LangevinSolver` runs only the solver's `simulate` step, never `postprocess`, so the viewer file is never canonicalized to the flat name locally. `SimulationData.getLangevinViewerFile()` falls back to the solver's `<base>_FOLDER/viewer_files/` subfolder (local) after trying the flat canonical name (server, archival-safe).

## Refinements (box + membrane)

- **Simulation box** wireframe (12 edges from the header extent); framing now includes the box.
- **Membrane** = the `z=0` plane as an **opaque** green surface, uniformly shaded from the plane's rotated normal (no banding), diced into a grid only to depth-sort against glyphs so molecules composite correctly on either side; cells overlap ~1px to hide anti-alias seams.
- Unified paint into one depth-sorted draw list (membrane + links + glyphs), all opaque.
- Toolbar toggles: **Box**, **Membrane** (+ existing **Links**).

Validated visually via `SpringSaladViewerRenderTest` (headless PNG/GIF preview) and by driving a local SpringSaLaD run in the desktop client (the "3D Trajectory" tab now appears and renders the box + membrane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)