### PR TITLE
Dockerfile: refresh the apt index in the same layer as the install (robustness, not the 8.0.6.01 fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,15 @@ LABEL \
     maintainer="BioSimulators Team <info@biosimulators.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt -y update && apt install -y software-properties-common
-RUN apt install -y --no-install-recommends curl python3.10 python3-pip build-essential dnsutils \
-    apt-utils libfreetype6 fontconfig fonts-dejavu
+# Keep the index refresh in the same layer as every install. Split across two RUNs,
+# the second install resolved against whatever index the first layer cached, and once
+# Ubuntu superseded a package the pinned version 404'd out of the pool — which is how
+# the 8.0.6.01 release build failed on linux-libc-dev_5.15.0-187.197.
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
+    && apt-get install -y --no-install-recommends curl python3.10 python3-pip build-essential dnsutils \
+        apt-utils libfreetype6 fontconfig fonts-dejavu \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/local/app/vcell/lib && \
     mkdir -p /usr/local/app/vcell/simulation && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,10 @@ LABEL \
 
 ENV DEBIAN_FRONTEND=noninteractive
 # Keep the index refresh in the same layer as every install. Split across two RUNs,
-# the second install resolved against whatever index the first layer cached, and once
-# Ubuntu superseded a package the pinned version 404'd out of the pool — which is how
-# the 8.0.6.01 release build failed on linux-libc-dev_5.15.0-187.197.
+# an install resolves against whatever index the earlier layer cached, and once Ubuntu
+# supersedes a package the version that index names is gone from the pool. (Note this
+# is a hazard for cached builds; the release job that prompted the change builds with
+# --no-cache, where a 404 instead means a transient archive.ubuntu.com mirror lag.)
 RUN apt-get update \
     && apt-get install -y software-properties-common \
     && apt-get install -y --no-install-recommends curl python3.10 python3-pip build-essential dnsutils \


### PR DESCRIPTION
Combines the two apt `RUN`s so `apt-get update` always runs in the same layer as the install that depends on it, plus the usual list cleanup. **Package selection is unchanged** — `software-properties-common` still installs with recommends, the rest still use `--no-install-recommends`.

## Correction — this is not the fix for the failure that prompted it

I originally filed this claiming the 8.0.6.01 biosimulators build failed because the split `RUN`s left a stale package index:

```
E: Failed to fetch .../linux-libc-dev_5.15.0-187.197_amd64.deb  404  Not Found
```

**That was wrong.** `cd.yml` builds with `--no-cache`, so there is no cached layer — the index was fetched fresh moments earlier in the same build. A 404 for a package the just-fetched index names, served from a specific mirror IP, points instead at **transient `archive.ubuntu.com` mirror lag** during a package rotation: the index had advanced but the mirror serving the `.deb` had not caught up. The remedy for that is a rerun, which is being done separately for 8.0.6.01.

## Why keep it anyway

The combined `RUN` removes a genuine hazard for builds that **do** use the layer cache — local builds, and any workflow that does not pass `--no-cache`. That is where this anti-pattern normally bites. So this is a robustness improvement on its own merits, just not the cure for the observed failure.

## Verification

**Not validated locally**: containers on this machine cannot reach `archive.ubuntu.com` through the corporate proxy on either arm64 or amd64, so even an unmodified build of this layer fails here for an unrelated reason. CI's `build` job includes a Docker image test, so that is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg