### PR TITLE
ci(vtk-wasm): build the VTK::WebAssembly module (fix configure)

### DIFF
--- a/tools/vtk-wasm/README.md
+++ b/tools/vtk-wasm/README.md
@@ -21,8 +21,18 @@ VTK's **own, self-consistent CI configuration** — cherry-picking module flags 
 So this build configures via VTK's `-C .gitlab/ci/configure_wasm32_emscripten_linux.cmake` (which
 transitively pulls `configure_wasm_common.cmake` + `configure_common.cmake`: `VTK_BUILD_ALL_MODULES`,
 `VTK_WRAP_SERIALIZATION`, `VTK_BUILD_TYPES_JSON`, `VTK_DISPATCH_SOA_ARRAYS`, `VTK_ENABLE_WEBGPU`,
-`VTK_WEBASSEMBLY_THREADS=OFF`, and the module-disable list), and only adds `VTK_WRAP_JAVASCRIPT=ON`
-and the `VTK_WASM_OPTIMIZATION` knob.
+`VTK_WEBASSEMBLY_THREADS=OFF`, and the module-disable list).
+
+**Do not set `VTK_WRAP_JAVASCRIPT`.** VTK has two wasm-bundle mechanisms and only one is the loader's:
+- `VTK_WRAP_JAVASCRIPT=ON` → the *older* per-class **`vtkweb.js`** (what VTK 9.6.2 emitted), and it
+  fails here because it links *all* modules — including the `VTK::WebAssembly` module, which is
+  itself an executable (`Target "VTK::WebAssembly" … may not be linked into another target`).
+- The **`VTK::WebAssembly` module** (`Web/WebAssembly`, `LIBRARY_NAME vtkWebAssembly`, depends on
+  `WebAssemblySession` + `SerializationManager`) → produces **`vtkWebAssembly.{js,wasm}`** with the
+  standalone-session API — *this* is what `@kitware/vtk-wasm` loads.
+
+VTK CI never sets `VTK_WRAP_JAVASCRIPT`; the bundle comes from the module. So we just ensure
+`VTK_MODULE_ENABLE_VTK_WebAssembly=YES` and build.
 
 ## Pins (bump together)
 

--- a/tools/vtk-wasm/build.sh
+++ b/tools/vtk-wasm/build.sh
@@ -33,33 +33,40 @@ if [ ! -e "$SRC/CMakeLists.txt" ]; then
   git checkout -q FETCH_HEAD
 fi
 
-# --- configure with VTK's own wasm CI cache (-C), plus JS wrapping + our optimization ---
+# --- configure with VTK's own wasm CI cache (-C) ---
 # The -C file transitively includes configure_wasm_linux.cmake -> configure_wasm_common.cmake ->
 # configure_common.cmake, giving the complete working set: VTK_BUILD_ALL_MODULES, WRAP_SERIALIZATION,
 # BUILD_TYPES_JSON, DISPATCH_SOA_ARRAYS, ENABLE_WEBGPU, WEBASSEMBLY_THREADS=OFF, and the module
-# disables for libs absent from the toolchain image. We only add VTK_WRAP_JAVASCRIPT (not set in the
-# cache files) and the optimization knob.
+# disables for libs absent from the toolchain image.
+#
+# The loader bundle (vtkWebAssembly.{mjs,wasm}, standalone-session API) is produced by the
+# **VTK::WebAssembly module** (Web/WebAssembly, LIBRARY_NAME vtkWebAssembly, depends on
+# WebAssemblySession + SerializationManager) — NOT by `VTK_WRAP_JAVASCRIPT` (that path emits the
+# older per-class `vtkweb.js` and, worse, tries to link the VTK::WebAssembly *executable* into its
+# own target → "may not be linked into another target"). So we do NOT set VTK_WRAP_JAVASCRIPT; we
+# just ensure the module is enabled (VTK's all-modules config already does, but be explicit).
 emcmake cmake -S "$SRC" -B "$BUILD" -G Ninja \
   -C "$SRC/.gitlab/ci/configure_wasm32_emscripten_linux.cmake" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DVTK_WRAP_JAVASCRIPT=ON \
+  -DVTK_MODULE_ENABLE_VTK_WebAssembly=YES \
   -DVTK_WASM_OPTIMIZATION="$OPT" \
   -DVTK_BUILD_TESTING=OFF
 
 # --- build (VTK's wasm cache pins the link job pool to 1 to dodge an emscripten file-lock bug) ---
 cmake --build "$BUILD"
 
-# --- collect the loader bundle ---
+# --- collect the loader bundle (the VTK::WebAssembly module emits vtkWebAssembly.{js|mjs,wasm}) ---
 mkdir -p "$OUT"
 find "$BUILD" -name "vtkWebAssembly.wasm" -exec cp {} "$OUT/" \;
-find "$BUILD" -name "vtkWebAssembly.mjs"  -exec cp {} "$OUT/" \;
-if [ ! -f "$OUT/vtkWebAssembly.wasm" ] || [ ! -f "$OUT/vtkWebAssembly.mjs" ]; then
-  echo "ERROR: expected vtkWebAssembly.{wasm,mjs} not produced — check VTK_WRAP_JAVASCRIPT" >&2
-  find "$BUILD" -name "vtk*.wasm" -o -name "vtk*.mjs" | head >&2
+find "$BUILD" \( -name "vtkWebAssembly.mjs" -o -name "vtkWebAssembly.js" \) -exec cp {} "$OUT/" \;
+GLUE="$(ls "$OUT"/vtkWebAssembly.mjs "$OUT"/vtkWebAssembly.js 2>/dev/null | head -1)"
+if [ ! -f "$OUT/vtkWebAssembly.wasm" ] || [ -z "$GLUE" ]; then
+  echo "ERROR: expected vtkWebAssembly.{wasm, mjs|js} not produced" >&2
+  find "$BUILD" -name "vtkWebAssembly*" -o -name "vtkweb*" | head >&2
   exit 1
 fi
 cd "$OUT"
-tar czf "vcell-vtk-wasm32-emscripten.tar.gz" vtkWebAssembly.wasm vtkWebAssembly.mjs
-echo ">>> bundle:"
+tar czf "vcell-vtk-wasm32-emscripten.tar.gz" vtkWebAssembly.wasm "$(basename "$GLUE")"
+echo ">>> bundle: $(basename "$GLUE") + vtkWebAssembly.wasm"
 ls -lh "$OUT"
 echo ">>> gzipped wasm: $(gzip -c vtkWebAssembly.wasm | wc -c | awk '{printf "%.1f MB", $1/1048576}')"


### PR DESCRIPTION
Fixes the first CI run's configure failure: `Target "VTK::WebAssembly" of type EXECUTABLE may not be linked into another target` (at `vtk_module_wrap_javascript`).

**Root cause:** VTK has two wasm-bundle paths. `VTK_WRAP_JAVASCRIPT=ON` builds the *older* per-class `vtkweb.js` and links **all** modules into its target — including the `VTK::WebAssembly` module, which is itself an **executable** → the link error. The `@kitware/vtk-wasm` loader actually consumes **`vtkWebAssembly.{js,wasm}`** (standalone-session API) produced by the **`VTK::WebAssembly` module** (`Web/WebAssembly`). VTK CI never sets `VTK_WRAP_JAVASCRIPT` — the bundle falls out of building that module. (This also explains the earlier `vtkweb.js` vs `vtkWebAssembly.mjs` naming confusion.)

**Fix:** drop `VTK_WRAP_JAVASCRIPT`; `VTK_MODULE_ENABLE_VTK_WebAssembly=YES`; collect `vtkWebAssembly.{mjs|js,wasm}`.

**Verified:** the corrected configure completes ("Configuring done / Generating done", no link error) on amd64. Merging enables re-dispatching the workflow for the full compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)