### PR TITLE
Add -Dtest.only to narrow the long sharded test suites

### DIFF
--- a/vcell-core/src/test/java/org/vcell/test/TestShard.java
+++ b/vcell-core/src/test/java/org/vcell/test/TestShard.java
@@ -32,7 +32,54 @@ public final class TestShard {
 	 */
 	public static final String INCLUDE_SLOW_PROPERTY = "test.include.slow";
 
+	/**
+	 * Narrow a sharded test to the cases whose name contains any of a comma-separated list of
+	 * substrings, e.g. {@code -Dtest.only=biomodel_59361239}.
+	 * <p>
+	 * These suites iterate hundreds of models and take hours; reproducing one reported failure
+	 * otherwise means running the lot, or hand-editing the parameter source — which is what the
+	 * commented-out {@code return Arrays.asList("biomodel_12522025.vcml:purkinje9")} lines in
+	 * MathGenCompareTest and MathOverrideApplyTest were for.
+	 * <p>
+	 * Matching is a plain substring test against each case's string form, so it works both for
+	 * suites whose cases are filenames ({@code biomodel_123.vcml:appName}) and for those whose
+	 * cases are objects naming a file.
+	 */
+	public static final String ONLY_PROPERTY = "test.only";
+
 	private TestShard() {
+	}
+
+	/**
+	 * Apply {@link #ONLY_PROPERTY}, if set.
+	 * <p>
+	 * A pattern matching nothing is an error rather than an empty run: surefire reports "Tests run:
+	 * 0" as BUILD SUCCESS, so a typo would otherwise look like a pass.
+	 */
+	private static <T> List<T> applyOnlyFilter(List<T> all) {
+		final String only = System.getProperty(ONLY_PROPERTY);
+		if (only == null || only.isBlank()) {
+			return all;
+		}
+		final List<String> patterns = new ArrayList<>();
+		for (String pattern : only.split(",")) {
+			if (!pattern.isBlank()) {
+				patterns.add(pattern.trim());
+			}
+		}
+		final List<T> kept = new ArrayList<>();
+		for (T t : all) {
+			final String name = String.valueOf(t);
+			if (patterns.stream().anyMatch(name::contains)) {
+				kept.add(t);
+			}
+		}
+		if (kept.isEmpty()) {
+			throw new IllegalArgumentException(ONLY_PROPERTY + "=" + only + " matched none of the "
+					+ all.size() + " cases this test would otherwise run. Note that cases excluded as"
+					+ " slow stay excluded - add -D" + INCLUDE_SLOW_PROPERTY + "=true to reach those.");
+		}
+		return kept;
 	}
 
 	/**
@@ -40,10 +87,12 @@ public final class TestShard {
 	 * @return the subset belonging to this shard (all of them if unsharded)
 	 */
 	public static <T> List<T> shard(Iterable<T> all) {
-		final List<T> list = new ArrayList<>();
+		final List<T> everything = new ArrayList<>();
 		for (T t : all) {
-			list.add(t);
+			everything.add(t);
 		}
+		// narrow before sharding, so -Dtest.only picks up its matches whichever shard they land in
+		final List<T> list = applyOnlyFilter(everything);
 		final int count = Integer.getInteger(SHARD_COUNT_PROPERTY, 1);
 		final int index = Integer.getInteger(SHARD_INDEX_PROPERTY, 0);
 		if (count <= 1) {

--- a/vcell-core/src/test/java/org/vcell/test/TestShardOnlyFilterTest.java
+++ b/vcell-core/src/test/java/org/vcell/test/TestShardOnlyFilterTest.java
@@ -1,0 +1,89 @@
+package org.vcell.test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** {@link TestShard#ONLY_PROPERTY}, which narrows a long sharded suite to named cases. */
+@Tag("Fast")
+public class TestShardOnlyFilterTest {
+
+	private static final List<String> CASES = List.of(
+			"biomodel_59361239.vcml:full_model",
+			"biomodel_59361239.vcml:receptor_density",
+			"biomodel_147699816.vcml:-sorafenib",
+			"biomodel_28625786.vcml:simple_1");
+
+	@AfterEach
+	public void clearProperties() {
+		System.clearProperty(TestShard.ONLY_PROPERTY);
+		System.clearProperty(TestShard.SHARD_COUNT_PROPERTY);
+		System.clearProperty(TestShard.SHARD_INDEX_PROPERTY);
+	}
+
+	@Test
+	public void unsetPropertyRunsEverything() {
+		assertEquals(CASES, TestShard.shard(CASES));
+	}
+
+	@Test
+	public void blankPropertyRunsEverything() {
+		System.setProperty(TestShard.ONLY_PROPERTY, "   ");
+		assertEquals(CASES, TestShard.shard(CASES));
+	}
+
+	@Test
+	public void selectsBySubstring() {
+		System.setProperty(TestShard.ONLY_PROPERTY, "biomodel_59361239");
+		assertEquals(List.of("biomodel_59361239.vcml:full_model", "biomodel_59361239.vcml:receptor_density"),
+				TestShard.shard(CASES));
+	}
+
+	@Test
+	public void selectsASingleApplication() {
+		System.setProperty(TestShard.ONLY_PROPERTY, "biomodel_59361239.vcml:receptor_density");
+		assertEquals(List.of("biomodel_59361239.vcml:receptor_density"), TestShard.shard(CASES));
+	}
+
+	@Test
+	public void acceptsACommaSeparatedList() {
+		System.setProperty(TestShard.ONLY_PROPERTY, "biomodel_147699816, biomodel_28625786");
+		assertEquals(List.of("biomodel_147699816.vcml:-sorafenib", "biomodel_28625786.vcml:simple_1"),
+				TestShard.shard(CASES));
+	}
+
+	/**
+	 * The point of failing loudly: surefire reports a zero-test run as BUILD SUCCESS, so a typo in
+	 * the pattern would otherwise look like everything passed.
+	 */
+	@Test
+	public void aPatternMatchingNothingIsAnError() {
+		System.setProperty(TestShard.ONLY_PROPERTY, "biomodel_does_not_exist");
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> TestShard.shard(CASES));
+		assertTrue(e.getMessage().contains(TestShard.INCLUDE_SLOW_PROPERTY),
+				"should point at the usual cause - the case is excluded as slow: " + e.getMessage());
+	}
+
+	/** Narrowing happens before sharding, so a selected case is not then sharded away. */
+	@Test
+	public void selectionIsNotLostToSharding() {
+		System.setProperty(TestShard.ONLY_PROPERTY, "biomodel_28625786");
+		System.setProperty(TestShard.SHARD_COUNT_PROPERTY, "4");
+		System.setProperty(TestShard.SHARD_INDEX_PROPERTY, "0");
+		assertEquals(List.of("biomodel_28625786.vcml:simple_1"), TestShard.shard(CASES));
+	}
+
+	@Test
+	public void shardingStillWorksWithoutTheFilter() {
+		System.setProperty(TestShard.SHARD_COUNT_PROPERTY, "2");
+		System.setProperty(TestShard.SHARD_INDEX_PROPERTY, "1");
+		assertEquals(List.of("biomodel_59361239.vcml:receptor_density", "biomodel_28625786.vcml:simple_1"),
+				TestShard.shard(CASES));
+	}
+}


### PR DESCRIPTION
## Why

The SEDML and MathGen suites iterate hundreds of models. Reproducing one reported
failure means running the lot — `SEDML_SBML_IT` with slow cases included takes
**just over 2 hours** single-threaded — or hand-editing the parameter source.
Two suites still carry the commented-out remnants of people doing the latter:

```java
//  return Arrays.asList("biomodel_12522025.vcml:purkinje9");          // MathGenCompareTest
//  return Arrays.asList("biomodel_34826524.vcml:NWasp Activation Cap=2");  // MathOverrideApplyTest
```

## What

`-Dtest.only=<substring>[,<substring>…]` keeps only cases whose name contains one
of the substrings:

```bash
mvn test -pl vcell-core -Dgroups=SEDML_SBML_IT -Dtest.include.slow=true \
    -Dtest.only=biomodel_147699816
```

**1 case in 20s, instead of 264 in 2 hours.**

Applied inside `TestShard.shard`, so all four sharded suites get it with no
per-suite wiring — `SEDMLExporterSBMLTest`, `SEDMLExporterVCMLTest`,
`MathGenCompareTest`, `MathOverrideApplyTest`. Matching is a plain substring test
against each case's string form, which covers both the suites whose cases are
`file.vcml:appName` strings and those whose cases are objects naming a file.
Narrowing happens *before* sharding, so a selected case is not then sharded away.

## A pattern matching nothing is an error

Surefire reports a zero-test run as **BUILD SUCCESS**, so a typo would otherwise
look like a pass. I hit exactly that trap trying to select a parameterized case
with `-Dtest=SEDMLExporterSBMLTest#test_sedml_roundtrip_SBML[*59361239*]`, which
silently matched nothing and reported success.

The message also names the usual cause, since "excluded as slow" is easy to miss:

```
test.only=biomodel_59361239 matched none of the 245 cases this test would
otherwise run. Note that cases excluded as slow stay excluded - add
-Dtest.include.slow=true to reach those.
```

## Testing

`TestShardOnlyFilterTest`, 8 cases: unset and blank run everything, substring and
exact-case selection, comma-separated lists, the no-match error (asserting it
mentions the slow flag), selection surviving sharding, and sharding still working
untouched when the filter is unset.

Verified against the real suite too — the two runs quoted above are actual output.

No behaviour change when `test.only` is unset, which is every CI invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvqmME7MkRUNEYje5HpiLt