### PR TITLE
Apply the outage-skip contract to the remaining PathwaySearchTest network tests

### DIFF
--- a/vcell-core/src/test/java/cbit/vcell/pathway/PathwaySearchTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/pathway/PathwaySearchTest.java
@@ -48,8 +48,6 @@ public class PathwaySearchTest {
     private static final Namespace BP_NS = Namespace.getNamespace("bp",
             "http://www.biopax.org/release/biopax-level2.owl#");
 
-    private static final String reactomeSite = "https://reactome.org";
-    private static final String ncbiSite = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi?db=taxonomy";
 
     private static final int CONNECT_TIMEOUT_MS = 10_000;
     private static final int READ_TIMEOUT_MS = 30_000;
@@ -77,10 +75,10 @@ public class PathwaySearchTest {
     corresponds to insulinPathway-5683177.xml
     */
     @Test
-    public void pathwayDownloadTest() throws MalformedURLException {
-        // skips the test if the external database is down, no point failing CI over something that's not our fault
-        Assumptions.assumeTrue(isDatabaseAvailable(reactomeSite), "Reactome is down — skipping test");
-
+    public void pathwayDownloadTest() throws IOException {
+        // Reactome being down is handled inside pathwayDownload, by inspecting the status of
+        // the request the test actually makes. The pre-flight isDatabaseAvailable(reactomeSite)
+        // probe that used to guard this checked the site root, not the API path below.
         String pathwayId = "5683177";  // Reactome pathway ID
         pathwayDownload(pathwayId);
         lg.debug("pathwayDownloadTest - done");
@@ -132,25 +130,35 @@ public class PathwaySearchTest {
 
     @Test
     public void fetchTaxonomyNameFromIdTest() {
-        Assumptions.assumeTrue(isDatabaseAvailable(ncbiSite), "Taxonomy Database is down — skipping test");
-
+        // As above, no pre-flight probe: the status of the real request decides. A timeout
+        // or unreachable host means NCBI is down, which used to fail() this test and, since
+        // it carries the Fast tag, block every merge in the repo.
         String taxonId = "9940"; // Ovis aries (sheep)
+        HttpResponse<String> response;
         try {
-            HttpResponse<String> response = OrganismLookup.fetchTaxonomyResponse(taxonId);
-            assertEquals(200, response.statusCode(), "Unexpected HTTP status");
-
-            String result = OrganismLookup.parseTaxonomyName(taxonId, response.body());
-            assertEquals("Ovis aries (sheep)", result, "Incorrect taxonomy name");
-
+            response = OrganismLookup.fetchTaxonomyResponse(taxonId);
         } catch (HttpTimeoutException e) {
-            fail("Timeout occurred while fetching taxonomy data");
+            Assumptions.abort("NCBI Taxonomy timed out — skipping test");
+            return;
         } catch (UnknownHostException e) {
-            fail("Host unreachable: check network or endpoint");
+            Assumptions.abort("NCBI Taxonomy is unreachable (check network or endpoint) — skipping test");
+            return;
         } catch (IOException e) {
-            fail("I/O error during taxonomy fetch: " + e.getMessage());
+            Assumptions.abort("I/O error contacting NCBI Taxonomy (" + e.getMessage() + ") — skipping test");
+            return;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            fail("Request interrupted");
+            Assumptions.abort("Request interrupted — skipping test");
+            return;
+        }
+
+        // their outage skips; a 4xx or the wrong name is still a real failure
+        assertEquals(200, statusOrSkip(response, "NCBI Taxonomy"), "Unexpected HTTP status");
+        try {
+            assertEquals("Ovis aries (sheep)", OrganismLookup.parseTaxonomyName(taxonId, response.body()),
+                    "Incorrect taxonomy name");
+        } catch (IOException e) {
+            fail("Malformed taxonomy response: " + e.getMessage());
         }
     }
 
@@ -163,11 +171,11 @@ public class PathwaySearchTest {
         return XmlUtil.stringToXML(xmlContent, null);
     }
 
-    private static String pathwayDownload(String pathwayId) throws MalformedURLException {
+    private static String pathwayDownload(String pathwayId) throws IOException {
         final URL url = new URL("https://reactome.org/ReactomeRESTfulAPI/RESTfulWS/biopaxExporter/Level2/" + pathwayId);
 
         String ERROR_CODE_TAG = "error_code";
-        String contentString = downloadBytes(url, Duration.ofSeconds(20));      // download
+        String contentString = downloadOrSkip(url, "Reactome");      // download, or skip if Reactome is down
 
         // assert response is XML
         assertTrue(contentString.trim().startsWith("<?xml"), "Response does not start with XML declaration");
@@ -434,26 +442,45 @@ public class PathwaySearchTest {
         } catch (IOException e) {
             return Assumptions.abort(serviceName + " is unreachable (" + e + ") — skipping test");
         }
+        return checkStatus(status, serviceName);
+    }
+
+    /** {@link #statusOrSkip(HttpURLConnection, String)} for the java.net.http client. */
+    private static int statusOrSkip(HttpResponse<?> response, String serviceName) {
+        return checkStatus(response.statusCode(), serviceName);
+    }
+
+    private static int checkStatus(int status, String serviceName) {
         Assumptions.assumeTrue(status < 500,
                 serviceName + " returned HTTP " + status + " — remote service outage, skipping test");
         return status;
     }
 
-    public static boolean isDatabaseAvailable(String urlString) {
-        try {
-            URL url = new URL(urlString);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setConnectTimeout(3000);   // 3 seconds
-            conn.setReadTimeout(3000);
-            conn.setRequestMethod("GET");   // HEAD is ideal, but some APIs reject it
-            conn.connect();
-
-            int code = conn.getResponseCode();
-            return code == 200;     // true only if return code is HTTP 200 OK
-        } catch (Exception e) {
-            return false;
+    /**
+     * GET the URL, skipping the test if the service is unreachable or failing on its
+     * side, and returning the body otherwise.
+     *
+     * <p>Deliberately does not use {@code ClientDownloader.downloadBytes}: that returns
+     * {@code response.body()} whatever the status, so during an outage the test received
+     * an HTML error page and failed on a content assertion — reporting a VCell
+     * regression when the truth was that the remote service was down.
+     */
+    private static String downloadOrSkip(URL url, String serviceName) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        conn.setReadTimeout(READ_TIMEOUT_MS);
+        int status = statusOrSkip(conn, serviceName);
+        assertEquals(200, status, "Unexpected HTTP status from " + url);
+        try (BufferedReader r = new BufferedReader(
+                new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            return r.lines().collect(Collectors.joining("\n"));
         }
     }
+
+    // isDatabaseAvailable(String) was removed deliberately. It probed a URL the test did
+    // not go on to use — a service can serve its home page (HTTP 200) while the API path
+    // is returning 502 — which is how a real PathwayCommons outage broke CI despite the
+    // guard. Every network test here now decides from the status of its own request.
 
 
 // ------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #1819, which fixed `searchTest` but deliberately left its two siblings. They carry the same defect and would block merges exactly the way the PathwayCommons outage did — these tests are tagged `Fast`, so they sit inside the **required** `CI-Test-group-Fast` check.

## `pathwayDownloadTest` — the status was never even visible

It downloaded through `ClientDownloader.downloadBytes`, which returns `response.body()` **whatever the status code**:

```java
HttpResponse<String> response = client.send(request, ...);
return response.body();          // 502? still returns the error page
```

So during a Reactome outage the test received an HTML error page and failed on `assertTrue(contentString.trim().startsWith("<?xml"))` — reporting a VCell regression when the truth was that a third party was down. Its pre-flight guard couldn't help either: it probed `https://reactome.org` (the site root) while the test downloads from `reactome.org/ReactomeRESTfulAPI/...`.

Now fetched via `downloadOrSkip(url, service)`, which inspects the status of the request the test actually makes.

## `fetchTaxonomyNameFromIdTest` — it explicitly failed on outage signals

```java
} catch (HttpTimeoutException e) {
    fail("Timeout occurred while fetching taxonomy data");
} catch (UnknownHostException e) {
    fail("Host unreachable: check network or endpoint");
} catch (IOException e) {
    fail("I/O error during taxonomy fetch: " + e.getMessage());
```

Every one of those means NCBI is unreachable, not that VCell is broken. They now skip. A 4xx, a malformed response, or the wrong taxonomy name still fails.

## `isDatabaseAvailable` is removed, not just unused

Probing a URL the test does not go on to use is the precise mistake that let the outage through — a service can serve its home page (200) while its API path returns 502. Leaving the helper in place would invite the same bug in the next network test, so it is deleted with a comment explaining why. All three tests now decide from the status of their own request.

## Verification

Against the live services (Reactome and NCBI up, PathwayCommons still 502):

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 1 — BUILD SUCCESS
```

The one skip is `searchTest` (PathwayCommons genuinely down); **both siblings still hit the real endpoints and pass**, so the assertions are intact rather than neutered.

Skip-vs-fail exercised through the real helpers against a local server:

```
HTTP 200     -> returned body (test proceeds)
HTTP 404     -> FAILED (real failure): expected: <200> but was: <404>
HTTP 502     -> SKIPPED: remote service outage
unreachable  -> SKIPPED: Connection refused
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
