### PR TITLE
Log "JMS transport resumed" only when a resume actually happened

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/jms/JmsFailoverWatchdog.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/JmsFailoverWatchdog.java
@@ -2,6 +2,7 @@ package cbit.vcell.message.jms;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.jms.Connection;
 
@@ -51,6 +52,9 @@ public final class JmsFailoverWatchdog {
 		if (!(connection instanceof ActiveMQConnection)) {
 			return;
 		}
+		// Scoped to this connection: attach() installs a fresh listener per connection,
+		// so this tracks only whether *this* transport was interrupted.
+		final AtomicBoolean wasInterrupted = new AtomicBoolean(false);
 		((ActiveMQConnection) connection).addTransportListener(new TransportListener() {
 			@Override
 			public void onCommand(Object command) {
@@ -62,11 +66,21 @@ public final class JmsFailoverWatchdog {
 			}
 			@Override
 			public void transportInterupted() {
+				wasInterrupted.set(true);
 				lg.warn("JMS transport interrupted, failover reconnecting");
 			}
 			@Override
 			public void transportResumed() {
-				lg.info("JMS transport resumed");
+				// The transport fires this on a first successful connect as well as after a
+				// genuine interruption, and only the latter is a "resume" worth reporting.
+				// Callers that create a connection per message (ConsumerContextJms) make the
+				// former overwhelmingly common: production logged ~3,300 of these a minute,
+				// with zero interruptions, drowning the log for no diagnostic gain.
+				if (wasInterrupted.getAndSet(false)) {
+					lg.info("JMS transport resumed");
+				} else {
+					lg.debug("JMS transport connected");
+				}
 			}
 		});
 	}

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/JmsFailoverWatchdog.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/JmsFailoverWatchdog.java
@@ -2,7 +2,6 @@ package cbit.vcell.message.jms;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.jms.Connection;
 
@@ -52,9 +51,6 @@ public final class JmsFailoverWatchdog {
 		if (!(connection instanceof ActiveMQConnection)) {
 			return;
 		}
-		// Scoped to this connection: attach() installs a fresh listener per connection,
-		// so this tracks only whether *this* transport was interrupted.
-		final AtomicBoolean wasInterrupted = new AtomicBoolean(false);
 		((ActiveMQConnection) connection).addTransportListener(new TransportListener() {
 			@Override
 			public void onCommand(Object command) {
@@ -66,21 +62,11 @@ public final class JmsFailoverWatchdog {
 			}
 			@Override
 			public void transportInterupted() {
-				wasInterrupted.set(true);
 				lg.warn("JMS transport interrupted, failover reconnecting");
 			}
 			@Override
 			public void transportResumed() {
-				// The transport fires this on a first successful connect as well as after a
-				// genuine interruption, and only the latter is a "resume" worth reporting.
-				// Callers that create a connection per message (ConsumerContextJms) make the
-				// former overwhelmingly common: production logged ~3,300 of these a minute,
-				// with zero interruptions, drowning the log for no diagnostic gain.
-				if (wasInterrupted.getAndSet(false)) {
-					lg.info("JMS transport resumed");
-				} else {
-					lg.debug("JMS transport connected");
-				}
+				lg.info("JMS transport resumed");
 			}
 		});
 	}

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.jms.Connection;
 
+import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.TransportConnector;
@@ -77,33 +78,35 @@ public class JmsFailoverWatchdogTest {
 	 */
 	@Test
 	public void transportResumed_isInfoOnlyAfterAnInterruption() throws Exception {
+		// Transport events are fired directly rather than provoked with a real broker:
+		// createConnection() can establish the transport before attach() registers the
+		// listener, so waiting for a natural connect is a race (it passed locally and
+		// failed in CI). ActiveMQConnection exposes these callbacks, so both branches
+		// are driven deterministically with no timing involved.
+		ActiveMQConnection connection =
+				(ActiveMQConnection) new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false")
+						.createConnection();
 		ListAppender captured = ListAppender.attachTo(JmsFailoverWatchdog.class);
-		BrokerService broker = new BrokerService();
-		broker.setPersistent(false);
-		broker.setUseJmx(false);
-		broker.setUseShutdownHook(false);
-		TransportConnector connector = broker.addConnector("tcp://localhost:0");
-		broker.start();
-		broker.waitUntilStarted();
-		int port = connector.getConnectUri().getPort();
-
-		String url = "failover:(tcp://localhost:" + port + ")"
-				+ "?startupMaxReconnectAttempts=-1"
-				+ "&initialReconnectDelay=50"
-				+ "&maxReconnectDelay=100";
-		Connection connection = new ActiveMQConnectionFactory(url).createConnection();
 		try {
 			JmsFailoverWatchdog.logOnly().attach(connection);
-			connection.start();   // first connect — a plain connect, not a resumption
 
-			assertTrue(captured.awaitMessage("JMS transport connected", 10, TimeUnit.SECONDS),
+			// a plain connect: not a resumption, so it must not reach INFO
+			connection.transportResumed();
+			assertTrue(captured.hasMessage("JMS transport connected"),
 					"a first connect should be reported as 'connected'");
 			assertEquals(0, captured.countAtLevel(Level.INFO),
 					"a first connect must not log at INFO — that is the per-message log flood");
+
+			// a genuine failover: interrupted then resumed, still fully visible
+			connection.transportInterupted();
+			connection.transportResumed();
+			assertEquals(1, captured.countAtLevel(Level.WARN), "interruption should log once at WARN");
+			assertEquals(1, captured.countAtLevel(Level.INFO), "a real resumption should log once at INFO");
+			assertTrue(captured.hasMessage("JMS transport resumed"),
+					"a resumption after an interruption should say 'resumed'");
 		} finally {
 			captured.detach();
 			try { connection.close(); } catch (Exception ignored) {}
-			try { broker.stop(); } catch (Exception ignored) {}
 		}
 	}
 
@@ -140,19 +143,10 @@ public class JmsFailoverWatchdogTest {
 			events.add(event.toImmutable());
 		}
 
-		boolean awaitMessage(String needle, long timeout, TimeUnit unit) throws InterruptedException {
-			long deadline = System.nanoTime() + unit.toNanos(timeout);
-			while (System.nanoTime() < deadline) {
-				synchronized (events) {
-					for (LogEvent e : events) {
-						if (e.getMessage().getFormattedMessage().contains(needle)) {
-							return true;
-						}
-					}
-				}
-				Thread.sleep(50);
+		boolean hasMessage(String needle) {
+			synchronized (events) {
+				return events.stream().anyMatch(e -> e.getMessage().getFormattedMessage().contains(needle));
 			}
-			return false;
 		}
 
 		long countAtLevel(Level level) {

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -128,13 +129,20 @@ public class JmsFailoverWatchdogTest {
 			ListAppender appender = new ListAppender(logger);
 			appender.start();
 			logger.addAppender(appender);
-			logger.setLevel(Level.DEBUG);   // so a DEBUG "connected" reaches us
+			// Configurator, not logger.setLevel(). The root level is warn (log4j2-test.xml), so
+			// the level has to be lowered for a DEBUG/INFO event to reach us at all. setLevel()
+			// on this Logger lowers it only for *this* instance, and the logger the class under
+			// test holds is a different instance of the same name (log4j creates one per message
+			// factory, and warns about exactly that mismatch here). Configurator updates the
+			// shared LoggerConfig and calls updateLoggers(), so both instances see DEBUG.
+			// The instance-local form passed locally but failed in CI's shared-JVM Fast shard.
+			Configurator.setLevel(cls.getName(), Level.DEBUG);
 			return appender;
 		}
 
 		void detach() {
 			logger.removeAppender(this);
-			logger.setLevel(previousLevel);
+			Configurator.setLevel(logger.getName(), previousLevel);
 			stop();
 		}
 

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
@@ -129,13 +129,12 @@ public class JmsFailoverWatchdogTest {
 			ListAppender appender = new ListAppender(logger);
 			appender.start();
 			logger.addAppender(appender);
-			// Configurator, not logger.setLevel(). The root level is warn (log4j2-test.xml), so
-			// the level has to be lowered for a DEBUG/INFO event to reach us at all. setLevel()
-			// on this Logger lowers it only for *this* instance, and the logger the class under
-			// test holds is a different instance of the same name (log4j creates one per message
-			// factory, and warns about exactly that mismatch here). Configurator updates the
-			// shared LoggerConfig and calls updateLoggers(), so both instances see DEBUG.
-			// The instance-local form passed locally but failed in CI's shared-JVM Fast shard.
+			// The root level is warn (log4j2-test.xml), so it has to be lowered for a DEBUG or
+			// INFO event to reach us at all. Configurator rather than logger.setLevel(): the
+			// latter lowers the level only for this Logger instance, and the class under test
+			// holds a different instance of the same name (log4j registers one per message
+			// factory and warns about that mismatch when this test runs). Configurator updates
+			// the shared LoggerConfig and calls updateLoggers(), so every instance sees DEBUG.
 			Configurator.setLevel(cls.getName(), Level.DEBUG);
 			return appender;
 		}

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
@@ -1,7 +1,11 @@
 package cbit.vcell.message.jms;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -10,6 +14,13 @@ import javax.jms.Connection;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.TransportConnector;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -53,6 +64,101 @@ public class JmsFailoverWatchdogTest {
 		} finally {
 			try { connection.close(); } catch (Exception ignored) {}
 			try { broker.stop(); } catch (Exception ignored) {}
+		}
+	}
+
+	/**
+	 * A first connect must not be reported as a "resume".
+	 *
+	 * <p>Callers that create a connection per message (ConsumerContextJms) fire
+	 * transportResumed once per connection; production logged ~3,300 of those a minute
+	 * at INFO with zero interruptions, which buried everything else. "Resumed" is only
+	 * meaningful after an interruption, so a plain connect is logged at DEBUG.
+	 */
+	@Test
+	public void transportResumed_isInfoOnlyAfterAnInterruption() throws Exception {
+		ListAppender captured = ListAppender.attachTo(JmsFailoverWatchdog.class);
+		BrokerService broker = new BrokerService();
+		broker.setPersistent(false);
+		broker.setUseJmx(false);
+		broker.setUseShutdownHook(false);
+		TransportConnector connector = broker.addConnector("tcp://localhost:0");
+		broker.start();
+		broker.waitUntilStarted();
+		int port = connector.getConnectUri().getPort();
+
+		String url = "failover:(tcp://localhost:" + port + ")"
+				+ "?startupMaxReconnectAttempts=-1"
+				+ "&initialReconnectDelay=50"
+				+ "&maxReconnectDelay=100";
+		Connection connection = new ActiveMQConnectionFactory(url).createConnection();
+		try {
+			JmsFailoverWatchdog.logOnly().attach(connection);
+			connection.start();   // first connect — a plain connect, not a resumption
+
+			assertTrue(captured.awaitMessage("JMS transport connected", 10, TimeUnit.SECONDS),
+					"a first connect should be reported as 'connected'");
+			assertEquals(0, captured.countAtLevel(Level.INFO),
+					"a first connect must not log at INFO — that is the per-message log flood");
+		} finally {
+			captured.detach();
+			try { connection.close(); } catch (Exception ignored) {}
+			try { broker.stop(); } catch (Exception ignored) {}
+		}
+	}
+
+	/** Captures events from one logger so a test can assert on level and message. */
+	private static final class ListAppender extends AbstractAppender {
+		private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+		private final Logger logger;
+		private final Level previousLevel;
+
+		private ListAppender(Logger logger) {
+			super("watchdog-test-capture", null, null, true, Property.EMPTY_ARRAY);
+			this.logger = logger;
+			this.previousLevel = logger.getLevel();
+		}
+
+		static ListAppender attachTo(Class<?> cls) {
+			LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+			Logger logger = ctx.getLogger(cls.getName());
+			ListAppender appender = new ListAppender(logger);
+			appender.start();
+			logger.addAppender(appender);
+			logger.setLevel(Level.DEBUG);   // so a DEBUG "connected" reaches us
+			return appender;
+		}
+
+		void detach() {
+			logger.removeAppender(this);
+			logger.setLevel(previousLevel);
+			stop();
+		}
+
+		@Override
+		public void append(LogEvent event) {
+			events.add(event.toImmutable());
+		}
+
+		boolean awaitMessage(String needle, long timeout, TimeUnit unit) throws InterruptedException {
+			long deadline = System.nanoTime() + unit.toNanos(timeout);
+			while (System.nanoTime() < deadline) {
+				synchronized (events) {
+					for (LogEvent e : events) {
+						if (e.getMessage().getFormattedMessage().contains(needle)) {
+							return true;
+						}
+					}
+				}
+				Thread.sleep(50);
+			}
+			return false;
+		}
+
+		long countAtLevel(Level level) {
+			synchronized (events) {
+				return events.stream().filter(e -> e.getLevel() == level).count();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Third item from the prod log review (after #1838 and #1837). Pure log-noise reduction, but it is what made the incident hard to read.

## Problem

`transportResumed()` fires on a **first successful connect** as well as after a genuine interruption, and the watchdog logged both at INFO. Because `ConsumerContextJms` creates a JMS connection (plus a temporary queue) **per message**, the first case dominates. Measured in one 60-second window on prod `api`:

| Event | Count |
|---|---|
| `JMS transport resumed` | **3,302** |
| `JMS transport interrupted` | **0** |

Zero interruptions — so every one of those 3,302 INFO lines was a plain connect being reported as a resumption. That is ~3,300 lines/minute of pure noise, and it buried everything else in the container exactly when the log was needed.

## Change

"Resumed" only means something after an interruption, so track that per connection (`attach()` installs a fresh listener for each, so the flag is correctly scoped) and log a plain first connect at DEBUG. A real failover still logs WARN then INFO, unchanged.

## Test

`transportResumed_isInfoOnlyAfterAnInterruption` asserts a first connect reports "connected" and produces **zero** INFO events, using a small log-capturing appender.

**Verified as a real pin, not a passing test:** against master's watchdog it fails —

```
JmsFailoverWatchdogTest.transportResumed_isInfoOnlyAfterAnInterruption:99
  a first connect should be reported as 'connected' ==> expected: <true> but was: <false>
```

— and passes with this change. The existing failover test still passes (2 run, 0 failures).

## Related

The underlying cost is the **per-message connection** in `ConsumerContextJms`; this only stops it shouting. That is tracked separately as a design item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg