### PR TITLE
Give each application a unique SED-ML id when names collide

### DIFF
--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -97,6 +97,10 @@ public class SEDMLExporter {
     private int simCount;
     private int overrideCount;
 
+    /** Application to the SED-ML id it was exported under; see {@link #getSimContextId}. */
+    private final Map<SimulationContext, String> simContextIdMap = new LinkedHashMap<>();
+    private final Set<String> usedSimContextIds = new LinkedHashSet<>();
+
     private final SBMLSupport sbmlSupport = new SBMLSupport();
 
 
@@ -274,9 +278,34 @@ public class SEDMLExporter {
         }
     }
 
+    /**
+     * The SED-ML id for an application, unique across the exported document.
+     * <p>
+     * {@link TokenMangler#mangleToSName} replaces every non-alphanumeric character with an
+     * underscore, so it is many-to-one: applications named {@code +sorafenib} and {@code -sorafenib}
+     * both mangle to {@code _sorafenib}. Both the model id and the SBML file name are derived from
+     * it, so without disambiguation the second application overwrites the first application's SBML
+     * file and re-uses its model id — leaving that application's data generators pointing at another
+     * application's parameters, and silently shipping the wrong model in the archive.
+     * <p>
+     * The suffix is {@code _app<n>} rather than {@code _<n>} to stay clear of the ids given to
+     * override-derived models, which are {@code <simContextId>_<overrideCount>}.
+     */
+    private String getSimContextId(SimulationContext simContext) {
+        return this.simContextIdMap.computeIfAbsent(simContext, sc -> {
+            String base = TokenMangler.mangleToSName(sc.getName());
+            String candidate = base;
+            int collisionCount = 0;
+            while (!this.usedSimContextIds.add(candidate)) {
+                candidate = base + "_app" + collisionCount++;
+            }
+            return candidate;
+        });
+    }
+
     private void writeModelVCML(String filePathStrRelative, SimulationContext simContext) {
         String simContextName = simContext.getName();
-        String simContextId = TokenMangler.mangleToSName(simContextName);
+        String simContextId = getSimContextId(simContext);
         this.sedmlModel.getSedML().addModel(new Model(new SId(simContextId), simContextName, this.vcmlLanguageURN, filePathStrRelative + "#" + VCMLSupport.getXPathForSimContext(simContextName)));
     }
 
@@ -286,7 +315,7 @@ public class SEDMLExporter {
         // create sedml objects (simulation, task, datagenerators, report, plot) for each simulation in simcontext
         // -------
         String simContextName = simContext.getName();
-        String simContextId = TokenMangler.mangleToSName(simContextName);
+        String simContextId = getSimContextId(simContext);
         this.simCount = 0;
         this.overrideCount = 0;
         simContext.getSimulations();
@@ -1026,7 +1055,7 @@ public class SEDMLExporter {
 
     private void writeModelSBML(String savePath, String sBaseFileName, String sbmlString, SimulationContext simContext) throws IOException {
         String simContextName = simContext.getName();
-        String simContextId = TokenMangler.mangleToSName(simContextName);
+        String simContextId = getSimContextId(simContext);
         String filePathStrAbsolute = Paths.get(savePath, sBaseFileName + "_" + simContextId + ".xml").toString();
         String filePathStrRelative = sBaseFileName + "_" + simContextId + ".xml";
         XmlUtil.writeXMLStringToFile(sbmlString, filePathStrAbsolute, true);

--- a/vcell-core/src/test/java/org/vcell/sbml/SEDMLExporterSBMLTest.java
+++ b/vcell-core/src/test/java/org/vcell/sbml/SEDMLExporterSBMLTest.java
@@ -79,7 +79,6 @@ public class SEDMLExporterSBMLTest extends SEDMLExporterCommon {
 		faults.put("biomodel_123465505.vcml", SEDML_FAULT.NO_MODELS_IN_OMEX);
 		faults.put("biomodel_124562627.vcml", SEDML_FAULT.NO_MODELS_IN_OMEX);
 		faults.put("biomodel_12522025.vcml", SEDML_FAULT.MATH_OVERRIDE_NAMES_DIFFERENT);  // simulation 'Simulation 1' in simContext 'purkinje9-ss'
-		faults.put("biomodel_13717231.vcml", SEDML_FAULT.SIMCONTEXT_NOT_FOUND_BY_NAME);  // round-tripped simulationContext not found with name 'double -'
 		faults.put("biomodel_13736736.vcml", SEDML_FAULT.NO_MODELS_IN_OMEX);
 		faults.put("biomodel_145545992.vcml", SEDML_FAULT.NO_MODELS_IN_OMEX);
 		faults.put("biomodel_148700996.vcml", SEDML_FAULT.MATH_OVERRIDE_NAMES_DIFFERENT); // simulation 'Full sim' in simContext 'Fast B Compartmental'


### PR DESCRIPTION
## The bug

`TokenMangler.mangleToSName` replaces every non-alphanumeric character with an
underscore, so it is many-to-one. `SEDMLExporter` derived **both** the SED-ML
model id **and** the SBML file name from it, with no uniqueness check:

```java
String simContextId = TokenMangler.mangleToSName(simContextName);
String filePathStrAbsolute = Paths.get(savePath, sBaseFileName + "_" + simContextId + ".xml")...
XmlUtil.writeXMLStringToFile(sbmlString, filePathStrAbsolute, true);      // second app OVERWRITES the first
sedmlModel.getSedML().addModel(new Model(new SId(simContextId), ...));   // and re-uses its model id
```

Two applications whose names differ only in punctuation therefore collapse onto
one file and one model id.

`biomodel_147699816` has applications **`+sorafenib`** and **`-sorafenib`**, both
mangling to `_sorafenib`. The archive shipped `+sorafenib`'s SBML under the id
`-sorafenib`'s tasks referenced, so those tasks' data generators pointed at output
functions that exist only in `-sorafenib`:

```
XPath /sbml:sbml/sbml:model/sbml:listOfParameters/sbml:parameter[@id='bounBRaf_frac']
  does not match any elements of model `_sorafenib`
```

**This is a data-correctness bug, not just a test failure.** The exported archive
contained the wrong model for one application. Outside the test suite nothing
would flag it — the file is well-formed, just not the model you asked for.

## Fix

Compute the id once per application and reuse it for the file name, the model id
and the tasks' `modelReference`, disambiguating collisions with an `_app<n>`
suffix.

The suffix deliberately avoids `_<n>`, which is already how override-derived
models are named (`<simContextId>_<overrideCount>`). The two schemes now nest
correctly:

| SED-ML model | application | source |
|---|---|---|
| `_sorafenib` | `-sorafenib` | `…__sorafenib.xml` |
| `_sorafenib_0` | `-sorafenib modified` | `#_sorafenib` |
| `_sorafenib_app0` | `+sorafenib` | `…__sorafenib_app0.xml` |
| `_sorafenib_app0_0` | `+sorafenib modified` | `#_sorafenib_app0` |

Each application now gets its own file with its own output functions
(`bounBRaf_frac`/`Raf1_tot` vs `boundBRaf_frac`).

## Also removes a known fault this fixes

`biomodel_13717231` was registered as `SIMCONTEXT_NOT_FOUND_BY_NAME`. That model
has applications **`double +`** and **`double -`** — the same collision — and the
entry's own comment recorded the symptom:

```java
// round-tripped simulationContext not found with name 'double -'
```

It round-trips now, so leaving the entry made the test fail for *passing*. Found
by a regression run rather than by looking for it — independent evidence that the
collision affects more than one model in the suite.

## Verification

A fix like this surfaces as a **failure**: any model whose `knownSEDMLFault` it
resolves starts failing with "passed SEDML Round trip, but knownSEDMLFault was
set". So the whole group was run, slow models included, to find any others.

**Full `SEDML_SBML_IT` with `-Dtest.include.slow=true`** — 264 tests, 4 failures,
all accounted for and none caused by this change:

| model | failure | owner |
|---|---|---|
| `biomodel_34826524` | fail-for-passing, stale fault | #1835 (not on this branch) |
| `biomodel_188880263` | undeclared unsupported applications | #1835 (not on this branch) |
| `biomodel_59361239` | OMEX — `initialAssignment` defect | unfixed, separate bug |
| `biomodel_28625786` | OMEX — duplicate SED-ML id | unfixed, separate bug |

`biomodel_147699816` passes as part of the group, and **no new fail-for-passing
appeared among the slow models** — so this change resolves no other registered
fault beyond `biomodel_13717231`.

Also run: the non-slow group alone is **245/245**. (An earlier revision of this
description quoted only that number. It was misleading: the non-slow set excludes
the ~20 slow models, including `biomodel_147699816` itself, which had only been
verified in isolation.)

I also unpacked the archive for `biomodel_147699816` and confirmed each
application now has its own file carrying its own output functions.

Note PR CI cannot exercise any of this — `SEDML_SBML_IT` runs only in
`regression.yml`, and these models are additionally behind `test.include.slow`.
The runs above are the evidence. The full slow run takes ~2h single-threaded,
which is why CI shards it across six runners.

## Not included

The two remaining OMEX failures are unrelated to id collisions and want separate
changes:

- `biomodel_59361239` — SED-ML targets `@initialConcentration` on species whose
  initial value the SBML exporter wrote as an `initialAssignment` instead
  (verified 17/17 across four models)
- `biomodel_28625786` — duplicate SED-ML id, not yet diagnosed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvqmME7MkRUNEYje5HpiLt