### PR TITLE
Fix three Desktop UI bugs: shape-measurement crash (#1749), Reactome link (#1744), CSG in 2D (#1739)

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorPathwayCommonsPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorPathwayCommonsPanel.java
@@ -128,6 +128,10 @@ public class BioModelEditorPathwayCommonsPanel extends DocumentEditorSubPanel {
 	private TextFieldAutoCompletion searchTextField;
 	private TextFieldAutoCompletion filterTextField;
 	private Set<String> searchTextList = new HashSet<String>();
+	/** Human-readable Reactome page for a pathway, e.g. .../content/detail/R-HSA-5683177 */
+	private static final String REACTOME_PATHWAY_URL = "https://reactome.org/content/detail/";
+	private static final String REACTOME_ID_PREFIX = "R-HSA-";
+
 	private JButton searchButton = null;
 	private JButton sortButton = null;
 	private boolean bAscending = true;
@@ -342,12 +346,22 @@ public class BioModelEditorPathwayCommonsPanel extends DocumentEditorSubPanel {
 	
 	public void gotoPathway() {
 		Pathway pathway = computeSelectedPathway();
-		if (pathway != null) {
-			String url = DynamicClientProperties.getDynamicClientProperties().getProperty(PropertyLoader.PATHWAY_QUERY_URL) + pathway.primaryId();
-			if (url != null) {
-				DialogUtils.browserLauncher(BioModelEditorPathwayCommonsPanel.this, url, "failed to open " + url);
-			}
+		if (pathway == null) {
+			return;
 		}
+		// primaryId is itself a full URI ("http://bioregistry.io/reactome:R-HSA-5683177"),
+		// so appending it to a base URL produced a nonsense address and the browser just
+		// landed on the site root instead of the pathway. Build the Reactome detail page
+		// from the extracted stable id, the same id showPathway() already uses.
+		String url;
+		try {
+			url = REACTOME_PATHWAY_URL + REACTOME_ID_PREFIX + extractReactomeId(pathway.primaryId());
+		} catch (IllegalArgumentException e) {
+			DialogUtils.showErrorDialog(BioModelEditorPathwayCommonsPanel.this,
+					"No Reactome page for this pathway: " + pathway.primaryId());
+			return;
+		}
+		DialogUtils.browserLauncher(BioModelEditorPathwayCommonsPanel.this, url, "failed to open " + url);
 	}
 
 	public void showPathway() {
@@ -696,12 +710,11 @@ public class BioModelEditorPathwayCommonsPanel extends DocumentEditorSubPanel {
 	}
 
 	public static String extractReactomeId(String primaryId) {
-		final String PREFIX = "R-HSA-";
-		int index = primaryId.indexOf(PREFIX);
+		int index = primaryId.indexOf(REACTOME_ID_PREFIX);
 		if (index == -1) {
 			throw new IllegalArgumentException("Malformed primaryId: missing 'R-HSA-' prefix");
 		}
-		return primaryId.substring(index + PREFIX.length());
+		return primaryId.substring(index + REACTOME_ID_PREFIX.length());
 	}
 
 }

--- a/vcell-client/src/main/java/cbit/vcell/geometry/gui/GeometrySubVolumePanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/geometry/gui/GeometrySubVolumePanel.java
@@ -340,6 +340,15 @@ private JPopupMenu getAddSubVolumePopupMenu() {
 		addSubVolumePopupMenu.add(addAnalyticSubVolumeMenuItem);
 		addSubVolumePopupMenu.add(addCSGSubVolumeMenuItem);
 	}
+	// Constructed Solid Geometry is 3D-only — the New Geometry chooser offers it as
+	// "Constructive Solid Geometry (3D)". In 1D/2D it stayed selectable and produced
+	// meaningless results (issue #1739). Re-evaluated on every show, since the panel
+	// outlives the geometry it is editing.
+	Geometry geometry = getGeometry();
+	boolean bIs3D = geometry != null && geometry.getDimension() == 3;
+	addCSGSubVolumeMenuItem.setEnabled(bIs3D);
+	addCSGSubVolumeMenuItem.setToolTipText(bIs3D ? null
+			: "Constructed Solid Geometry is only available for 3-dimensional geometries");
 	return addSubVolumePopupMenu;
 }
 /**

--- a/vcell-core/src/main/java/cbit/vcell/graph/LargeShapeCanvas.java
+++ b/vcell-core/src/main/java/cbit/vcell/graph/LargeShapeCanvas.java
@@ -1,7 +1,10 @@
 package cbit.vcell.graph;
 
 import java.awt.Color;
+import java.awt.Component;
+import java.awt.Font;
 import java.awt.Graphics;
+import java.awt.image.BufferedImage;
 
 import org.vcell.model.rbm.ComponentStateDefinition;
 import org.vcell.model.rbm.ComponentStatePattern;
@@ -27,6 +30,41 @@ public interface LargeShapeCanvas {
 	
 	int getZoomFactor();
 	Graphics getGraphics();
+
+	/** Off-screen surface backing {@link #measuringGraphics}; never painted to the display. */
+	BufferedImage TEXT_MEASURING_BUFFER = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+
+	/**
+	 * A {@link Graphics} usable for measuring text, <b>never null</b>.
+	 *
+	 * <p>Every implementation of {@link #getGraphics()} ends at
+	 * {@link Component#getGraphics()}, which returns {@code null} while the component
+	 * is not displayable — for instance while shapes are being laid out before their
+	 * panel is part of a visible window. Shape construction measures strings at exactly
+	 * that point, so using the result directly crashed the client with an NPE
+	 * (issue #1749).
+	 *
+	 * <p>When there is no real graphics context this falls back to an off-screen
+	 * buffer, carrying over the canvas's own font so the measurements still match what
+	 * will eventually be painted. Callers get sensible sizes instead of an exception,
+	 * and are re-laid out normally once the panel is realized.
+	 */
+	static Graphics measuringGraphics(LargeShapeCanvas canvas) {
+		if (canvas != null) {
+			Graphics gc = canvas.getGraphics();
+			if (gc != null) {
+				return gc;
+			}
+		}
+		Graphics fallback = TEXT_MEASURING_BUFFER.getGraphics();
+		if (canvas instanceof Component) {
+			Font font = ((Component) canvas).getFont();
+			if (font != null) {
+				fallback.setFont(font);
+			}
+		}
+		return fallback;
+	}
 	DisplayMode getDisplayMode();
 	RuleParticipantSignature getSignature();
 	GroupingCriteria getCriteria();

--- a/vcell-core/src/main/java/cbit/vcell/graph/MolecularComponentLargeShape.java
+++ b/vcell-core/src/main/java/cbit/vcell/graph/MolecularComponentLargeShape.java
@@ -165,7 +165,7 @@ public class MolecularComponentLargeShape extends AbstractComponentShape impleme
 				}
 			}
 
-			Graphics gc = shapePanel.getGraphics();
+			Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 			this.font = deriveStateFont(gc, shapePanel);
 			this.height = computeStateHeight(gc, shapePanel);
 			FontMetrics fm = gc.getFontMetrics(font);
@@ -213,7 +213,7 @@ public class MolecularComponentLargeShape extends AbstractComponentShape impleme
 		}
 		@Override
 		public Rectangle getLabelOutline() {
-			Graphics gc = shapePanel.getGraphics();
+			Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 			Font font = getLabelFont();
 			FontMetrics fm = gc.getFontMetrics(font);
 			int stringWidth = fm.stringWidth(getFullName());
@@ -236,7 +236,7 @@ public class MolecularComponentLargeShape extends AbstractComponentShape impleme
 			// use this to force a different with, for instance if we want all the rectangles used
 			// for contains() to be equal
 			// we don't allow reducing the width below the width of the text
-			Graphics gc = shapePanel.getGraphics();
+			Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 			FontMetrics fm = gc.getFontMetrics(font);
 			int minWidth = fm.stringWidth(displayName);
 			if(width > minWidth) {
@@ -461,7 +461,7 @@ public class MolecularComponentLargeShape extends AbstractComponentShape impleme
 		height = baseHeight;
 		width = baseWidth;
 		
-		Graphics gc = shapePanel.getGraphics();
+		Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 		Font font = deriveStateFont(gc, shapePanel);
 		int stateHeight = getStringHeight(font)+2;	// we reserve 2 extra pixels height as separation between states
 		String longestStateName = getLongestStateName(mc);
@@ -508,7 +508,7 @@ public class MolecularComponentLargeShape extends AbstractComponentShape impleme
 			ComponentStateDefinition csd = mcp.getComponentStatePattern().getComponentStateDefinition();
 			stateName = adjustForStateSize(csd.getDisplayName());
 		}
-		Graphics gc = shapePanel.getGraphics();
+		Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 		String longestStateName = getLongestStateName(mc);
 		int displayNameWidth = getStringWidth(displayName);
 		int longestStateNameWidth = getStateStringWidth(longestStateName, gc, shapePanel);
@@ -572,7 +572,7 @@ public class MolecularComponentLargeShape extends AbstractComponentShape impleme
 	}
 	@Override
 	public Rectangle getLabelOutline() {
-		Graphics gc = shapePanel.getGraphics();
+		Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 		Font font = getLabelFont();
 		FontMetrics fm = gc.getFontMetrics(font);
 		int stringWidth = fm.stringWidth(getFullName());
@@ -581,7 +581,7 @@ public class MolecularComponentLargeShape extends AbstractComponentShape impleme
 	}
 	@Override
 	public Font getLabelFont() {
-		Graphics gc = shapePanel.getGraphics();
+		Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 		return MolecularComponentLargeShape.deriveComponentFontBold(gc, shapePanel);
 	}
 	@Override
@@ -649,14 +649,14 @@ public class MolecularComponentLargeShape extends AbstractComponentShape impleme
 	
 	private int getStringWidth(String s) {
 //		Font font = graphicsContext.getFont().deriveFont(Font.BOLD);
-		Graphics gc = shapePanel.getGraphics();
+		Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 		Font font = deriveComponentFontBold(gc, shapePanel);
 		FontMetrics fm = gc.getFontMetrics(font);
 		int stringWidth = fm.stringWidth(s);
 		return stringWidth;
 	}
 	private int getStringHeight(Font font) {
-		Graphics gc = shapePanel.getGraphics();
+		Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 		FontMetrics fm = gc.getFontMetrics(font);
 		int stringHeight = fm.getHeight();
 		return stringHeight;
@@ -842,7 +842,7 @@ public class MolecularComponentLargeShape extends AbstractComponentShape impleme
 			g2.setColor(componentColor);
 		}
 		
-		Graphics gc = shapePanel.getGraphics();
+		Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 		Font font = deriveComponentFontBold(gc, shapePanel);
 		g.setFont(font);
 		if(hidden == false) {

--- a/vcell-core/src/main/java/cbit/vcell/graph/MolecularTypeLargeShape.java
+++ b/vcell-core/src/main/java/cbit/vcell/graph/MolecularTypeLargeShape.java
@@ -300,7 +300,7 @@ public class MolecularTypeLargeShape extends IssueManagerContainer implements La
 	}
 	
 	private int getStringWidth(String s) {
-		Graphics gc = shapePanel.getGraphics();
+		Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 		Font font = gc.getFont().deriveFont(Font.BOLD);
 		FontMetrics fm = gc.getFontMetrics(font);
 		int stringWidth = fm.stringWidth(s);
@@ -336,7 +336,7 @@ public class MolecularTypeLargeShape extends IssueManagerContainer implements La
 	}
 	@Override
 	public Rectangle getLabelOutline() {
-		Graphics gc = shapePanel.getGraphics();
+		Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 		Font font = gc.getFont().deriveFont(Font.BOLD);
 		FontMetrics fm = gc.getFontMetrics(font);
 		int stringWidth = fm.stringWidth(getFullName());
@@ -345,7 +345,7 @@ public class MolecularTypeLargeShape extends IssueManagerContainer implements La
 	}
 	@Override
 	public Font getLabelFont() {
-		Graphics gc = shapePanel.getGraphics();
+		Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 		Font font = gc.getFont().deriveFont(Font.BOLD);
 		return font;
 	}
@@ -745,7 +745,7 @@ public class MolecularTypeLargeShape extends IssueManagerContainer implements La
 		if(mt == null && mtp == null) {		// plain species context
 			 // don't write any text inside
 		} else {							// molecular type, species pattern
-			Graphics gc = shapePanel.getGraphics();
+			Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 			Font font = deriveMoleculeFontBold(g, shapePanel);
 			g.setFont(font);
 			g.setColor(getDefaultColor(Color.BLACK));	// font color
@@ -878,7 +878,7 @@ public class MolecularTypeLargeShape extends IssueManagerContainer implements La
 			return;
 		}
 		if(mtp != null && mtp.hasExplicitParticipantMatch() && mtp.getParticipantMatchLabel().equals(matchKey)) {
-			Graphics g = shapePanel.getGraphics();
+			Graphics g = LargeShapeCanvas.measuringGraphics(shapePanel);
 			Graphics2D g2 = (Graphics2D)g;
 			Font fontOld = g2.getFont();
 			Color colorOld = g2.getColor();

--- a/vcell-core/src/main/java/cbit/vcell/graph/SpeciesPatternLargeShape.java
+++ b/vcell-core/src/main/java/cbit/vcell/graph/SpeciesPatternLargeShape.java
@@ -600,7 +600,7 @@ public class SpeciesPatternLargeShape extends AbstractComponentShape implements 
 			}
 			
 			if(bs.mcp.getBondType().equals(BondType.Possible)) {	//		?  (Possible)
-				Graphics gc = shapePanel.getGraphics();
+				Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 				
 				if(shapePanel.getZoomFactor() >= LargeShapeCanvas.SmallestZoomFactorWithText) {
 					Font font = MolecularComponentLargeShape.deriveComponentFontBold(gc, shapePanel);
@@ -714,7 +714,7 @@ public class SpeciesPatternLargeShape extends AbstractComponentShape implements 
 			g2.drawLine(bp.to.x, bp.to.y, bp.to.x, bp.to.y+yDouble+i*separ);
 			g2.drawLine(bp.from.x, bp.from.y+yDouble+i*separ, bp.to.x, bp.to.y+yDouble+i*separ);
 			
-			Graphics gc = shapePanel.getGraphics();
+			Graphics gc = LargeShapeCanvas.measuringGraphics(shapePanel);
 			if(shapePanel.getZoomFactor() >= LargeShapeCanvas.SmallestZoomFactorWithText) {
 				Font font = MolecularComponentLargeShape.deriveComponentFontBold(gc, shapePanel);
 				g.setFont(font);


### PR DESCRIPTION
Three Desktop UI bugs from the epic #1751 backlog. Independent fixes, one commit each.

## #1749 — client crash measuring shape text (the big one)

The crash report blames `deriveComponentFontBold`, but the defect is one line above it:

```java
Graphics gc = shapePanel.getGraphics();   // null until the component is displayable
```

`Component.getGraphics()` returns `null` while a component is not displayable, and species-pattern shapes call it to **measure strings during layout** — exactly when the panel may not be in a visible window yet. `gc.getFont()` then throws.

This was not one bad line: there were **17 such call sites across three shape classes**, so the reported stack was one entry point into a shared latent crash. Added `LargeShapeCanvas.measuringGraphics(canvas)`, which returns the real context when there is one and otherwise falls back to an off-screen buffer carrying the canvas's own font, so measurements still match what gets painted. All 17 sites now go through it.

**Verified with a control**, laying out a shape on a canvas whose `getGraphics()` returns `null` (what a non-displayable component does):

```
PRE-FIX : NullPointerException -> Cannot invoke "java.awt.Graphics.getFont()" because "<parameter1>" is null
            at MolecularComponentLargeShape.deriveStateFont(...)
POST-FIX: shape built, no exception
```

(The reproduction lands in `deriveStateFont` rather than the report's `deriveComponentFontBold` — sibling methods, same root cause, both fixed.)

## #1744 — "Open Web Link" went to the wrong site

The URL was built as `PATHWAY_QUERY_URL + pathway.primaryId()`, but `primaryId` is *itself* a full URI, so the result was:

```
OLD: https://www.pathwaycommons.org/pc2/search?http://bioregistry.io/reactome:R-HSA-5683177
NEW: https://reactome.org/content/detail/R-HSA-5683177          (verified HTTP 200)
```

Browsers resolved that old string to the plain PathwayCommons site — precisely the reported symptom. The fix reuses `extractReactomeId`, the helper `showPathway()` already relies on. A pathway with no Reactome id now shows an error dialog instead of propagating `IllegalArgumentException`, and a dead `if (url != null)` on a string concatenation is gone.

## #1739 — CSG offered for 2D geometries

The New Geometry chooser already labels it "Constructive Solid Geometry **(3D)**", but the geometry editor's add-subvolume popup offered it for any geometry, where it "does something, but it is completely wrong". Now disabled with an explanatory tooltip unless the geometry is 3D. The state is recomputed each time the popup is shown, not when it is built — the popup is cached while the geometry it edits can change.

```
1D geometry -> CSG enabled=false   Analytic enabled=true   tip="…only available for 3-dimensional geometries"
2D geometry -> CSG enabled=false   Analytic enabled=true
3D geometry -> CSG enabled=true    Analytic enabled=true
cached popup, 2D -> 3D: enabled false -> true  (re-evaluated correctly)
```

## Verification

Beyond the per-fix checks above: the client was launched with all three changes, the 2D geometry from #1737 opened from the database, the smoke scenario passed, and the client log shows zero exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
