### PR TITLE
Cover MathModel references on publications with a Quarkus test (#1741)

### DIFF
--- a/vcell-rest/src/test/java/org/vcell/restq/TestEndpointUtils.java
+++ b/vcell-rest/src/test/java/org/vcell/restq/TestEndpointUtils.java
@@ -25,8 +25,11 @@ import org.vcell.restclient.ApiException;
 import org.vcell.restclient.CustomObjectMapper;
 import org.vcell.restclient.api.UsersResourceApi;
 import org.vcell.restclient.model.BiomodelRef;
+import org.vcell.restclient.model.MathModelSummary;
+import org.vcell.restclient.model.MathmodelRef;
 import org.vcell.restclient.model.Publication;
 import org.vcell.restclient.model.UserLoginInfoForMapping;
+import org.vcell.restclient.model.VersionRep;
 import org.vcell.restq.db.AgroalConnectionFactory;
 import org.vcell.util.BigString;
 import org.vcell.util.DataAccessException;
@@ -137,6 +140,25 @@ public class TestEndpointUtils {
         ref.setOwnerKey(biomodel.getOwnerKey() != null ? Long.parseLong(biomodel.getOwnerKey()) : -1);
         ref.setVersionFlag(biomodel.getVersionFlag());
         ref.setPrivacy(biomodel.getPrivacy());
+        return ref;
+    }
+
+    /**
+     * Build a MathmodelRef from a saved math model, the way the webapp's publication
+     * editor does: it fetches the summary and reads the reference out of its version.
+     */
+    public static MathmodelRef mathmodelRefFromSummary(MathModelSummary summary) {
+        VersionRep version = summary.getVersion();
+        if (version == null) {
+            throw new IllegalStateException("math model summary has no version: " + summary);
+        }
+        MathmodelRef ref = new MathmodelRef();
+        ref.setMmKey(version.getVersionKey() != null ? Long.parseLong(version.getVersionKey()) : -1);
+        ref.setName(version.getName());
+        ref.setOwnerName(version.getOwner() != null ? version.getOwner().getUserName() : null);
+        ref.setOwnerKey(version.getOwner() != null && version.getOwner().getKey() != null
+                ? Long.parseLong(version.getOwner().getKey()) : -1);
+        ref.setVersionFlag(version.getFlag());
         return ref;
     }
 

--- a/vcell-rest/src/test/java/org/vcell/restq/apiclient/PublicationApiTest.java
+++ b/vcell-rest/src/test/java/org/vcell/restq/apiclient/PublicationApiTest.java
@@ -1,7 +1,6 @@
 package org.vcell.restq.apiclient;
 
 import cbit.vcell.biomodel.BioModel;
-import cbit.vcell.mathmodel.MathModel;
 import cbit.vcell.resource.PropertyLoader;
 import cbit.vcell.xml.XMLSource;
 import cbit.vcell.xml.XmlHelper;
@@ -150,9 +149,12 @@ public class PublicationApiTest {
 
         int initialPubSize = apiInstance.getPublications().size();
 
-        MathModel mathModel = TestEndpointUtils.getTestMathModel();
+        // save the VCML resource as-is, the way MathModelApiTest does; round-tripping it
+        // through the object model keeps a reference to a database geometry that does not
+        // exist in the ephemeral test database
+        String testVCML = TestEndpointUtils.getResourceString("/TestMath.vcml");
         String savedMathModelKey = XmlHelper.XMLToMathModel(new XMLSource(
-                        mathModelAPI.saveMathModel(XmlHelper.mathModelToXML(mathModel), null, null)))
+                        mathModelAPI.saveMathModel(testVCML, "MathModelForPublicationTest", null)))
                 .getVersion().getVersionKey().toString();
 
         // the webapp builds the reference from the summary, so do the same here

--- a/vcell-rest/src/test/java/org/vcell/restq/apiclient/PublicationApiTest.java
+++ b/vcell-rest/src/test/java/org/vcell/restq/apiclient/PublicationApiTest.java
@@ -1,6 +1,7 @@
 package org.vcell.restq.apiclient;
 
 import cbit.vcell.biomodel.BioModel;
+import cbit.vcell.mathmodel.MathModel;
 import cbit.vcell.resource.PropertyLoader;
 import cbit.vcell.xml.XMLSource;
 import cbit.vcell.xml.XmlHelper;
@@ -13,7 +14,10 @@ import org.junit.jupiter.api.*;
 import org.vcell.restclient.ApiClient;
 import org.vcell.restclient.ApiException;
 import org.vcell.restclient.api.BioModelResourceApi;
+import org.vcell.restclient.api.MathModelResourceApi;
 import org.vcell.restclient.api.PublicationResourceApi;
+import org.vcell.restclient.model.MathModelSummary;
+import org.vcell.restclient.model.MathmodelRef;
 import org.vcell.restclient.model.Publication;
 import org.vcell.restclient.model.PublishModelsRequest;
 import org.vcell.restq.TestEndpointUtils;
@@ -128,6 +132,64 @@ public class PublicationApiTest {
 
         // remove added BioModel
         bioModelAPI.deleteBioModel(savedModelKey);
+    }
+
+    /**
+     * A publication must be able to carry a MathModel, not just BioModels.
+     *
+     * <p>Attaching a MathModel was unimplemented in the webapp for a long time — the
+     * editor popped "adding MathModels not yet implemented - requires API changes" —
+     * and the surrounding tests only ever exercised empty mathmodelRefs, so nothing
+     * covered the round trip. This asserts the reference survives create → read back
+     * (issue #1741).
+     */
+    @Test
+    public void testAddMathModelToPublication() throws Exception {
+        PublicationResourceApi apiInstance = new PublicationResourceApi(aliceAPIClient);
+        MathModelResourceApi mathModelAPI = new MathModelResourceApi(aliceAPIClient);
+
+        int initialPubSize = apiInstance.getPublications().size();
+
+        MathModel mathModel = TestEndpointUtils.getTestMathModel();
+        String savedMathModelKey = XmlHelper.XMLToMathModel(new XMLSource(
+                        mathModelAPI.saveMathModel(XmlHelper.mathModelToXML(mathModel), null, null)))
+                .getVersion().getVersionKey().toString();
+
+        // the webapp builds the reference from the summary, so do the same here
+        MathModelSummary summary = mathModelAPI.getSummary(savedMathModelKey);
+        MathmodelRef mathmodelRef = TestEndpointUtils.mathmodelRefFromSummary(summary);
+
+        Publication publication = TestEndpointUtils.defaultPublication();
+        assert publication.getMathmodelRefs() != null;
+        publication.getMathmodelRefs().add(mathmodelRef);
+
+        Long newPubKey = apiInstance.createPublication(publication);
+        Assertions.assertNotNull(newPubKey);
+        try {
+            Publication roundTripped = apiInstance.getPublicationById(newPubKey);
+            Assertions.assertNotNull(roundTripped.getMathmodelRefs());
+            Assertions.assertEquals(1, roundTripped.getMathmodelRefs().size(),
+                    "the MathModel reference did not survive the round trip");
+
+            MathmodelRef persisted = roundTripped.getMathmodelRefs().get(0);
+            Assertions.assertEquals(Long.parseLong(savedMathModelKey), persisted.getMmKey());
+            Assertions.assertEquals(mathmodelRef.getName(), persisted.getName());
+            Assertions.assertEquals(mathmodelRef.getOwnerName(), persisted.getOwnerName());
+
+            // and it must still be there when the publication is listed, which is what
+            // the desktop client and the website both read
+            Publication listed = apiInstance.getPublications().stream()
+                    .filter(p -> newPubKey.equals(p.getPubKey()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("new publication missing from the list"));
+            Assertions.assertEquals(1, listed.getMathmodelRefs().size());
+            Assertions.assertEquals(Long.parseLong(savedMathModelKey), listed.getMathmodelRefs().get(0).getMmKey());
+        } finally {
+            apiInstance.deletePublication(newPubKey);
+            mathModelAPI.deleteMathModel(savedMathModelKey);
+        }
+
+        Assertions.assertEquals(initialPubSize, apiInstance.getPublications().size());
     }
 
     @Test


### PR DESCRIPTION
Adds the regression coverage that was missing behind #1741, and records what checking that issue turned up.

## #1741 does not reproduce — it was already fixed

The screenshot in the issue shows the message **"adding MathModels not yet implemented - requires API changes"**. That string existed in exactly one place, `publication-edit.component.ts`, and #1714 deleted it on 2026-06-25 while implementing the feature:

```diff
-    this.snackBar.open("adding MathModels not yet implemented - requires API changes", ...);
-    console.error("add MathmodelRef not yet implemented");
+    this.mathModelService.getSummary(key.toString(), "response").subscribe({ ... });
```

It is not present anywhere on master today. The issue was filed 2026-07-17, three weeks after that merge, so the reporter was on a pre-#1714 build — the same stale-deployment pattern as #1740, which was fixed by a sibling PR merged the very same day.

## The gap worth closing

Every existing publication test passed `new MathmodelRef[0]`. **Nothing covered a non-empty `mathmodelRefs` list**, so the API side of "a publication can carry a MathModel" was untested in either direction.

`PublicationApiTest.testAddMathModelToPublication` now saves a math model, builds the reference from its summary **the way the webapp's publication editor does**, creates a publication carrying it, and asserts the reference survives both reads that matter:

- `getPublicationById` — what the editor reloads
- `getPublications` — what the desktop client's database panel and the website list

It then deletes both in a `finally` block and asserts the publication count returns to its starting value, so the test leaves no residue in the shared ephemeral database.

## Verification — now actually run

**Updated:** this was originally compile-verified only, because every `@QuarkusTest` failed at boot with `{"error":"invalid_request","error_description":"HTTPS required"}`. That turned out to be a Docker Desktop defect, not a VCell one: its gvisor network stack was presenting a **public CDN address** as the source of host→container connections, which is not site-local, so Keycloak's default `sslRequired: external` rejected every OIDC call ([docker/desktop-feedback#133](https://github.com/docker/desktop-feedback/issues/133)). Switching to the vpnkit stack restored the expected `172.17.0.1` gateway source.

With that cleared, the test runs — and immediately caught two real defects in its own first draft, both fixed here:

- round-tripping the math model through the object model kept a reference to a database geometry absent from the ephemeral database (`500 ObjectNotFoundException: Geometry id=259882409 not found`) — now the VCML resource is passed through unchanged, as `MathModelApiTest` does;
- that VCML carries a stored-model identity, so saving it without a new name returned `500 "Stored model has been changed or removed, please use 'Save As..'"` — now an explicit name is supplied.

Both would have failed in CI. Current local result against Keycloak + PostgreSQL testcontainers:

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
  (whole PublicationApiTest class, ~15s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg

