### PR TITLE
Debug bridge: JTable row selection, double-click and right-click

### DIFF
--- a/tools/debug-bridge/bridge.sh
+++ b/tools/debug-bridge/bridge.sh
@@ -16,6 +16,7 @@
 #   settext <selector> <text> [--enter]
 #   tab <selector> <index>      row <selector> <row>     rrow <selector> <row>
 #   expand <selector> <row> [true|false]                 drow <selector> <row>
+#   trow <selector> <row> [col]   dtrow <selector> <row> [col]   rtrow <selector> <row> [col]
 #   menu "<Menu>Item[>Sub]" [window]
 #   highlight <selector> [ms]
 # Synchronize / assert (exit 0 on success, 1 on failure):
@@ -134,6 +135,12 @@ case "$cmd" in
   expand)    get expandTreeRow --data-urlencode "path=$1" --data-urlencode "row=$2" \
                --data-urlencode "expand=${3:-true}" | pretty ;;
   drow)      get doubleClickTreeRow --data-urlencode "path=$1" --data-urlencode "row=$2" | pretty ;;
+  trow)      get selectTableRow --data-urlencode "path=$1" --data-urlencode "row=$2" \
+               ${3:+--data-urlencode "column=$3"} | pretty ;;
+  dtrow)     get doubleClickTableRow --data-urlencode "path=$1" --data-urlencode "row=$2" \
+               ${3:+--data-urlencode "column=$3"} | pretty ;;
+  rtrow)     get rightClickTableRow --data-urlencode "path=$1" --data-urlencode "row=$2" \
+               ${3:+--data-urlencode "column=$3"} | pretty ;;
   rrow)      get rightClickTreeRow --data-urlencode "path=$1" --data-urlencode "row=$2" | pretty ;;
   menu)      get menu --data-urlencode "path=$1" ${2:+--data-urlencode "window=$2"} | pretty ;;
   props)     get props --data-urlencode "path=$1" | pretty ;;

--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -67,6 +67,9 @@ A selector that doesn't resolve reports `did not resolve` (or `false`) rather th
 | `GET /setText?path=&text=&enter=` | JSON `{"set": true\|false}` |
 | `GET /selectTab?path=&index=` | JSON `{"selected": true\|false}` |
 | `GET /selectTreeRow?path=&row=N` | select row N of the JTree; JSON `{"selected": bool}` |
+| `GET /selectTableRow?path=&row=N[&column=M]` | select row N of a `JTable` and scroll it into view; JSON `{"selected": bool}`. Row/column are **view** indices, matching the `table` block in `/tree` and the user's current sort order |
+| `GET /doubleClickTableRow?path=&row=N[&column=M]` | synthetic double-click on a table row; JSON `{"doubleClicked": bool}`. Table-backed UIs commonly act on the raw `MouseEvent` click count — this is how you pick a file in the file chooser |
+| `GET /rightClickTableRow?path=&row=N[&column=M]` | select row N then right-click it (opens its context menu); JSON `{"rightClicked": bool}` |
 | `GET /expandTreeRow?path=&row=N[&expand=false]` | expand (or collapse) row N — row indices only cover *expanded* rows, so this is how a driver walks down a tree; JSON `{"expanded": bool}` |
 | `GET /doubleClickTreeRow?path=&row=N` | synthetic double-click on row N; JSON `{"doubleClicked": bool}`. Needed because VCell's database trees open a document straight from the `MouseEvent` (`MOUSE_PRESSED` + `getClickCount()==2`), which no higher-level API reproduces |
 | `GET /rightClickTreeRow?path=&row=N` | right-click row N (opens its context menu); JSON `{"rightClicked": bool}` |

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
@@ -116,6 +116,9 @@ public final class SwingDebugBridge {
 			s.createContext("/selectTab", wrap(SwingDebugBridge::handleSelectTab));
 			s.createContext("/selectTreeRow", wrap(SwingDebugBridge::handleSelectTreeRow));
 			s.createContext("/rightClickTreeRow", wrap(SwingDebugBridge::handleRightClickTreeRow));
+			s.createContext("/selectTableRow", wrap(SwingDebugBridge::handleSelectTableRow));
+			s.createContext("/doubleClickTableRow", wrap(SwingDebugBridge::handleDoubleClickTableRow));
+			s.createContext("/rightClickTableRow", wrap(SwingDebugBridge::handleRightClickTableRow));
 			s.createContext("/expandTreeRow", wrap(SwingDebugBridge::handleExpandTreeRow));
 			s.createContext("/doubleClickTreeRow", wrap(SwingDebugBridge::handleDoubleClickTreeRow));
 			s.createContext("/rightClick", wrap(SwingDebugBridge::handleRightClick));
@@ -342,6 +345,34 @@ public final class SwingDebugBridge {
 		}
 		boolean ok = SwingInspector.selectTreeRow(path, Integer.parseInt(q.get("row")));
 		return "{\"selected\":" + ok + ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	/** Shared parsing for the table-row endpoints: require path + row, optional column. */
+	private interface TableRowAction {
+		boolean apply(String path, int row, int column);
+	}
+
+	private static String tableRowRequest(HttpExchange ex, String resultKey, TableRowAction action) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty() || !q.containsKey("row")) {
+			return "{\"error\":\"require 'path' and 'row' query parameters\"}";
+		}
+		int column = Integer.parseInt(q.getOrDefault("column", "-1"));
+		boolean ok = action.apply(path, Integer.parseInt(q.get("row")), column);
+		return "{\"" + resultKey + "\":" + ok + ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	private static String handleSelectTableRow(HttpExchange ex) {
+		return tableRowRequest(ex, "selected", SwingInspector::selectTableRow);
+	}
+
+	private static String handleDoubleClickTableRow(HttpExchange ex) {
+		return tableRowRequest(ex, "doubleClicked", SwingInspector::doubleClickTableRow);
+	}
+
+	private static String handleRightClickTableRow(HttpExchange ex) {
+		return tableRowRequest(ex, "rightClicked", SwingInspector::rightClickTableRow);
 	}
 
 	private static String handleExpandTreeRow(HttpExchange ex) {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -923,6 +923,107 @@ public final class SwingInspector {
 		}
 	}
 
+	// ---------------------------------------------------------------------
+	// JTable rows — the counterpart to the JTree row operations below. Needed
+	// for any list-of-things rendered as a table rather than a tree, including
+	// the file chooser, where selecting a row is the only way to pick a file.
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Select (and scroll to) a row of the {@link JTable} at the given path. Rows and
+	 * columns are as reported by the {@code table} block in the JSON dump — note that
+	 * both are <b>view</b> indices, so they follow the user's current sort order.
+	 *
+	 * @param column column to make lead, or -1 to select the whole row
+	 * @return true if the table resolved and the row was in range
+	 */
+	public static boolean selectTableRow(final String path, final int row, final int column) {
+		return Boolean.TRUE.equals(onEdt(() -> {
+			JTable table = tableAt(path, row, column);
+			if (table == null) {
+				return false;
+			}
+			int col = column < 0 ? 0 : column;
+			table.setRowSelectionInterval(row, row);
+			if (column >= 0 && table.getColumnSelectionAllowed()) {
+				table.setColumnSelectionInterval(col, col);
+			}
+			table.scrollRectToVisible(table.getCellRect(row, col, true));
+			return true;
+		}));
+	}
+
+	/**
+	 * Double-click a row of the {@link JTable} at the given path. A synthetic
+	 * {@link Robot} click pair is required rather than a selection change because
+	 * table-backed UIs commonly act on the raw {@code MouseEvent} click count — the
+	 * file chooser opens the selected file that way.
+	 *
+	 * @return true if the table/row resolved and the double-click was issued
+	 */
+	public static boolean doubleClickTableRow(final String path, final int row, final int column) {
+		return clickTableRow(path, row, column, InputEvent.BUTTON1_DOWN_MASK, 2);
+	}
+
+	/**
+	 * Right-click a row of the {@link JTable} at the given path, to open its context
+	 * menu. The row is selected first, as a real right-click would.
+	 *
+	 * @return true if the table/row resolved and the right-click was issued
+	 */
+	public static boolean rightClickTableRow(final String path, final int row, final int column) {
+		return clickTableRow(path, row, column, InputEvent.BUTTON3_DOWN_MASK, 1);
+	}
+
+	private static boolean clickTableRow(final String path, final int row, final int column,
+			final int buttonMask, final int clickCount) {
+		Point screenPt = onEdt(() -> {
+			JTable table = tableAt(path, row, column);
+			if (table == null || !table.isShowing()) {
+				return null;
+			}
+			int col = column < 0 ? 0 : column;
+			table.setRowSelectionInterval(row, row);
+			Rectangle cell = table.getCellRect(row, col, true);
+			table.scrollRectToVisible(cell);
+			// re-read: scrolling moves the cell under the viewport
+			cell = table.getCellRect(row, col, true);
+			Point loc = table.getLocationOnScreen();
+			return new Point(loc.x + cell.x + Math.min(cell.width / 2, 60),
+					loc.y + cell.y + cell.height / 2);
+		});
+		if (screenPt == null) {
+			return false;
+		}
+		try {
+			Robot robot = new Robot();
+			robot.mouseMove(screenPt.x, screenPt.y);
+			for (int i = 0; i < clickCount; i++) {
+				robot.mousePress(buttonMask);
+				robot.mouseRelease(buttonMask);
+			}
+			return true;
+		} catch (Exception e) {
+			throw new RuntimeException("robot table click failed at " + screenPt, e);
+		}
+	}
+
+	/** Resolve a selector to a JTable and bounds-check row/column. Must run on the EDT. */
+	private static JTable tableAt(String path, int row, int column) {
+		Component c = findByPath(path);
+		if (!(c instanceof JTable)) {
+			return null;
+		}
+		JTable table = (JTable) c;
+		if (row < 0 || row >= table.getRowCount()) {
+			return null;
+		}
+		if (column >= table.getColumnCount()) {
+			return null;
+		}
+		return table;
+	}
+
 	/**
 	 * Select (and scroll to) a specific row of the {@link JTree} at the given
 	 * path. Rows are as reported by the {@code tree} block in the JSON dump.


### PR DESCRIPTION
Closes the last known gap in the debug bridge's interaction surface.

## The gap

The bridge could drive `JTree` rows (`/selectTreeRow`, `/expandTreeRow`, `/doubleClickTreeRow`, `/rightClickTreeRow`) but had no equivalent for `JTable`. Any table-backed UI was therefore undrivable — including the **file chooser**, where selecting a row is the only way to pick a file.

That is not hypothetical: it is what stopped #1821 (issue #1748) from getting a full UI reproduction, which I flagged in that PR as an acknowledged limitation.

## What's added

| Endpoint | Purpose |
|---|---|
| `GET /selectTableRow?path=&row=N[&column=M]` | select the row and scroll it into view |
| `GET /doubleClickTableRow?path=&row=N[&column=M]` | synthetic double-click on the row |
| `GET /rightClickTableRow?path=&row=N[&column=M]` | select then right-click (context menu) |

Row and column are **view** indices, matching the `table` block already emitted by `/tree` and following the user's current sort order. Double-click is a real `Robot` click pair rather than a selection change, because table-backed UIs commonly act on the raw `MouseEvent` click count — the file chooser opens the selected file exactly that way. `bridge.sh` gains `trow` / `dtrow` / `rtrow`.

## Verification — by finishing the reproduction that motivated it

Drove `File > Open > Local...`, listed the chooser's table, selected a deliberately corrupt `.vcml` at row 4, and double-clicked it:

```
chooser table = c443
  row 0: jubula.vfrap
  row 1: optoPlexin_PRG_rule_based.xml
  row 2: Solver_Suite_6_2.xml
  row 3: SpringSalad_SolverSuite.vcml
  row 4: zz-broken-model.vcml

trow  c443 4  -> {"selected":true}        (Open button became enabled)
dtrow c443 4  -> {"doubleClicked":true}
```

Result — an error dialog, not a crash:

> **RuntimeException-Unable to determine the type of file `/…/zz-broken-model.vcml`. It is not a recognized VCML, SBML, SED-ML/OMEX, BNGL or SSLD document.**

with **zero NullPointerExceptions** in the client log. So this also retroactively confirms the #1748 fix in the real UI, closing the gap left open in #1821.

The temporary corrupt file was removed from `exampleModels/` afterwards; `git status` there is clean.

Purely additive: 142 insertions, 0 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
