### PR TITLE
Put the OMEX validation errors in the exception message

### DIFF
--- a/vcell-core/src/main/java/org/vcell/sbml/OmexPythonUtils.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/OmexPythonUtils.java
@@ -21,15 +21,19 @@ public class OmexPythonUtils {
         public final List<OmexValidationError> errors;
 
         public OmexValidationException(List<OmexValidationError> errors) {
+            // The detail has to go to super. JUnit, surefire and most logging report getMessage(),
+            // so building it only in toString() left getMessage() null: a validation failure showed
+            // up in CI as a bare "» OmexValidation" with no hint of what was wrong, and callers
+            // logging e.getMessage() printed "null", even though the errors were right here.
+            super(buildMessage(errors));
             this.errors = errors;
         }
 
-        public String toString() {
+        private static String buildMessage(List<OmexValidationError> errors) {
             StringBuilder sb = new StringBuilder();
-            sb.append("OMEX VALIDATION FAILED\n");
+            sb.append("OMEX VALIDATION FAILED with ").append(errors.size()).append(" error(s)");
             for (OmexValidationError error : errors) {
-                sb.append(error.toString());
-                sb.append("\n");
+                sb.append("\n").append(error);
             }
             return sb.toString();
         }

--- a/vcell-core/src/test/java/org/vcell/sbml/OmexValidationExceptionTest.java
+++ b/vcell-core/src/test/java/org/vcell/sbml/OmexValidationExceptionTest.java
@@ -1,0 +1,64 @@
+package org.vcell.sbml;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.vcell.sbml.OmexPythonUtils.OmexValidationError;
+import org.vcell.sbml.OmexPythonUtils.OmexValidationErrorType;
+import org.vcell.sbml.OmexPythonUtils.OmexValidationException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The validation errors have to reach {@code getMessage()}.
+ * <p>
+ * They used to be assembled only in {@code toString()}, which meant JUnit, surefire and any caller
+ * logging {@code e.getMessage()} all reported nothing: a nightly regression failure appeared in CI
+ * as a bare {@code » OmexValidation} for ten consecutive nights, with the actual SED-ML errors
+ * recoverable only by downloading the surefire XML.
+ */
+@Tag("Fast")
+public class OmexValidationExceptionTest {
+
+	private static final String XPATH_ERROR =
+			"XPath `/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='Src_plasmamembrane']` "
+					+ "does not match any elements of model `full_model`";
+
+	@Test
+	public void messageCarriesEveryError() {
+		OmexValidationException e = new OmexValidationException(List.of(
+				new OmexValidationError(OmexValidationErrorType.OMEX_PARSE_ERROR, XPATH_ERROR),
+				new OmexValidationError(OmexValidationErrorType.OMEX_VALIDATION_ERROR, "second problem")));
+
+		String message = e.getMessage();
+		assertNotNull(message, "getMessage() must not be null - CI reports it");
+		assertTrue(message.contains(XPATH_ERROR), message);
+		assertTrue(message.contains("second problem"), message);
+		assertTrue(message.contains("OMEX_PARSE_ERROR"), "error type should be identifiable: " + message);
+		assertTrue(message.contains("2 error(s)"), "should say how many: " + message);
+	}
+
+	/** Stack traces and log lines render the exception via toString(), which derives from the message. */
+	@Test
+	public void toStringCarriesTheErrorsToo() {
+		OmexValidationException e = new OmexValidationException(List.of(
+				new OmexValidationError(OmexValidationErrorType.OMEX_PARSE_ERROR, XPATH_ERROR)));
+		assertTrue(e.toString().contains(XPATH_ERROR), e.toString());
+	}
+
+	/** Callers branch on the error types, so the list stays available alongside the message. */
+	@Test
+	public void errorsRemainAccessible() {
+		OmexValidationError error =
+				new OmexValidationError(OmexValidationErrorType.OMEX_PARSE_ERROR, XPATH_ERROR);
+		OmexValidationException e = new OmexValidationException(List.of(error));
+		assertTrue(e.errors.stream().anyMatch(err -> err.type == OmexValidationErrorType.OMEX_PARSE_ERROR));
+	}
+
+	@Test
+	public void emptyErrorListStillProducesAMessage() {
+		assertNotNull(new OmexValidationException(List.of()).getMessage());
+	}
+}


### PR DESCRIPTION
## Symptom

The nightly regression reports OMEX validation failures like this:

```
[ERROR] SEDMLExporterSBMLTest.test_sedml_roundtrip_SBML:348
          ->SEDMLExporterCommon.sedml_roundtrip_common:183 » OmexValidation
```

That is the entire diagnostic. Nothing about which model, which check, or why.

## Cause

`OmexValidationException` built its detail only in `toString()` and never passed
it to `super`, so `getMessage()` was **null**:

```java
public OmexValidationException(List<OmexValidationError> errors) {
    this.errors = errors;          // no super(message)
}
public String toString() { /* builds the detail here */ }
```

JUnit, surefire and ordinary logging all report `getMessage()`. The errors were
present in the object the whole time, just unreachable by everything that prints
exceptions.

This also silently degraded `SEDMLExporterCommon`, which logs `e.getMessage()`
when deciding whether a fault is already recorded — those lines have been
printing `null`.

## What was hiding behind it

Recovered from the uploaded surefire XML for run 30796032928. These are specific
and actionable, not environmental:

```
biomodel_59361239.vcml   XPath …/sbml:species[@id='Src_plasmamembrane']/@initialConcentration
                         does not match any elements of model `full_model`
biomodel_147699816.vcml  XPath …/sbml:parameter[@id='bounBRaf_frac']
                         does not match any elements of model `_sorafenib`
biomodel_28625786.vcml   Each identified SED object must have a unique id.
                         Multiple objects have the following ids: [compartmental]
```

The exported SED-ML references entities by XPath that are absent from the
exported SBML. Those export defects are **not** addressed here — this PR only
makes them visible. They have been failing every nightly in the retained history
(10 of 10 runs, back to 2026-07-25) and all sit in the `slowModels` set, so they
never run in the merge gate or in a plain `workflow_dispatch`.

## Change

Build the message in the constructor and pass it to `super`. The `toString()`
override becomes redundant and is dropped, so stack traces show the standard
`class: message` form instead of a bare message with no exception type.

CI will now print the model, the failing XPath and the error type directly.

## Tests

New `OmexValidationExceptionTest` (4 cases): the message is non-null and contains
every error and its type, `toString()` still carries the detail, the `errors`
list stays available for callers that branch on error type, and an empty list
still yields a message. Full `vcell-core` Fast group passes (437).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvqmME7MkRUNEYje5HpiLt