### PR TITLE
Guard the export progress divisions that produced Infinity

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/export/server/ASCIIExporter.java
+++ b/vcell-core/src/main/java/cbit/vcell/export/server/ASCIIExporter.java
@@ -44,6 +44,24 @@ import java.util.*;
 public class ASCIIExporter {
     private final static Logger lg = LogManager.getLogger(ASCIIExporter.class);
 
+    /**
+     * A completed fraction in [0,1], safe when there is nothing to divide by.
+     *
+     * <p>Export progress denominators are counts that can legitimately be zero — a
+     * geometry selection with no curves and no points, or no variables chosen. They are
+     * doubles, so {@code x / 0.0} silently produces Infinity (or NaN when x is 0) rather
+     * than throwing, and that value used to be published as export progress. It then
+     * reached JSON serialization, which rejects non-finite doubles, and the resulting
+     * failure made the event permanently undeliverable.
+     */
+    static double fraction(double completed, double total) {
+        if (!(total > 0) || !Double.isFinite(completed)) {
+            return 0.0;
+        }
+        double f = completed / total;
+        return f < 0 ? 0.0 : (f > 1 ? 1.0 : f);
+    }
+
     private ExportEventController exportServiceImpl = null;
 
     /**
@@ -452,7 +470,7 @@ public class ASCIIExporter {
                 progressCounter++;
                 if((System.currentTimeMillis() - lastTime) > MESSAGE_LIMIT){
                     lastTime = System.currentTimeMillis();
-                    exportServiceImpl.fireExportProgress(jobID, orig_vcdID, "multisim-point", progressCounter / (SIM_COUNT * TIME_COUNT));
+                    exportServiceImpl.fireExportProgress(jobID, orig_vcdID, "multisim-point", fraction(progressCounter, (double) SIM_COUNT * TIME_COUNT));
                 }
                 int simJobIndex = simNameSimDataIDs[simIndex].getDefaultJobIndex();
                 VCDataIdentifier vcdID = simNameSimDataIDs[simIndex].getVCDataIdentifier(simJobIndex);
@@ -574,6 +592,13 @@ public class ASCIIExporter {
                 TOTAL_EXPORTS_OPS = SIM_COUNT * PARAMSCAN_COUNT * variableSpecs.getVariableNames().length * TIME_COUNT;
                 break;
         }
+        // Any factor above can legitimately be zero — a selection with no curves and no
+        // points, or no variables — and TOTAL_EXPORTS_OPS is a double, so dividing by it
+        // yields Infinity rather than throwing. Divisions below go through fraction().
+        if(TOTAL_EXPORTS_OPS <= 0){
+            lg.warn("export job {} has no work to measure progress against (sims={}, paramScans={}, vars={}, mode={}); progress stays at 0",
+                    jobID, SIM_COUNT, PARAMSCAN_COUNT, variableSpecs.getVariableNames().length, geometrySpecs.getMode());
+        }
         File hdf5TempFile = null;
         if(asciiSpecs.getCSVRoiLayout() == ASCIISpecs.CsvRoiLayout.time_sim_var){
             exportOutputV.add(new ExportOutput[]{sofyaFormat(outputContext, jobID, user, dataServerImpl, orig_vcdID, variableSpecs, timeSpecs, geometrySpecs, asciiSpecs, contextName, fileDataContainerManager)});
@@ -685,7 +710,7 @@ public class ASCIIExporter {
                                                 getPointsTimeSeries(pointsCurvesSlices[v][varNameIndx], hdf5GroupVarID, outputContext, user, dataServerImpl, vcdID, variableSpecs.getVariableNames()[varNameIndx], geometrySpecs, allTimes, beginTimeIndex, endTimeIndex, asciiSpecs.getSwitchRowsColumns(), fileDataContainerManager));
                                         fileDataContainerManager.append(exportOutput1.getFileDataContainerID(), "\n");
                                         progressCounter++;
-                                        exportServiceImpl.fireExportProgress(jobID, orig_vcdID, "CSV", progressCounter / TOTAL_EXPORTS_OPS);
+                                        exportServiceImpl.fireExportProgress(jobID, orig_vcdID, "CSV", fraction(progressCounter, TOTAL_EXPORTS_OPS));
                                         if(hdf5GroupVarID != -1){
                                             H5.H5Gclose(hdf5GroupVarID);
                                         }
@@ -717,7 +742,7 @@ public class ASCIIExporter {
                                                 fileDataContainerManager.append(exportOutput1.getFileDataContainerID(), getCurveTimeSeries(hdf5GroupVarID, pointsCurvesSlices[v][varNameIndx], outputContext, user, dataServerImpl, vcdID, variableSpecs.getVariableNames()[varNameIndx], geometrySpecs.getCurves()[s], allTimes, beginTimeIndex, endTimeIndex, asciiSpecs.getSwitchRowsColumns(), fileDataContainerManager));
                                                 fileDataContainerManager.append(exportOutput1.getFileDataContainerID(), "\n");
                                                 progressCounter++;
-                                                exportServiceImpl.fireExportProgress(jobID, orig_vcdID, "CSV", progressCounter / TOTAL_EXPORTS_OPS);
+                                                exportServiceImpl.fireExportProgress(jobID, orig_vcdID, "CSV", fraction(progressCounter, TOTAL_EXPORTS_OPS));
                                             }
                                         }
                                         if(hdf5GroupVarID != -1){
@@ -769,7 +794,7 @@ public class ASCIIExporter {
 //									}
 //								}
                                         progressCounter++;
-                                        exportServiceImpl.fireExportProgress(jobID, orig_vcdID, "CSV", progressCounter / TOTAL_EXPORTS_OPS);
+                                        exportServiceImpl.fireExportProgress(jobID, orig_vcdID, "CSV", fraction(progressCounter, TOTAL_EXPORTS_OPS));
                                     }
                                     sliceHelper.closeHDF5GroupAndValues();
                                 }

--- a/vcell-core/src/main/java/cbit/vcell/export/server/ClientExportEventController.java
+++ b/vcell-core/src/main/java/cbit/vcell/export/server/ClientExportEventController.java
@@ -4,6 +4,8 @@ import cbit.rmi.event.ExportEvent;
 import cbit.rmi.event.ExportListener;
 import cbit.rmi.event.ExportEventController;
 import cbit.vcell.solver.VCSimulationDataIdentifier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.vcell.util.document.ExternalDataIdentifier;
 import org.vcell.util.document.KeyValue;
 import org.vcell.util.document.User;
@@ -13,6 +15,7 @@ import java.util.Hashtable;
 
 // Old implementation of ExportServiceImpl's event controller.
 public class ClientExportEventController implements ExportEventController {
+    private final static Logger lg = LogManager.getLogger(ClientExportEventController.class);
     private javax.swing.event.EventListenerList listenerList = new javax.swing.event.EventListenerList();
     private Hashtable<Long, User> jobRequestIDs = new Hashtable<Long, User>();
 
@@ -90,6 +93,16 @@ public class ClientExportEventController implements ExportEventController {
         Object object = jobRequestIDs.get(new Long(jobID));
         if (object != null) {
             user = (User)object;
+        }
+        // Backstop for every EXPORT_PROGRESS event: this is the one place they are built,
+        // so a non-finite value cannot escape here regardless of which exporter computed
+        // it. JSON has no representation for Infinity or NaN, and such a value used to
+        // make the event permanently undeliverable. Individual exporters guard their own
+        // divisions (see ASCIIExporter.fraction); this catches anything they miss.
+        if (!Double.isFinite(progress)) {
+            lg.warn("export job {} ({}) reported non-finite progress {}; reporting 0 instead",
+                    jobID, format, progress);
+            progress = 0.0;
         }
         ExportEvent event = new ExportEvent(this, jobID, user, vcdID, ExportEnums.ExportProgressType.EXPORT_PROGRESS, format, null, new Double(progress));
         fireExportEvent(event);

--- a/vcell-core/src/main/java/cbit/vcell/export/server/RasterExporter.java
+++ b/vcell-core/src/main/java/cbit/vcell/export/server/RasterExporter.java
@@ -467,7 +467,9 @@ private NrrdInfo[] exportPDEData(OutputContext outputContext,long jobID, User us
 	private static long fireThrottledProgress(ExportEventController exportServiceImpl, long lastUpdateTime, String message, long jobID, VCDataIdentifier vcdID, int progressIndex, int endIndex){
 		if(lastUpdateTime == 0 || (System.currentTimeMillis() - lastUpdateTime)>5000){
 			lastUpdateTime = System.currentTimeMillis();
-			exportServiceImpl.fireExportProgress(jobID, vcdID, message,(double)(progressIndex)/(double)(endIndex+1));
+			// endIndex+1 is zero for an empty range; the double division would then publish
+			// Infinity as progress, which JSON cannot represent (see ASCIIExporter.fraction).
+			exportServiceImpl.fireExportProgress(jobID, vcdID, message, ASCIIExporter.fraction(progressIndex, endIndex + 1));
 		}
 		return lastUpdateTime;
 	}


### PR DESCRIPTION
Root-cause companion to #1837, which contains the symptom. This stops the bad value being produced.

## Cause

Export progress denominators are counts that can legitimately be zero, and they are `double`s — so `x / 0.0` silently yields `Infinity` (or `NaN` when `x` is 0) instead of throwing. That value was published as export progress, reached JSON serialization, and made the event permanently undeliverable — ~4,900 error lines a minute on production until the pods were rolled.

The reachable case is `ASCIIExporter`'s `TOTAL_EXPORTS_OPS`:

```java
SIM_COUNT * PARAMSCAN_COUNT * variableNames.length
  * (geometrySpecs.getCurves().length + (getPointCount() > 0 ? 1 : 0))
```

zero for a geometry selection with **no curves and no points**, or with no variables chosen. `RasterExporter.fireThrottledProgress` divides by `endIndex+1`, zero for an empty range.

**Correction to my earlier analysis in #1837:** I first suspected `ASCIIExporter`'s per-variable loop. That is *not* reachable — both enclosing loops guarantee `variableNames.length >= 1` and `endIndex >= beginIndex`, so that denominator is always ≥ 2. The real culprit is the block above.

## Changes

- **`ASCIIExporter.fraction(completed, total)`** — returns a value in [0,1], and 0 when there is nothing to divide by. The four progress divisions use it, and a zero total is logged once with the counts that caused it, so the offending export is identifiable.
- **`RasterExporter.fireThrottledProgress`** — same helper.
- **`ClientExportEventController.fireExportProgress`** — the single place every `EXPORT_PROGRESS` event is constructed, now rejects a non-finite value as a backstop. Guarding ~15 scattered call sites individually would be easy to get wrong; this one chokepoint is provably complete.

## Verified

```
fraction(  5.0, 10.0) = 0.5   finite, in [0,1] ✓
fraction(  0.0,  0.0) = 0.0   ✓   (was NaN — no curves and no points)
fraction(  3.0,  0.0) = 0.0   ✓   (was Infinity)
fraction( -1.0, 10.0) = 0.0   ✓
fraction( 15.0, 10.0) = 1.0   ✓
fraction(  NaN, 10.0) = 0.0   ✓
```

Both edited exporters are CRLF files; line endings are preserved (diff is 45 insertions / 5 deletions, no whitespace churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg