### PR TITLE
Swing debug bridge phase 2: semantic selectors, waits, menu automation, committed tooling

### DIFF
--- a/tools/debug-bridge/README.md
+++ b/tools/debug-bridge/README.md
@@ -1,0 +1,26 @@
+# Debug-bridge tooling
+
+Committed fixtures around the [Swing debug bridge](../../vcell-client/src/main/java/org/vcell/client/debug/README.md)
+so getting a live, drivable client takes one command instead of a rediscovered recipe.
+
+| Script | Purpose |
+|---|---|
+| `launch-client.sh` | Launch the client **from `target/classes`** (no packaging) with the bridge on, using the bundled install4j JRE and a cached dependency classpath. Backgrounds itself and waits for `/health`. |
+| `bridge.sh` | CLI over the bridge's HTTP endpoints: `tree`, `find`, `menu`, `wait`, `assert`, `shot`, `log`, … URL-encodes arguments, pretty-prints via `jq` when available; `wait`/`assert` exit non-zero on failure so scenarios are plain shell. |
+| `scenarios/` | Reusable end-to-end scripts built on `bridge.sh` — `smoke.sh` checks bridge, main frame, menus, EDT and screenshots using only semantic selectors. |
+
+## Quick start
+
+```bash
+mvn compile -pl vcell-client -am -DskipTests   # after code changes
+tools/debug-bridge/launch-client.sh            # client up, bridge on :9123
+tools/debug-bridge/bridge.sh menus             # read the menu structure
+tools/debug-bridge/bridge.sh menu "Account>Login"
+tools/debug-bridge/bridge.sh wait --type JDialog --contains Login --timeout 5000
+tools/debug-bridge/scenarios/smoke.sh          # end-to-end sanity
+```
+
+`launch-client.sh` defaults to the dev server (`vcell-dev.cam.uchc.edu:443`) and a
+local install at `~/Applications/VCell_Alpha` for the JRE/native libs; override with
+`VCELL_API_HOST` / `VCELL_INSTALL_DIR`. The client's real log is
+`~/.vcell/logs/vcellrun_<site>.log` — or just `bridge.sh log 100`.

--- a/tools/debug-bridge/bridge.sh
+++ b/tools/debug-bridge/bridge.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# CLI for the Swing debug bridge (vcell-client/src/main/java/org/vcell/client/debug).
+# Thin curl wrapper with URL-encoding, jq pretty-printing when available, and
+# meaningful exit codes for `wait` / `assert` so scenarios can be plain shell.
+#
+# Usage: bridge.sh [-p PORT] <command> [args]   (or BRIDGE_PORT=N bridge.sh ...)
+#
+# Observe:
+#   health | windows | tree [maxDepth] | menus
+#   find    [--type T] [--name N] [--text T] [--contains S] [--limit N]
+#   props   <selector>          listeners <selector>
+#   shot [window]               log [lines]
+# Act:
+#   click <selector>            rclick <selector>
+#   settext <selector> <text> [--enter]
+#   tab <selector> <index>      row <selector> <row>     rrow <selector> <row>
+#   menu "<Menu>Item[>Sub]" [window]
+#   highlight <selector> [ms]
+# Synchronize / assert (exit 0 on success, 1 on failure):
+#   wait   [find opts] [--state showing|enabled|gone] [--timeout MS] [--interval MS]
+#   assert [find opts] [--gone]
+#   idle
+#
+# A <selector> is a tree path ("0/3/2") or a stable component id ("c42").
+
+set -eo pipefail
+
+PORT="${BRIDGE_PORT:-9123}"
+if [ "${1:-}" = "-p" ]; then
+  PORT="$2"
+  shift 2
+fi
+BASE="http://127.0.0.1:$PORT"
+
+pretty() {
+  if command -v jq >/dev/null 2>&1; then jq .; else cat; echo; fi
+}
+
+get() { # get <endpoint> [--data-urlencode k=v ...]
+  local ep="$1"
+  shift
+  curl -fsS -G "$BASE/$ep" "$@"
+}
+
+# Build curl query args from shared find/wait selector options; leftover
+# options are placed in EXTRA_OPTS for the caller.
+FIND_ARGS=()
+EXTRA_OPTS=()
+parse_find_opts() {
+  FIND_ARGS=()
+  EXTRA_OPTS=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --type)     FIND_ARGS+=(--data-urlencode "type=$2"); shift 2 ;;
+      --name)     FIND_ARGS+=(--data-urlencode "name=$2"); shift 2 ;;
+      --text)     FIND_ARGS+=(--data-urlencode "text=$2"); shift 2 ;;
+      --contains) FIND_ARGS+=(--data-urlencode "textContains=$2"); shift 2 ;;
+      --limit)    FIND_ARGS+=(--data-urlencode "limit=$2"); shift 2 ;;
+      *)          EXTRA_OPTS+=("$1"); shift ;;
+    esac
+  done
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+  health)    get health; echo ;;
+  windows)   get windows | pretty ;;
+  tree)      get tree ${1:+--data-urlencode "maxDepth=$1"} | pretty ;;
+  menus)     get menus | pretty ;;
+  idle)      get idle | pretty ;;
+  log)       get log --data-urlencode "lines=${1:-200}" ;;
+  shot)      get screenshot ${1:+--data-urlencode "window=$1"} | pretty ;;
+
+  find)
+    parse_find_opts "$@"
+    get find "${FIND_ARGS[@]}" | pretty
+    ;;
+
+  wait)
+    parse_find_opts "$@"
+    state=showing timeout=10000 interval=250
+    set -- ${EXTRA_OPTS[@]+"${EXTRA_OPTS[@]}"}
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --state)    state="$2"; shift 2 ;;
+        --timeout)  timeout="$2"; shift 2 ;;
+        --interval) interval="$2"; shift 2 ;;
+        *) echo "wait: unknown option $1" >&2; exit 2 ;;
+      esac
+    done
+    out="$(get waitFor "${FIND_ARGS[@]}" \
+      --data-urlencode "state=$state" \
+      --data-urlencode "timeoutMs=$timeout" \
+      --data-urlencode "intervalMs=$interval")"
+    echo "$out" | pretty
+    echo "$out" | grep -q '"satisfied":true'
+    ;;
+
+  assert)
+    parse_find_opts "$@"
+    gone=false
+    for opt in ${EXTRA_OPTS[@]+"${EXTRA_OPTS[@]}"}; do
+      [ "$opt" = "--gone" ] && gone=true
+    done
+    out="$(get find "${FIND_ARGS[@]}")"
+    if [ "$out" = "[]" ]; then present=false; else present=true; fi
+    if [ "$present" != "$gone" ]; then
+      echo "$out" | pretty
+      exit 0
+    fi
+    if [ "$gone" = true ]; then expected="no matches"; else expected="at least one match"; fi
+    echo "ASSERT FAILED: expected $expected, got: $out" >&2
+    exit 1
+    ;;
+
+  click)     get click --data-urlencode "path=$1" | pretty ;;
+  rclick)    get rightClick --data-urlencode "path=$1" | pretty ;;
+  settext)
+    sel="$1" text="$2"
+    enter=false
+    [ "${3:-}" = "--enter" ] && enter=true
+    get setText --data-urlencode "path=$sel" --data-urlencode "text=$text" \
+      --data-urlencode "enter=$enter" | pretty
+    ;;
+  tab)       get selectTab --data-urlencode "path=$1" --data-urlencode "index=$2" | pretty ;;
+  row)       get selectTreeRow --data-urlencode "path=$1" --data-urlencode "row=$2" | pretty ;;
+  rrow)      get rightClickTreeRow --data-urlencode "path=$1" --data-urlencode "row=$2" | pretty ;;
+  menu)      get menu --data-urlencode "path=$1" ${2:+--data-urlencode "window=$2"} | pretty ;;
+  props)     get props --data-urlencode "path=$1" | pretty ;;
+  listeners) get listeners --data-urlencode "path=$1" | pretty ;;
+  highlight) get highlight --data-urlencode "path=$1" --data-urlencode "ms=${2:-2000}" | pretty ;;
+
+  help|*)
+    sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+    [ "$cmd" = help ] || exit 2
+    ;;
+esac

--- a/tools/debug-bridge/launch-client.sh
+++ b/tools/debug-bridge/launch-client.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Fast-iteration launcher for the VCell desktop client with the Swing debug
+# bridge enabled — runs straight from the modules' target/classes so a
+# `mvn compile -pl vcell-client -am` (or a single javac) is enough to test a
+# change, no packaging step. Complements ./vcell.sh, which runs packaged jars.
+#
+# Classpath = each module's target/classes PREPENDED to vcell-client's
+# dependency classpath, so freshly compiled classes shadow the jars from the
+# last full build. Native libs / bundled JRE come from a local install4j
+# install (default ~/Applications/VCell_Alpha).
+#
+# Usage:
+#   tools/debug-bridge/launch-client.sh [options] [-- extra VCellClientMain args]
+#
+# Options:
+#   --port=N        debug bridge port (default 9123)
+#   --refresh-cp    regenerate the cached dependency classpath
+#   --foreground    run in the foreground instead of detaching
+#
+# Environment overrides:
+#   VCELL_INSTALL_DIR       local install4j install (default ~/Applications/VCell_Alpha)
+#   VCELL_API_HOST          server host[:port]      (default vcell-dev.cam.uchc.edu:443)
+#   VCELL_SOFTWARE_VERSION  version string          (default Alpha_Version_8.0.0_build_07)
+#
+# The client's stdout/stderr are redirected by the client itself to
+# ~/.vcell/logs/vcellrun_<site>.log — read them there (or via the bridge's
+# /log endpoint), not from this launcher's output.
+
+set -eo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALL_DIR="${VCELL_INSTALL_DIR:-$HOME/Applications/VCell_Alpha}"
+API_HOST="${VCELL_API_HOST:-vcell-dev.cam.uchc.edu:443}"
+VERSION="${VCELL_SOFTWARE_VERSION:-Alpha_Version_8.0.0_build_07}"
+
+PORT=9123
+REFRESH_CP=false
+FOREGROUND=false
+passthrough=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --port=*)     PORT="${1#*=}" ;;
+    --refresh-cp) REFRESH_CP=true ;;
+    --foreground) FOREGROUND=true ;;
+    --)           shift; passthrough+=("$@"); break ;;
+    *)            passthrough+=("$1") ;;
+  esac
+  shift
+done
+
+# --- JRE: prefer the bundled install4j JRE (matches shipped runtime) --------
+JAVA_BIN="$INSTALL_DIR/.install4j/jre.bundle/Contents/Home/bin/java"
+if [ ! -x "$JAVA_BIN" ]; then
+  JAVA_BIN="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+  echo "note: no bundled JRE under $INSTALL_DIR, using $JAVA_BIN" >&2
+fi
+
+# --- classpath: module classes first, then the dependency jars --------------
+MODULES=(vcell-client vcell-core vcell-util vcell-math vcell-api-types
+         vcell-apiclient vcell-restclient vcell-server vcell-api)
+CP=""
+for m in "${MODULES[@]}"; do
+  CP+="$REPO/$m/target/classes:"
+done
+
+if [ ! -d "$REPO/vcell-client/target/classes" ]; then
+  echo "ERROR: $REPO/vcell-client/target/classes missing." >&2
+  echo "Compile first, e.g.:  mvn compile -pl vcell-client -am -DskipTests" >&2
+  exit 1
+fi
+
+DEP_CP_FILE="$REPO/vcell-client/target/debug-bridge-deps-cp.txt"
+if $REFRESH_CP || [ ! -s "$DEP_CP_FILE" ]; then
+  echo "resolving vcell-client dependency classpath (cached at $DEP_CP_FILE)..." >&2
+  (cd "$REPO" && mvn -q dependency:build-classpath -pl vcell-client \
+      -Dmdep.outputFile="$DEP_CP_FILE")
+fi
+CP+="$(cat "$DEP_CP_FILE")"
+
+# --- JVM options mirrored from the install4j launcher ------------------------
+vmopts=(
+  --add-exports java.desktop/sun.awt.image=ALL-UNNAMED
+  "-Dvcell.installDir=$INSTALL_DIR"
+  -Dvcell.autoflushlog=true
+  "-Dvcell.softwareVersion=$VERSION"
+  "-Dvcell.serverHost=$API_HOST"
+  -Dvcell.serverPrefix.v0=/api/v0
+  -Dvcell.serverPrefix.v1=/api/v1
+  -Dvcell.onlineResourcesURL=http://vcell.org
+  -Dvcell.bioformatsJarFileName=vcell-bioformats-0.0.9-jar-with-dependencies.jar
+  -Dvcell.bioformatsJarDownloadURL=http://vcell.org/webstart/vcell-bioformats-0.0.9-jar-with-dependencies.jar
+  -Dvcell.debugBridge=true
+  "-Dvcell.debugBridge.port=$PORT"
+)
+
+echo "VCell client (target/classes): host=$API_HOST version=$VERSION bridge=:$PORT" >&2
+
+if $FOREGROUND; then
+  exec "$JAVA_BIN" "${vmopts[@]}" -cp "$CP" cbit.vcell.client.VCellClientMain \
+    --api-host="$API_HOST" ${passthrough[@]+"${passthrough[@]}"}
+fi
+
+nohup "$JAVA_BIN" "${vmopts[@]}" -cp "$CP" cbit.vcell.client.VCellClientMain \
+  --api-host="$API_HOST" ${passthrough[@]+"${passthrough[@]}"} \
+  >/tmp/vcell-debug-launch.out 2>&1 &
+PID=$!
+echo "launched pid=$PID (pre-redirect output: /tmp/vcell-debug-launch.out)" >&2
+
+# --- wait for the bridge to come up ------------------------------------------
+for _ in $(seq 1 90); do
+  if curl -fsS -m 1 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+    echo "bridge up: http://127.0.0.1:$PORT (try: tools/debug-bridge/bridge.sh windows)" >&2
+    exit 0
+  fi
+  if ! kill -0 "$PID" 2>/dev/null; then
+    echo "ERROR: client exited during startup; see /tmp/vcell-debug-launch.out" >&2
+    exit 1
+  fi
+  sleep 1
+done
+echo "ERROR: bridge did not answer on :$PORT within 90s (client pid=$PID still running)" >&2
+exit 1

--- a/tools/debug-bridge/scenarios/smoke.sh
+++ b/tools/debug-bridge/scenarios/smoke.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Smoke scenario: verifies bridge + running client end-to-end using only
+# semantic selectors (no hard-coded index paths, so it survives UI changes).
+#
+# Prereq: a client running with the bridge enabled, e.g.
+#   tools/debug-bridge/launch-client.sh        (from target/classes)
+#   ./vcell.sh --debug-bridge                  (from packaged jars)
+#
+# Usage: scenarios/smoke.sh [port]
+
+set -euo pipefail
+
+BRIDGE="$(cd "$(dirname "$0")/.." && pwd)/bridge.sh"
+export BRIDGE_PORT="${1:-${BRIDGE_PORT:-9123}}"
+
+step() { echo; echo "== $* =="; }
+
+step "bridge is answering"
+"$BRIDGE" health
+
+step "a VCell frame is showing (waits up to 60s for startup)"
+"$BRIDGE" wait --type JFrame --contains VCell --timeout 60000 >/dev/null
+echo ok
+
+step "menu bar has a File menu with items"
+"$BRIDGE" assert --type JMenu --text File >/dev/null
+echo ok
+
+step "menu structure is readable without opening popups"
+"$BRIDGE" menus | head -40
+
+step "EDT is responsive"
+"$BRIDGE" idle
+
+step "screenshot renders"
+"$BRIDGE" shot
+
+echo
+echo "SMOKE OK"

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/DatabaseSearchPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/DatabaseSearchPanel.java
@@ -335,6 +335,7 @@ public class DatabaseSearchPanel extends CollapsiblePanel {
 	private void initialize() {
 //		JLabel nameLabel = new JLabel("Search ");
 		nameSearchTextField = new TextFieldAutoCompletion();
+		nameSearchTextField.setName("DatabaseSearchTextField");
 		nameSearchTextField.putClientProperty("JTextField.variant", "search");
 		textFieldAutoComSet.add(nameSearchTextField);
 		
@@ -356,8 +357,10 @@ public class DatabaseSearchPanel extends CollapsiblePanel {
 		advancedOptions.add(endDatePanel);
 		
 		searchButton = new JButton("Search");		
+		searchButton.setName("DatabaseSearchButton");
 		searchButton.setActionCommand(SEARCH_Command);
 		cancelButton = new JButton("Show All");
+		cancelButton.setName("DatabaseShowAllButton");
 		cancelButton.setActionCommand(SEARCH_SHOW_ALL_COMMAND);
 		 
 		JPanel mainPanel = new JPanel();
@@ -389,6 +392,7 @@ public class DatabaseSearchPanel extends CollapsiblePanel {
 		mainPanel.add(advancedButton, gbc);
 
 		chckbxHasSpatial = new JCheckBox("Has Spatial");
+		chckbxHasSpatial.setName("HasSpatialCheckBox");
 		GridBagConstraints gbc_chckbxHasSpatial = new GridBagConstraints();
 		gbc_chckbxHasSpatial.anchor = GridBagConstraints.WEST;
 		gbc_chckbxHasSpatial.insets = new Insets(0, 5,5,0);
@@ -444,6 +448,7 @@ public class DatabaseSearchPanel extends CollapsiblePanel {
 		lblSpeciesName.setVisible(bEnableSpeciesSearch);
 		
 		textFieldSpeciesName = new JTextField();
+		textFieldSpeciesName.setName("SpeciesNameSearchTextField");
 		GridBagConstraints gbc_textFieldSpeciesName = new GridBagConstraints();
 		gbc_textFieldSpeciesName.insets = new Insets(0, 0, 5, 0);
 		gbc_textFieldSpeciesName.fill = GridBagConstraints.HORIZONTAL;

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/DatabaseWindowPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/DatabaseWindowPanel.java
@@ -484,6 +484,7 @@ private JTabbedPane getJTabbedPane1() {
 	if (ivjJTabbedPane1 == null) {
 		try {
 			ivjJTabbedPane1 = new JTabbedPaneEnhanced();
+			ivjJTabbedPane1.setName("DatabaseTabbedPane");
 			ivjJTabbedPane1.insertTab("BioModels", null, getBioModelDbTreePanel1(), null, 0);
 			ivjJTabbedPane1.insertTab("MathModels", null, getMathModelDbTreePanel1(), null, 1);
 			ivjJTabbedPane1.insertTab("Geometries", null, getGeometryTreePanel1(), null, 2);

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorModelPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorModelPanel.java
@@ -614,13 +614,20 @@ public class BioModelEditorModelPanel extends DocumentEditorSubPanel implements 
 	
 	private void initialize(){
 		newButton = new JButton("New");
+		newButton.setName("ModelNewButton");
 		newButton2 = new JButton("New Rule");
+		newButton2.setName("ModelNewRuleButton");
 		newMemButton = new JButton("New Membrane");
+		newMemButton.setName("ModelNewMembraneButton");
 		deleteButton = new JButton("Delete");
+		deleteButton.setName("ModelDeleteButton");
 		duplicateButton = new JButton("Duplicate");
+		duplicateButton.setName("ModelDuplicateButton");
 		pathwayButton = new JButton("Pathway Links", new DownArrowIcon());
+		pathwayButton.setName("ModelPathwayLinksButton");
 		pathwayButton.setHorizontalTextPosition(SwingConstants.LEFT);
 		textFieldSearch = new JTextField();
+		textFieldSearch.setName("ModelSearchTextField");
 		textFieldSearch.putClientProperty("JTextField.variant", "search");
 		
 		structuresTable = new EditorScrollTable();
@@ -719,6 +726,7 @@ public class BioModelEditorModelPanel extends DocumentEditorSubPanel implements 
 		/* button panel */
 		
 		tabbedPane = new JTabbedPaneEnhanced();
+		tabbedPane.setName("ModelTabbedPane");
 		tabbedPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
 		modelPanelTabs[ModelPanelTabID.reaction_diagram.ordinal()] = new ModelPanelTab(ModelPanelTabID.reaction_diagram, reactionCartoonEditorPanel, VCellIcons.diagramIcon);
 //		modelPanelTabs[ModelPanelTabID.structure_diagram.ordinal()] = new ModelPanelTab(ModelPanelTabID.structure_diagram, cartoonEditorPanel, VCellIcons.structureIcon);

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorPathwayCommonsPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorPathwayCommonsPanel.java
@@ -501,25 +501,32 @@ public class BioModelEditorPathwayCommonsPanel extends DocumentEditorSubPanel {
 	
 	private void initialize() {
 		searchTextField = new TextFieldAutoCompletion();
+		searchTextField.setName("PathwayCommonsSearchTextField");
 		searchTextField.addActionListener(eventHandler);
 		searchTextField.putClientProperty("JTextField.variant", "search");
 
 		filterTextField = new TextFieldAutoCompletion();
+		filterTextField.setName("PathwayCommonsFilterTextField");
 		filterTextField.addActionListener(eventHandler);
 		filterTextField.addKeyListener(eventHandler);
 		filterTextField.putClientProperty("JTextField.variant", "filter");
 
 		searchButton = new JButton("Search");
+		searchButton.setName("PathwayCommonsSearchButton");
 		searchButton.addActionListener(eventHandler);
 		sortButton = new JButton("Sort");
+		sortButton.setName("PathwayCommonsSortButton");
 		sortButton.addActionListener(eventHandler);
 		showPathwayButton = new JButton("Preview");
+		showPathwayButton.setName("PathwayCommonsPreviewButton");
 		showPathwayButton.addActionListener(eventHandler);
 		showPathwayButton.setEnabled(false);
 		gotoPathwayButton = new JButton("Open Web Link");
+		gotoPathwayButton.setName("PathwayCommonsWebLinkButton");
 		gotoPathwayButton.addActionListener(eventHandler);
 		gotoPathwayButton.setEnabled(false);
 		responseTree = new JTree();
+		responseTree.setName("PathwayCommonsResponseTree");
 		responseTreeModel = new ResponseTreeModel();
 		responseTree.setModel(responseTreeModel);
 		ToolTipManager.sharedInstance().registerComponent(responseTree);

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelsNetPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelsNetPanel.java
@@ -419,16 +419,21 @@ TODO:
 
 	private void initialize() {
 		searchTextField = new JTextField(10);
+		searchTextField.setName("BioModelsNetSearchTextField");
 		searchTextField.putClientProperty("JTextField.variant", "search");
 		searchTextField.addActionListener(eventHandler);
 		searchButton = new JButton("Search");
+		searchButton.setName("BioModelsNetSearchButton");
 		searchButton.addActionListener(eventHandler);
 		showAllButton = new JButton("Show All");
+		showAllButton.setName("BioModelsNetShowAllButton");
 		showAllButton.addActionListener(eventHandler);
 		importButton = new JButton("Import");
+		importButton.setName("BioModelsNetImportButton");
 		importButton.addActionListener(eventHandler);
 		importButton.setEnabled(false);
 		tree = new JTree();
+		tree.setName("BioModelsNetTree");
 		tree.setCellRenderer(new BioModelsNetTreeCellRenderer());
 		ToolTipManager.sharedInstance().registerComponent(tree);
 		treeModel = new BioModelsNetTreeModel();

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/DocumentEditor.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/DocumentEditor.java
@@ -505,6 +505,7 @@ private void initialize() {
 		JSplitPane leftSplitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
 		databaseWindowPanel = new DatabaseWindowPanel(false, false);
 		leftBottomTabbedPane  = new JTabbedPaneEnhanced();
+		leftBottomTabbedPane.setName("LeftBottomTabbedPane");
 		leftBottomTabbedPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
 		leftBottomTabbedPane.addTab("VCell DB", databaseWindowPanel);
 		
@@ -553,6 +554,7 @@ private void initialize() {
 
 		issuePanel = new IssuePanel();		
 		rightBottomTabbedPane = new JTabbedPaneEnhanced();
+		rightBottomTabbedPane.setName("RightBottomTabbedPane");
 		rightBottomTabbedPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
 		rightBottomEmptyPanel.setBorder(GuiConstants.TAB_PANEL_BORDER);
 		rightBottomEmptyAnnotationsPanel.setBorder(GuiConstants.TAB_PANEL_BORDER);

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/IssuePanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/IssuePanel.java
@@ -90,12 +90,14 @@ public class IssuePanel extends DocumentEditorSubPanel {
 	public IssuePanel() {
 		super();
 		refreshButton = new JButton("Refresh");
+		refreshButton.setName("IssuePanelRefreshButton");
 		refreshButton.addActionListener(e -> {
 				if (issueManager != null) {
 					issueManager.updateIssues();
 				}			
 		});
 		showWarningCheckBox = new JCheckBox("Show Warnings");
+		showWarningCheckBox.setName("ShowWarningsCheckBox");
 		showWarningCheckBox.setSelected(true);
 		showWarningCheckBox.addActionListener(e-> {
 				issueTableModel.setShowWarning(showWarningCheckBox.isSelected());

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -62,6 +62,8 @@ Every node in `/tree` and `/windows` carries a stable **`id`** (`c0`, `c1`, …)
 | `GET /find?type=&name=&text=&textContains=&limit=` | JSON: components matching ALL given criteria (each param optional, at least one required). `type` is a simple class name matched against the class **or any superclass** (`JButton`, `AbstractButton`); `text` is exact, `textContains` case-insensitive. Returns full nodes (path + id + state), no children |
 | `GET /waitFor?{find params}&state=&timeoutMs=&intervalMs=` | Poll the same selector until `state` holds: `showing` (default), `enabled`, or `gone`. JSON `{"satisfied": bool, "elapsedMs": N, "matches": [...]}` — the deterministic-wait primitive for automation (no more sleep-and-hope) |
 | `GET /idle` | Wait for the EDT to drain (two no-op round-trips); JSON `{"idle": true, "waitedMs": N}`. Call between act and observe |
+| `GET /menus` | JSON: complete menu-bar structure of every window (nested items, separators, accelerators), read from the menu models — **no popups are opened**, so this works even for menus you'd otherwise have to click through |
+| `GET /menu?path=Account>Login[&window=N]` | Activate a menu item by visible text (case-insensitive, `>`-separated). Fires the leaf item's `doClick()` directly — replaces the old open-popup-then-click-by-index dance. Lazily-populated menus get their `MenuListener` fired first |
 | `GET /listeners?path=0/3/2` | JSON: registered `ActionListener` classes, action command, mouse-listener count — "is this control actually wired up?" |
 | `GET /log[?lines=N]` | text/plain tail (default 200 lines) of the client's real log — VCell redirects System.out/err to `<vcellHome>/logs/vcellrun_<site>.log`, so exceptions never appear on the launcher's stdout |
 

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -73,6 +73,13 @@ Buttons/checkboxes are clicked via `doClick()` posted with `invokeLater` (no
 cursor movement, and the request returns immediately even if the action opens a
 modal dialog); other components get a synthetic `Robot` click at their center.
 
+## Tooling
+
+Committed fixtures live in [`tools/debug-bridge/`](../../../../../../../tools/debug-bridge/README.md):
+`launch-client.sh` (run the client from `target/classes` with the bridge on),
+`bridge.sh` (CLI with `wait`/`assert` exit codes for scripting), and
+`scenarios/` (reusable end-to-end scripts, e.g. `smoke.sh`).
+
 ## Typical loop
 
 ```bash

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -59,6 +59,9 @@ Every node in `/tree` and `/windows` carries a stable **`id`** (`c0`, `c1`, …)
 | `GET /selectTreeRow?path=&row=N` | select row N of the JTree; JSON `{"selected": bool}` |
 | `GET /rightClickTreeRow?path=&row=N` | right-click row N (opens its context menu); JSON `{"rightClicked": bool}` |
 | `GET /rightClick?path=` | right-click a component's center; JSON `{"rightClicked": bool}` |
+| `GET /find?type=&name=&text=&textContains=&limit=` | JSON: components matching ALL given criteria (each param optional, at least one required). `type` is a simple class name matched against the class **or any superclass** (`JButton`, `AbstractButton`); `text` is exact, `textContains` case-insensitive. Returns full nodes (path + id + state), no children |
+| `GET /waitFor?{find params}&state=&timeoutMs=&intervalMs=` | Poll the same selector until `state` holds: `showing` (default), `enabled`, or `gone`. JSON `{"satisfied": bool, "elapsedMs": N, "matches": [...]}` — the deterministic-wait primitive for automation (no more sleep-and-hope) |
+| `GET /idle` | Wait for the EDT to drain (two no-op round-trips); JSON `{"idle": true, "waitedMs": N}`. Call between act and observe |
 | `GET /listeners?path=0/3/2` | JSON: registered `ActionListener` classes, action command, mouse-listener count — "is this control actually wired up?" |
 | `GET /log[?lines=N]` | text/plain tail (default 200 lines) of the client's real log — VCell redirects System.out/err to `<vcellHome>/logs/vcellrun_<site>.log`, so exceptions never appear on the launcher's stdout |
 

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -65,6 +65,8 @@ Every node in `/tree` and `/windows` carries a stable **`id`** (`c0`, `c1`, …)
 | `GET /menus` | JSON: complete menu-bar structure of every window (nested items, separators, accelerators), read from the menu models — **no popups are opened**, so this works even for menus you'd otherwise have to click through |
 | `GET /menu?path=Account>Login[&window=N]` | Activate a menu item by visible text (case-insensitive, `>`-separated). Fires the leaf item's `doClick()` directly — replaces the old open-popup-then-click-by-index dance. Lazily-populated menus get their `MenuListener` fired first |
 | `GET /listeners?path=0/3/2` | JSON: registered `ActionListener` classes, action command, mouse-listener count — "is this control actually wired up?" |
+| `GET /props?path=` | JSON: extended properties of one component — full class chain, focus state, colors/font, accessible role/name/description, button/text-component detail, listener counts. The "inspect element" panel to `/tree`'s DOM |
+| `GET /highlight?path=[&ms=2000]` | Flash a translucent red overlay over the component so a human watching the screen sees what a selector resolves to. Glass-pane based; restores the original glass pane (and visibility) afterwards |
 | `GET /log[?lines=N]` | text/plain tail (default 200 lines) of the client's real log — VCell redirects System.out/err to `<vcellHome>/logs/vcellrun_<site>.log`, so exceptions never appear on the launcher's stdout |
 
 Buttons/checkboxes are clicked via `doClick()` posted with `invokeLater` (no

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
@@ -49,6 +49,9 @@ import com.sun.net.httpserver.HttpServer;
  *   GET /selectTab?path=..&amp;index=N            -&gt; JSON {"selected": true|false}
  *   GET /listeners?path=0/3/2   -&gt; JSON, registered listeners of the component
  *   GET /log[?lines=N]          -&gt; text/plain tail of the client's real log
+ *   GET /find?type=&amp;name=&amp;text=&amp;textContains=&amp;limit=  -&gt; JSON, semantic component search
+ *   GET /waitFor?{find params}&amp;state=showing|enabled|gone&amp;timeoutMs=&amp;intervalMs=  -&gt; JSON, poll until state holds
+ *   GET /idle                   -&gt; JSON, waits for the EDT to drain
  * </pre>
  *
  * Example: {@code curl -s localhost:9123/tree?maxDepth=6 | jq}
@@ -111,6 +114,9 @@ public final class SwingDebugBridge {
 			s.createContext("/rightClickTreeRow", wrap(SwingDebugBridge::handleRightClickTreeRow));
 			s.createContext("/rightClick", wrap(SwingDebugBridge::handleRightClick));
 			s.createContext("/listeners", wrap(SwingDebugBridge::handleListeners));
+			s.createContext("/find", wrap(SwingDebugBridge::handleFind));
+			s.createContext("/waitFor", wrap(SwingDebugBridge::handleWaitFor));
+			s.createContext("/idle", wrap(SwingDebugBridge::handleIdle));
 			s.createContext("/log", ex -> {
 				try {
 					respond(ex, 200, "text/plain; charset=utf-8", handleLog(ex).getBytes(StandardCharsets.UTF_8));
@@ -217,6 +223,52 @@ public final class SwingDebugBridge {
 		}
 		ConsoleCapture.CurrentContent content = cc.getLastLines(lines);
 		return content.isAvailable ? content.content : "(log content unavailable)";
+	}
+
+	/**
+	 * Shared selector parameters for /find and /waitFor: {@code type} (simple
+	 * class name, superclasses included), {@code name}, {@code text} (exact),
+	 * {@code textContains} (case-insensitive substring). At least one required.
+	 */
+	private static String handleFind(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String type = emptyToNull(q.get("type"));
+		String name = emptyToNull(q.get("name"));
+		String text = emptyToNull(q.get("text"));
+		String contains = emptyToNull(q.get("textContains"));
+		if (type == null && name == null && text == null && contains == null) {
+			return "{\"error\":\"require at least one of 'type', 'name', 'text', 'textContains'\"}";
+		}
+		int limit = Integer.parseInt(q.getOrDefault("limit", "25"));
+		return SwingInspector.findMatchesJson(type, name, text, contains, limit);
+	}
+
+	private static String handleWaitFor(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String type = emptyToNull(q.get("type"));
+		String name = emptyToNull(q.get("name"));
+		String text = emptyToNull(q.get("text"));
+		String contains = emptyToNull(q.get("textContains"));
+		if (type == null && name == null && text == null && contains == null) {
+			return "{\"error\":\"require at least one of 'type', 'name', 'text', 'textContains'\"}";
+		}
+		String state = q.getOrDefault("state", "showing");
+		if (!state.equals("showing") && !state.equals("enabled") && !state.equals("gone")) {
+			return "{\"error\":\"'state' must be one of showing, enabled, gone\"}";
+		}
+		// cap the wait so a stuck poller can't pin one of the bridge's few worker threads forever
+		long timeoutMs = Math.min(Long.parseLong(q.getOrDefault("timeoutMs", "10000")), 120_000L);
+		long intervalMs = Math.max(Long.parseLong(q.getOrDefault("intervalMs", "250")), 50L);
+		return SwingInspector.waitFor(type, name, text, contains, state, timeoutMs, intervalMs);
+	}
+
+	private static String handleIdle(HttpExchange ex) {
+		long waitedMs = SwingInspector.waitForIdle();
+		return "{\"idle\":true,\"waitedMs\":" + waitedMs + '}';
+	}
+
+	private static String emptyToNull(String s) {
+		return (s == null || s.isEmpty()) ? null : s;
 	}
 
 	private static String handleListeners(HttpExchange ex) {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
@@ -54,6 +54,8 @@ import com.sun.net.httpserver.HttpServer;
  *   GET /idle                   -&gt; JSON, waits for the EDT to drain
  *   GET /menus                  -&gt; JSON, full menu-bar structure of every window (no popups needed)
  *   GET /menu?path=Account&gt;Login[&amp;window=N]  -&gt; activate a menu item by its visible text
+ *   GET /props?path=            -&gt; JSON, extended properties of one component
+ *   GET /highlight?path=[&amp;ms=]  -&gt; flash an overlay over the component on screen
  * </pre>
  *
  * Example: {@code curl -s localhost:9123/tree?maxDepth=6 | jq}
@@ -121,6 +123,8 @@ public final class SwingDebugBridge {
 			s.createContext("/idle", wrap(SwingDebugBridge::handleIdle));
 			s.createContext("/menus", wrap(SwingDebugBridge::handleMenus));
 			s.createContext("/menu", wrap(SwingDebugBridge::handleMenu));
+			s.createContext("/props", wrap(SwingDebugBridge::handleProps));
+			s.createContext("/highlight", wrap(SwingDebugBridge::handleHighlight));
 			s.createContext("/log", ex -> {
 				try {
 					respond(ex, 200, "text/plain; charset=utf-8", handleLog(ex).getBytes(StandardCharsets.UTF_8));
@@ -273,6 +277,26 @@ public final class SwingDebugBridge {
 
 	private static String emptyToNull(String s) {
 		return (s == null || s.isEmpty()) ? null : s;
+	}
+
+	private static String handleProps(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty()) {
+			return "{\"error\":\"missing 'path' query parameter\"}";
+		}
+		return SwingInspector.propsJson(path);
+	}
+
+	private static String handleHighlight(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty()) {
+			return "{\"error\":\"missing 'path' query parameter\"}";
+		}
+		int ms = Integer.parseInt(q.getOrDefault("ms", "2000"));
+		boolean ok = SwingInspector.highlight(path, ms);
+		return "{\"highlighted\":" + ok + ",\"ms\":" + ms + '}';
 	}
 
 	private static String handleMenus(HttpExchange ex) {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
@@ -52,6 +52,8 @@ import com.sun.net.httpserver.HttpServer;
  *   GET /find?type=&amp;name=&amp;text=&amp;textContains=&amp;limit=  -&gt; JSON, semantic component search
  *   GET /waitFor?{find params}&amp;state=showing|enabled|gone&amp;timeoutMs=&amp;intervalMs=  -&gt; JSON, poll until state holds
  *   GET /idle                   -&gt; JSON, waits for the EDT to drain
+ *   GET /menus                  -&gt; JSON, full menu-bar structure of every window (no popups needed)
+ *   GET /menu?path=Account&gt;Login[&amp;window=N]  -&gt; activate a menu item by its visible text
  * </pre>
  *
  * Example: {@code curl -s localhost:9123/tree?maxDepth=6 | jq}
@@ -117,6 +119,8 @@ public final class SwingDebugBridge {
 			s.createContext("/find", wrap(SwingDebugBridge::handleFind));
 			s.createContext("/waitFor", wrap(SwingDebugBridge::handleWaitFor));
 			s.createContext("/idle", wrap(SwingDebugBridge::handleIdle));
+			s.createContext("/menus", wrap(SwingDebugBridge::handleMenus));
+			s.createContext("/menu", wrap(SwingDebugBridge::handleMenu));
 			s.createContext("/log", ex -> {
 				try {
 					respond(ex, 200, "text/plain; charset=utf-8", handleLog(ex).getBytes(StandardCharsets.UTF_8));
@@ -269,6 +273,20 @@ public final class SwingDebugBridge {
 
 	private static String emptyToNull(String s) {
 		return (s == null || s.isEmpty()) ? null : s;
+	}
+
+	private static String handleMenus(HttpExchange ex) {
+		return SwingInspector.menusJson();
+	}
+
+	private static String handleMenu(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty()) {
+			return "{\"error\":\"missing 'path' query parameter (e.g. path=Account>Login)\"}";
+		}
+		int window = Integer.parseInt(q.getOrDefault("window", "-1"));
+		return SwingInspector.clickMenu(path, window);
 	}
 
 	private static String handleListeners(HttpExchange ex) {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -1000,6 +1000,188 @@ public final class SwingInspector {
 	}
 
 	// ---------------------------------------------------------------------
+	// Deep inspection of a single component
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Extended property dump for one component — everything the tree dump
+	 * deliberately omits for brevity: full class hierarchy, focus state,
+	 * colors/font, accessible role/name/description, widget-specific detail
+	 * and listener counts.
+	 */
+	public static String propsJson(final String selector) {
+		return onEdt(() -> {
+			Component c = findByPath(selector);
+			if (c == null) {
+				return "{\"error\":\"selector did not resolve\"}";
+			}
+			StringBuilder sb = new StringBuilder(1024);
+			sb.append('{');
+			kv(sb, "id", idFor(c));
+			sb.append(",\"classChain\":[");
+			boolean first = true;
+			for (Class<?> k = c.getClass(); k != null && k != Object.class; k = k.getSuperclass()) {
+				if (!first) {
+					sb.append(',');
+				}
+				first = false;
+				sb.append('"').append(escape(k.getName())).append('"');
+			}
+			sb.append(']');
+			comma(sb);
+			kv(sb, "name", nz(c.getName()));
+			String text = textOf(c);
+			if (text != null) {
+				comma(sb);
+				kv(sb, "text", text.length() <= 2000 ? text : text.substring(0, 2000) + "…");
+			}
+			comma(sb);
+			raw(sb, "visible", c.isVisible());
+			comma(sb);
+			raw(sb, "showing", c.isShowing());
+			comma(sb);
+			raw(sb, "enabled", c.isEnabled());
+			comma(sb);
+			raw(sb, "focusable", c.isFocusable());
+			comma(sb);
+			raw(sb, "hasFocus", c.hasFocus());
+			comma(sb);
+			raw(sb, "opaque", c.isOpaque());
+			Rectangle b = c.getBounds();
+			sb.append(",\"bounds\":{\"x\":").append(b.x).append(",\"y\":").append(b.y)
+					.append(",\"w\":").append(b.width).append(",\"h\":").append(b.height).append('}');
+			if (c.isShowing()) {
+				Point p = c.getLocationOnScreen();
+				sb.append(",\"screen\":{\"x\":").append(p.x).append(",\"y\":").append(p.y).append('}');
+			}
+			java.awt.Font f = c.getFont();
+			if (f != null) {
+				sb.append(",\"font\":\"").append(escape(f.getName() + ' ' + f.getSize()
+						+ (f.isBold() ? " bold" : "") + (f.isItalic() ? " italic" : ""))).append('"');
+			}
+			sb.append(",\"foreground\":\"").append(hexColor(c.getForeground()));
+			sb.append("\",\"background\":\"").append(hexColor(c.getBackground())).append('"');
+			if (c instanceof JComponent) {
+				JComponent jc = (JComponent) c;
+				if (jc.getToolTipText() != null) {
+					comma(sb);
+					kv(sb, "tooltip", jc.getToolTipText());
+				}
+				if (jc.getBorder() != null) {
+					comma(sb);
+					kv(sb, "border", jc.getBorder().getClass().getName());
+				}
+			}
+			javax.accessibility.AccessibleContext ac = c.getAccessibleContext();
+			if (ac != null) {
+				sb.append(",\"accessible\":{");
+				kv(sb, "role", ac.getAccessibleRole().toDisplayString());
+				comma(sb);
+				kv(sb, "name", nz(ac.getAccessibleName()));
+				comma(sb);
+				kv(sb, "description", nz(ac.getAccessibleDescription()));
+				sb.append('}');
+			}
+			if (c instanceof AbstractButton) {
+				AbstractButton btn = (AbstractButton) c;
+				comma(sb);
+				kv(sb, "actionCommand", nz(btn.getActionCommand()));
+				comma(sb);
+				raw(sb, "selected", btn.isSelected());
+			}
+			if (c instanceof JTextComponent) {
+				JTextComponent tc = (JTextComponent) c;
+				comma(sb);
+				raw(sb, "editable", tc.isEditable());
+				sb.append(",\"caretPosition\":").append(tc.getCaretPosition());
+				sb.append(",\"documentLength\":").append(tc.getDocument().getLength());
+			}
+			sb.append(",\"listeners\":{");
+			if (c instanceof AbstractButton) {
+				sb.append("\"action\":").append(((AbstractButton) c).getActionListeners().length).append(',');
+			}
+			sb.append("\"mouse\":").append(c.getMouseListeners().length);
+			sb.append(",\"key\":").append(c.getKeyListeners().length);
+			sb.append(",\"focus\":").append(c.getFocusListeners().length);
+			sb.append('}');
+			sb.append('}');
+			return sb.toString();
+		});
+	}
+
+	private static String hexColor(java.awt.Color c) {
+		return c == null ? "" : String.format("#%02x%02x%02x", c.getRed(), c.getGreen(), c.getBlue());
+	}
+
+	// ---------------------------------------------------------------------
+	// Highlight: show a human where a selector points
+	// ---------------------------------------------------------------------
+
+	private static final class GlassState {
+		final Component pane;
+		final boolean wasVisible;
+
+		GlassState(Component pane, boolean wasVisible) {
+			this.pane = pane;
+			this.wasVisible = wasVisible;
+		}
+	}
+
+	/** Original glass pane per root, saved while a highlight overlay is up. EDT-confined. */
+	private static final java.util.Map<javax.swing.JRootPane, GlassState> savedGlass = new java.util.IdentityHashMap<>();
+
+	/**
+	 * Flash a translucent red overlay over the component so a human watching the
+	 * screen can see what a selector resolves to. Swaps the window's glass pane
+	 * for the duration and restores the original (and its visibility — VCell
+	 * uses visible glass panes to block input during long tasks) afterwards.
+	 *
+	 * @return true if the component resolved and is showing
+	 */
+	public static boolean highlight(final String selector, final int durationMs) {
+		return Boolean.TRUE.equals(onEdt(() -> {
+			Component c = findByPath(selector);
+			if (c == null || !c.isShowing()) {
+				return false;
+			}
+			javax.swing.JRootPane root = SwingUtilities.getRootPane(c);
+			if (root == null) {
+				return false;
+			}
+			if (!savedGlass.containsKey(root)) {
+				Component old = root.getGlassPane();
+				savedGlass.put(root, new GlassState(old, old != null && old.isVisible()));
+			}
+			final Rectangle r = (c.getParent() == null) ? new Rectangle(0, 0, c.getWidth(), c.getHeight())
+					: SwingUtilities.convertRectangle(c.getParent(), c.getBounds(), root.getGlassPane());
+			JComponent overlay = new JComponent() {
+				@Override
+				protected void paintComponent(java.awt.Graphics g) {
+					java.awt.Graphics2D g2 = (java.awt.Graphics2D) g;
+					g2.setColor(new java.awt.Color(255, 0, 0, 60));
+					g2.fillRect(r.x, r.y, r.width, r.height);
+					g2.setStroke(new java.awt.BasicStroke(3f));
+					g2.setColor(java.awt.Color.RED);
+					g2.drawRect(r.x, r.y, r.width, r.height);
+				}
+			};
+			overlay.setOpaque(false);
+			root.setGlassPane(overlay);
+			overlay.setVisible(true);
+			javax.swing.Timer timer = new javax.swing.Timer(durationMs, e -> {
+				GlassState orig = savedGlass.remove(root);
+				if (orig != null && orig.pane != null) {
+					root.setGlassPane(orig.pane);
+					orig.pane.setVisible(orig.wasVisible);
+				}
+			});
+			timer.setRepeats(false);
+			timer.start();
+			return true;
+		}));
+	}
+
+	// ---------------------------------------------------------------------
 	// Screenshots
 	// ---------------------------------------------------------------------
 

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -35,6 +35,9 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JList;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
 import javax.swing.JTabbedPane;
 import javax.swing.JTable;
 import javax.swing.JTree;
@@ -277,7 +280,44 @@ public final class SwingInspector {
 			appendTable(sb, (JTable) c);
 		} else if (c instanceof JTree) {
 			appendTree(sb, (JTree) c);
+		} else if (c instanceof JMenu) {
+			// popup contents are not in the component hierarchy until shown;
+			// serialize them statically so menus are discoverable without popups
+			sb.append(",\"menuItems\":");
+			appendMenuItems(sb, (JMenu) c, 0);
 		}
+	}
+
+	private static final int MAX_MENU_DEPTH = 5;
+
+	private static void appendMenuItems(StringBuilder sb, JMenu menu, int depth) {
+		sb.append('[');
+		for (int i = 0; i < menu.getItemCount(); i++) {
+			if (i > 0) {
+				sb.append(',');
+			}
+			JMenuItem item = menu.getItem(i);
+			if (item == null) {
+				sb.append("{\"separator\":true}");
+				continue;
+			}
+			sb.append('{');
+			kv(sb, "text", nz(item.getText()));
+			comma(sb);
+			kv(sb, "id", idFor(item));
+			comma(sb);
+			raw(sb, "enabled", item.isEnabled());
+			if (item.getAccelerator() != null) {
+				comma(sb);
+				kv(sb, "accelerator", String.valueOf(item.getAccelerator()));
+			}
+			if (item instanceof JMenu && depth < MAX_MENU_DEPTH) {
+				sb.append(",\"items\":");
+				appendMenuItems(sb, (JMenu) item, depth + 1);
+			}
+			sb.append('}');
+		}
+		sb.append(']');
 	}
 
 	private static void appendTree(StringBuilder sb, JTree t) {
@@ -615,6 +655,173 @@ public final class SwingInspector {
 		}
 		sb.append(']');
 		return sb.toString();
+	}
+
+	// ---------------------------------------------------------------------
+	// Menus: enumerate and activate by visible text, no popup choreography
+	// ---------------------------------------------------------------------
+
+	/**
+	 * @return JSON array: for every showing window with a {@link JMenuBar}, its
+	 *         complete menu structure (nested items, separators, accelerators),
+	 *         read from the models without opening any popup.
+	 */
+	public static String menusJson() {
+		return onEdt(() -> {
+			StringBuilder sb = new StringBuilder(2048);
+			sb.append('[');
+			List<Window> windows = showingWindows();
+			boolean first = true;
+			for (int i = 0; i < windows.size(); i++) {
+				JMenuBar bar = menuBarOf(windows.get(i));
+				if (bar == null) {
+					continue;
+				}
+				if (!first) {
+					sb.append(',');
+				}
+				first = false;
+				sb.append("{\"window\":").append(i).append(',');
+				kv(sb, "title", nz(textOf(windows.get(i))));
+				sb.append(",\"menus\":[");
+				for (int m = 0; m < bar.getMenuCount(); m++) {
+					if (m > 0) {
+						sb.append(',');
+					}
+					JMenu menu = bar.getMenu(m);
+					if (menu == null) {
+						sb.append("{}");
+						continue;
+					}
+					sb.append('{');
+					kv(sb, "text", nz(menu.getText()));
+					comma(sb);
+					kv(sb, "id", idFor(menu));
+					comma(sb);
+					raw(sb, "enabled", menu.isEnabled());
+					sb.append(",\"items\":");
+					appendMenuItems(sb, menu, 0);
+					sb.append('}');
+				}
+				sb.append("]}");
+			}
+			sb.append(']');
+			return sb.toString();
+		});
+	}
+
+	/**
+	 * Activate a menu item addressed by its visible text, e.g.
+	 * {@code "Account > Login"} — segments separated by {@code '>'}, matched
+	 * case-insensitively against menu/item text. The leaf item's action fires
+	 * via {@code doClick()} without animating popups, so callers no longer walk
+	 * transient popup windows by index. Menus that build their items lazily in
+	 * a {@link javax.swing.event.MenuListener} get that listener fired first,
+	 * the same way opening the menu would.
+	 *
+	 * @param windowIndex restrict the search to one window (index into
+	 *                    {@link #showingWindows()}), or -1 for all windows
+	 * @return JSON describing what was clicked, or an error
+	 */
+	public static String clickMenu(final String menuPath, final int windowIndex) {
+		return onEdt(() -> {
+			String[] segs = menuPath.split(">");
+			for (int i = 0; i < segs.length; i++) {
+				segs[i] = segs[i].trim();
+			}
+			if (segs.length == 0 || segs[0].isEmpty()) {
+				return "{\"clicked\":false,\"error\":\"empty menu path\"}";
+			}
+			List<Window> windows = showingWindows();
+			for (int i = 0; i < windows.size(); i++) {
+				if (windowIndex >= 0 && windowIndex != i) {
+					continue;
+				}
+				JMenuBar bar = menuBarOf(windows.get(i));
+				if (bar == null) {
+					continue;
+				}
+				JMenu top = null;
+				for (int m = 0; m < bar.getMenuCount(); m++) {
+					JMenu menu = bar.getMenu(m);
+					if (menu != null && segs[0].equalsIgnoreCase(nz(menu.getText()).trim())) {
+						top = menu;
+						break;
+					}
+				}
+				if (top == null) {
+					continue;
+				}
+				if (segs.length == 1) {
+					return "{\"clicked\":false,\"error\":\"path must name an item inside menu '"
+							+ escape(segs[0]) + "', e.g. " + escape(segs[0]) + ">Item\"}";
+				}
+				JMenuItem cur = top;
+				StringBuilder resolved = new StringBuilder(nz(top.getText()));
+				for (int s = 1; s < segs.length; s++) {
+					if (!(cur instanceof JMenu)) {
+						return "{\"clicked\":false,\"error\":\"'" + escape(resolved.toString())
+								+ "' is not a submenu\"}";
+					}
+					JMenuItem next = childItem((JMenu) cur, segs[s]);
+					if (next == null) {
+						return "{\"clicked\":false,\"error\":\"no item '" + escape(segs[s]) + "' under '"
+								+ escape(resolved.toString()) + "'\"}";
+					}
+					cur = next;
+					resolved.append(" > ").append(nz(cur.getText()));
+				}
+				if (!cur.isEnabled()) {
+					return "{\"clicked\":false,\"error\":\"item '" + escape(resolved.toString())
+							+ "' is disabled\"}";
+				}
+				final JMenuItem target = cur;
+				// fire-and-forget: the action may open a modal dialog
+				SwingUtilities.invokeLater(target::doClick);
+				return "{\"clicked\":true,\"item\":\"" + escape(resolved.toString()) + "\",\"id\":\""
+						+ idFor(target) + "\",\"window\":" + i + '}';
+			}
+			return "{\"clicked\":false,\"error\":\"no showing window has a menu '" + escape(segs[0]) + "'\"}";
+		});
+	}
+
+	private static JMenuBar menuBarOf(Window w) {
+		if (w instanceof JFrame) {
+			return ((JFrame) w).getJMenuBar();
+		}
+		if (w instanceof JDialog) {
+			return ((JDialog) w).getJMenuBar();
+		}
+		return null;
+	}
+
+	/** Find a direct child item by text, firing lazy-population MenuListeners if needed. */
+	private static JMenuItem childItem(JMenu menu, String text) {
+		JMenuItem hit = scanItems(menu, text);
+		if (hit == null && menu.getMenuListeners().length > 0) {
+			// menus populated on menuSelected (e.g. recent-file lists) are empty
+			// until "opened"; fire their listeners the way opening them would
+			javax.swing.event.MenuEvent ev = new javax.swing.event.MenuEvent(menu);
+			for (javax.swing.event.MenuListener l : menu.getMenuListeners()) {
+				try {
+					l.menuSelected(ev);
+				} catch (RuntimeException e) {
+					// a listener assuming a visible popup may object; matching below still gets its chance
+				}
+			}
+			hit = scanItems(menu, text);
+		}
+		return hit;
+	}
+
+	private static JMenuItem scanItems(JMenu menu, String text) {
+		for (int i = 0; i < menu.getItemCount(); i++) {
+			JMenuItem item = menu.getItem(i);
+			if (item != null && text.equalsIgnoreCase(nz(item.getText()).trim())) {
+				return item;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -453,6 +453,170 @@ public final class SwingInspector {
 		return null;
 	}
 
+	// ---------------------------------------------------------------------
+	// Semantic finders: locate components by what they ARE (type/name/text)
+	// instead of where they sit (index path), so automation survives layout
+	// shifts between builds and sessions.
+	// ---------------------------------------------------------------------
+
+	/** A matched component plus the index path it was found at. */
+	private static final class PathMatch {
+		final Component component;
+		final String path;
+
+		PathMatch(Component component, String path) {
+			this.component = component;
+			this.path = path;
+		}
+	}
+
+	/**
+	 * JSON array of components matching ALL given criteria (null criteria are
+	 * ignored). Each element is a full node as in the tree dump, minus children.
+	 *
+	 * @param type         simple class name matched against the component's class
+	 *                     or any superclass (e.g. "JButton", "AbstractButton")
+	 * @param name         exact {@link Component#getName()} match
+	 * @param text         exact match on the node's {@code text} (button/label
+	 *                     text, text-component content, window title)
+	 * @param textContains case-insensitive substring of that text
+	 * @param limit        maximum matches to emit (&lt;=0 = unlimited)
+	 */
+	public static String findMatchesJson(String type, String name, String text, String textContains, int limit) {
+		return onEdt(() -> emitMatches(collectAll(type, name, text, textContains),
+				limit <= 0 ? Integer.MAX_VALUE : limit));
+	}
+
+	/**
+	 * Poll the semantic finder until the requested state holds or the timeout
+	 * elapses. States: {@code showing} (default) — at least one match is showing;
+	 * {@code enabled} — at least one match is showing and enabled; {@code gone} —
+	 * no showing match. Callers must be off the EDT (each poll hops onto it).
+	 *
+	 * @return JSON {@code {"satisfied":bool,"state":..,"elapsedMs":N,"matches":[..]}}
+	 */
+	public static String waitFor(String type, String name, String text, String textContains,
+			String state, long timeoutMs, long intervalMs) {
+		String st = (state == null || state.isEmpty()) ? "showing" : state;
+		boolean wantGone = "gone".equals(st);
+		boolean needEnabled = "enabled".equals(st);
+		long start = System.currentTimeMillis();
+		while (true) {
+			String matches = matchesInStateJson(type, name, text, textContains, needEnabled, 10);
+			boolean present = !"[]".equals(matches);
+			boolean satisfied = wantGone != present;
+			long elapsed = System.currentTimeMillis() - start;
+			if (satisfied || elapsed >= timeoutMs) {
+				return "{\"satisfied\":" + satisfied + ",\"state\":\"" + escape(st) + "\",\"elapsedMs\":" + elapsed
+						+ ",\"matches\":" + matches + '}';
+			}
+			try {
+				Thread.sleep(intervalMs);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return "{\"satisfied\":false,\"interrupted\":true,\"elapsedMs\":"
+						+ (System.currentTimeMillis() - start) + '}';
+			}
+		}
+	}
+
+	/**
+	 * Wait for the EDT to drain: two no-op round-trips (the first flushes events
+	 * queued before the call, the second anything the first batch enqueued).
+	 *
+	 * @return milliseconds the round-trips took
+	 */
+	public static long waitForIdle() {
+		long start = System.currentTimeMillis();
+		onEdt(() -> null);
+		onEdt(() -> null);
+		return System.currentTimeMillis() - start;
+	}
+
+	/** Matches that are showing (and optionally enabled), as a JSON array. EDT-hopping. */
+	private static String matchesInStateJson(String type, String name, String text, String textContains,
+			boolean needEnabled, int limit) {
+		return onEdt(() -> {
+			List<PathMatch> filtered = new ArrayList<>();
+			for (PathMatch m : collectAll(type, name, text, textContains)) {
+				if (m.component.isShowing() && (!needEnabled || m.component.isEnabled())) {
+					filtered.add(m);
+				}
+			}
+			return emitMatches(filtered, limit);
+		});
+	}
+
+	/** DFS every showing window for criteria matches. Must run on the EDT. */
+	private static List<PathMatch> collectAll(String type, String name, String text, String textContains) {
+		List<PathMatch> out = new ArrayList<>();
+		List<Window> windows = new ArrayList<>();
+		for (Window w : Window.getWindows()) {
+			if (w.isShowing()) {
+				windows.add(w);
+			}
+		}
+		for (int i = 0; i < windows.size(); i++) {
+			collectMatches(windows.get(i), Integer.toString(i), type, name, text, textContains, out);
+		}
+		return out;
+	}
+
+	private static void collectMatches(Component c, String path, String type, String name, String text,
+			String textContains, List<PathMatch> out) {
+		if (matchesCriteria(c, type, name, text, textContains)) {
+			out.add(new PathMatch(c, path));
+		}
+		if (c instanceof Container) {
+			Component[] kids = ((Container) c).getComponents();
+			for (int i = 0; i < kids.length; i++) {
+				collectMatches(kids[i], path + '/' + i, type, name, text, textContains, out);
+			}
+		}
+	}
+
+	private static boolean matchesCriteria(Component c, String type, String name, String text, String textContains) {
+		if (type != null) {
+			boolean hit = false;
+			for (Class<?> k = c.getClass(); k != null; k = k.getSuperclass()) {
+				if (k.getSimpleName().equals(type)) {
+					hit = true;
+					break;
+				}
+			}
+			if (!hit) {
+				return false;
+			}
+		}
+		if (name != null && !name.equals(c.getName())) {
+			return false;
+		}
+		String t = textOf(c);
+		if (text != null && !text.equals(t)) {
+			return false;
+		}
+		if (textContains != null && (t == null || !t.toLowerCase().contains(textContains.toLowerCase()))) {
+			return false;
+		}
+		return true;
+	}
+
+	/** Emit matches as a JSON array of childless nodes. Must run on the EDT. */
+	private static String emitMatches(List<PathMatch> hits, int limit) {
+		StringBuilder sb = new StringBuilder(1024);
+		sb.append('[');
+		int shown = Math.min(hits.size(), limit);
+		for (int i = 0; i < shown; i++) {
+			if (i > 0) {
+				sb.append(',');
+			}
+			// depth == maxDepth, so appendNode emits the node without children
+			appendNode(sb, hits.get(i).component, hits.get(i).path, 0, 0);
+		}
+		sb.append(']');
+		return sb.toString();
+	}
+
 	/**
 	 * Click a component identified by node path. Buttons/checkboxes use
 	 * {@link AbstractButton#doClick()} (EDT-safe, no native cursor movement);

--- a/vcell-client/src/main/java/org/vcell/client/logicalwindow/LWTopFrame.java
+++ b/vcell-client/src/main/java/org/vcell/client/logicalwindow/LWTopFrame.java
@@ -78,10 +78,12 @@ public abstract class LWTopFrame extends JFrame implements LWContainerHandle {
 	public static JMenu createWindowMenu(boolean bTextMenu ) {
 		JMenu mnWindow = new JMenu( );
 		if (bTextMenu) {
+			mnWindow.setName("WindowMenu");
 			mnWindow.setText("Window");
 			mnWindow.setMnemonic('W');
 		}
 		else {
+			mnWindow.setName("WindowIconMenu");
 			mnWindow.setIcon(LWButton.SHOW_WINDOW_MENU_ICON);
 			mnWindow.setToolTipText("Show open windows");
 		}


### PR DESCRIPTION
## What

Phase 2 of the Swing debug bridge (#1750): moves automation from low-level index-path arithmetic to semantic, layout-resilient primitives, and commits the launch/CLI tooling that previously lived in session scratch.

### New endpoints (`org.vcell.client.debug`)

| Endpoint | Purpose |
|---|---|
| `/find?type=&name=&text=&textContains=&limit=` | Locate components by what they **are** (simple class name incl. superclasses, `Component.getName()`, exact or substring text) instead of where they sit |
| `/waitFor?{find params}&state=showing\|enabled\|gone&timeoutMs=` | Deterministic-wait primitive: poll a selector until a state holds — replaces sleep-and-hope |
| `/idle` | Drain the EDT between act and observe |
| `/menus` | Full menu-bar structure of every window, read from the menu models — **no popups opened** |
| `/menu?path=Account>Login` | Activate a menu item by visible text; fires `doClick()` on the leaf, fires `MenuListener`s first for lazily-populated menus. Replaces the fragile open-popup-then-click-by-index dance |
| `/props?path=` | "Inspect element" for one component: class chain, focus, colors/font, accessibility, listener counts |
| `/highlight?path=` | Flash an overlay so a human sees what a selector resolves to (glass-pane based, restores original incl. visibility) |

`/tree` also now serializes `menuItems` on every `JMenu` node.

### Committed tooling (`tools/debug-bridge/`)

- `launch-client.sh` — run the client from `target/classes` (no packaging) with the bridge on: bundled install4j JRE, module classes prepended to a cached dependency classpath, backgrounds itself and polls `/health`
- `bridge.sh` — CLI over all endpoints; URL-encodes args, jq pretty-print, and `wait`/`assert` exit non-zero on failure so scenarios are plain shell
- `scenarios/smoke.sh` — end-to-end sanity using only semantic selectors


### setName sweep (follow-up commit)

Inventoried the live UI with `/find` itself and named the key unnamed interactive widgets — 32 pure-additive `setName` lines across 8 classes (Window menus, DocumentEditor/database/model tabbed panes, database search panels, BioModelsNet + Pathway Commons panels, IssuePanel, model action buttons). All verified live: every name resolves via `/find?name=`, making `--name` selectors the most robust way to drive these controls.

## Safety

Unchanged from #1750: everything is off unless `-Dvcell.debugBridge=true`, loopback-only, never fatal. Zero production footprint.

## Verified live

Against a running client (vcell-dev, from `target/classes` via the new launcher):
- `scenarios/smoke.sh` passes end-to-end (health → waitFor main frame → menu assertions → `/menus` → `/idle` → screenshot)
- `/menu "File>New>BioModel"` activated a 3-level nested item with no popups; `/waitFor textContains=BioModel2` caught the new frame in 971 ms
- superclass type matching, `/props`, `/highlight`, error paths, and `wait`/`assert` exit codes all confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
