### PR TITLE
Add timeouts to the Pathway Commons search in the model editor

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorPathwayCommonsPanel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorPathwayCommonsPanel.java
@@ -132,6 +132,11 @@ public class BioModelEditorPathwayCommonsPanel extends DocumentEditorSubPanel {
 	private static final String REACTOME_PATHWAY_URL = "https://reactome.org/content/detail/";
 	private static final String REACTOME_ID_PREFIX = "R-HSA-";
 
+	// Pathway Commons is a third party; without these an outage hangs the search task for
+	// minutes (observed ~130s before the server returned 502) instead of failing promptly.
+	private static final int PATHWAY_COMMONS_CONNECT_TIMEOUT_MS = 10_000;
+	private static final int PATHWAY_COMMONS_READ_TIMEOUT_MS = 30_000;
+
 	private JButton searchButton = null;
 	private JButton sortButton = null;
 	private boolean bAscending = true;
@@ -454,6 +459,8 @@ public class BioModelEditorPathwayCommonsPanel extends DocumentEditorSubPanel {
 				System.out.println(uri);
 
 				HttpURLConnection conn = (HttpURLConnection)new URL(uri).openConnection();
+				conn.setConnectTimeout(PATHWAY_COMMONS_CONNECT_TIMEOUT_MS);
+				conn.setReadTimeout(PATHWAY_COMMONS_READ_TIMEOUT_MS);
 				conn.setRequestProperty("Accept", "application/xml");
 
 				Element searchResponse = null;


### PR DESCRIPTION
## The gap

`BioModelEditorPathwayCommonsPanel` opens its Pathway Commons search connection
with no connect or read timeout:

```java
HttpURLConnection conn = (HttpURLConnection)new URL(uri).openConnection();
conn.setRequestProperty("Accept", "application/xml");
```

During a pathwaycommons.org outage that means the "searching" task waits about
**130 seconds** before the server answers 502. It runs on an `AsynchClientTask`,
so the UI stays responsive, but the user waits over two minutes to be told it
failed.

#1819 fixed the same missing timeouts — along with proper outage-vs-defect
handling — in `PathwaySearchTest`, but it touched only the test file. This is the
production call it left behind, using the identical URL.

## Change

10s connect, 30s read, as named constants beside the existing ones.

## Verification

Against the outage that is live as of this PR:

```
before:  HTTP 502 after 129.4s
after:   SocketTimeoutException: Read timed out after 30.9s
```

Confirmed the service really is down, not moved: `/pc2/*` returns 502 (its own
"PC Error 50x" page) while `/sifgraph/v1/…` on the same host returns 200, and the
current Pathway Commons API console still documents `pc2/` paths with no
deprecation or host change.

The file is CRLF; patched in binary mode so the diff is 7 added lines with no
line-ending churn.

## Not included

The user still sees a bare "Read timed out" rather than something naming the
service. Making that legible is a larger change to how this panel surfaces task
failures, so I kept it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvqmME7MkRUNEYje5HpiLt