### PR TITLE
Target the initialAssignment when a species has no initialConcentration

### DIFF
--- a/vcell-core/src/main/java/org/jlibsedml/modelsupport/SBMLSupport.java
+++ b/vcell-core/src/main/java/org/jlibsedml/modelsupport/SBMLSupport.java
@@ -235,6 +235,28 @@ public class SBMLSupport implements IXPathToVariableIDResolver {
     			+ mappingID + "']/@spatial:" + compartmentAttribute;
     }
 
+    /**
+     * Gets XPath expression to identify the SBML initialAssignment for a symbol.
+     * <p>
+     * Needed where a species' or parameter's initial value was exported as an
+     * {@code <initialAssignment>} rather than as an {@code initialConcentration} (or
+     * {@code value}) attribute: the attribute is then absent, so an XPath naming it matches
+     * nothing. Note SBML gives an initialAssignment precedence over the attribute, so a change
+     * aimed at the attribute would be ignored even where both are present.
+     *
+     * @param symbol the id of the species, compartment or parameter being initialised
+     * @return An XPath string which can be set into the 'target' field of an
+     *         XPath-containing element in SED-ML.
+     */
+    public String getXPathForInitialAssignment(String symbol) {
+        return getXPathForListOfInitialAssignments() + "/sbml:initialAssignment[@symbol='" + symbol
+                + "']";
+    }
+
+    String getXPathForListOfInitialAssignments() {
+        return "/sbml:sbml/sbml:model/sbml:listOfInitialAssignments";
+    }
+
     String getXPathForListOfCompartments() {
         return "/sbml:sbml/sbml:model/sbml:listOfCompartments";
     }

--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -49,6 +49,7 @@ import org.jlibsedml.modelsupport.SBMLSupport.SpeciesAttribute;
 import org.jlibsedml.modelsupport.SUPPORTED_LANGUAGE;
 import org.jmathml.ASTNode;
 import org.sbml.jsbml.Annotation;
+import org.sbml.jsbml.InitialAssignment;
 import org.sbml.jsbml.Parameter;
 import org.sbml.jsbml.SBMLDocument;
 import org.sbml.jsbml.SBMLReader;
@@ -100,6 +101,14 @@ public class SEDMLExporter {
     /** Application to the SED-ML id it was exported under; see {@link #getSimContextId}. */
     private final Map<SimulationContext, String> simContextIdMap = new LinkedHashMap<>();
     private final Set<String> usedSimContextIds = new LinkedHashSet<>();
+
+    /**
+     * Ids the current application's SBML gave an {@code <initialAssignment>} rather than an
+     * initial-value attribute. Read back from the emitted SBML rather than predicted, so the
+     * SED-ML targets whatever the export actually chose. Reset per application by
+     * {@link #exportSimulations}.
+     */
+    private Set<String> speciesWithInitialAssignment = Collections.emptySet();
 
     private final SBMLSupport sbmlSupport = new SBMLSupport();
 
@@ -316,6 +325,7 @@ public class SEDMLExporter {
         // -------
         String simContextName = simContext.getName();
         String simContextId = getSimContextId(simContext);
+        this.speciesWithInitialAssignment = readInitialAssignmentSymbols(sbmlString);
         this.simCount = 0;
         this.overrideCount = 0;
         simContext.getSimulations();
@@ -1121,6 +1131,32 @@ public class SEDMLExporter {
         }
     }
 
+    /**
+     * The symbols this SBML initialises with an {@code <initialAssignment>}. Empty for the VCML
+     * export path, where {@code sbmlString} is null.
+     */
+    private static Set<String> readInitialAssignmentSymbols(String sbmlString) {
+        if (sbmlString == null) {
+            return Collections.emptySet();
+        }
+        try {
+            SBMLDocument sbmlDoc = new SBMLReader().readSBMLFromString(sbmlString);
+            Set<String> symbols = new LinkedHashSet<>();
+            for (InitialAssignment initialAssignment : sbmlDoc.getModel().getListOfInitialAssignments()) {
+                if (initialAssignment.isSetVariable()) {
+                    symbols.add(initialAssignment.getVariable());
+                }
+            }
+            return symbols;
+        } catch (XMLStreamException e) {
+            // the SBML was produced a moment ago and is parsed again elsewhere; if it somehow will
+            // not parse, fall back to the attribute target rather than fail the whole export
+            logger.warn("could not re-read exported SBML to find initialAssignments; "
+                    + "SED-ML will target initialConcentration attributes", e);
+            return Collections.emptySet();
+        }
+    }
+
     private XPathTarget getTargetAttributeXPath(SymbolTableEntry ste, Map<Pair<String, String>, String> l2gMap, SimulationContext simContext) {
         // VCML model format
         if (l2gMap == null) return this.getVCMLTargetXPath(ste, simContext);
@@ -1147,7 +1183,16 @@ public class SEDMLExporter {
             if (speciesAttr.isEmpty()) {
                 targetXpath = new XPathTarget(sbmlSupport.getXPathForCompartment(speciesId));
             } else if (speciesAttr.equalsIgnoreCase("initialConcentration") || speciesAttr.equalsIgnoreCase("initConc")) {
-                targetXpath = new XPathTarget(sbmlSupport.getXPathForSpecies(speciesId, SpeciesAttribute.initialConcentration));
+                // Follow whichever form the SBML export actually emitted. SBMLExporter writes an
+                // initialConcentration attribute only when the initial expression evaluates to a
+                // constant, and an <initialAssignment> otherwise (a membrane species carrying the
+                // KMOLE unit conversion takes the latter path), in which case the attribute is
+                // absent and an XPath naming it matches nothing. Retargeting rather than adding the
+                // attribute is also the only correct option: SBML gives an initialAssignment
+                // precedence, so a change aimed at the attribute would be silently ignored.
+                targetXpath = this.speciesWithInitialAssignment.contains(speciesId)
+                        ? new XPathTarget(sbmlSupport.getXPathForInitialAssignment(speciesId))
+                        : new XPathTarget(sbmlSupport.getXPathForSpecies(speciesId, SpeciesAttribute.initialConcentration));
             } else if (speciesAttr.equalsIgnoreCase("initialCount") || speciesAttr.equalsIgnoreCase("initCount")) {
                 targetXpath = new XPathTarget(sbmlSupport.getXPathForSpecies(speciesId, SpeciesAttribute.initialAmount));
             } else if (speciesAttr.equalsIgnoreCase("diff")) {

--- a/vcell-core/src/test/java/org/vcell/sbml/SEDMLExporterSBMLTest.java
+++ b/vcell-core/src/test/java/org/vcell/sbml/SEDMLExporterSBMLTest.java
@@ -160,8 +160,6 @@ public class SEDMLExporterSBMLTest extends SEDMLExporterCommon {
 		faults.put("biomodel_220138948.vcml",SEDML_FAULT.OMEX_VALIDATION_ERRORS);  //  XPATH_BAD:  XPath `/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='OAT1']/@initialConcentration` does not match any elements of model `_0D`.
 		faults.put("biomodel_31523791.vcml", SEDML_FAULT.OMEX_PARSER_ERRORS);      //  XPATH_BAD:  XPath `/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='cAMP_Intracellular']/@initialConcentration` does not match any elements of model `Dose_response`.
 		faults.put("biomodel_34855932.vcml", SEDML_FAULT.OMEX_PARSER_ERRORS);      //  XPATH_BAD:  XPath `/sbml:sbml/sbml:model/sbml:listOfParameters/sbml:parameter[@id='Kf_GPCR_to_ICSC']/@value` does not match any elements of model `cell5`
-		faults.put("biomodel_40882931.vcml", SEDML_FAULT.OMEX_PARSER_ERRORS);  //  XPATH_BAD:  XPath `/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='ZO1staticF_PM']/@initialConcentration` does not match any elements of model `_3d_image`
-		faults.put("biomodel_40883509.vcml", SEDML_FAULT.OMEX_PARSER_ERRORS);  //  XPATH_BAD:  XPath `/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='PIK_PM']/@initialConcentration` does not match any elements of model `_3d_image`
 		faults.put("biomodel_65311813.vcml", SEDML_FAULT.OMEX_PARSER_ERRORS);  //  XPATH_BAD:  XPath `/sbml:sbml/sbml:model/sbml:listOfParameters/sbml:parameter[@id='Ran_nuc_diff']/@value` does not match any elements of model `_3d_image_0`
 		return faults;
 	}


### PR DESCRIPTION
## The bug

`SEDMLExporter` always emitted this for a `ROLE_InitialConcentration` override:

```
/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='X']/@initialConcentration
```

But `SBMLExporter` writes that attribute only when the initial expression evaluates
to a constant:

```java
Double initConcConstantValue = initConcExp.evaluateConstantSafe();
if (initConcConstantValue != null) {
    sbmlSpecies.setInitialConcentration(initConcConstantValue);   // attribute
} else {
    InitialAssignment initAssignment = sbmlModel.createInitialAssignment();   // no attribute
}
```

so for the other branch the SED-ML change targeted something never emitted:

```
XPath …/sbml:species[@id='Src_plasmamembrane']/@initialConcentration
  does not match any elements of model `full_model`
```

## Why those species take that branch

In `biomodel_59361239` all **19** initialAssignments arise this way, and 17 of them
reference nothing but **`KMOLE`** — VCell's reserved unit-conversion constant,
itself `constant="true"`. The value *is* constant; the expression simply is not a
literal, so `evaluateConstantSafe()` returns null.

That also explains why every failing target is a membrane species: only those carry
the surface-to-volume conversion.

## Fix

Emit the initialAssignment XPath when that is what the export produced — read back
from the emitted SBML rather than predicted, so the target follows the exporter's
actual decision instead of guessing it. Adds `getXPathForInitialAssignment` to
`SBMLSupport` (this repo's jlibsedml fork, extended before for the L3 kinetic-law
naming scheme).

### Why not constant-fold KMOLE instead

That was the first idea and it is worse. It would change the exported SBML for many
models and lose the symbolic form, and it would only rescue initial conditions that
happen to be numerically constant — a genuinely variable one would still target a
missing attribute.

Adding the attribute *alongside* the initialAssignment would be unsound: **SBML
gives an initialAssignment precedence**, so the archive would validate while every
change was silently ignored at simulation time. Retargeting is the only option that
is correct in both cases.

## Verification

The validator was asked directly, by rebuilding the failing archive with each
candidate target:

| target | validator |
|---|---|
| `…/species[@id='X']/@initialConcentration` (before) | ❌ invalid |
| `…/listOfInitialAssignments/initialAssignment[@symbol='X']` | ✅ valid |
| `…/listOfInitialAssignments/initialAssignment[@symbol='X']/math:math` | ✅ valid |

The element form is used, matching `computeChange` semantics.

The exported **SBML is byte-identical** to before (`diff` clean) — `KMOLE` stays
symbolic — and only the SED-ML target moves. The data-generator variable still
points at the species itself.

## Also removes two stale known faults this fixes

`biomodel_40882931` and `biomodel_40883509` carried `OMEX_PARSER_ERRORS` whose own
comments recorded this exact symptom:

```java
//  XPATH_BAD:  XPath …/sbml:species[@id='ZO1staticF_PM']/@initialConcentration
//              does not match any elements of model `_3d_image`
```

`ZO1staticF_PM` and `PIK_PM` — membrane species again. They pass now, so leaving the
entries made the tests fail for *passing*. Found by the regression run rather than
by looking for them.

| run | result |
|---|---|
| non-slow group, fix + stale faults still registered | 243/245 |
| non-slow group, faults removed | **245/245** |
| `biomodel_59361239` (slow, `-Dtest.only`) | **passes** |

Note PR CI cannot exercise this — `SEDML_SBML_IT` runs only in `regression.yml`.

## Remaining

`biomodel_28625786` (duplicate SED-ML id) is a separate, still-undiagnosed defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvqmME7MkRUNEYje5HpiLt