### PR TITLE
Report failed imports instead of crashing on a null document (#1748)

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/ClientRequestManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ClientRequestManager.java
@@ -3161,7 +3161,9 @@ private BioModel createDefaultBioModelDocument(BngUnitSystem bngUnitSystem) thro
 			ExternalDocInfo externalDocInfo = (ExternalDocInfo) documentInfo;
 
 			File file = externalDocInfo.getFile();
-			if (file != null && !file.getName().isEmpty() && file.getName().endsWith("bngl")) {
+			// lower-cased to match the sibling .sedx/.omex/.ssld checks: a file named
+			// Model.BNGL used to skip this pass, then fail as an unrecognized format
+			if (file != null && !file.getName().isEmpty() && file.getName().toLowerCase().endsWith(".bngl")) {
 
 				BngUnitSystem bngUnitSystem = new BngUnitSystem(BngUnitOrigin.DEFAULT);
 				String fileText;
@@ -3496,13 +3498,32 @@ private BioModel createDefaultBioModelDocument(BngUnitSystem bngUnitSystem) thro
 							}
 						}
 					}
-					if (doc == null && docs == null) {
-						File f = externalDocInfo.getFile();
-						if (f != null) {
-							throw new RuntimeException("Unable to determine type of file " + f.getCanonicalPath());
-						}
-						throw new ProgrammingException();
+				}
+				// Nothing was produced: the load or import failed without saying so. Until this
+				// was caught here it surfaced as an NPE out of Hashtable.put("doc", null) just
+				// below, which is what users actually saw (issue #1748).
+				//
+				// The previous version of this check was dead code: it tested "docs == null",
+				// but docs is initialized to an empty list and is never null. It also sat
+				// inside the ExternalDocInfo branch, so it could never have covered the other
+				// document types either way.
+				if (doc == null && docs.isEmpty()) {
+					File f = (documentInfo instanceof ExternalDocInfo)
+							? ((ExternalDocInfo) documentInfo).getFile()
+							: null;
+					if (f != null) {
+						throw new RuntimeException("Unable to determine the type of file '" + f.getCanonicalPath()
+								+ "'. It is not a recognized VCML, SBML, SED-ML/OMEX, BNGL or SSLD document.");
 					}
+					// No file: the content arrived as a string, e.g. SBML fetched from
+					// BioModels.net. An empty or non-XML payload means that retrieval failed.
+					String name = (documentInfo instanceof ExternalDocInfo)
+							? ((ExternalDocInfo) documentInfo).getDefaultName()
+							: null;
+					throw new RuntimeException("Unable to read the document"
+							+ (name == null ? "" : " '" + name + "'")
+							+ ": the content is empty or not in a recognized format."
+							+ " If it was retrieved from a remote database, that request may have failed.");
 				}
 				// create biopax objects using annotation
 				if (doc instanceof BioModel) {


### PR DESCRIPTION
Fixes #1748.

A document import that produced nothing left `doc == null`, which then reached `hashTable.put("doc", doc)` — and `Hashtable.put` throws on a null value. That is the reported NPE, seen independently on macOS and Windows.

## The guard that should have caught it was dead code

```java
if (doc == null && docs == null) {          // docs is never null
    File f = externalDocInfo.getFile();
    if (f != null) {
        throw new RuntimeException("Unable to determine type of file " + f.getCanonicalPath());
    }
    throw new ProgrammingException();
}
```

`docs` is initialized to `new ArrayList<>()` a few lines earlier and is never reassigned to null, so this condition can never be true. It also sat **inside** the `ExternalDocInfo` branch, so it could not have covered the database-backed types even if it had worked.

Fixed by making the condition live (`docs.isEmpty()`) and hoisting it out so it covers every branch.

## Why a null document happens

The `ExternalDocInfo` path has a branch with no `else`:

```java
} else if (!externalDocInfo.isXML()) {
    if (hashTable.containsKey(BNG_UNIT_SYSTEM)) { ... doc = bioModel; }
}                                               // falls through with doc == null
```

`BNG_UNIT_SYSTEM` is only set by a pre-pass that is itself guarded on `file != null && …endsWith("bngl")`. So content that is neither valid XML nor routed through that pre-pass falls straight through. The most plausible trigger for the reports is a remote fetch — SBML from BioModels.net is passed as a **string with no file** — returning an empty or error payload, which is consistent with the failures being OS-independent.

That case previously ended at `throw new ProgrammingException()`, which is the wrong diagnosis: a failed network fetch is not a bug in our code. Both messages now say what actually happened and name the file or document.

## Also fixed

The BNGL check used `file.getName().endsWith("bngl")` while its `.sedx` / `.omex` / `.ssld` siblings all lower-case first, so `Model.BNGL` skipped the pre-pass and then failed as an unrecognized format. Now `toLowerCase().endsWith(".bngl")`.

## Verification

The mechanics were reproduced in isolation:

```
OLD guard 'doc == null && docs == null' -> false    (never fires: docs is an ArrayList)
  -> java.util.Hashtable.put NPE                    == the crash users saw
NEW guard 'doc == null && docs.isEmpty()' -> true
  -> RuntimeException with an actionable message
SED-ML (doc == null, docs non-empty) -> guard fires? false   (correct: must not fire)

Model.BNGL   old endsWith("bngl")=false   new toLowerCase().endsWith(".bngl")=true
```

**Honest limitation:** I could not drive the full UI reproduction. The command-line open path fails earlier in `XmlUtil.readXML` and never reaches this code, and the `File > Open > Local...` route needs a selection in the Aqua file chooser's table, which the debug bridge cannot yet drive (it has tree-row selection but not table-row selection — a gap worth closing separately). The static analysis is solid — every claim above was checked against the source — but a reviewer should confirm the error dialog once by opening a corrupt file.

## Follow-up worth considering

`BioModelsNetPropertiesPanel` and `BioModelsNetJPanel` wrap the fetched SBML string in an `ExternalDocInfo` without checking it is non-empty; one of them then does `if (externalDocInfo != null)`, which is always true and so guards nothing. Validating the payload at the source would turn this into a clearer "the BioModels.net request failed" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
