### PR TITLE
Run the update check before the GUI and wait for it, so the update alert stays on top

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,15 @@ LABEL \
     maintainer="BioSimulators Team <info@biosimulators.org>"
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt -y update && apt install -y software-properties-common
-RUN apt install -y --no-install-recommends curl python3.10 python3-pip build-essential dnsutils \
-    apt-utils libfreetype6 fontconfig fonts-dejavu
+# Keep the index refresh in the same layer as every install. Split across two RUNs,
+# the second install resolved against whatever index the first layer cached, and once
+# Ubuntu superseded a package the pinned version 404'd out of the pool — which is how
+# the 8.0.6.01 release build failed on linux-libc-dev_5.15.0-187.197.
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
+    && apt-get install -y --no-install-recommends curl python3.10 python3-pip build-essential dnsutils \
+        apt-utils libfreetype6 fontconfig fonts-dejavu \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/local/app/vcell/lib && \
     mkdir -p /usr/local/app/vcell/simulation && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,10 @@ LABEL \
 
 ENV DEBIAN_FRONTEND=noninteractive
 # Keep the index refresh in the same layer as every install. Split across two RUNs,
-# the second install resolved against whatever index the first layer cached, and once
-# Ubuntu superseded a package the pinned version 404'd out of the pool — which is how
-# the 8.0.6.01 release build failed on linux-libc-dev_5.15.0-187.197.
+# an install resolves against whatever index the earlier layer cached, and once Ubuntu
+# supersedes a package the version that index names is gone from the pool. (Note this
+# is a hazard for cached builds; the release job that prompted the change builds with
+# --no-cache, where a 404 instead means a transient archive.ubuntu.com mirror lag.)
 RUN apt-get update \
     && apt-get install -y software-properties-common \
     && apt-get install -y --no-install-recommends curl python3.10 python3-pip build-essential dnsutils \

--- a/vcell-client/src/main/java/cbit/vcell/client/VCellClient.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/VCellClient.java
@@ -22,6 +22,7 @@ import cbit.vcell.server.VCellConnectionFactory;
 import com.google.inject.Inject;
 import com.install4j.api.launcher.ApplicationLauncher;
 import org.vcell.api.client.VCellApiClient;
+import org.vcell.util.gui.DialogUtils;
 import org.vcell.api.messaging.RemoteProxyVCellConnectionFactory;
 import org.vcell.api.server.ClientServerManager;
 import org.vcell.api.server.ClientServerManager.InteractiveContextDefaultProvider;
@@ -38,6 +39,14 @@ import java.util.Hashtable;
  * @author: Ion Moraru
  */
 public class VCellClient {
+	private static final org.apache.logging.log4j.Logger lg =
+			org.apache.logging.log4j.LogManager.getLogger(VCellClient.class);
+
+	/** install4j id of the "Updater with silent version check" application in VCell.install4j. */
+	private static final String UPDATER_APPLICATION_ID = "127";
+	/** Set by the update-check task when it fails, so the GUI task can report it with an owner. */
+	private static final String UPDATE_CHECK_FAILURE = "updateCheckFailure";
+
 	private final VCellConnectionFactory vcellConnectionFactory; // injected in constructor
 	private final Auth0ConnectionUtils auth0ConnectionUtils;
 
@@ -204,6 +213,17 @@ public void startClient(final VCDocument startupDoc, final ClientServerInfo clie
 
 		    // dev-only introspection surface; no-op unless -Dvcell.debugBridge=true
 		    org.vcell.client.debug.SwingDebugBridge.startIfEnabled();
+
+		    // Report a failed update check now that there is a window to own the dialog.
+		    // Startup continues either way — the user is told, not blocked.
+		    String updateCheckFailure = (String) hashTable.get(UPDATE_CHECK_FAILURE);
+		    if (updateCheckFailure != null) {
+		    	DialogUtils.showWarningDialog(currWindowManager == null ? null : currWindowManager.getComponent(),
+		    			"VCell could not check whether a newer version is available:\n\n"
+		    			+ updateCheckFailure
+		    			+ "\n\nVCell will continue with the version already installed."
+		    			+ " The latest version can be downloaded from https://vcell.org.");
+		    }
 		}
 	};
 	
@@ -212,17 +232,32 @@ public void startClient(final VCDocument startupDoc, final ClientServerInfo clie
 		@Override
 		public void run(Hashtable<String, Object> hashTable) throws Exception {
 			try {
-				String[] install4jArgs = null;
-				boolean blocking = false;
-				ApplicationLauncher.Callback callback = null;
-				ApplicationLauncher.launchApplication("127", install4jArgs, blocking, callback);
-
-			} catch (Exception e) {
-				e.printStackTrace();
+				// Blocking, and scheduled before the GUI is created. The updater's dialog belongs
+				// to install4j, so it can never be an LW-owned child and nothing can raise it back
+				// once something covers it. Previously this launched non-blocking, so the main
+				// window appeared and the Auth0 browser flow handed focus back while the update
+				// alert was still up — the alert flashed and sank behind VCell. Holding startup
+				// here means nothing of ours is on screen to bury it.
+				//
+				// Declining the update just ends the updater, which returns normally: VCell then
+				// carries on starting with the installed version.
+				ApplicationLauncher.launchApplication(UPDATER_APPLICATION_ID, null, true, null);
+			} catch (Throwable e) {
+				// A failed update check must never stop VCell from starting. Throwable rather than
+				// Exception because a source build has no install4j runtime, which surfaces as a
+				// LinkageError; and an AsynchClientTask that throws aborts every later task,
+				// including login.
+				//
+				// It also must not be silent — this used to be swallowed by printStackTrace. The
+				// message is handed to the GUI task so the dialog is owned by the main window,
+				// rather than floating unparented here where no window exists yet.
+				lg.error("VCell update check failed", e);
+				if (System.getProperty("install4j.launcherId") != null) {
+					hashTable.put(UPDATE_CHECK_FAILURE, e.getMessage() == null ? e.toString() : e.getMessage());
+				}
 			}
-			
 		}
-		
+
 	};
 
 	AsynchClientTask task3a = ClientLogin.popupLogin();
@@ -231,7 +266,9 @@ public void startClient(final VCDocument startupDoc, final ClientServerInfo clie
 	
 	AsynchClientTask task4  = ClientLogin.connectToServer(auth0ConnectionUtils, clientServerInfo);
 
-	AsynchClientTask[] taskArray = new AsynchClientTask[] { task1, task2,  task2a, task3a, task3b, task4};
+	// task2a (update check) runs before task2 (GUI) so the install4j update alert has the
+	// screen to itself; it blocks, so login only starts once the user has dealt with it.
+	AsynchClientTask[] taskArray = new AsynchClientTask[] { task1, task2a, task2, task3a, task3b, task4};
 	ClientTaskDispatcher.dispatch(null, hash, taskArray);
 }
 


### PR DESCRIPTION
Fixes the update alert flashing and sinking behind the main window, so users never see that a new VCell is available.

## Cause

`task2a "Checking for Updates"` launched the install4j updater **non-blocking**, and ran **after** the GUI task:

```java
boolean blocking = false;                     // ← races everything that follows
ApplicationLauncher.launchApplication("127", install4jArgs, blocking, callback);
```

So the alert appeared while the main window was already on screen, and the Auth0 browser flow then handed focus back, re-raising the main window over it.

As @jcschaff noted, the LW framework cannot rescue this: the alert is **install4j's own window**, so it can never be an owned child, and it is stuck on the best-effort `toFront()` path that `docs/windowing-design-patterns.md` §7.1 documents as unreliable. The fix is to stop racing it.

## Change

- `task2a` now runs **before** `task2`, so no VCell window exists to bury the alert.
- It launches the updater with **`blocking = true`**, so login (and the browser flow) only begins after the user has dealt with the alert.

## Fail-safe

A version check must never keep VCell from starting:

| Situation | Behavior |
|---|---|
| User declines the update | Updater exits, call returns, VCell starts on the installed version |
| Check fails (network, no install4j runtime, anything) | Caught, logged, **startup continues** |
| Failure under an install4j launch | Warning dialog **after** the GUI exists, so it is owned by the main window |
| Failure in a source build | No dialog — developers are not nagged every launch |

`Throwable` rather than `Exception` is deliberate: a source build has no install4j runtime and fails with a `LinkageError`, and an `AsynchClientTask` that throws sets `TASK_ABORTED_BY_ERROR`, which would skip every later task including login. The old code swallowed failures with `printStackTrace()` — that is what "not silent" replaces.

## Verified live

- **Source build** (`launchApplication` throws `FileNotFoundException: …/i4jparams.conf` after ~150ms): client starts normally, GUI comes up, no dialog.
- **Simulated install4j launch** (`-Dinstall4j.launcherId=999`): the same failure produces an `LWTitledOptionPaneDialog | Warning` **owned by the main window**, reading "VCell could not check whether a newer version is available… VCell will continue with the version already installed." Startup proceeds to login once dismissed.

## Not verified here

The end-to-end ordering against a **real** install4j installation with an update actually available — that needs an installed build and a newer version on the update site. Worth one manual check on the next alpha installer, since that is the case the bug is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
