### PR TITLE
Don't let a non-finite export progress wedge event delivery (clamp, don't null)

### DIFF
--- a/vcell-api/src/main/java/org/vcell/rest/events/RestEventService.java
+++ b/vcell-api/src/main/java/org/vcell/rest/events/RestEventService.java
@@ -3,6 +3,10 @@ package org.vcell.rest.events;
 import cbit.rmi.event.*;
 import cbit.vcell.message.VCMessagingService;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vcell.api.types.events.*;
@@ -18,6 +22,43 @@ import java.util.concurrent.atomic.AtomicLong;
 public class RestEventService {
 	private final static Logger lg = LogManager.getLogger(RestEventService.class);
 	
+	/**
+	 * Serializes events, tolerating non-finite doubles.
+	 *
+	 * <p>JSON has no representation for Infinity or NaN, so a stock {@link Gson}
+	 * throws {@code IllegalArgumentException} on one. That used to be caught, logged
+	 * and the event dropped — but the message was then redelivered, failed again, and
+	 * kept failing: a single export whose {@code progress} came out Infinity produced
+	 * roughly 4,900 error lines a minute on production, and because the consumer loop
+	 * creates a JMS connection and temporary queue per message, each redelivery cost
+	 * one of each.
+	 *
+	 * <p>A non-finite value is written as {@code null} instead. Every representation
+	 * already declares {@code progress} as a nullable {@link Double} and already sends
+	 * null for events carrying none (EXPORT_START, EXPORT_ASSEMBLING), so consumers
+	 * handle its absence. Losing one progress reading beats losing the event and
+	 * wedging the consumer.
+	 *
+	 * <p>This does not excuse producing a non-finite progress — the WARN below names
+	 * the value so the upstream division stays findable.
+	 */
+	private final static Gson gson = new GsonBuilder()
+			.registerTypeAdapter(Double.class, nonFiniteAsNull())
+			.registerTypeAdapter(double.class, nonFiniteAsNull())
+			.create();
+
+	private static JsonSerializer<Double> nonFiniteAsNull() {
+		return (src, typeOfSrc, context) -> {
+			if (src == null || src.isInfinite() || src.isNaN()) {
+				if (src != null) {
+					lg.warn("non-finite value {} in an outgoing event; sending null instead", src);
+				}
+				return JsonNull.INSTANCE;
+			}
+			return new JsonPrimitive(src);
+		};
+	}
+
 	final static AtomicLong eventSequence = new AtomicLong(0);
 	final static ConcurrentLinkedDeque<EventWrapper> events = new ConcurrentLinkedDeque<>();
 	ClientTopicMessageCollector clientTopicMessageCollector = null;
@@ -52,7 +93,6 @@ public class RestEventService {
 				if (!Compare.isEqual(event2.getJobID(),exportEvent.getJobID())) {
 					throw new RuntimeException("Export event round-trip failed");
 				}
-				Gson gson = new Gson();
 				String eventJSON = gson.toJson(exportEventRep);
 				insert(exportEventRep.username, EventWrapper.EventType.ExportEvent,eventJSON);
 			}catch (Exception e) {
@@ -69,7 +109,6 @@ public class RestEventService {
 				if (!Compare.isEqual(event2.getProgress(),simJobEvent.getProgress())) {
 					throw new RuntimeException("SimulationJobStatus <PROGRESS> event round-trip failed");
 				}
-				Gson gson = new Gson();
 				String eventJSON = gson.toJson(simJobEventRep);
 				insert(simJobEventRep.username, EventWrapper.EventType.SimJob,eventJSON);
 			}catch (Exception e) {
@@ -92,7 +131,6 @@ public class RestEventService {
 					return;
 				}
 				//Add new broadcast message
-				Gson gson = new Gson();
 				String eventJSON = gson.toJson(broadcastEventRepresentation);
 				insert(null, EventWrapper.EventType.Broadcast,eventJSON);
 			}else {
@@ -115,7 +153,6 @@ public class RestEventService {
 				if (!Compare.isEqual(event2.getProgress(),dataJobEvent.getProgress())) {
 					throw new RuntimeException("DataJob <PROGRESS> event round-trip failed");
 				}
-				Gson gson = new Gson();
 				String eventJSON = gson.toJson(dataJobEventRep);
 				insert(dataJobEventRep.username, EventWrapper.EventType.DataJob,eventJSON);
 			}catch (Exception e) {

--- a/vcell-api/src/main/java/org/vcell/rest/events/RestEventService.java
+++ b/vcell-api/src/main/java/org/vcell/rest/events/RestEventService.java
@@ -33,14 +33,19 @@ public class RestEventService {
 	 * creates a JMS connection and temporary queue per message, each redelivery cost
 	 * one of each.
 	 *
-	 * <p>A non-finite value is written as {@code null} instead. Every representation
-	 * already declares {@code progress} as a nullable {@link Double} and already sends
-	 * null for events carrying none (EXPORT_START, EXPORT_ASSEMBLING), so consumers
-	 * handle its absence. Losing one progress reading beats losing the event and
-	 * wedging the consumer.
+	 * <p>A non-finite value is written as {@code null} instead — a last-resort net so
+	 * serialization can never throw. Clients tolerate a missing value here: the Python
+	 * client declares {@code Optional[float] = None}, the TypeScript client
+	 * {@code progress?: number}, and the desktop client null-checks sim-job progress
+	 * ({@code SimulationListPanel}).
 	 *
-	 * <p>This does not excuse producing a non-finite progress — the WARN below names
-	 * the value so the upstream division stays findable.
+	 * <p><b>Export progress is the exception</b> and is clamped before it reaches this
+	 * net — see {@link #withFiniteProgress}. The desktop client dereferences it without
+	 * a null check for EXPORT_PROGRESS events, so emitting null there would swap a
+	 * server-side serialization failure for a client-side NPE.
+	 *
+	 * <p>Neither excuses producing a non-finite progress — the WARN below names the
+	 * value so the upstream division stays findable.
 	 */
 	private final static Gson gson = new GsonBuilder()
 			.registerTypeAdapter(Double.class, nonFiniteAsNull())
@@ -57,6 +62,28 @@ public class RestEventService {
 			}
 			return new JsonPrimitive(src);
 		};
+	}
+
+	/**
+	 * A copy whose {@code progress} is guaranteed finite, or the original if it already
+	 * was (or is null, which is normal for EXPORT_START / EXPORT_ASSEMBLING).
+	 *
+	 * <p>Clamped into [0,1] rather than nulled because the desktop client does
+	 * {@code event.getProgress().doubleValue() * 100} inside {@code case EXPORT_PROGRESS}
+	 * ({@code ExportMonitorTableModel}) and compares two progress values by auto-unboxing
+	 * in {@code ExportEvent.isSupercededBy} — a null in either place is an NPE. A wrong
+	 * but finite progress bar is a far better failure than a crashed client.
+	 */
+	private static ExportEventRepresentation withFiniteProgress(ExportEventRepresentation rep) {
+		if (rep.progress == null || !(rep.progress.isInfinite() || rep.progress.isNaN())) {
+			return rep;
+		}
+		double clamped = rep.progress.isNaN() ? 0.0 : (rep.progress > 0 ? 1.0 : 0.0);
+		lg.warn("export job {} reported non-finite progress {}; clamping to {}",
+				rep.jobid, rep.progress, clamped);
+		return new ExportEventRepresentation(rep.eventType, clamped, rep.format, rep.location,
+				rep.username, rep.userkey, rep.jobid, rep.dataIdString, rep.dataKey,
+				rep.exportTimeSpecs, rep.exportVariableSpecs, rep.exportHumanReadableDataSpec);
 	}
 
 	final static AtomicLong eventSequence = new AtomicLong(0);
@@ -93,6 +120,7 @@ public class RestEventService {
 				if (!Compare.isEqual(event2.getJobID(),exportEvent.getJobID())) {
 					throw new RuntimeException("Export event round-trip failed");
 				}
+				exportEventRep = withFiniteProgress(exportEventRep);
 				String eventJSON = gson.toJson(exportEventRep);
 				insert(exportEventRep.username, EventWrapper.EventType.ExportEvent,eventJSON);
 			}catch (Exception e) {


### PR DESCRIPTION
Fixes the `Infinity is not a valid double value as per JSON specification` flood seen on production, and the message-redelivery wedge behind it.

## What was happening

A stock `Gson` throws `IllegalArgumentException` on `Infinity`/`NaN`, because JSON cannot represent them. `RestEventService` caught that, logged it, and **dropped the event** — but the message was then redelivered, failed again, and kept failing.

Measured on prod in one 60-second window:

| Signal | Count |
|---|---|
| `Infinity is not a valid double` | 4,902 |
| new JMS connections (`transport resumed`) | 3,302 |
| `JMS transport interrupted` | **0** |

The zero interruptions matter: the transport was never flapping. `ConsumerContextJms` creates a **connection and a temporary queue per message**, so every redelivery of the one poisoned event cost one of each. A single export whose `progress` came out `Infinity` generated ~4,900 error lines a minute, and the flood only stopped when the `api` pods were rolled — discarding the message rather than fixing it.

## The change — two layers

**1. Export progress is clamped to a finite value** (`+Inf → 1.0`, `-Inf → 0.0`, `NaN → 0.0`), leaving genuine nulls (`EXPORT_START`, `EXPORT_ASSEMBLING`) untouched.

**2. A shared `Gson` writes any other non-finite double as `null`** — replacing the four per-call `new Gson()` instances — so serialization can never throw.

## Why clamp rather than null — a client audit

An earlier revision of this PR nulled the value. That was wrong, and the client survey shows why:

| Client | How it reads `progress` | Null-safe? |
|---|---|---|
| **Java desktop** | `getProgress().doubleValue() * 100` inside `case EXPORT_PROGRESS` (`ExportMonitorTableModel`), and `getProgress() < other.getProgress()` auto-unboxing **both** operands (`ExportEvent.isSupercededBy`) | **No — NPE** |
| **Python** (`python-restclient`) | `progress: Optional[Union[StrictFloat, StrictInt]] = None` | Yes |
| **TypeScript** (`webapp-ng`) | `progress?: number` | Yes |

Both Java dereferences are gated on `EXPORT_PROGRESS` — precisely the event type that carries progress and where the `Infinity` arises. Emitting null there would have swapped a contained server-side failure for a **client-side NPE in the export monitor**, which is strictly worse. A wrong but finite progress bar is a much better failure mode than a crashed client.

The null path is retained only where clients tolerate it: `timePoint`, anything added later, and sim-job progress (which the desktop client already null-checks in `SimulationListPanel`).

Deliberately **not** `GsonBuilder.serializeSpecialFloatingPointValues()`, which the error message itself suggests — it emits a bare `Infinity` token, invalid JSON, relocating the failure into every client's parser.

## Verified against the real representation

```
progress     stock Gson                  with this change
0.42         ok                          0.42          finite ✓   ← unchanged
Infinity     IllegalArgumentException    1.0           finite ✓
-Infinity    IllegalArgumentException    0.0           finite ✓
NaN          IllegalArgumentException    0.0           finite ✓
null         ok                          null (no progress reported)
```

The `0.42` row is the regression case: normal progress reporting is untouched.

## Scope

**Containment, not the root cause.** Export progress is computed by unguarded division — e.g. `ASCIIExporter:1015` divides by `2 * variableNames.length * (endIndex-beginIndex+1)`, which yields `Infinity` when the denominator is 0. That still needs a guard; this change ensures such a value can no longer make an event permanently undeliverable. The new WARN names the export job id, which the original flood never did.

Separately worth revisiting: creating a JMS connection and temporary queue **per message** (~55/second here) is expensive regardless of what rides along, and `ExportEventRepresentation` carries fields (`progress`, `location`, the spec objects) that only apply to some `eventType` values — the overloading that invites this class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
