### PR TITLE
Fix flaky SimulationDispatcherTest

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/server/dispatcher/SimulationDispatcher.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/dispatcher/SimulationDispatcher.java
@@ -242,10 +242,49 @@ public class SimulationDispatcher {
 		}
 		lastSpecialUserCheck = System.currentTimeMillis();
 	}
+	/**
+	 * Lets a test wait for a worker to finish a pass without racing it.
+	 * <p>
+	 * A bare {@code wait()}/{@code notify()} pair cannot do this: these workers start as soon as
+	 * they are constructed, so the pass often completes before the test reaches its {@code wait()},
+	 * the notification is lost, and the test blocks until the suite times out. Counting completed
+	 * passes gives the waiter a condition it can test, so it can see a pass that already happened.
+	 */
+	public static final class CompletionSignal {
+		private int completedPasses;
+
+		/** Called by the worker at the end of every pass. */
+		synchronized void signalCompleted() {
+			completedPasses++;
+			notifyAll();
+		}
+
+		public synchronized int getCompletedPasses() {
+			return completedPasses;
+		}
+
+		/**
+		 * Wait until at least {@code targetPasses} passes have completed.
+		 *
+		 * @return false if the timeout expired first
+		 */
+		public synchronized boolean awaitCompletedPasses(int targetPasses, long timeoutMs) throws InterruptedException {
+			long deadline = System.currentTimeMillis() + timeoutMs;
+			while (completedPasses < targetPasses) {
+				long remaining = deadline - System.currentTimeMillis();
+				if (remaining <= 0) {
+					return false;
+				}
+				wait(remaining);
+			}
+			return true;
+		}
+	}
+
 	public class DispatchThread extends Thread {
 
 		final Object dispatcherNotifyObject = new Object();
-		final Object finishListener = new Object(); //used for tests
+		public final CompletionSignal finishListener = new CompletionSignal(); //used for tests
 
 		public DispatchThread() {
 			super();
@@ -339,9 +378,7 @@ public class SimulationDispatcher {
 					lg.error(ex.getMessage(), ex);
 				}
 				finally {
-					synchronized (finishListener){
-						finishListener.notify();
-					}
+					finishListener.signalCompleted();
 				}
 
 				// if there are no messages or no qualified jobs or exceptions, sleep for a few seconds while
@@ -449,7 +486,7 @@ public class SimulationDispatcher {
 		 class QueueFlusher implements Runnable {
 			protected final static String timeOutFailure = "failed: timed out";
 			protected final static String unreferencedFailure = "failed: unreferenced simulation";
-			protected final Object finishListener = new Object(); //used for tests
+			protected final CompletionSignal finishListener = new CompletionSignal(); //used for tests
 			public void run() {
 				try {
 					traceThread(this);
@@ -468,9 +505,7 @@ public class SimulationDispatcher {
 				} catch (Exception e1) {
 					lg.error(e1.getMessage(), e1);
 				} finally {
-					synchronized (finishListener){
-						finishListener.notify();
-					}
+					finishListener.signalCompleted();
 				}
 			}
 			

--- a/vcell-server/src/test/java/cbit/vcell/message/server/dispatcher/SimulationDispatcherTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/dispatcher/SimulationDispatcherTest.java
@@ -88,6 +88,13 @@ public class SimulationDispatcherTest {
     @Test
     public void dispatcherThreadFailsJobsWithNoSimulationReference() throws SQLException, DataAccessException, InterruptedException {
         DispatcherTestUtils.insertOrUpdateStatus(mockSimulationDB, SimulationJobStatus.SchedulerStatus.WAITING);
+
+        // The job is WAITING before the dispatcher exists. Asserting this after starting the
+        // dispatcher would be a race: the dispatch thread runs as soon as it is constructed, so it
+        // may already have failed the job by then - which is what made this test flaky.
+        SimulationJobStatus jobStatus = mockSimulationDB.getLatestSimulationJobStatus(DispatcherTestUtils.simKey, 0);
+        Assertions.assertTrue(jobStatus.getSchedulerStatus().isWaiting(), "job starts out waiting");
+
         SimulationDispatcher simulationDispatcher = SimulationDispatcher.simulationDispatcherCreator(mockSimulationDB, mockMessagingServiceInternal,
                 mockMessagingServiceSim, mockHtcProxy, true);
         SimulationDispatcher.DispatchThread thread = simulationDispatcher.dispatchThread;
@@ -95,13 +102,7 @@ public class SimulationDispatcherTest {
             thread.dispatcherNotifyObject.notify();
         }
 
-        // Check that the simulation is in waiting, for the dispatcher hasn't consumed it's request yet
-        SimulationJobStatus jobStatus = mockSimulationDB.getLatestSimulationJobStatus(DispatcherTestUtils.simKey, 0);
-        Assertions.assertTrue(jobStatus.getSchedulerStatus().isWaiting(), "Still waiting.");
-
-        synchronized (thread.finishListener){
-            thread.finishListener.wait();
-        }
+        awaitDispatchPass(thread);
 
         // Makes sure that requests that have no simulation reference within the DB are failed
         jobStatus = mockSimulationDB.getLatestSimulationJobStatus(DispatcherTestUtils.simKey, 0);
@@ -111,23 +112,45 @@ public class SimulationDispatcherTest {
 
     @Test
     public void dispatcherThreadDispatchesWaitingJobsWithSimulationsIn() throws SQLException, DataAccessException, InterruptedException, PropertyVetoException, MathException, ExpressionBindingException {
-        SimulationDispatcher simulationDispatcher = SimulationDispatcher.simulationDispatcherCreator(mockSimulationDB, mockMessagingServiceInternal,
-                mockMessagingServiceSim, mockHtcProxy, true);
-        SimulationDispatcher.DispatchThread thread = simulationDispatcher.dispatchThread;
-        // Create and insert simulation. Then ensure that this simulation has it's job status changed to dispatched
+        // Insert the simulation BEFORE starting the dispatcher, so that any completed pass has
+        // necessarily seen it. Inserting afterwards would mean the first pass might have run
+        // before the insert, and waiting for it would prove nothing.
         Simulation mockSimulation = DispatcherTestUtils.createMockSimulation(20, 20, 20);
         mockSimulationDB.insertSimulation(DispatcherTestUtils.alice, mockSimulation);
         DispatcherTestUtils.insertOrUpdateStatus(mockSimulation.getKey(), DispatcherTestUtils.jobIndex, DispatcherTestUtils.taskID, DispatcherTestUtils.alice,
                 SimulationJobStatus.SchedulerStatus.WAITING, mockSimulationDB);
+
+        SimulationDispatcher simulationDispatcher = SimulationDispatcher.simulationDispatcherCreator(mockSimulationDB, mockMessagingServiceInternal,
+                mockMessagingServiceSim, mockHtcProxy, true);
+        SimulationDispatcher.DispatchThread thread = simulationDispatcher.dispatchThread;
         synchronized (thread.dispatcherNotifyObject){
             thread.dispatcherNotifyObject.notify();
         }
-        synchronized (thread.finishListener){
-            thread.finishListener.wait();
-        }
+        awaitDispatchPass(thread);
 
         SimulationJobStatus jobStatus = mockSimulationDB.getLatestSimulationJobStatus(mockSimulation.getKey(), 0);
         Assertions.assertTrue(jobStatus.getSchedulerStatus().isDispatched(), "Dispatches");
+    }
+
+    /** Timeout for waiting on a worker pass - generous, since it only bites when something hangs. */
+    private static final long PASS_TIMEOUT_MS = 30_000;
+
+    /**
+     * Wait for the dispatch thread to finish a pass over the job table.
+     * <p>
+     * The job under test is inserted before the dispatcher is constructed, so any completed pass
+     * has seen it; waiting for a count rather than a bare notify means a pass that finished before
+     * we got here still counts, instead of hanging forever on a missed notification.
+     */
+    private static void awaitDispatchPass(SimulationDispatcher.DispatchThread thread) throws InterruptedException {
+        Assertions.assertTrue(thread.finishListener.awaitCompletedPasses(1, PASS_TIMEOUT_MS),
+                "dispatch thread did not complete a pass within " + PASS_TIMEOUT_MS + "ms");
+    }
+
+    private static void awaitFlush(SimulationDispatcher.SimulationMonitor.QueueFlusher queueFlusher)
+            throws InterruptedException {
+        Assertions.assertTrue(queueFlusher.finishListener.awaitCompletedPasses(1, PASS_TIMEOUT_MS),
+                "queue flusher did not complete within " + PASS_TIMEOUT_MS + "ms");
     }
 
 
@@ -183,9 +206,7 @@ public class SimulationDispatcherTest {
         synchronized (simMonitor.monitorNotifyObject){
             simMonitor.monitorNotifyObject.notify();
         }
-        synchronized (queueFlusher.finishListener){
-            queueFlusher.finishListener.wait();
-        }
+        awaitFlush(queueFlusher);
 
         SimulationJobStatus status = mockSimulationDB.getLatestSimulationJobStatus(DispatcherTestUtils.simKey, DispatcherTestUtils.jobIndex);
         Assertions.assertTrue(status.getSchedulerStatus().isFailed());
@@ -216,9 +237,7 @@ public class SimulationDispatcherTest {
         synchronized (simMonitor.monitorNotifyObject){
             simMonitor.monitorNotifyObject.notify();
         }
-        synchronized (queueFlusher.finishListener){
-            queueFlusher.finishListener.wait();
-        }
+        awaitFlush(queueFlusher);
         SimulationJobStatus status = mockSimulationDB.getLatestSimulationJobStatus(DispatcherTestUtils.simKey, DispatcherTestUtils.jobIndex);
         Assertions.assertTrue(status.getSchedulerStatus().isFailed());
         Assertions.assertTrue(mockHtcProxy.jobsKilledUnsafely.contains(status.getSimulationExecutionStatus().getHtcJobID()));


### PR DESCRIPTION
## The failure

`dispatcherThreadFailsJobsWithNoSimulationReference` fails intermittently on CI:

```
SimulationDispatcherTest.dispatcherThreadFailsJobsWithNoSimulationReference:100
  Still waiting. ==> expected: <true> but was: <false>
```

It went red on `master` again today, and the usual response is to re-run the job.

## It is the test, not the server

`DispatchThread.run()` does its work **first** and only then waits:

```java
public void run() {
    reloadSpecialUsers();
    while (true) {
        ... dispatch all active jobs ...
        finishListener.notify();              // end of pass
        dispatcherNotifyObject.wait(waitTime); // only now does it sleep
    }
}
```

The thread starts when the dispatcher is constructed, so it is already dispatching
before the test does anything else. The test then asserted the job was *still*
`WAITING`, commenting "the dispatcher hasn't consumed it's request yet". That is
not something the test can guarantee — it asserts that the worker is slow, which
is not a requirement. On a loaded runner the pass completes first, the job is
correctly `FAILED`, and the assertion fails.

The server behaved correctly in every one of these failures.

## Changes

**The racy assertion moves to where it is deterministic** — before the dispatcher
exists, `WAITING` is just the state the test inserted a line earlier.
`dispatcherThreadDispatchesWaitingJobsWithSimulationsIn` likewise now inserts its
simulation *before* starting the dispatcher, so any completed pass has necessarily
seen it. (Waiting for "one pass" would otherwise prove nothing, since the pass
could predate the insert.)

**A latent hang is fixed too.** All four handshakes did a bare
`finishListener.wait()` with no state guard:

```java
synchronized (thread.finishListener) { thread.finishListener.wait(); }
```

Same root cause — the worker starts immediately, so if it reaches `notify()`
before the test reaches `wait()`, the notification is lost and the test blocks
until the suite times out. That is a worse failure than a red assertion and it
has not bitten yet purely by luck.

`finishListener` becomes a small `CompletionSignal` that counts completed passes.
Tests wait for a count, with a timeout, so a pass that already happened still
counts and a worker that never runs fails with a message rather than hanging.

## Caveat, stated plainly

**I could not reproduce the original failure locally** — not under 8x CPU load,
and not with CI's parallel-classes settings. This is an 8-core M-series Mac; CI
uses 2-core runners, where the window is far wider.

So this fix rests on the race being structural rather than on a reproduction: the
old assertion observed a value that the running worker was concurrently changing,
and the new one does not. If the flake recurs after this, the diagnosis above is
wrong and it should be reopened rather than re-run.

## Verification

- full `vcell-server` Fast group passes (51 tests)
- `SimulationDispatcherTest` passed 8/8 under 8x CPU load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvqmME7MkRUNEYje5HpiLt