### PR TITLE
Fix geometry viewer opening behind the GUI and blank (#1737)

### DIFF
--- a/tools/debug-bridge/bridge.sh
+++ b/tools/debug-bridge/bridge.sh
@@ -15,6 +15,7 @@
 #   click <selector>            rclick <selector>
 #   settext <selector> <text> [--enter]
 #   tab <selector> <index>      row <selector> <row>     rrow <selector> <row>
+#   expand <selector> <row> [true|false]                 drow <selector> <row>
 #   menu "<Menu>Item[>Sub]" [window]
 #   highlight <selector> [ms]
 # Synchronize / assert (exit 0 on success, 1 on failure):
@@ -127,6 +128,9 @@ case "$cmd" in
     ;;
   tab)       get selectTab --data-urlencode "path=$1" --data-urlencode "index=$2" | pretty ;;
   row)       get selectTreeRow --data-urlencode "path=$1" --data-urlencode "row=$2" | pretty ;;
+  expand)    get expandTreeRow --data-urlencode "path=$1" --data-urlencode "row=$2" \
+               --data-urlencode "expand=${3:-true}" | pretty ;;
+  drow)      get doubleClickTreeRow --data-urlencode "path=$1" --data-urlencode "row=$2" | pretty ;;
   rrow)      get rightClickTreeRow --data-urlencode "path=$1" --data-urlencode "row=$2" | pretty ;;
   menu)      get menu --data-urlencode "path=$1" ${2:+--data-urlencode "window=$2"} | pretty ;;
   props)     get props --data-urlencode "path=$1" | pretty ;;

--- a/tools/debug-bridge/bridge.sh
+++ b/tools/debug-bridge/bridge.sh
@@ -23,7 +23,10 @@
 #   assert [find opts] [--gone]
 #   idle
 #
-# A <selector> is a tree path ("0/3/2") or a stable component id ("c42").
+# A <selector> is one of:
+#   name=SearchButton[N]  by Component name (best); showing match wins, [N] disambiguates
+#   c42                   stable component id from /tree
+#   0/3/2                 positional node path (brittle)
 
 set -eo pipefail
 

--- a/vcell-client/src/main/java/cbit/vcell/client/ClientMDIManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ClientMDIManager.java
@@ -247,6 +247,9 @@ public DocumentWindow createNewDocumentWindow(final DocumentWindowManager window
 	getRequestManager().updateStatusNow(); // initialize status bar with current status (also syncs all other windows)
 	// done
 	documentWindow.setVisible(true);
+	// the work area is only inside a realized window now, which is what any child
+	// window of this document needs in order to attach itself
+	windowManager.documentWindowShown();
 	return documentWindow;
 }
 

--- a/vcell-client/src/main/java/cbit/vcell/client/ClientRequestManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ClientRequestManager.java
@@ -3548,8 +3548,13 @@ private BioModel createDefaultBioModelDocument(BngUnitSystem bngUnitSystem) thro
 							if (inNewWindow) {
 								windowManager = createDocumentWindowManager(doc);
 								// request was to create a new top-level window with this doc
-								getMdiManager().createNewDocumentWindow(windowManager);
-
+								DocumentWindow dw = getMdiManager().createNewDocumentWindow(windowManager);
+								// raise the window we just opened. Without this the only thing that
+								// raises it is task4's setWindowFocus, which goes through
+								// DocumentWindowManager.getDocumentEditor() and so does nothing for a
+								// Geometry (GeometryWindowManager has no DocumentEditor) — the window
+								// then opens behind the window the user launched it from.
+								setFinalWindow(hashTable, dw);
 							} else {
 								// request was to replace the document in an existing window
 								windowManager = (DocumentWindowManager) requester;

--- a/vcell-client/src/main/java/cbit/vcell/client/DocumentWindowManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/DocumentWindowManager.java
@@ -268,5 +268,15 @@ public void startExport(Component requester,OutputContext outputContext,ExportSp
 public abstract void updateConnectionStatus(ConnectionStatus connStatus);
 
 public abstract DocumentEditor getDocumentEditor( );
+
+/**
+ * Called once this document's top-level window has been made visible. Only then is
+ * the work-area panel inside a realized window, which is what child windows need in
+ * order to find their {@link cbit.vcell.client.ChildWindowManager}. Managers whose
+ * content lives in a child window rather than in the work area itself override this
+ * to open that child window; the default is to do nothing.
+ */
+public void documentWindowShown() {
+}
 }
 

--- a/vcell-client/src/main/java/cbit/vcell/client/GeometryWindowManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/GeometryWindowManager.java
@@ -343,4 +343,17 @@ public void updateConnectionStatus(ConnectionStatus connStatus) {
 public DocumentEditor getDocumentEditor() {
 	return null;
 }
+
+/**
+ * Open the geometry viewer as soon as the document window is up. The work area of a
+ * geometry window holds only the GeometryEditor toolbar; the geometry itself is drawn
+ * in a child window. GeometryEditor starts with its "Geometry Editor" toggle already
+ * selected, so without this the window shows two buttons and nothing else, and the
+ * user's first click on the toggle merely deselects it (hiding a viewer that was never
+ * shown) — they had to click twice to see anything.
+ */
+@Override
+public void documentWindowShown() {
+	showGeometryViewer();
+}
 }

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -57,6 +57,8 @@ Every node in `/tree` and `/windows` carries a stable **`id`** (`c0`, `c1`, …)
 | `GET /setText?path=&text=&enter=` | JSON `{"set": true\|false}` |
 | `GET /selectTab?path=&index=` | JSON `{"selected": true\|false}` |
 | `GET /selectTreeRow?path=&row=N` | select row N of the JTree; JSON `{"selected": bool}` |
+| `GET /expandTreeRow?path=&row=N[&expand=false]` | expand (or collapse) row N — row indices only cover *expanded* rows, so this is how a driver walks down a tree; JSON `{"expanded": bool}` |
+| `GET /doubleClickTreeRow?path=&row=N` | synthetic double-click on row N; JSON `{"doubleClicked": bool}`. Needed because VCell's database trees open a document straight from the `MouseEvent` (`MOUSE_PRESSED` + `getClickCount()==2`), which no higher-level API reproduces |
 | `GET /rightClickTreeRow?path=&row=N` | right-click row N (opens its context menu); JSON `{"rightClicked": bool}` |
 | `GET /rightClick?path=` | right-click a component's center; JSON `{"rightClicked": bool}` |
 | `GET /find?type=&name=&text=&textContains=&limit=` | JSON: components matching ALL given criteria (each param optional, at least one required). `type` is a simple class name matched against the class **or any superclass** (`JButton`, `AbstractButton`); `text` is exact, `textContains` case-insensitive. Returns full nodes (path + id + state), no children |

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -45,7 +45,17 @@ On startup you'll see a `WARN` log line: `Swing debug bridge listening on http:/
 
 ## Endpoints
 
-Every node in `/tree` and `/windows` carries a stable **`id`** (`c0`, `c1`, …) in addition to its `path`. Any endpoint's `path=` parameter accepts either form — prefer the `id`, which stays valid across dumps and doesn't break when the component tree shifts. (Registry is non-invasive; it never touches `Component.getName()`.)
+Every endpoint's `path=` parameter accepts **three interchangeable selector forms**:
+
+| Form | Example | Notes |
+|---|---|---|
+| **name** | `name=DatabaseSearchButton` | Most robust — survives layout changes entirely. Where several components share a name (VCell reuses panels, e.g. one search panel per database tab), a **showing** match wins over a hidden one; disambiguate with an index, `name=DatabaseSearchButton[1]`, using the `/find` ordering. |
+| **id** | `c42` | Stable registry id emitted as `id` on every node in `/tree` and `/windows`; valid across dumps. The registry is non-invasive — it never touches `Component.getName()`. |
+| **node path** | `0/3/2` | Positional (window 0 → child 3 → child 2). Brittle; prefer the forms above. |
+
+A selector that doesn't resolve reports `did not resolve` (or `false`) rather than erroring — a malformed selector never throws.
+
+> Naming widgets is what makes the `name=` form work: see the tip below on `setName`.
 
 | Endpoint | Returns |
 |---|---|

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
@@ -116,6 +116,8 @@ public final class SwingDebugBridge {
 			s.createContext("/selectTab", wrap(SwingDebugBridge::handleSelectTab));
 			s.createContext("/selectTreeRow", wrap(SwingDebugBridge::handleSelectTreeRow));
 			s.createContext("/rightClickTreeRow", wrap(SwingDebugBridge::handleRightClickTreeRow));
+			s.createContext("/expandTreeRow", wrap(SwingDebugBridge::handleExpandTreeRow));
+			s.createContext("/doubleClickTreeRow", wrap(SwingDebugBridge::handleDoubleClickTreeRow));
 			s.createContext("/rightClick", wrap(SwingDebugBridge::handleRightClick));
 			s.createContext("/listeners", wrap(SwingDebugBridge::handleListeners));
 			s.createContext("/find", wrap(SwingDebugBridge::handleFind));
@@ -340,6 +342,27 @@ public final class SwingDebugBridge {
 		}
 		boolean ok = SwingInspector.selectTreeRow(path, Integer.parseInt(q.get("row")));
 		return "{\"selected\":" + ok + ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	private static String handleExpandTreeRow(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty() || !q.containsKey("row")) {
+			return "{\"error\":\"require 'path' and 'row' query parameters\"}";
+		}
+		boolean expand = Boolean.parseBoolean(q.getOrDefault("expand", "true"));
+		boolean ok = SwingInspector.expandTreeRow(path, Integer.parseInt(q.get("row")), expand);
+		return "{\"expanded\":" + ok + ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	private static String handleDoubleClickTreeRow(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty() || !q.containsKey("row")) {
+			return "{\"error\":\"require 'path' and 'row' query parameters\"}";
+		}
+		boolean ok = SwingInspector.doubleClickTreeRow(path, Integer.parseInt(q.get("row")));
+		return "{\"doubleClicked\":" + ok + ",\"path\":\"" + jsonEscape(path) + "\"}";
 	}
 
 	private static String handleRightClickTreeRow(HttpExchange ex) {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -888,6 +888,77 @@ public final class SwingInspector {
 	}
 
 	/**
+	 * Expand or collapse a row of the {@link JTree} at the given path. Needed to reach
+	 * nodes that are not visible yet: row indices only cover currently-expanded rows,
+	 * so a driver walks down a tree by expanding and re-reading the rows.
+	 *
+	 * @return true if the tree resolved and the row was in range
+	 */
+	public static boolean expandTreeRow(final String path, final int row, final boolean expand) {
+		return Boolean.TRUE.equals(onEdt(() -> {
+			Component c = findByPath(path);
+			if (!(c instanceof JTree)) {
+				return false;
+			}
+			JTree tree = (JTree) c;
+			if (row < 0 || row >= tree.getRowCount()) {
+				return false;
+			}
+			if (expand) {
+				tree.expandRow(row);
+			} else {
+				tree.collapseRow(row);
+			}
+			tree.scrollRowToVisible(row);
+			return true;
+		}));
+	}
+
+	/**
+	 * Double-click a row of the {@link JTree} at the given path with a synthetic
+	 * {@link Robot} click pair. A real double-click is required (rather than firing a
+	 * listener directly) because VCell's database trees open a document from the raw
+	 * {@link java.awt.event.MouseEvent} — {@code MOUSE_PRESSED} with
+	 * {@code getClickCount() == 2} — so no higher-level API reproduces it.
+	 *
+	 * @return true if the tree/row resolved and the double-click was issued
+	 */
+	public static boolean doubleClickTreeRow(final String path, final int row) {
+		Point screenPt = onEdt(() -> {
+			Component c = findByPath(path);
+			if (!(c instanceof JTree)) {
+				return null;
+			}
+			JTree tree = (JTree) c;
+			if (row < 0 || row >= tree.getRowCount() || !tree.isShowing()) {
+				return null;
+			}
+			tree.setSelectionRow(row);
+			tree.scrollRowToVisible(row);
+			Rectangle rb = tree.getRowBounds(row);
+			if (rb == null) {
+				return null;
+			}
+			Point loc = tree.getLocationOnScreen();
+			return new Point(loc.x + rb.x + Math.min(rb.width / 2, 40), loc.y + rb.y + rb.height / 2);
+		});
+		if (screenPt == null) {
+			return false;
+		}
+		try {
+			Robot robot = new Robot();
+			robot.mouseMove(screenPt.x, screenPt.y);
+			for (int i = 0; i < 2; i++) {
+				robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+				robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+			}
+			return true;
+		} catch (Exception e) {
+			throw new RuntimeException("robot double-click failed at " + screenPt, e);
+		}
+	}
+
+	/**
 	 * Right-click a specific row of the {@link JTree} at the given path, which is
 	 * how VCell's tree explorer opens a node's context menu (e.g. right-clicking
 	 * the "Applications" node to create a new Application). The row is selected

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -386,19 +386,40 @@ public final class SwingInspector {
 	// Lookup + interaction
 	// ---------------------------------------------------------------------
 
+	private static final java.util.regex.Pattern NAME_WITH_INDEX =
+			java.util.regex.Pattern.compile("^(.*)\\[(\\d+)\\]$");
+
 	/**
-	 * Resolve a selector to a live component. A selector is either a registry id
-	 * ("c42", as emitted in each node's {@code id}) or a node path ("0/3/2", as
-	 * emitted in {@code path}); ids and paths are syntactically distinct, so a
-	 * single method resolves both and every endpoint accepts either. First path
-	 * segment indexes {@link #showingWindows()}; remaining segments index
-	 * {@link Container#getComponents()}.
+	 * Resolve a selector to a live component. Every endpoint that takes a
+	 * {@code path} parameter accepts any of these three forms, which are
+	 * syntactically distinct:
+	 *
+	 * <ul>
+	 * <li><b>registry id</b> — {@code c42}, as emitted in each node's {@code id}.
+	 *     Stable across dumps.</li>
+	 * <li><b>name</b> — {@code name=SearchButton}, matching
+	 *     {@link Component#getName()}. The most robust form: it survives layout
+	 *     changes entirely. When several components share a name (VCell reuses
+	 *     panels — e.g. one database search panel per tab), a <i>showing</i> match
+	 *     wins over a hidden one; add an index, {@code name=SearchButton[1]}, to
+	 *     pick a specific one out of the {@code /find} ordering.</li>
+	 * <li><b>node path</b> — {@code 0/3/2}, as emitted in {@code path}. First
+	 *     segment indexes {@link #showingWindows()}, the rest index
+	 *     {@link Container#getComponents()}. Brittle; prefer the forms above.</li>
+	 * </ul>
 	 *
 	 * @return the component, or {@code null} if the selector does not resolve
+	 *         (including a malformed selector — resolution never throws)
 	 */
 	public static Component findByPath(final String path) {
-		if (path != null && path.matches("c\\d+")) {
+		if (path == null || path.isEmpty()) {
+			return null;
+		}
+		if (path.matches("c\\d+")) {
 			return findById(path);
+		}
+		if (path.startsWith("name=")) {
+			return findByNameSelector(path.substring("name=".length()));
 		}
 		return onEdt(() -> {
 			String[] segs = path.split("/");
@@ -408,23 +429,60 @@ public final class SwingInspector {
 					windows.add(w);
 				}
 			}
-			int wi = Integer.parseInt(segs[0]);
-			if (wi < 0 || wi >= windows.size()) {
-				return null;
-			}
-			Component cur = windows.get(wi);
-			for (int s = 1; s < segs.length; s++) {
+			Component cur = null;
+			for (int s = 0; s < segs.length; s++) {
+				int i;
+				try {
+					i = Integer.parseInt(segs[s]);
+				} catch (NumberFormatException e) {
+					return null; // not a node path after all; report "did not resolve"
+				}
+				if (s == 0) {
+					if (i < 0 || i >= windows.size()) {
+						return null;
+					}
+					cur = windows.get(i);
+					continue;
+				}
 				if (!(cur instanceof Container)) {
 					return null;
 				}
 				Component[] kids = ((Container) cur).getComponents();
-				int ci = Integer.parseInt(segs[s]);
-				if (ci < 0 || ci >= kids.length) {
+				if (i < 0 || i >= kids.length) {
 					return null;
 				}
-				cur = kids[ci];
+				cur = kids[i];
 			}
 			return cur;
+		});
+	}
+
+	/** Resolve the {@code name=...} selector form, with optional {@code [index]} suffix. */
+	private static Component findByNameSelector(String spec) {
+		String name = spec;
+		int index = -1;
+		java.util.regex.Matcher m = NAME_WITH_INDEX.matcher(spec);
+		if (m.matches()) {
+			name = m.group(1);
+			index = Integer.parseInt(m.group(2));
+		}
+		final String targetName = name;
+		final int wanted = index;
+		return onEdt(() -> {
+			List<PathMatch> matches = collectAll(null, targetName, null, null);
+			if (matches.isEmpty()) {
+				return null;
+			}
+			if (wanted >= 0) {
+				return wanted < matches.size() ? matches.get(wanted).component : null;
+			}
+			// an unqualified name should act on what the user can actually see
+			for (PathMatch pm : matches) {
+				if (pm.component.isShowing()) {
+					return pm.component;
+				}
+			}
+			return matches.get(0).component;
 		});
 	}
 


### PR DESCRIPTION
Fixes #1737.

Opening a geometry from the Database window's **Geometries** tab gave a window that opened *behind* the main GUI and was blank. These turned out to be two independent bugs that happened to land on the same window.

## 1. Opens behind the GUI

`ClientRequestManager.openAfterChecking` creates the new document window but never raises it — unlike the other two `createNewDocumentWindow` call sites, which pair it with `setFinalWindow`. BioModel and MathModel windows get away with this because task4's `setWindowFocus` raises them, but it works through `DocumentWindowManager.getDocumentEditor()`, and `GeometryWindowManager` returns `null` there. So nothing raised a geometry window at all — which is exactly why this bug is geometry-specific.

Fixed by adopting the established `setFinalWindow` pattern at that call site.

Per `docs/windowing-design-patterns.md` §7.1: a `DocumentWindow` is an `LWTopFrame`, and a `JFrame` cannot have a native owner, so `toFront()` (Path B) is the only mechanism available for it. Path B is unreliable only when VCell is *not* the foreground app; here the user just double-clicked inside VCell, so it holds.

## 2. Blank window

A geometry window's work area holds only the `GeometryEditor` toolbar — the geometry itself is drawn in a child window. `GeometryEditor` initializes with its "Geometry Editor" toggle **already selected** while no viewer has been shown, so the user's first click merely *deselected* it, hiding a window that never existed. That is precisely the reporter's follow-up comment: clicking around for a long time before anything appears, and needing to visit the editor before the Surface Viewer works.

Added a `documentWindowShown()` hook on `DocumentWindowManager`, called once the window is visible (and its work area therefore inside a realized window — `ChildWindowManager.findChildWindowManager` throws otherwise). `GeometryWindowManager` overrides it to open the viewer through `ChildWindowManager` — the §3 gateway, which yields an owned `LWChildDialog` (§7.1 Path A, OS-enforced above its owner). The default implementation does nothing, so no other window changes behavior.

## Verification

Driven against a real client on vcell-dev through the Swing debug bridge, navigating the actual Database → Geometries tree and double-clicking a geometry.

**Before** — the geometry window exists but is completely covered by the BioModel window, and there is no child viewer at all:

```
0 DocumentWindow | BIOMODEL: BioModel1 ...
1 DocumentWindow | GEOMETRY: 10 spines ...      <- behind, blank
```

**After** — frontmost, with the geometry rendered immediately and zero clicks:

```
0 DocumentWindow | BIOMODEL: BioModel1 ...
1 DocumentWindow | GEOMETRY: 10 spines ...      <- frontmost
2 ChildWindowManager$ModelessChild | Geometry Editor   <- geometry visible
```

Confirmed with real screen captures (not the bridge's occlusion-free `printAll` screenshots, which by design cannot show z-order).

## Also included

Two tooling commits on the debug bridge, both driven by friction hit while reproducing this bug:

- **`name=` selectors on every endpoint.** `/find` could match on `Component` name, but the action endpoints couldn't *use* one — driving a named widget meant a `/find` round-trip to convert name → id, and passing a name directly returned HTTP 500. Now `name=Foo` works anywhere a selector is accepted, alongside `c42` and `0/3/2`. Where several components share a name (VCell reuses panels — one search panel per database tab), a **showing** match wins over a hidden one, so an unqualified name acts on what the user can actually see; `name=Foo[2]` disambiguates. Malformed selectors now report "did not resolve" instead of throwing. The whole repro above runs on names alone, no ids or positional paths.
- **`/expandTreeRow` and `/doubleClickTreeRow`** — both were needed to script this repro. Tree row indices only cover *expanded* rows, and VCell's database trees open a document straight from the raw `MouseEvent` (`MOUSE_PRESSED` + `getClickCount()==2`), which no higher-level API reproduces.

This is the first bug fixed under epic #1751, and it exercises exactly what that epic's second workstream was for: its open question was "how do we observe window z-order for automated verification," and the answer used here is a scripted repro plus a real screen capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg

