### PR TITLE
Release-cut docs for 8.0.6.01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,66 @@ followed by flat Keep-a-Changelog categories. API consumers should scan
 
 _(Release-manager scratchpad. Populated at release-cut time.)_
 
+## [8.0.6.01] - 2026-08-05
+
+**Highlights.** Desktop UI bug-fix release. Five reported client bugs are
+fixed: the geometry viewer opening behind the main window and appearing
+blank, a crash while sizing species-pattern text, PathwayCommons links
+landing on the wrong site, Constructed Solid Geometry being offered for
+2D geometries, and a failed import crashing instead of explaining itself.
+The SpringSaLaD 3D viewer gains a species selector and MP4 export, login
+no longer fails when a second client is already running, and a
+third-party outage can no longer block CI.
+
+### Added
+- SpringSaLaD 3D viewer: per-species visibility selector and MP4 export of
+  trajectory animations, plus a color correction. (#1814)
+- Swing debug bridge — a developer tool for inspecting and driving the
+  desktop client, **off unless `-Dvcell.debugBridge=true`** and bound to
+  loopback only. Semantic `name=`/type selectors, deterministic waits,
+  popup-free menu activation, JTree/JTable row interaction, component
+  property inspection, and committed launch/CLI/scenario tooling under
+  `tools/debug-bridge/`. (#1817, #1823, #1830)
+- Internal: CI build of a custom VTK.wasm and a golden-file test for
+  client-side WindowedSinc smoothing, feeding the upcoming web field
+  visualization; not shipped in any release artifact. (#1812, #1822)
+- Internal: test coverage for MathModel references on publications, which
+  previously had none — every publication test passed an empty list. (#1828)
+
+### Fixed
+- Opening a geometry from the Database window's Geometries tab no longer
+  puts the viewer behind the main window, and it now shows the geometry
+  immediately. The window was never raised (only BioModel/MathModel windows
+  were, via a path a geometry has no equivalent for), and its editor toggle
+  started selected while no viewer had been opened, so the first click
+  merely deselected it. (#1818, issue #1737)
+- Client no longer crashes with a `NullPointerException` while sizing
+  species-pattern text before the drawing canvas is displayable. The same
+  fault existed at 17 call sites across the shape classes and was fixed at
+  all of them. (#1820, issue #1749)
+- PathwayCommons "Open Web Link" now opens the pathway's Reactome page
+  instead of the PathwayCommons site root. (#1820, issue #1744)
+- Constructed Solid Geometry is no longer offered for 1D/2D geometries,
+  where it produced meaningless results; it is 3D-only. (#1820, issue #1739)
+- A document import that produces nothing now reports what went wrong —
+  naming the file, or noting that a remote fetch returned no usable
+  content — instead of failing with a `NullPointerException`. (#1821,
+  issue #1748)
+- Login no longer fails when another VCell client is already running; the
+  authentication callback server now binds its port up front rather than
+  probing for a free one. (#1815)
+- Pathway Commons searches in the model editor now time out instead of
+  hanging when the service is slow or unreachable. (#1826)
+- Internal: `SimulationDispatcherTest` flakiness (#1816), and
+  `PathwaySearchTest` now skips when PathwayCommons, Reactome or NCBI is
+  unreachable or failing, instead of failing the required CI check — a
+  multi-hour third-party outage had been blocking every merge. (#1819, #1825)
+
+### Notes for API consumers
+- No `/api/v1/` schema changes in this build; `tools/openapi.yaml` is
+  unchanged since 8.0.5.01, and the generated Java, Python and
+  TypeScript clients are unaffected.
+
 ## [8.0.5.01] - 2026-07-31
 
 **Highlights.** Hardens publications against the null publication-date bug

--- a/release-notes/major/8.0.0.md
+++ b/release-notes/major/8.0.0.md
@@ -107,6 +107,8 @@ resolving a parser ambiguity with state labels.
   on modern macOS and Windows, where they could previously slip behind the
   main window. The results viewers also no longer crash when a model is
   edited while results are open (issue #1746).
+- SpringSaLaD 3D viewer: choose which species are visible, and export a
+  trajectory animation to MP4 (8.0.6.01).
 
 ## Bug fixes
 
@@ -122,6 +124,21 @@ thread-safety fix in unit-of-measurement formatting.)_
   records without one (8.0.5.01).
 - SpringSaLaD 3D viewer: bonds now stop at the sphere surfaces instead of
   being drawn into the balls (8.0.5.01).
+- Opening a geometry from the Database window no longer places the viewer
+  behind the main window, and the geometry is shown immediately rather than
+  after several clicks (8.0.6.01).
+- Fixed a crash while sizing species-pattern text, which could occur
+  whenever those shapes were laid out before their panel was on screen
+  (8.0.6.01).
+- "Open Web Link" for a Pathway Commons result now opens the pathway's
+  Reactome page rather than the Pathway Commons site, and searches there
+  time out instead of hanging (8.0.6.01).
+- Constructed Solid Geometry is no longer offered for 1D and 2D
+  geometries, where it could not work (8.0.6.01).
+- A document that cannot be imported now explains why instead of failing
+  with an internal error (8.0.6.01).
+- Login no longer fails when a second VCell client is already running
+  (8.0.6.01).
 
 ## API and integration changes
 


### PR DESCRIPTION
Release-cut documentation for **8.0.6.01**, per `docs/RELEASING.md` — lands before tagging so the tag points at a self-describing tree.

- `CHANGELOG.md`: new `## [8.0.6.01]` section (Highlights, Added, Fixed, Notes for API consumers).
- `release-notes/major/8.0.0.md`: user-facing items folded into Improvements and Bug fixes.

Scope is the 15 PRs merged since 8.0.5.01. Verified `tools/openapi.yaml` is unchanged since that tag, so the "no /api/v1/ schema changes" note is accurate.

Version rationale: PATCH bump — the SaLaD viewer changes in #1814 iterate on a feature already GA'd in 8.0.4.01, and everything else is bug fixes or developer tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg