### PR TITLE
docs(release): cut 8.0.5.01

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: deploy
+description: Cut a VCell release and deploy it — pick the next version, write the changelog, tag + GitHub release (triggers the CI-full image build), then CD-sites to a site (alpha→dev namespace, rel→prod, test→stage). Use when asked to "deploy to alpha/dev/prod/stage", "cut a release", or "bump the version and deploy".
+---
+
+# VCell release & deploy
+
+**Always present the full plan (version, target site, ordered steps) and get the
+user's explicit confirmation BEFORE tagging, releasing, or deploying anything.**
+The first three version parts are release-engineering decisions a human makes
+(`docs/RELEASING.md`); the target site decides who is affected. Research and
+draft autonomously; execute only after sign-off.
+
+## Version scheme
+
+`MAJOR.MINOR.PATCH.BUILD` — `docs/RELEASING.md` is authoritative.
+
+- Current latest: `gh release list --repo virtualcell/vcell --limit 1` (or `git tag --sort=-creatordate | head -1`).
+- Bugfix-only release → bump PATCH, reset BUILD to `01` (e.g. 8.0.4.01 → 8.0.5.01).
+- New backwards-compatible feature → bump MINOR.
+- Iterating on an already-cut line (another build of the same fixes/features) → increment BUILD only.
+- The version lives ONLY in the git tag / GitHub release — there is no version file in the repo.
+
+## Site mapping
+
+CD-sites (`.github/workflows/site_deploy.yml`) uses legacy site names; its last
+job dispatches `vcell-fluxcd`'s `deploy.yaml`, which flips the kustomize overlay
+image tags and lets Flux reconcile the namespace.
+
+| `vcell_site` | K8s overlay / namespace | URL | installer dir (vcellapi.cam.uchc.edu) |
+|---|---|---|---|
+| `alpha` | `dev` | vcell-dev.cam.uchc.edu | webstart/Alpha |
+| `rel` | `prod` | vcell.cam.uchc.edu | webstart/Rel |
+| `test` | `stage` | vcell-stage.cam.uchc.edu | webstart/Test |
+
+## Procedure
+
+0. **Preconditions.** `master` is green: CI passed on the merge, and
+   `regression.yml` passed on master (after an admin-merge it must be kicked
+   manually: `gh workflow run regression.yml --ref master`). Do not tag a
+   master that hasn't passed regression.
+
+1. **Release-cut docs** (per `docs/RELEASING.md`): add a `## [X.Y.Z.BB]`
+   section to `CHANGELOG.md` (Highlights + categories + "Notes for API
+   consumers"), fold notable items into `release-notes/major/<MAJOR.MINOR>.md`,
+   and land both on master via PR **before** tagging, so the tag points at a
+   self-describing tree.
+
+2. **Tag + release.** `gh release create X.Y.Z.BB --target master
+   --title "X.Y.Z.BB (<short description>)" --notes-file <changelog-section.md>`.
+   Publishing the release auto-triggers `CI-full.yml`, which builds and pushes
+   all Docker images tagged `X.Y.Z.BB` to ghcr.io.
+
+3. **Watch CI-full to completion.** NEVER cancel it before the tag-and-push
+   job — that job (needs ALL docker builds) creates the friendly
+   `version.build` image tags every deploy pulls; without them the deploy fails
+   with "manifest unknown". If a job fails, recover with
+   `gh run rerun <id> --failed`. The clientgen image is release-critical:
+   desktop installers must match the server version.
+
+4. **Dispatch CD-sites.**
+   `gh workflow run site_deploy.yml --ref master -f vcell_version=X.Y.Z
+   -f vcell_build=BB -f vcell_site=<site> -f server_only=false`
+   (checkout ref is the tag `X.Y.Z.BB`, so the tag must exist first).
+   This builds + notarizes desktop installers, publishes them to
+   `webstart/<Site>`, then POSTs `vcell-fluxcd/deploy.yaml` with
+   `{overlay, tag, swversion}`.
+
+5. **Verify.** A "Changed image tag of <overlay> to X.Y.Z.BB" commit appears in
+   vcell-fluxcd; `KUBECONFIG=~/.kube/kubeconfig_vxrails.yaml kubectl -n <ns>
+   get pods` shows pods Running on the new tag; the site URL loads; then a
+   targeted smoke test of whatever this release changed.
+
+6. **Post-deploy.** Only when PROD rolls to a new `MAJOR.MINOR` line:
+   transcribe `release-notes/major/<MAJOR.MINOR>.md` to the vcell.org
+   accordion (see `docs/RELEASING.md` "vcell.org transcription").

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,37 @@ followed by flat Keep-a-Changelog categories. API consumers should scan
 
 _(Release-manager scratchpad. Populated at release-cut time.)_
 
+## [8.0.5.01] - 2026-07-31
+
+**Highlights.** Hardens publications against the null publication-date bug
+that broke every desktop-client login on production 8.0.0.03, and fixes
+SpringSaLaD bond rendering so bonds stop at sphere surfaces.
+
+### Added
+- Internal: CI scaffolding for a custom VTK.wasm (WebGL2) build feeding the
+  upcoming web field visualization; not shipped in any release artifact.
+  (#1805, #1806, #1807, #1808, #1809)
+
+### Fixed
+- Publication date is now required end-to-end. A curator could clear the Date
+  field in the webapp publication editor and save; the resulting `NULL`
+  `vc_publication.pubdate` crashed every desktop client at login
+  (`SimpleDateFormat.format(null)` NPE while sorting the published-models
+  tree). The webapp form now requires the field, the REST API rejects a null
+  date with 400, the declared schema is `NOT NULL`, and the client tolerates
+  null dates from legacy rows (sorts last, renders `?` with a warning icon).
+  (#1810)
+- SpringSaLaD 3D viewer: bond edges are truncated by ball radius in world
+  space, so bonds stop at sphere surfaces instead of being drawn into the
+  balls. (#1802)
+
+### Notes for API consumers
+- `createPublication` and `updatePublication` now return **400** when `date`
+  is null — an additive `400` response in the OpenAPI spec (Java/Python
+  clients regenerated, TypeScript client unchanged). No other `/api/v1/`
+  schema changes in this build. A `NOT NULL` constraint on
+  `vc_publication.pubdate` accompanies this in the production database.
+
 ## [8.0.2.07] - 2026-07-27
 
 **Highlights.** Sixth hotfix on the 8.0.2 line, and a **server-only** deploy.

--- a/release-notes/major/8.0.0.md
+++ b/release-notes/major/8.0.0.md
@@ -116,6 +116,13 @@ notably the JMS failover watchdog, the OOM exit handler, the DNS
 negative-cache fix, charset-aware Oracle CLOB reads, and a
 thread-safety fix in unit-of-measurement formatting.)_
 
+- A publication saved without a date no longer breaks VCell login for all
+  users. The publication date is now required in the curation tools, the
+  API rejects a missing date, and the desktop client tolerates legacy
+  records without one (8.0.5.01).
+- SpringSaLaD 3D viewer: bonds now stop at the sphere surfaces instead of
+  being drawn into the balls (8.0.5.01).
+
 ## API and integration changes
 
 The REST API surface in 8.0.0 is the same as the final 7.7 builds.


### PR DESCRIPTION
Release-cut docs for 8.0.5.01 (null publication-date fix #1810, SpringSaLaD bond truncation #1802):

- `CHANGELOG.md` — new `[8.0.5.01]` section (Highlights, Added, Fixed, API-consumer notes)
- `release-notes/major/8.0.0.md` — bug-fix bullets folded in
- `.claude/skills/deploy/SKILL.md` — new project /deploy skill holding the release/deploy procedure (version scheme, site→overlay mapping alpha→dev / rel→prod / test→stage, CI-full tag-and-push rule, CD-sites dispatch, verification steps), with plan-verification-before-execution as its first rule

Docs-only; tag 8.0.5.01 will be cut from master once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So1rNdiDrK36y1fAiu7pHV