### PR TITLE
Skip PathwaySearchTest on a PathwayCommons outage instead of failing CI

### DIFF
--- a/vcell-core/src/test/java/cbit/vcell/pathway/PathwaySearchTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/pathway/PathwaySearchTest.java
@@ -50,7 +50,9 @@ public class PathwaySearchTest {
 
     private static final String reactomeSite = "https://reactome.org";
     private static final String ncbiSite = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi?db=taxonomy";
-    private static final String pathwaysSite = "https://www.pathwaycommons.org";
+
+    private static final int CONNECT_TIMEOUT_MS = 10_000;
+    private static final int READ_TIMEOUT_MS = 30_000;
 
 
     @BeforeAll
@@ -89,8 +91,6 @@ public class PathwaySearchTest {
     // returns the searchResponse.xml resource
     @Test
     public void searchTest() throws IOException {
-        Assumptions.assumeTrue(isDatabaseAvailable(pathwaysSite), "PathwayCommons is down — skipping test");
-
         String searchText = "Insulin";
         String encodedQ = URLEncoder.encode('"' + searchText + '"', StandardCharsets.UTF_8.name());
         String uri = "https://www.pathwaycommons.org/pc2/search?"
@@ -100,6 +100,15 @@ public class PathwaySearchTest {
 
         HttpURLConnection conn = (HttpURLConnection) new URL(uri).openConnection();
         conn.setRequestProperty("Accept", "application/xml");
+        conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        conn.setReadTimeout(READ_TIMEOUT_MS);
+
+        // Skips if PathwayCommons itself is failing. This deliberately replaces a
+        // pre-flight isDatabaseAvailable(pathwaysSite) check: that probed the site
+        // root, which stays HTTP 200 while /pc2/search returns 502 — so the guard
+        // passed and the request below then failed the build during a real outage.
+        int status = statusOrSkip(conn, "PathwayCommons");
+        assertEquals(200, status, "Unexpected HTTP status from " + uri);
 
         String content = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))
                 .lines()
@@ -404,6 +413,30 @@ public class PathwaySearchTest {
         } catch (IOException e) {
             lg.warn("Failed to write filtered pathway to file", e);
         }
+    }
+
+    /**
+     * Response status of a live request, skipping the test when the fault is the remote
+     * service's rather than ours. A third party being unreachable or returning 5xx is an
+     * outage, not a VCell regression, and must not fail CI — these tests sit in the
+     * required "Fast" check, so a sustained outage would otherwise block every merge.
+     * A 4xx still fails: that means <em>our</em> request is wrong.
+     *
+     * <p>Prefer this over a pre-flight {@link #isDatabaseAvailable} probe. That probe
+     * asks a different URL than the test goes on to use — a service can serve its home
+     * page while the API path is down — and even a probe of the exact URL races with the
+     * request that follows it.
+     */
+    private static int statusOrSkip(HttpURLConnection conn, String serviceName) {
+        final int status;
+        try {
+            status = conn.getResponseCode();
+        } catch (IOException e) {
+            return Assumptions.abort(serviceName + " is unreachable (" + e + ") — skipping test");
+        }
+        Assumptions.assumeTrue(status < 500,
+                serviceName + " returned HTTP " + status + " — remote service outage, skipping test");
+        return status;
     }
 
     public static boolean isDatabaseAvailable(String urlString) {


### PR DESCRIPTION
`PathwaySearchTest.searchTest` has been failing every `master` run and blocking PRs since ~23:30 UTC, because pathwaycommons.org is down.

## The actual defect

The test **already** tried to skip during an outage:

```java
Assumptions.assumeTrue(isDatabaseAvailable(pathwaysSite), "PathwayCommons is down — skipping test");
```

But `pathwaysSite` is the site **root**, and the test then queries the **`/pc2/search` API**. Those have different health right now:

```
https://www.pathwaycommons.org              -> HTTP 200   (guard sees this, assumption holds)
https://www.pathwaycommons.org/pc2/search?… -> HTTP 502   (test then calls this, and errors)
```

So the skip logic passed and the request underneath it failed the build. Probing one URL to predict another's health can't work — and even probing the *exact* URL only narrows a race, since the service can fail between probe and request.

## The fix

`statusOrSkip(conn, service)` inspects the status of the request the test actually makes, and splits by whose fault it is:

| Outcome | Behavior | Rationale |
|---|---|---|
| Unreachable (`IOException`) | **skip** | their outage |
| 5xx | **skip** | their outage |
| 4xx | **fail** | our request is wrong |
| 200 + wrong content | **fail** | real regression |

So an outage stops blocking merges while genuine breakage is still caught. Also added explicit connect/read timeouts — an outage now costs ~30s instead of the 130s each failing run was burning.

## Why this matters beyond one test

This test carries the `Fast` tag, so it sits inside the **required** `CI-Test-group-Fast` check. While a third party is down, *no* PR in this repo can merge normally — each one needs an admin override, which is precisely what bypasses the merge queue and the regression gate. A third party's uptime should not be able to do that.

## Verification

Run during the live outage:

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 1 — BUILD SUCCESS
  SKIPPED  searchTest
  PASSED   pathwayDownloadTest
  PASSED   fetchTaxonomyNameFromIdTest
```

(Previously: `Errors: 1`, build failed.) The skip-vs-fail split was checked against a local server on all four paths — 200 proceeds, 404 fails, 502 skips, connection-refused skips.

## Follow-up, deliberately not in this PR

The sibling network tests have the same latent flaw and should get the same treatment once this lands: `pathwayDownloadTest` probes the Reactome root but downloads from `reactome.org/ReactomeRESTfulAPI/…`, and `fetchTaxonomyNameFromIdTest` calls `fail()` outright on `IOException`, so an NCBI outage would fail CI the same way. Both are currently passing, so I kept this PR to the one test that is actually broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
