### PR TITLE
ci(vtk-wasm): scaffold custom VTK.wasm build workflow (increment 1)

### DIFF
--- a/.github/workflows/vtk-wasm-build.yml
+++ b/.github/workflows/vtk-wasm-build.yml
@@ -1,0 +1,44 @@
+name: Build custom VTK.wasm bundle
+
+# Manual-only (and path-scoped) — this is a heavy, infrequent build (bumped only when the
+# @kitware/vtk-wasm loader / VTK pin changes). It never runs on normal PRs, so it does not affect
+# the main CI. Produces the trimmed vtkWebAssembly.{mjs,wasm} bundle VCell's field viewer loads.
+# See tools/vtk-wasm/README.md for the recipe and the open work (module trimming, reader exposure).
+on:
+  workflow_dispatch:
+    inputs:
+      vtk_commit:
+        description: "VTK commit (default = the @kitware/vtk-wasm loader's pinned commit, 9.7.20260726)"
+        default: "8fcb79cafc338bf890579ba9f565019130c7b1e8"
+        type: string
+      optimization:
+        description: "VTK_WASM_OPTIMIZATION"
+        default: "SMALL"
+        type: choice
+        options: [NO_OPTIMIZATION, LITTLE, MORE, BEST, SMALL, SMALLEST, SMALLEST_WITH_CLOSURE]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest        # native amd64 — matches VTK's own CI toolchain
+    timeout-minutes: 350          # VTK all-modules wasm build is large; see README
+    container:
+      image: emscripten/emsdk:4.0.20   # the emsdk VTK's CI pins for this commit
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: apt-get update && apt-get install -y --no-install-recommends ninja-build git ca-certificates
+
+      - name: Build custom VTK.wasm bundle
+        env:
+          VTK_COMMIT: ${{ inputs.vtk_commit }}
+          VTK_WASM_OPTIMIZATION: ${{ inputs.optimization }}
+          OUT_DIR: ${{ github.workspace }}/dist
+        run: bash tools/vtk-wasm/build.sh
+
+      - name: Upload bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: vcell-vtk-wasm-${{ inputs.optimization }}
+          path: dist/vcell-vtk-wasm32-emscripten.tar.gz
+          if-no-files-found: error

--- a/tools/vtk-wasm/Dockerfile
+++ b/tools/vtk-wasm/Dockerfile
@@ -1,0 +1,16 @@
+# Local reproduction of the CI vtk.wasm build (the CI uses `container: emscripten/emsdk:4.0.20`
+# directly; this Dockerfile is the equivalent for `docker build`).
+#
+#   On Apple Silicon you MUST target amd64 to match VTK's CI toolchain — the arm64 emscripten
+#   image resolves an embind template overload differently and fails to compile VTK's SOA-array
+#   bindings:
+#
+#     docker build --platform linux/amd64 -t vcell-vtk-wasm tools/vtk-wasm
+#     docker run --rm --platform linux/amd64 -e VTK_WASM_OPTIMIZATION=SMALL \
+#         -v "$PWD/dist:/out" -e OUT_DIR=/out vcell-vtk-wasm
+FROM emscripten/emsdk:4.0.20
+RUN apt-get update && apt-get install -y --no-install-recommends ninja-build git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY build.sh /work/build.sh
+WORKDIR /work
+ENTRYPOINT ["bash", "/work/build.sh"]

--- a/tools/vtk-wasm/README.md
+++ b/tools/vtk-wasm/README.md
@@ -1,0 +1,70 @@
+# Custom VTK.wasm build for VCell's field viewer
+
+Builds a **VTK compiled to WebAssembly** bundle (`vtkWebAssembly.{mjs,wasm}`) for the browser PDE
+field viewer described in `docs/salad-3d-renderer-design.md` §8 / §8B. The bundle is loaded by the
+[`@kitware/vtk-wasm`](https://www.npmjs.com/package/@kitware/vtk-wasm) JavaScript loader and does the
+mesh processing (`vtkThreshold` → `vtkWindowedSincPolyDataFilter`), slicing, contouring, and
+rendering **client-side** — the same code path for the web app and for local desktop runs (served by
+a small local Java HTTP server + the system browser). No Python or native VTK on the client.
+
+## Why a from-source build (and why it's fiddly)
+
+The released `@kitware/vtk-wasm` bundle already ships the renderer + several filters, but **lacks the
+IO readers and `FiltersGeometry` (surface extraction)** we need. So we rebuild VTK with the modules
+we require. The hard part is that VTK's JS-wrapped wasm build only configures/compiles cleanly with
+VTK's **own, self-consistent CI configuration** — cherry-picking module flags fails in a cascade:
+
+- omit `VTK_WRAP_SERIALIZATION` → the SOA/serialization array classes emit embind bindings that don't
+  compile (`no matching member function for call to 'function'` — "couldn't infer 'Callable'"), and
+- add it piecemeal → the next inconsistency (`VTK_BUILD_TYPES_JSON`, the wrap-target link error) …
+
+So this build configures via VTK's `-C .gitlab/ci/configure_wasm32_emscripten_linux.cmake` (which
+transitively pulls `configure_wasm_common.cmake` + `configure_common.cmake`: `VTK_BUILD_ALL_MODULES`,
+`VTK_WRAP_SERIALIZATION`, `VTK_BUILD_TYPES_JSON`, `VTK_DISPATCH_SOA_ARRAYS`, `VTK_ENABLE_WEBGPU`,
+`VTK_WEBASSEMBLY_THREADS=OFF`, and the module-disable list), and only adds `VTK_WRAP_JAVASCRIPT=ON`
+and the `VTK_WASM_OPTIMIZATION` knob.
+
+## Pins (bump together)
+
+| Pin | Value | Why |
+|---|---|---|
+| VTK commit | `8fcb79cafc338bf890579ba9f565019130c7b1e8` | the commit the `@kitware/vtk-wasm` 2.1.8 loader's bundle (`9.7.20260726`) tracks — matches the loader's glue API + `vtkWebAssembly` naming + standalone-session |
+| emsdk | `4.0.20` | what VTK's CI pins at that commit (`.gitlab/ci/download_emsdk.cmake`) |
+| platform | **amd64** | VTK CI is amd64; the arm64 emscripten image miscompiles VTK's SOA embind |
+
+## Run it
+
+**CI (recommended):** GitHub Actions → *Build custom VTK.wasm bundle* (`workflow_dispatch`). Runs
+natively on an amd64 runner inside `emscripten/emsdk:4.0.20`, uploads the bundle as an artifact.
+Inputs: `vtk_commit`, `optimization`.
+
+**Locally** (Apple Silicon needs `--platform linux/amd64`; emulated → slow):
+
+```bash
+docker build --platform linux/amd64 -t vcell-vtk-wasm tools/vtk-wasm
+mkdir -p dist
+docker run --rm --platform linux/amd64 -e VTK_WASM_OPTIMIZATION=SMALL \
+    -e OUT_DIR=/out -v "$PWD/dist:/out" vcell-vtk-wasm
+```
+
+## Status / open work
+
+This scaffold produces VTK's **all-modules** bundle (guaranteed to compile — it's what Kitware
+ships). Before it's production-ready:
+
+1. **Verify what the bundle exposes.** Load the artifact through `@kitware/vtk-wasm` and confirm the
+   session namespace actually surfaces `vtkXMLImageDataReader` / `vtkXMLUnstructuredGridReader`,
+   `vtkThreshold`, `vtkGeometryFilter`, `vtkWindowedSincPolyDataFilter`. (A probe of the *released*
+   bundle showed the XML reader was **not** registered in the session even though the module builds —
+   so this needs confirming, and if readers aren't wrapped we build the grid in-memory via the
+   data-model API instead, which the released bundle already exposes.)
+2. **Golden-file test:** client-side `vtkThreshold` + `vtkWindowedSincPolyDataFilter` (12 iters,
+   pass-band 0.05, feature angle 120°) reproduces the pyvcell/Java `.vtu` for a real VCell mesh.
+3. **Trim modules** from the working all-modules baseline to cut size (all-modules is ~77 MB /
+   ~12 MB gz; a trimmed `IOXML` + `FiltersGeometry`/`Core`/`General` + rendering set at `SMALLEST`
+   should be far smaller). Trim incrementally and keep it building — see the cascade warning above.
+4. **Build time / cost:** the all-modules wasm build is large; on a stock GitHub runner it is slow.
+   Consider a larger runner and/or ccache before making this routine.
+5. **Publish + consume:** once trimmed and verified, publish the bundle (release asset / GitHub
+   Packages / an `@virtualcell/vtk-wasm` npm package) and have `webapp-ng` pin + fetch it. If this
+   grows its own lifecycle, graduate it to a dedicated `virtualcell/vcell-vtk-wasm` repo.

--- a/tools/vtk-wasm/build.sh
+++ b/tools/vtk-wasm/build.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Build a custom VTK.wasm bundle for VCell's browser field viewer.
+#
+# Produces vtkWebAssembly.{mjs,wasm} (the format the @kitware/vtk-wasm loader consumes) by
+# compiling VTK to WebAssembly with VTK's *own* wasm CI configuration, which is the only
+# self-consistent way to get a working JS-wrapped bundle (cherry-picking module flags fails in a
+# cascade — see README.md). Run in CI (see .github/workflows/vtk-wasm-build.yml, inside the
+# emscripten/emsdk container on a native amd64 runner) or locally via tools/vtk-wasm/Dockerfile.
+#
+# Requires emscripten on PATH (emcmake/em++), cmake >= 3.29, ninja, git.
+set -euo pipefail
+
+# The VTK commit the @kitware/vtk-wasm loader (2.1.8, bundle "9.7.20260726") tracks. Building a
+# different commit risks the loader-vs-bundle glue API drifting; bump both together.
+VTK_COMMIT="${VTK_COMMIT:-8fcb79cafc338bf890579ba9f565019130c7b1e8}"
+# NO_OPTIMIZATION | LITTLE | MORE | BEST | SMALL | SMALLEST | SMALLEST_WITH_CLOSURE
+OPT="${VTK_WASM_OPTIMIZATION:-SMALL}"
+
+SRC="${VTK_SRC_DIR:-/tmp/vtk-src}"
+BUILD="${VTK_BUILD_DIR:-/tmp/vtk-build}"
+OUT="${OUT_DIR:-$PWD/dist}"
+
+echo ">>> VTK commit : $VTK_COMMIT"
+echo ">>> optimization: $OPT"
+
+# --- fetch VTK at the pinned commit (shallow) ---
+if [ ! -e "$SRC/CMakeLists.txt" ]; then
+  mkdir -p "$SRC"; cd "$SRC"
+  git init -q
+  git remote add origin https://github.com/Kitware/VTK.git 2>/dev/null || true
+  git fetch --depth 1 origin "$VTK_COMMIT"
+  git checkout -q FETCH_HEAD
+fi
+
+# --- configure with VTK's own wasm CI cache (-C), plus JS wrapping + our optimization ---
+# The -C file transitively includes configure_wasm_linux.cmake -> configure_wasm_common.cmake ->
+# configure_common.cmake, giving the complete working set: VTK_BUILD_ALL_MODULES, WRAP_SERIALIZATION,
+# BUILD_TYPES_JSON, DISPATCH_SOA_ARRAYS, ENABLE_WEBGPU, WEBASSEMBLY_THREADS=OFF, and the module
+# disables for libs absent from the toolchain image. We only add VTK_WRAP_JAVASCRIPT (not set in the
+# cache files) and the optimization knob.
+emcmake cmake -S "$SRC" -B "$BUILD" -G Ninja \
+  -C "$SRC/.gitlab/ci/configure_wasm32_emscripten_linux.cmake" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DVTK_WRAP_JAVASCRIPT=ON \
+  -DVTK_WASM_OPTIMIZATION="$OPT" \
+  -DVTK_BUILD_TESTING=OFF
+
+# --- build (VTK's wasm cache pins the link job pool to 1 to dodge an emscripten file-lock bug) ---
+cmake --build "$BUILD"
+
+# --- collect the loader bundle ---
+mkdir -p "$OUT"
+find "$BUILD" -name "vtkWebAssembly.wasm" -exec cp {} "$OUT/" \;
+find "$BUILD" -name "vtkWebAssembly.mjs"  -exec cp {} "$OUT/" \;
+if [ ! -f "$OUT/vtkWebAssembly.wasm" ] || [ ! -f "$OUT/vtkWebAssembly.mjs" ]; then
+  echo "ERROR: expected vtkWebAssembly.{wasm,mjs} not produced — check VTK_WRAP_JAVASCRIPT" >&2
+  find "$BUILD" -name "vtk*.wasm" -o -name "vtk*.mjs" | head >&2
+  exit 1
+fi
+cd "$OUT"
+tar czf "vcell-vtk-wasm32-emscripten.tar.gz" vtkWebAssembly.wasm vtkWebAssembly.mjs
+echo ">>> bundle:"
+ls -lh "$OUT"
+echo ">>> gzipped wasm: $(gzip -c vtkWebAssembly.wasm | wc -c | awk '{printf "%.1f MB", $1/1048576}')"


### PR DESCRIPTION
**Increment 1** of the field-viz plan (design doc §8B): a `workflow_dispatch`-gated GitHub Actions build that compiles **VTK → WebAssembly** for the browser field viewer, producing the `vtkWebAssembly.{mjs,wasm}` bundle the `@kitware/vtk-wasm` loader consumes and that does the mesh smoothing/slicing/contouring client-side.

## What's here
- **`.github/workflows/vtk-wasm-build.yml`** — manual-only, native **amd64** runner inside `emscripten/emsdk:4.0.20`; inputs `vtk_commit` + `optimization`; uploads the bundle artifact. Never runs on normal PRs.
- **`tools/vtk-wasm/{build.sh,Dockerfile,README.md}`** — the build (fetch VTK at the pin → configure with VTK's own wasm cache → build → package) + local reproduction + the full recipe/findings.

## The reverse-engineered recipe (from the prototype debugging arc)
- Pin **VTK `8fcb79cafc33`** (`9.7.20260726` — the exact commit the loader tracks) + **emsdk 4.0.20**, built **native amd64** (the arm64 emscripten image miscompiles VTK's SOA-array embind — Apple-Silicon `--platform linux/amd64` note included).
- Configure via VTK's **own** `-C configure_wasm32_emscripten_linux.cmake` (all-modules + `WRAP_SERIALIZATION` + `BUILD_TYPES_JSON` + `DISPATCH_SOA_ARRAYS` + WebGPU + module disables) + `VTK_WRAP_JAVASCRIPT`. **Cherry-picking module flags fails in a cascade**, so we use VTK's self-consistent config wholesale, then trim from a working baseline.

## Status
Produces the **all-modules baseline** — guaranteed to compile (it's what Kitware ships). The README enumerates the follow-on work: verify the readers/filters are exposed in the loader session, golden-file test vs pyvcell/Java `.vtu`, **trim modules** for size, and publish + wire into `webapp-ng`.

Docs/CI only — no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)