### PR TITLE
Debug bridge: report JTree text as the renderer draws it

### DIFF
--- a/vcell-client/src/main/java/org/vcell/client/debug/README.md
+++ b/vcell-client/src/main/java/org/vcell/client/debug/README.md
@@ -67,6 +67,7 @@ A selector that doesn't resolve reports `did not resolve` (or `false`) rather th
 | `GET /setText?path=&text=&enter=` | JSON `{"set": true\|false}` |
 | `GET /selectTab?path=&index=` | JSON `{"selected": true\|false}` |
 | `GET /selectTreeRow?path=&row=N` | select row N of the JTree; JSON `{"selected": bool}` |
+| *(JTree rows in `/tree`)* | Row text is what the tree **displays**, obtained from its `TreeCellRenderer` — VCell's database trees hold domain objects whose `toString()` is useless (`PublicationInfo@415f5f4f`), so this reports "Lee 2026 Systems-level consequences…" as a user sees it. `<html>` markup is stripped; falls back to `convertValueToText` then `toString` |
 | `GET /selectTableRow?path=&row=N[&column=M]` | select row N of a `JTable` and scroll it into view; JSON `{"selected": bool}`. Row/column are **view** indices, matching the `table` block in `/tree` and the user's current sort order |
 | `GET /doubleClickTableRow?path=&row=N[&column=M]` | synthetic double-click on a table row; JSON `{"doubleClicked": bool}`. Table-backed UIs commonly act on the raw `MouseEvent` click count — this is how you pick a file in the file chooser |
 | `GET /rightClickTableRow?path=&row=N[&column=M]` | select row N then right-click it (opens its context menu); JSON `{"rightClicked": bool}` |

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -320,6 +320,93 @@ public final class SwingInspector {
 		sb.append(']');
 	}
 
+	/**
+	 * The text a {@link JTree} row actually displays.
+	 *
+	 * <p>A node's {@code toString()} is useless in VCell: its database trees hold domain
+	 * objects and render them through a custom {@link javax.swing.tree.TreeCellRenderer},
+	 * so the raw value serializes as {@code PublicationInfo@415f5f4f} while the user sees
+	 * "Lee 2026 Systems-level consequences…". Ask the renderer what it would paint, so a
+	 * driver reads the same labels a person does.
+	 *
+	 * <p>Falls back through {@link JTree#convertValueToText} (honoured by trees that
+	 * override it instead of supplying a renderer) to {@code toString()}, and never
+	 * propagates a renderer's exception — a renderer that assumes a paint context must
+	 * not break the whole tree dump.
+	 */
+	private static String treeRowText(JTree tree, int row, javax.swing.tree.TreePath path) {
+		Object value = path.getLastPathComponent();
+		boolean selected = tree.isRowSelected(row);
+		boolean expanded = tree.isExpanded(row);
+		boolean leaf = tree.getModel().isLeaf(value);
+
+		javax.swing.tree.TreeCellRenderer renderer = tree.getCellRenderer();
+		if (renderer != null) {
+			try {
+				Component rendered = renderer.getTreeCellRendererComponent(
+						tree, value, selected, expanded, leaf, row, false);
+				String text = renderedText(rendered);
+				if (text != null && !text.isEmpty()) {
+					return stripHtml(text);
+				}
+			} catch (RuntimeException e) {
+				// fall through to the plainer forms below
+			}
+		}
+		try {
+			String converted = tree.convertValueToText(value, selected, expanded, leaf, row, false);
+			if (converted != null && !converted.isEmpty()) {
+				return stripHtml(converted);
+			}
+		} catch (RuntimeException e) {
+			// fall through
+		}
+		return String.valueOf(value);
+	}
+
+	/** Text carried by a renderer's component; composite renderers are flattened. */
+	private static String renderedText(Component c) {
+		if (c instanceof JLabel) {
+			return ((JLabel) c).getText();
+		}
+		if (c instanceof AbstractButton) {
+			return ((AbstractButton) c).getText();
+		}
+		if (c instanceof JTextComponent) {
+			return ((JTextComponent) c).getText();
+		}
+		if (c instanceof Container) {
+			StringBuilder sb = new StringBuilder();
+			for (Component kid : ((Container) c).getComponents()) {
+				String kidText = renderedText(kid);
+				if (kidText != null && !kidText.isEmpty()) {
+					if (sb.length() > 0) {
+						sb.append(' ');
+					}
+					sb.append(kidText);
+				}
+			}
+			return sb.toString();
+		}
+		return null;
+	}
+
+	/** VCell renderers often emit {@code <html>…} for styling; report the readable text. */
+	private static String stripHtml(String s) {
+		if (s == null || !s.regionMatches(true, 0, "<html", 0, 5)) {
+			return s;
+		}
+		String text = s.replaceAll("(?i)<br\\s*/?>", " ")
+				.replaceAll("<[^>]*>", "")
+				.replace("&nbsp;", " ")
+				.replace("&amp;", "&")
+				.replace("&lt;", "<")
+				.replace("&gt;", ">")
+				.replaceAll("\\s+", " ")
+				.trim();
+		return text.isEmpty() ? s : text;
+	}
+
 	private static void appendTree(StringBuilder sb, JTree t) {
 		int rows = t.getRowCount();
 		int maxR = Math.min(rows, MAX_TREE_ROWS);
@@ -333,7 +420,7 @@ public final class SwingInspector {
 			javax.swing.tree.TreePath path = t.getPathForRow(r);
 			String text;
 			try {
-				text = String.valueOf(path.getLastPathComponent());
+				text = treeRowText(t, r, path);
 			} catch (Exception e) {
 				text = "?";
 			}


### PR DESCRIPTION
Closes the last known readability gap in the bridge's `/tree` output.

## The gap

Rows were serialized with `String.valueOf(path.getLastPathComponent())`. That is fine for trees whose nodes are strings, but VCell's database trees hold **domain objects** rendered through a custom `TreeCellRenderer`, so the JSON was unusable:

```
row 6 d3 org.vcell.util.document.PublicationInfo@415f5f4f
row 7 d3 org.vcell.util.document.PublicationInfo@4a290e28
```

while the user sees "Lee 2026 Systems-level consequences…". Checking issue #1736 (published models missing from the database panel) had to fall back to **screenshots** purely because of this — the one investigation this session where the tooling could not answer the question.

## The fix

Ask the tree's own renderer what it would paint. Composite renderers (those returning a panel) are flattened, and the `<html>` markup VCell uses for styling is stripped so the text is machine-readable. It falls back to `convertValueToText` — honoured by trees that override it instead of supplying a renderer — and finally `toString`, and it swallows renderer exceptions so a single row that assumes a paint context cannot break the whole dump.

## Verified live against vcell-dev

The exact data I previously had to screenshot:

```
row 5 d2 Published (227)
row 6 d3 Lee 2026 Systems-level consequences of low R...
row 7 d3 Nakata 2026 Graded regulation of microtu... (2)
row 8 d3 Peterson 2026 Mesoscale simulations of m... (2)
row 9 d3 Khan S 2025 Resistance and germination of sp...
```

Geometry tree, previously `VCDocumentInfoNode@f15b69ca`:

```
row 1 d1 My Geometries (schaff) (1022)
row 2 d2 10 spines
row 3 d2 10 spines1148138450
```

No regression on plain trees — `bioModelEditorTree` still reads `BioModel1 / Physiology / Reaction Diagram / Reactions (0)` — and the smoke scenario passes.

With this, `#1736`-style questions ("does the panel show anything after 2024?") are answerable directly from `/tree`, no screenshot required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
