### PR TITLE
Require publication date end-to-end (null pubdate broke logins in 8.0.0.03)

### DIFF
--- a/python-restclient/.openapi-generator/FILES
+++ b/python-restclient/.openapi-generator/FILES
@@ -114,12 +114,6 @@ docs/Vcellopt.md
 docs/VcelloptStatus.md
 docs/VersionRep.md
 test/__init__.py
-test/test_group_access_rep.py
-test/test_group_member_rep.py
-test/test_preview_rep.py
-test/test_publication_info_rep.py
-test/test_user_rep.py
-test/test_version_rep.py
 tox.ini
 vcell_client/__init__.py
 vcell_client/api/__init__.py

--- a/python-restclient/docs/PublicationResourceApi.md
+++ b/python-restclient/docs/PublicationResourceApi.md
@@ -78,6 +78,7 @@ Name | Type | Description  | Notes
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | OK |  -  |
+**400** | Bad Request. |  -  |
 **401** | Not Authenticated |  -  |
 **403** | Not Allowed |  -  |
 **500** | Data Access Exception |  -  |
@@ -421,6 +422,7 @@ Name | Type | Description  | Notes
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | OK |  -  |
+**400** | Bad Request. |  -  |
 **401** | Not Authenticated |  -  |
 **403** | Not Allowed |  -  |
 **500** | Data Access Exception |  -  |

--- a/python-restclient/vcell_client/api/publication_resource_api.py
+++ b/python-restclient/vcell_client/api/publication_resource_api.py
@@ -103,6 +103,7 @@ class PublicationResourceApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "int",
+            '400': "VCellHTTPError",
             '401': "VCellHTTPError",
             '403': "VCellHTTPError",
             '500': "VCellHTTPError"
@@ -173,6 +174,7 @@ class PublicationResourceApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "int",
+            '400': "VCellHTTPError",
             '401': "VCellHTTPError",
             '403': "VCellHTTPError",
             '500': "VCellHTTPError"
@@ -243,6 +245,7 @@ class PublicationResourceApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "int",
+            '400': "VCellHTTPError",
             '401': "VCellHTTPError",
             '403': "VCellHTTPError",
             '500': "VCellHTTPError"
@@ -1431,6 +1434,7 @@ class PublicationResourceApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Publication",
+            '400': "VCellHTTPError",
             '401': "VCellHTTPError",
             '403': "VCellHTTPError",
             '500': "VCellHTTPError"
@@ -1501,6 +1505,7 @@ class PublicationResourceApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Publication",
+            '400': "VCellHTTPError",
             '401': "VCellHTTPError",
             '403': "VCellHTTPError",
             '500': "VCellHTTPError"
@@ -1571,6 +1576,7 @@ class PublicationResourceApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "Publication",
+            '400': "VCellHTTPError",
             '401': "VCellHTTPError",
             '403': "VCellHTTPError",
             '500': "VCellHTTPError"

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -1728,6 +1728,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Publication'
+        "400":
+          description: Bad Request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VCellHTTPError'
         "401":
           description: Not Authenticated
           content:
@@ -1767,6 +1773,12 @@ paths:
               schema:
                 format: int64
                 type: integer
+        "400":
+          description: Bad Request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VCellHTTPError'
         "401":
           description: Not Authenticated
           content:

--- a/vcell-api/src/main/java/org/vcell/rest/server/PublicationServerResource.java
+++ b/vcell-api/src/main/java/org/vcell/rest/server/PublicationServerResource.java
@@ -116,6 +116,9 @@ public class PublicationServerResource extends AbstractServerResource implements
 				PublicationRepresentation publication = getPublicationRepresentation(((VCellApiApplication) getApplication()).getRestDatabaseService(), vcellUser, new KeyValue(pubidObj.toString()));
 				dataModel.put("publicationRepr", publication);
 			} else if (pubop.equals("applyEdit")) {
+				if (form.getFirstValue("pubdate") == null || form.getFirstValue("pubdate").trim().length() == 0) {
+					return new StringRepresentation("publication date is required");
+				}
 				SimpleDateFormat sdf = new java.text.SimpleDateFormat("MM/dd/yyyy", java.util.Locale.US);
 				String[] authors = StringUtils.split(form.getFirstValue("authors"), ";");
 				for (int i = 0; i < authors.length; i++) {

--- a/vcell-client/src/main/java/cbit/vcell/desktop/BioModelCellRenderer.java
+++ b/vcell-client/src/main/java/cbit/vcell/desktop/BioModelCellRenderer.java
@@ -90,7 +90,7 @@ public java.awt.Component getTreeCellRendererComponent(JTree tree, Object value,
 			if(name.contains(",")) {
 				name = name.substring(0, name.indexOf(","));
 			}
-			int year = Integer.parseInt((new SimpleDateFormat("yyyy")).format(pi.getPubDate()));
+			String year = pi.getPubDate() == null ? "?" : (new SimpleDateFormat("yyyy")).format(pi.getPubDate());
 			String label2 = name + " " + year + " " + label;
 			int maxLen = MaxPublicationLabelLength + (node.getChildCount() > 1 ? 0 : 4);
 			if(label2.length() > maxLen) {
@@ -104,7 +104,7 @@ public java.awt.Component getTreeCellRendererComponent(JTree tree, Object value,
 			}
 			component.setText("<html>" + label2 + "</html>");			
 			component.setToolTipText("<html>" + label + "</html>");			
-			if(pi.getPubDate().compareTo(Calendar.getInstance().getTime()) > 0) {	// sanity check
+			if(pi.getPubDate() == null || pi.getPubDate().compareTo(Calendar.getInstance().getTime()) > 0) {	// sanity check
 				setIcon(fieldFolderWarningIcon);
 			} else if(pi.getDoi() == null) {
 				setIcon(fieldFolderWarningIcon);

--- a/vcell-client/src/main/java/cbit/vcell/desktop/MathModelCellRenderer.java
+++ b/vcell-client/src/main/java/cbit/vcell/desktop/MathModelCellRenderer.java
@@ -70,7 +70,7 @@ public java.awt.Component getTreeCellRendererComponent(JTree tree, Object value,
 			if(name.contains(",")) {
 				name = name.substring(0, name.indexOf(","));
 			}
-			int year = Integer.parseInt((new SimpleDateFormat("yyyy")).format(pi.getPubDate()));
+			String year = pi.getPubDate() == null ? "?" : (new SimpleDateFormat("yyyy")).format(pi.getPubDate());
 			String label2 = name + " " + year + " " + label;
 			int maxLen = MaxPublicationLabelLength + (node.getChildCount() > 1 ? 0 : 4);
 			if(label2.length() > maxLen) {
@@ -84,7 +84,7 @@ public java.awt.Component getTreeCellRendererComponent(JTree tree, Object value,
 			}
 			component.setText("<html>" + label2 + "</html>");			
 			component.setToolTipText("<html>" + label + "</html>");
-			if(pi.getPubDate().compareTo(Calendar.getInstance().getTime()) > 0) {	// sanity check
+			if(pi.getPubDate() == null || pi.getPubDate().compareTo(Calendar.getInstance().getTime()) > 0) {	// sanity check
 				setIcon(fieldFolderWarningIcon);
 			} else if(pi.getDoi() == null) {
 				setIcon(fieldFolderWarningIcon);

--- a/vcell-client/src/main/java/cbit/vcell/desktop/VCDocumentDbTreeModel.java
+++ b/vcell-client/src/main/java/cbit/vcell/desktop/VCDocumentDbTreeModel.java
@@ -480,10 +480,11 @@ private static void shallowOrderByPublication(LinkedHashMap<KeyValue, LinkedList
 
 			PublicationInfo lpi = p.get(lhs.getKey());
 			PublicationInfo rpi = p.get(rhs.getKey());
-			
-			int ly = Integer.parseInt((new SimpleDateFormat("yyyy")).format(lpi.getPubDate()));
+
+			// null pubdate must not break the sort (see 8.0.0.03 login failure); sort those entries last
+			int ly = lpi.getPubDate() == null ? Integer.MIN_VALUE : Integer.parseInt((new SimpleDateFormat("yyyy")).format(lpi.getPubDate()));
 			String[] lt = lpi.getAuthors();
-			int ry = Integer.parseInt((new SimpleDateFormat("yyyy")).format(rpi.getPubDate()));
+			int ry = rpi.getPubDate() == null ? Integer.MIN_VALUE : Integer.parseInt((new SimpleDateFormat("yyyy")).format(rpi.getPubDate()));
 			String[] rt = rpi.getAuthors();
 
 			

--- a/vcell-rest/src/main/java/org/vcell/restq/handlers/PublicationResource.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/handlers/PublicationResource.java
@@ -71,8 +71,11 @@ public class PublicationResource {
 //    @RolesAllowed("curator")
     @RolesAllowed("user")
     @Operation(operationId = "createPublication", summary = "Create publication")
-    public Long add(Publication publication) throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException {
+    public Long add(Publication publication) throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException, BadRequestWebException {
         Log.debug(securityIdentity.getPrincipal().getName()+" with roles " + securityIdentity.getRoles() + " is adding publication "+publication.title());
+        if (publication.date() == null) {
+            throw new BadRequestWebException("publication date is required");
+        }
         try {
             User vcellUser = userRestService.getUserFromIdentity(securityIdentity);
             KeyValue key = publicationService.savePublication(publication, vcellUser);
@@ -92,8 +95,11 @@ public class PublicationResource {
 //    @RolesAllowed("curator")
     @RolesAllowed("user")
     @Operation(operationId = "updatePublication", summary = "Update publication")
-    public Publication update(Publication publication) throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException {
+    public Publication update(Publication publication) throws PermissionWebException, NotAuthenticatedWebException, DataAccessWebException, BadRequestWebException {
         Log.debug(securityIdentity.getPrincipal().getName()+" with roles " + securityIdentity.getRoles() + " is adding publication "+publication.title());
+        if (publication.date() == null) {
+            throw new BadRequestWebException("publication date is required");
+        }
         try {
             User vcellUser = userRestService.getUserFromIdentity(securityIdentity);
             Publication pub = publicationService.updatePublication(publication, vcellUser);

--- a/vcell-rest/src/test/java/org/vcell/restq/PublicationResourceTest.java
+++ b/vcell-rest/src/test/java/org/vcell/restq/PublicationResourceTest.java
@@ -63,6 +63,47 @@ public class PublicationResourceTest {
     KeycloakTestClient keycloakClient = new KeycloakTestClient();
 
     @Test
+    public void testNullDateRejected() throws JsonProcessingException, ApiException {
+        String pubuser = "alice";
+        boolean mapped = new UsersResourceApi(aliceAPIClient).mapUser(TestEndpointUtils.administratorUserLoginInfo);
+        Assertions.assertTrue(mapped);
+
+        // a null publication date once reached the database and broke client logins (NPE while
+        // sorting published models) - create and update must reject it before it is persisted
+        Publication nullDatePublication = new Publication(
+                null,
+                "publication without date",
+                new String[]{"author1"},
+                1994,
+                "citation",
+                "pubmedId",
+                "doi",
+                0,
+                "url",
+                0,
+                new BiomodelRef[0],
+                new MathmodelRef[0],
+                null);
+        String nullDatePublication_json = objectMapper.writeValueAsString(nullDatePublication);
+
+        given().auth().oauth2(keycloakClient.getAccessToken(pubuser))
+                .body(nullDatePublication_json)
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("/api/v1/publications")
+                .then()
+                .statusCode(400);
+
+        given().auth().oauth2(keycloakClient.getAccessToken(pubuser))
+                .body(nullDatePublication_json)
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .put("/api/v1/publications")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
     public void testAddListRemove() throws JsonProcessingException, SQLException, DataAccessException, ApiException {
         String pubuser = "alice";
         String nonpubuser = "bob";

--- a/vcell-restclient/.openapi-generator/FILES
+++ b/vcell-restclient/.openapi-generator/FILES
@@ -236,9 +236,3 @@ src/main/java/org/vcell/restclient/model/VariableType.java
 src/main/java/org/vcell/restclient/model/Vcellopt.java
 src/main/java/org/vcell/restclient/model/VcelloptStatus.java
 src/main/java/org/vcell/restclient/model/VersionRep.java
-src/test/java/org/vcell/restclient/model/GroupAccessRepTest.java
-src/test/java/org/vcell/restclient/model/GroupMemberRepTest.java
-src/test/java/org/vcell/restclient/model/PreviewRepTest.java
-src/test/java/org/vcell/restclient/model/PublicationInfoRepTest.java
-src/test/java/org/vcell/restclient/model/UserRepTest.java
-src/test/java/org/vcell/restclient/model/VersionRepTest.java

--- a/vcell-restclient/api/openapi.yaml
+++ b/vcell-restclient/api/openapi.yaml
@@ -1814,6 +1814,12 @@ paths:
                 format: int64
                 type: integer
           description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VCellHTTPError'
+          description: Bad Request.
         "401":
           content:
             application/json:
@@ -1854,6 +1860,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Publication'
           description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VCellHTTPError'
+          description: Bad Request.
         "401":
           content:
             application/json:

--- a/vcell-restclient/docs/PublicationResourceApi.md
+++ b/vcell-restclient/docs/PublicationResourceApi.md
@@ -83,6 +83,7 @@ public class Example {
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
+| **400** | Bad Request. |  -  |
 | **401** | Not Authenticated |  -  |
 | **403** | Not Allowed |  -  |
 | **500** | Data Access Exception |  -  |
@@ -154,6 +155,7 @@ ApiResponse<**Long**>
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
+| **400** | Bad Request. |  -  |
 | **401** | Not Authenticated |  -  |
 | **403** | Not Allowed |  -  |
 | **500** | Data Access Exception |  -  |
@@ -763,6 +765,7 @@ public class Example {
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
+| **400** | Bad Request. |  -  |
 | **401** | Not Authenticated |  -  |
 | **403** | Not Allowed |  -  |
 | **500** | Data Access Exception |  -  |
@@ -834,6 +837,7 @@ ApiResponse<[**Publication**](Publication.md)>
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
+| **400** | Bad Request. |  -  |
 | **401** | Not Authenticated |  -  |
 | **403** | Not Allowed |  -  |
 | **500** | Data Access Exception |  -  |

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/PublicationTable.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/PublicationTable.java
@@ -45,7 +45,7 @@ public class PublicationTable extends Table {
 	public final Field endnoteid			= new Field("endnoteid",		SQLDataType.integer,		"");
 	public final Field url					= new Field("url",				SQLDataType.varchar2_128,	"");
 	public final Field wittid				= new Field("wittid",			SQLDataType.integer,		"");
-	public final Field pubdate				= new Field("pubDate",			SQLDataType.date,			"");
+	public final Field pubdate				= new Field("pubDate",			SQLDataType.date,			"NOT NULL");
 	
 	private final Field fields[] = {title,authors,year,citation,pubmedid,doi,endnoteid,url,wittid,pubdate };
 	

--- a/webapp-ng/src/app/components/publication-edit/publication-edit.component.html
+++ b/webapp-ng/src/app/components/publication-edit/publication-edit.component.html
@@ -87,7 +87,8 @@
 
     <mat-form-field class="full-width">
       <mat-label>Date</mat-label>
-      <input matInput type="date" [(ngModel)]="publication.date" name="date">
+      <input matInput type="date" [(ngModel)]="publication.date" name="date" required>
+      <mat-error *ngIf="publicationForm.controls['date']?.invalid">Date is required</mat-error>
     </mat-form-field>
 
     <div *ngIf="showPublishControls" class="publish-row">


### PR DESCRIPTION
## Problem

While editing a publication through the Angular webapp, the publication date could be cleared and saved as `NULL`. One null-date row in `vc_publication` then crashed **every** desktop client at login on production 8.0.0.03: `shallowOrderByPublication` calls `SimpleDateFormat.format(pubDate)` while sorting the published-models tree, and `format(null)` throws NPE. Published models are visible to all users, so all logins broke.

## Fix (defense in depth)

- **webapp-ng**: `Date` is now a required field on the publication edit/new form (it was the only field without `required`).
- **vcell-rest**: `createPublication` / `updatePublication` return **400** when `date` is null (`BadRequestWebException`); regression test asserts 400 on both POST and PUT. Legacy `/api/v0/` publication form gets the same guard.
- **modeldb**: `PublicationTable.pubdate` now declares `NOT NULL`, so freshly created schemas enforce it.
- **vcell-client**: null-guards at all three NPE sites — null dates sort last in the tree comparator and render as `?` with the warning icon in both cell renderers, so a bad row can never again break login.
- **openapi**: regenerated spec + Java/Python clients (new 400 responses); Angular client unchanged.

## Production DDL (separate, manual step)

```sql
ALTER TABLE vcell.vc_publication MODIFY (pubdate NOT NULL);
```

Verified against prod as `vcell_dev`: `PUBDATE` is currently `nullable=Y` with no constraint, and all 250 rows have a non-null date (the incident row was already repaired), so the ALTER is safe. Must be run by the table owner or a DBA (`vcell_dev` lacks ALTER privilege).

## Verification

- vcell-server / vcell-rest / vcell-client / vcell-api compile; `mvn compile test-compile -pl vcell-rest -am` passes after client regen; `npm run build_prod` passes.
- New `PublicationResourceTest#testNullDateRejected` could not run locally (all local `@QuarkusTest` boots currently fail on a Keycloak-devservices "HTTPS required" Docker quirk, verified on untouched test classes) — relying on `CI-Test-group-Quarkus` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So1rNdiDrK36y1fAiu7pHV