### PR TITLE
Fix two stale SEDML export test expectations

### DIFF
--- a/vcell-core/src/test/java/org/vcell/sbml/SEDMLExporterSBMLTest.java
+++ b/vcell-core/src/test/java/org/vcell/sbml/SEDMLExporterSBMLTest.java
@@ -120,7 +120,6 @@ public class SEDMLExporterSBMLTest extends SEDMLExporterCommon {
 		faults.put("biomodel_2962862.vcml", SEDML_FAULT.NO_MODELS_IN_OMEX);
 		faults.put("biomodel_32568171.vcml", SEDML_FAULT.NO_MODELS_IN_OMEX);
 		faults.put("biomodel_32568356.vcml", SEDML_FAULT.NO_MODELS_IN_OMEX);
-		faults.put("biomodel_34826524.vcml", SEDML_FAULT.MATH_OVERRIDE_NOT_EQUIVALENT); // simulation 'Cap=1, cof, prof varied' in simContext 'Steady State Turnover'
 		faults.put("biomodel_34855932.vcml", SEDML_FAULT.MATH_OVERRIDE_NOT_EQUIVALENT); // simulation 'INIT' in simContext 'cell4'
 		faults.put("biomodel_38086434.vcml", SEDML_FAULT.NO_MODELS_IN_OMEX); // new
 		faults.put("biomodel_55178308.vcml", SEDML_FAULT.NO_MODELS_IN_OMEX); // new
@@ -190,6 +189,14 @@ public class SEDMLExporterSBMLTest extends SEDMLExporterCommon {
 		unsupportedApplications.add(new UnsupportedApplication("biomodel_16804037.vcml","PipDecay","Reaction 'KCNQcurrent' has electric current defined, SBML Export is not supported"));
 		unsupportedApplications.add(new UnsupportedApplication("biomodel_169993006.vcml","Pattern_formation","Species 'A' has FieldData as initial condition, SBML Export is not supported"));
 		unsupportedApplications.add(new UnsupportedApplication("biomodel_17098642.vcml","PipDecay","Reaction 'KCNQcurrent' has electric current defined, SBML Export is not supported"));
+		unsupportedApplications.add(new UnsupportedApplication("biomodel_188880263.vcml","Stochastic mRNA Number Sweep","Application 'Stochastic mRNA Number Sweep' has reaction rules, SBML Export is not supported"));
+		unsupportedApplications.add(new UnsupportedApplication("biomodel_188880263.vcml","Stochastic Make mRNA Sweep Const Prot","Application 'Stochastic Make mRNA Sweep Const Prot' has reaction rules, SBML Export is not supported"));
+		unsupportedApplications.add(new UnsupportedApplication("biomodel_188880263.vcml","Stochastic mRNA Number Sweep Const Nucl Chaparones","Application 'Stochastic mRNA Number Sweep Const Nucl Chaparones' has reaction rules, SBML Export is not supported"));
+		unsupportedApplications.add(new UnsupportedApplication("biomodel_188880263.vcml","Stochastic Make mRNA Sweep","Application 'Stochastic Make mRNA Sweep' has reaction rules, SBML Export is not supported"));
+		unsupportedApplications.add(new UnsupportedApplication("biomodel_188880263.vcml","Stochastic","Application 'Stochastic' has reaction rules, SBML Export is not supported"));
+		unsupportedApplications.add(new UnsupportedApplication("biomodel_188880263.vcml","Continuous_Low L1DNA","Application 'Continuous_Low L1DNA' has reaction rules, SBML Export is not supported"));
+		unsupportedApplications.add(new UnsupportedApplication("biomodel_188880263.vcml","Network Free","Application 'Network Free' has reaction rules, SBML Export is not supported"));
+		unsupportedApplications.add(new UnsupportedApplication("biomodel_188880263.vcml","Continuous_Med L1DNA","Application 'Continuous_Med L1DNA' has reaction rules, SBML Export is not supported"));
 		unsupportedApplications.add(new UnsupportedApplication("biomodel_189321805.vcml","Application0","Application 'Application0' has reaction rules, SBML Export is not supported"));
 		unsupportedApplications.add(new UnsupportedApplication("biomodel_189512756.vcml","Modeling PI cycle","Reaction 'KCNQ2/3' has electric current defined, SBML Export is not supported"));
 		unsupportedApplications.add(new UnsupportedApplication("biomodel_189513183.vcml","modeling PI cycle","Reaction 'KCNQ2/3' has electric current defined, SBML Export is not supported"));


### PR DESCRIPTION
Two of the five failures in the nightly `SEDML_SBML_IT` regression are test
bookkeeping, not product defects. Both models are in the slow set, so they run
only on the nightly and never in the merge gate.

## biomodel_188880263.vcml — undeclared unsupported applications

The test declared no unsupported applications; the exporter reports eight. Every
application in that model is rule-based, and SBML export does not support
reaction rules, so the exporter is right and the declaration was simply never
filled in. The assertion has been printing the exact lines to add:

```
declared: []
found:    [Stochastic mRNA Number Sweep, Stochastic Make mRNA Sweep Const Prot,
           Stochastic mRNA Number Sweep Const Nucl Chaparones, Stochastic Make mRNA Sweep,
           Stochastic, Continuous_Low L1DNA, Network Free, Continuous_Med L1DNA]
           …each: "has reaction rules, SBML Export is not supported"
```

Added all eight, in the file-ordered position the list already uses.

## biomodel_34826524.vcml — a known fault that no longer happens

It had `SEDML_FAULT.MATH_OVERRIDE_NOT_EQUIVALENT` registered, so it failed for
**passing**:

```
file SBML.biomodel_34826524.vcml passed SEDML Round trip, but knownSEDMLFault was set
  ==> expected: <null>
```

Removed the entry.

## Verification

Run individually — these need `-Dtest.include.slow=true`, since both are
slow-gated and are otherwise skipped:

| model | before | after |
|---|---|---|
| `biomodel_188880263.vcml` | AssertionFailedError | **pass**, 51s |
| `biomodel_34826524.vcml`  | AssertionFailedError | **pass**, 346s |

Note this repo's PR CI cannot exercise either: `SEDML_SBML_IT` runs only in
`regression.yml`, and these two are additionally behind `test.include.slow`. The
checks on this PR say nothing about the change; the runs above are the evidence.

Incidentally `biomodel_34826524` took 346s locally against the 129s recorded next
to it in `slowModels`, so that annotation is optimistic.

## Not included

The other three nightly failures are genuine export defects — exported SED-ML
referencing species and parameters by XPath that are absent from the exported
SBML, plus one duplicate SED-ML id. Those deserve a real fix rather than a
`knownSEDMLFault` entry, which would make a live bug permanently invisible. See
also #1827, which makes those failures legible in CI output (they currently
report as a bare `» OmexValidation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvqmME7MkRUNEYje5HpiLt