### PR TITLE
Open a producer session's JMS connection on first use, not per message

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
@@ -38,7 +38,6 @@ import cbit.vcell.mongodb.VCMongoDbDriver;
 import cbit.vcell.resource.PropertyLoader;
 
 public class MessageProducerSessionJms implements VCMessageSession {
-    //		private static int tmpQCnt = 0;
     private VCMessagingServiceJms vcMessagingServiceJms = null;
     private TemporaryQueue commonTemporaryQueue = null;
     private Connection connection = null;
@@ -47,21 +46,79 @@ public class MessageProducerSessionJms implements VCMessageSession {
     private static Logger lg = LogManager.getLogger(MessageProducerSessionJms.class);
 
     public MessageProducerSessionJms(VCMessagingServiceJms vcMessagingServiceJms) throws JMSException, VCMessagingException{
-//			lg.info("-----\nmpjms MessageProducerSessionJms(VCMessagingServiceJms vcMessagingServiceJms)\ntmpQCnt="+(++tmpQCnt)+"----------");
-//			Thread.dumpStack();
         this.vcMessagingServiceJms = vcMessagingServiceJms;
-        this.connection = vcMessagingServiceJms.createConnectionFactory().createConnection();
-        vcMessagingServiceJms.getFailoverWatchdog().attach(this.connection);
-        this.connection.setExceptionListener(new ExceptionListener() {
+        this.bIndependent = true;
+    }
+
+    /**
+     * Opens the connection and session on first use rather than in the constructor.
+     *
+     * ConsumerContextJms builds one of these for every message it receives and hands it to
+     * the listener, but most listeners never send anything through it: the pooled consumers
+     * (SimDataServer, DatabaseServer, HtcSimulationWorker) substitute their own shared
+     * session, and the client-status topic listener ignores the argument altogether. Opening
+     * eagerly therefore cost a connection per message for consumers that had no use for one,
+     * which is what turned a redelivery loop in production into ~3,300 connections a minute.
+     * Deferring means those paths pay nothing, while the paths that do send (the dispatcher's
+     * worker-event and sim-request handlers) behave exactly as before.
+     */
+    private synchronized Session getSession() throws JMSException{
+        if(session == null){
+            Connection newConnection = createConnection();
+            try {
+                newConnection.start();
+                boolean bTransacted = true;
+                this.session = newConnection.createSession(bTransacted, Session.AUTO_ACKNOWLEDGE);
+                this.connection = newConnection;
+            } catch(JMSException e){
+                try {
+                    newConnection.close();
+                } catch(JMSException ignored){
+                }
+                throw e;
+            }
+        }
+        return session;
+    }
+
+    /**
+     * Opens the connection now instead of on first use. Long-lived sessions handed out by
+     * {@link VCMessagingServiceJms#createProducerSession()} are opened at server startup and
+     * are always used, so they open eagerly and a broker problem still surfaces there rather
+     * than at the first send.
+     */
+    void open() throws JMSException{
+        getSession();
+    }
+
+    private Connection createConnection() throws JMSException{
+        Connection newConnection;
+        try {
+            newConnection = vcMessagingServiceJms.createConnectionFactory().createConnection();
+        } catch(VCMessagingException e){
+            // callers of getSession() can only propagate JMSException
+            JMSException jmsException = new JMSException("unable to create JMS connection: " + e.getMessage());
+            jmsException.initCause(e);
+            throw jmsException;
+        }
+        vcMessagingServiceJms.getFailoverWatchdog().attach(newConnection);
+        newConnection.setExceptionListener(new ExceptionListener() {
             public void onException(JMSException arg0){
                 MessageProducerSessionJms.this.onException(arg0);
             }
         });
-        this.connection.start();
-        boolean bTransacted = true;
-        this.session = connection.createSession(bTransacted, Session.AUTO_ACKNOWLEDGE);
-        this.commonTemporaryQueue = session.createTemporaryQueue();
-        this.bIndependent = true;
+        return newConnection;
+    }
+
+    /**
+     * The temporary queue is a reply destination for sendRpcMessage and nothing else, so it
+     * is created with the first RPC rather than alongside the session.
+     */
+    private synchronized TemporaryQueue getReplyQueue() throws JMSException{
+        if(commonTemporaryQueue == null){
+            commonTemporaryQueue = getSession().createTemporaryQueue();
+        }
+        return commonTemporaryQueue;
     }
 
 //		public MessageProducerSessionJms(Session session, VCMessagingServiceJms vcMessagingServiceJms) {
@@ -79,8 +136,9 @@ public class MessageProducerSessionJms implements VCMessageSession {
             if(!bIndependent){
                 throw new VCMessagingException("cannot invoke RpcMessage from within another transaction, create an independent message producer");
             }
-            Destination destination = session.createQueue(queue.getName());
-            messageProducer = session.createProducer(destination);
+            Session jmsSession = getSession();
+            Destination destination = jmsSession.createQueue(queue.getName());
+            messageProducer = jmsSession.createProducer(destination);
 
             //
             // use MessageProducerSessionJms to create the rpcRequest message (allows "Blob" messages to be formed as needed).
@@ -100,10 +158,10 @@ public class MessageProducerSessionJms implements VCMessageSession {
             }
 
             if(returnRequired){
-                rpcMessage.setJMSReplyTo(commonTemporaryQueue);
+                rpcMessage.setJMSReplyTo(getReplyQueue());
                 messageProducer.setTimeToLive(timeoutMS);
                 messageProducer.send(rpcMessage);
-                session.commit();
+                jmsSession.commit();
                 vcMessagingServiceJms.getDelegate().onRpcRequestSent(vcRpcRequest, userLoginInfo, vcRpcRequestMessage);
                 if(lg.isTraceEnabled())
                     lg.trace("MessageProducerSessionJms.sendRpcMessage(): looking for reply message with correlationID = " + rpcMessage.getJMSMessageID());
@@ -111,7 +169,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                 MessageConsumer replyConsumer = null;
                 Message replyMessage = null;
                 try {
-                    replyConsumer = session.createConsumer(commonTemporaryQueue, filter);
+                    replyConsumer = jmsSession.createConsumer(getReplyQueue(), filter);
                     replyMessage = replyConsumer.receive(timeoutMS);
                 } finally {
                     replyConsumer.close();
@@ -135,7 +193,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                     }
                 }
             } else {
-                rpcMessage.setJMSReplyTo(commonTemporaryQueue);
+                rpcMessage.setJMSReplyTo(getReplyQueue());
                 messageProducer.setTimeToLive(timeoutMS);
                 messageProducer.send(rpcMessage);
                 commit();
@@ -167,8 +225,9 @@ public class MessageProducerSessionJms implements VCMessageSession {
         if(message instanceof VCMessageJms){
             MessageProducer messageProducer = null;
             try {
-                Destination destination = session.createQueue(queue.getName());
-                messageProducer = session.createProducer(destination);
+                Session jmsSession = getSession();
+                Destination destination = jmsSession.createQueue(queue.getName());
+                messageProducer = jmsSession.createProducer(destination);
                 if(persistent == null || persistent.booleanValue()){
                     messageProducer.setDeliveryMode(DeliveryMode.PERSISTENT);
                 } else {
@@ -179,7 +238,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                 }
                 messageProducer.send(((VCMessageJms) message).getJmsMessage());
                 if(bIndependent){
-                    session.commit();
+                    jmsSession.commit();
                 }
                 vcMessagingServiceJms.getDelegate().onMessageSent(message, queue);
             } catch(JMSException e){
@@ -206,10 +265,11 @@ public class MessageProducerSessionJms implements VCMessageSession {
         if(message instanceof VCMessageJms){
             VCMessageJms jmsMessage = (VCMessageJms) message;
             try {
-                MessageProducer producer = session.createProducer(session.createTopic(topic.getName()));
+                Session jmsSession = getSession();
+                MessageProducer producer = jmsSession.createProducer(jmsSession.createTopic(topic.getName()));
                 producer.send(jmsMessage.getJmsMessage());
                 if(bIndependent){
-                    session.commit();
+                    jmsSession.commit();
                 }
                 vcMessagingServiceJms.getDelegate().onMessageSent(message, topic);
             } catch(JMSException e){
@@ -220,7 +280,10 @@ public class MessageProducerSessionJms implements VCMessageSession {
         }
     }
 
-    public void rollback(){
+    public synchronized void rollback(){
+        if(session == null){
+            return;   // never opened, so there is nothing to roll back
+        }
         try {
             session.rollback();
         } catch(JMSException e){
@@ -228,7 +291,10 @@ public class MessageProducerSessionJms implements VCMessageSession {
         }
     }
 
-    public void commit(){
+    public synchronized void commit(){
+        if(session == null){
+            return;   // never opened, so there is nothing to commit
+        }
         try {
             session.commit();
         } catch(JMSException e){
@@ -238,7 +304,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
 
     public VCMessage createTextMessage(String text){
         try {
-            Message jmsMessage = session.createTextMessage(text);
+            Message jmsMessage = getSession().createTextMessage(text);
             return new VCMessageJms(jmsMessage, vcMessagingServiceJms.getDelegate());
         } catch(JMSException e){
             onException(e);
@@ -278,7 +344,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                     channel.close();
                     fileOutputStream.close();
 
-                    ObjectMessage objectMessage = session.createObjectMessage("emptyObject");
+                    ObjectMessage objectMessage = getSession().createObjectMessage("emptyObject");
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_PERSISTENCE_TYPE, VCMessageJms.BLOB_MESSAGE_PERSISTENCE_TYPE_FILE);
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_PRODUCER_TEMPDIR, tempdir.getAbsolutePath());
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_FILE_NAME, blobFile.getName());
@@ -289,7 +355,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                 } else {
                     String hexString = Long.toHexString(Math.abs(new Random().nextLong()));
                     ObjectId objectId = VCMongoDbDriver.getInstance().storeBLOB("jmsblob_name_" + hexString, "jmsblob", serializedBytes);
-                    ObjectMessage objectMessage = session.createObjectMessage("emptyObject");
+                    ObjectMessage objectMessage = getSession().createObjectMessage("emptyObject");
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_PERSISTENCE_TYPE, VCMessageJms.BLOB_MESSAGE_PERSISTENCE_TYPE_MONGODB);
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_MONGODB_OBJECTID, objectId.toHexString());
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_OBJECT_TYPE, object.getClass().getName());
@@ -298,7 +364,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                     return new VCMessageJms(objectMessage, object, vcMessagingServiceJms.getDelegate());
                 }
             } else {
-                ObjectMessage objectMessage = (ObjectMessage) session.createObjectMessage(object);
+                ObjectMessage objectMessage = (ObjectMessage) getSession().createObjectMessage(object);
                 int size = (serializedBytes != null) ? (serializedBytes.length) : (0);
                 String objectType = (serializedBytes != null) ? (object.getClass().getName()) : ("NULL");
                 vcMessagingServiceJms.getDelegate().onTraceEvent("MessageProducerSessionJms.createObjectMessage: (NOBLOB) size=" + size + ", type=" + objectType + ", elapsedTime = " + (System.currentTimeMillis() - t1) + " ms");
@@ -315,7 +381,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
 
     public VCMessage createMessage(){
         try {
-            Message jmsMessage = session.createMessage();
+            Message jmsMessage = getSession().createMessage();
             return new VCMessageJms(jmsMessage, vcMessagingServiceJms.getDelegate());
         } catch(JMSException e){
             onException(e);
@@ -331,13 +397,9 @@ public class MessageProducerSessionJms implements VCMessageSession {
         lg.error(e);
     }
 
-    public void close(){
+    public synchronized void close(){
+        // a session that was never opened has nothing to close -- see getSession()
         try {
-//				lg.info("---------------\nmpjms close()\ntmpQCnt="+(--tmpQCnt)+"--------------------");
-//				Thread.dumpStack();
-////				if(msgProducers.size() > 0){
-//					Thread.dumpStack();
-//				}
             if(session != null){
                 session.close();
             }

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
@@ -111,6 +111,24 @@ public class MessageProducerSessionJms implements VCMessageSession {
     }
 
     /**
+     * Opens the session for a send, failing loudly if it cannot be opened.
+     *
+     * The send methods deliberately swallow a JMSException from send() itself, but failing
+     * to open the connection is not that: before the connection was deferred it happened in
+     * the constructor, so ConsumerContextJms saw it before the listener ran and left the
+     * incoming message uncommitted for redelivery. Throwing here keeps that -- otherwise a
+     * listener would be told its send succeeded and the inbound message would be committed.
+     */
+    private Session openSessionForSend() throws VCMessagingException{
+        try {
+            return getSession();
+        } catch(JMSException e){
+            onException(e);
+            throw new VCMessagingException("unable to open JMS session: " + e.getMessage(), e);
+        }
+    }
+
+    /**
      * The temporary queue is a reply destination for sendRpcMessage and nothing else, so it
      * is created with the first RPC rather than alongside the session.
      */
@@ -223,9 +241,9 @@ public class MessageProducerSessionJms implements VCMessageSession {
     @Override
     public void sendQueueMessage(VCellQueue queue, VCMessage message, Boolean persistent, Long timeToLiveMS) throws VCMessagingException{
         if(message instanceof VCMessageJms){
+            Session jmsSession = openSessionForSend();
             MessageProducer messageProducer = null;
             try {
-                Session jmsSession = getSession();
                 Destination destination = jmsSession.createQueue(queue.getName());
                 messageProducer = jmsSession.createProducer(destination);
                 if(persistent == null || persistent.booleanValue()){
@@ -264,8 +282,8 @@ public class MessageProducerSessionJms implements VCMessageSession {
     public void sendTopicMessage(VCellTopic topic, VCMessage message) throws VCMessagingException{
         if(message instanceof VCMessageJms){
             VCMessageJms jmsMessage = (VCMessageJms) message;
+            Session jmsSession = openSessionForSend();
             try {
-                Session jmsSession = getSession();
                 MessageProducer producer = jmsSession.createProducer(jmsSession.createTopic(topic.getName()));
                 producer.send(jmsMessage.getJmsMessage());
                 if(bIndependent){

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/VCMessagingServiceJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/VCMessagingServiceJms.java
@@ -122,6 +122,7 @@ public abstract class VCMessagingServiceJms implements VCMessagingService {
 					super.close();
 				}
 			};
+			messageProducerSession.open();
 			messagingProducerSessions.add(messageProducerSession);
 			return messageProducerSession;
 		} catch (JMSException | VCMessagingException e) {

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -132,8 +132,9 @@ public class MessageProducerSessionJmsTest {
 			assertEquals(afterSetup, service.connectionsOpened.get(),
 					"a listener that never sends must not cost a connection per message");
 		} finally {
+			// the consumer is left registered so service.close() shuts it down and closes its
+			// connection; removeMessageConsumer only stops the thread and leaks the connection
 			producerSession.close();
-			service.removeMessageConsumer(consumer);
 		}
 	}
 

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -1,0 +1,184 @@
+package cbit.vcell.message.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import cbit.vcell.message.VCDestination;
+import cbit.vcell.message.VCMessageSelector;
+import cbit.vcell.message.VCMessageSession;
+import cbit.vcell.message.VCQueueConsumer;
+import cbit.vcell.message.VCellQueue;
+
+/**
+ * Pins the cost of a {@link MessageProducerSessionJms}: it opens a JMS connection when it is
+ * first used to send something, not when it is constructed.
+ *
+ * This matters because ConsumerContextJms constructs one for every message it receives and
+ * hands it to the listener, and most listeners never send through it.
+ */
+@Tag("Fast")
+public class MessageProducerSessionJmsTest {
+
+	private static final String BROKER_NAME = "MessageProducerSessionJmsTestBroker";
+	private static final VCellQueue TEST_QUEUE = new VCellQueue("MessageProducerSessionJmsTestQueue");
+
+	private static CountingMessagingService service;
+
+	@BeforeAll
+	public static void startBroker() throws Exception {
+		service = new CountingMessagingService();
+		service.startBroker();
+	}
+
+	@AfterAll
+	public static void stopBroker() throws Exception {
+		if (service != null) {
+			try {
+				service.close();
+			} finally {
+				service.stopBroker();
+			}
+		}
+	}
+
+	@Test
+	public void producerSessionOpensNoConnectionUntilItIsUsed() throws Exception {
+		int before = service.connectionsOpened.get();
+		MessageProducerSessionJms producerSession = new MessageProducerSessionJms(service);
+		try {
+			assertEquals(before, service.connectionsOpened.get(),
+					"constructing a producer session must not open a JMS connection");
+
+			producerSession.createTextMessage("first use");
+			assertEquals(before + 1, service.connectionsOpened.get(),
+					"the first use should open exactly one connection");
+
+			producerSession.createTextMessage("second use");
+			assertEquals(before + 1, service.connectionsOpened.get(),
+					"later uses should reuse the connection already open");
+		} finally {
+			producerSession.close();
+		}
+	}
+
+	/** commit/rollback/close on a session that was never used must not open one to do nothing with. */
+	@Test
+	public void anUnusedProducerSessionCostsNothing() throws Exception {
+		int before = service.connectionsOpened.get();
+		MessageProducerSessionJms producerSession = new MessageProducerSessionJms(service);
+		producerSession.commit();
+		producerSession.rollback();
+		producerSession.close();
+		assertEquals(before, service.connectionsOpened.get(),
+				"an unused producer session must never open a connection");
+	}
+
+	/** Long-lived sessions are always used, so they still open up front. */
+	@Test
+	public void createProducerSessionOpensEagerly() throws Exception {
+		int before = service.connectionsOpened.get();
+		VCMessageSession producerSession = service.createProducerSession();
+		try {
+			assertEquals(before + 1, service.connectionsOpened.get(),
+					"a long-lived producer session should open at creation, so a broker problem surfaces there");
+		} finally {
+			producerSession.close();
+		}
+	}
+
+	/**
+	 * The regression this was written for: delivering messages to a listener that never sends
+	 * anything used to cost one connection (and one temporary queue) per message.
+	 */
+	@Test
+	public void consumerOpensNoConnectionPerMessage() throws Exception {
+		int messageCount = 5;
+		CountDownLatch delivered = new CountDownLatch(messageCount);
+
+		VCQueueConsumer consumer = new VCQueueConsumer(TEST_QUEUE,
+				(vcMessage, session) -> delivered.countDown(),
+				null, "MessageProducerSessionJmsTest consumer", 1);
+		service.addMessageConsumer(consumer);
+
+		VCMessageSession producerSession = service.createProducerSession();
+		try {
+			int afterSetup = service.connectionsOpened.get();
+
+			for (int i = 0; i < messageCount; i++) {
+				producerSession.sendQueueMessage(TEST_QUEUE,
+						producerSession.createTextMessage("message " + i), Boolean.FALSE, 60000L);
+			}
+			assertTrue(delivered.await(30, TimeUnit.SECONDS),
+					"all " + messageCount + " messages should reach the listener");
+
+			assertEquals(afterSetup, service.connectionsOpened.get(),
+					"a listener that never sends must not cost a connection per message");
+		} finally {
+			producerSession.close();
+			service.removeMessageConsumer(consumer);
+		}
+	}
+
+	/** An embedded-broker messaging service that counts every JMS connection opened through it. */
+	private static final class CountingMessagingService extends VCMessagingServiceJms {
+		final AtomicInteger connectionsOpened = new AtomicInteger();
+		private BrokerService broker = null;
+
+		void startBroker() throws Exception {
+			broker = new BrokerService();
+			broker.setBrokerName(BROKER_NAME);   // not "localhost" -- other tests run their own vm:// broker
+			broker.setPersistent(false);
+			broker.setUseJmx(false);
+			broker.setUseShutdownHook(false);
+			broker.start();
+			broker.waitUntilStarted();
+		}
+
+		void stopBroker() throws Exception {
+			if (broker != null) {
+				broker.stop();
+				broker.waitUntilStopped();
+			}
+		}
+
+		@Override
+		public ConnectionFactory createConnectionFactory() {
+			return new ActiveMQConnectionFactory("vm://" + BROKER_NAME + "?create=false") {
+				@Override
+				public Connection createConnection() throws JMSException {
+					connectionsOpened.incrementAndGet();
+					return super.createConnection();
+				}
+			};
+		}
+
+		@Override
+		public MessageConsumer createConsumer(Session jmsSession, VCDestination vcDestination,
+				VCMessageSelector vcSelector, int prefetchLimit) throws JMSException {
+			Destination destination = (vcDestination instanceof VCellQueue)
+					? jmsSession.createQueue(vcDestination.getName())
+					: jmsSession.createTopic(vcDestination.getName());
+			return (vcSelector == null)
+					? jmsSession.createConsumer(destination)
+					: jmsSession.createConsumer(destination, vcSelector.getSelectionString());
+		}
+	}
+}

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -1,6 +1,7 @@
 package cbit.vcell.message.jms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
@@ -22,8 +23,10 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import cbit.vcell.message.VCDestination;
+import cbit.vcell.message.VCMessage;
 import cbit.vcell.message.VCMessageSelector;
 import cbit.vcell.message.VCMessageSession;
+import cbit.vcell.message.VCMessagingException;
 import cbit.vcell.message.VCQueueConsumer;
 import cbit.vcell.message.VCellQueue;
 
@@ -138,9 +141,31 @@ public class MessageProducerSessionJmsTest {
 		}
 	}
 
+	/**
+	 * Deferring the connection moved the point where a broker problem is noticed from the
+	 * constructor into the send. It must still be noticed: a listener told that its send
+	 * succeeded would let ConsumerContextJms commit the message it was handling.
+	 */
+	@Test
+	public void aSendThatCannotOpenAConnectionThrows() throws Exception {
+		VCMessage message = service.createProducerSession().createTextMessage("never sent");
+
+		MessageProducerSessionJms producerSession = new MessageProducerSessionJms(service);
+		service.failConnections = true;
+		try {
+			assertThrows(VCMessagingException.class,
+					() -> producerSession.sendQueueMessage(TEST_QUEUE, message, Boolean.FALSE, 60000L),
+					"a send that cannot open its connection must not report success");
+		} finally {
+			service.failConnections = false;
+			producerSession.close();
+		}
+	}
+
 	/** An embedded-broker messaging service that counts every JMS connection opened through it. */
 	private static final class CountingMessagingService extends VCMessagingServiceJms {
 		final AtomicInteger connectionsOpened = new AtomicInteger();
+		volatile boolean failConnections = false;
 		private BrokerService broker = null;
 
 		void startBroker() throws Exception {
@@ -165,6 +190,9 @@ public class MessageProducerSessionJmsTest {
 			return new ActiveMQConnectionFactory("vm://" + BROKER_NAME + "?create=false") {
 				@Override
 				public Connection createConnection() throws JMSException {
+					if (failConnections) {
+						throw new JMSException("simulated broker outage");
+					}
 					connectionsOpened.incrementAndGet();
 					return super.createConnection();
 				}


### PR DESCRIPTION
Follow-up to #1837 / #1838: removes the structural cost that turned one bad export
progress value into a connection storm.

## The problem

`ConsumerContextJms` builds a `MessageProducerSessionJms` for **every message it
receives** and hands it to the listener. The constructor opened a JMS connection, a
session and a temporary queue. Most listeners never send through it:

| consumer | container | uses the session? |
|---|---|---|
| `ClientTopicMessageCollector` (ClientStatusTopic) | `api` | no — parameter never referenced |
| `SimDataServer` (pooled) | `data` | no — `VCPooledQueueConsumer` substitutes its own |
| `DatabaseServer` (pooled) | `db` | no — likewise |
| `HtcSimulationWorker` (pooled) | `submit` | no — likewise |
| `JavaSimulationExecutable` (control topic) | solver | no |
| `SimulationDispatcher` worker events + sim requests | `sched` | **yes** |

Five of seven paid a connection, a session and a temporary queue per message for
something they never touched. During the 2026-08-06 incident that reached ~3,300
connections a minute against **zero** transport interruptions.

## The change

- The connection and session open on **first use** instead of in the constructor.
- The temporary queue is created only when `sendRpcMessage` needs a reply destination
  — nothing else uses one.
- `commit()` / `rollback()` / `close()` on a session that was never used are no-ops.
- `createProducerSession()` calls `open()` explicitly: those sessions are long-lived and
  always used, so they still open at startup and a broker problem surfaces there rather
  than at the first send.

Senders behave exactly as before — same session, same transaction boundaries.

## Verification

`MessageProducerSessionJmsTest` runs a real embedded broker and counts every connection
opened. Controlled by reverting the production files to `master` with the test kept:

```
producerSessionOpensNoConnectionUntilItIsUsed  expected: <0>  but was: <1>
anUnusedProducerSessionCostsNothing            expected: <2>  but was: <3>
consumerOpensNoConnectionPerMessage            expected: <5>  but was: <10>
```

Five messages, five extra connections — the per-message cost, quantified. The fourth
test, `createProducerSessionOpensEagerly`, passes both ways: it pins the behaviour this
change deliberately preserves.

Full `vcell-server` Fast group: 56 passed.

## Not addressed here

- `sendRpcMessage` still builds a second `MessageProducerSessionJms` purely to create the
  message (its own connection per RPC). The session-sharing constructor for that is
  commented out in the source with no explanation of why, so changing it needs more than a
  guess. It no longer creates a temporary queue, at least.
- `sendTopicMessage` creates a `MessageProducer` and never closes it. Harmless while
  sessions are short-lived; it would matter if these were ever pooled.
- `removeMessageConsumer` stops the polling thread but never closes the consumer's
  connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
