### PR TITLE
Build the RPC request message on a session, not a second connection

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
@@ -110,6 +110,12 @@ public class MessageProducerSessionJms implements VCMessageSession {
         return newConnection;
     }
 
+    /** The open connection, opening it if necessary. Unlike Session, Connection is thread-safe. */
+    private synchronized Connection getConnection() throws JMSException{
+        getSession();
+        return connection;
+    }
+
     /**
      * Opens the session for a send, failing loudly if it cannot be opened.
      *
@@ -139,17 +145,9 @@ public class MessageProducerSessionJms implements VCMessageSession {
         return commonTemporaryQueue;
     }
 
-//		public MessageProducerSessionJms(Session session, VCMessagingServiceJms vcMessagingServiceJms) {
-//			lg.info("-----\nmpjms MessageProducerSessionJms(Session session, VCMessagingServiceJms vcMessagingServiceJms)\ntmpQCnt="+(++tmpQCnt)+"----------");
-//			Thread.dumpStack();
-//			this.vcMessagingServiceJms = vcMessagingServiceJms;
-//			this.session = session;
-//			this.bIndependent = false;
-//		}
-
     public /*synchronized*/ Object sendRpcMessage(VCellQueue queue, VCRpcRequest vcRpcRequest, boolean returnRequired, long timeoutMS, String[] specialProperties, Object[] specialValues, UserLoginInfo userLoginInfo) throws VCMessagingException, VCMessagingInvocationTargetException{
         MessageProducer messageProducer = null;
-        MessageProducerSessionJms tempMessageProducerSessionJms = null;
+        Session messageSession = null;
         try {
             if(!bIndependent){
                 throw new VCMessagingException("cannot invoke RpcMessage from within another transaction, create an independent message producer");
@@ -159,11 +157,21 @@ public class MessageProducerSessionJms implements VCMessageSession {
             messageProducer = jmsSession.createProducer(destination);
 
             //
-            // use MessageProducerSessionJms to create the rpcRequest message (allows "Blob" messages to be formed as needed).
+            // Build the request message on a session of its own so that forming it -- which for a
+            // large request means serializing and writing a BLOB -- does not touch the session this
+            // RPC is being sent on. RpcService hands a single producer session to every request
+            // thread, so that session is in concurrent use (see the commented-out `synchronized` on
+            // this method).
             //
-            tempMessageProducerSessionJms = new MessageProducerSessionJms(vcMessagingServiceJms);
-//				tempMessageProducerSessionJms = new MessageProducerSessionJms(session,vcMessagingServiceJms);
-            VCMessageJms vcRpcRequestMessage = (VCMessageJms) tempMessageProducerSessionJms.createObjectMessage(vcRpcRequest);
+            // Bug 4668 (2016) got that isolation by building a whole second MessageProducerSessionJms
+            // here, which meant a JMS connection, session and temporary queue per RPC. It had to be
+            // independent only because the same commit added close() in the finally block, and
+            // closing a shared session would have closed the caller's. A session off the connection
+            // we already hold gives the same isolation: Connection is thread-safe, Session is not,
+            // and creating one costs no new connection.
+            //
+            messageSession = getConnection().createSession(false, Session.AUTO_ACKNOWLEDGE);
+            VCMessageJms vcRpcRequestMessage = (VCMessageJms) createObjectMessage(messageSession, vcRpcRequest);
             Message rpcMessage = vcRpcRequestMessage.getJmsMessage();
 
             rpcMessage.setStringProperty(VCMessagingConstants.MESSAGE_TYPE_PROPERTY, VCMessagingConstants.MESSAGE_TYPE_RPC_SERVICE_VALUE);
@@ -224,9 +232,9 @@ public class MessageProducerSessionJms implements VCMessageSession {
         } finally {
             try {
 
-                if(tempMessageProducerSessionJms != null){
-                    tempMessageProducerSessionJms.commit();
-                    tempMessageProducerSessionJms.close();
+                if(messageSession != null){
+                    // not transacted and never sent on, so there is nothing to commit
+                    messageSession.close();
                 }
 
                 if(messageProducer != null){
@@ -332,6 +340,19 @@ public class MessageProducerSessionJms implements VCMessageSession {
 
     public VCMessage createObjectMessage(Serializable object){
         try {
+            return createObjectMessage(getSession(), object);
+        } catch(JMSException e){
+            onException(e);
+            throw new RuntimeException("unable to create object message", e);
+        }
+    }
+
+    /**
+     * Builds the message on the given session rather than this one, so that sendRpcMessage can
+     * keep message construction off a session that other request threads may be using.
+     */
+    private VCMessage createObjectMessage(Session jmsSession, Serializable object){
+        try {
             // if the serialized object is very large, send it as a BlobMessage (ActiveMQ specific).
             long t1 = System.currentTimeMillis();
             byte[] serializedBytes = null;
@@ -362,7 +383,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                     channel.close();
                     fileOutputStream.close();
 
-                    ObjectMessage objectMessage = getSession().createObjectMessage("emptyObject");
+                    ObjectMessage objectMessage = jmsSession.createObjectMessage("emptyObject");
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_PERSISTENCE_TYPE, VCMessageJms.BLOB_MESSAGE_PERSISTENCE_TYPE_FILE);
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_PRODUCER_TEMPDIR, tempdir.getAbsolutePath());
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_FILE_NAME, blobFile.getName());
@@ -373,7 +394,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                 } else {
                     String hexString = Long.toHexString(Math.abs(new Random().nextLong()));
                     ObjectId objectId = VCMongoDbDriver.getInstance().storeBLOB("jmsblob_name_" + hexString, "jmsblob", serializedBytes);
-                    ObjectMessage objectMessage = getSession().createObjectMessage("emptyObject");
+                    ObjectMessage objectMessage = jmsSession.createObjectMessage("emptyObject");
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_PERSISTENCE_TYPE, VCMessageJms.BLOB_MESSAGE_PERSISTENCE_TYPE_MONGODB);
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_MONGODB_OBJECTID, objectId.toHexString());
                     objectMessage.setStringProperty(VCMessageJms.BLOB_MESSAGE_OBJECT_TYPE, object.getClass().getName());
@@ -382,7 +403,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                     return new VCMessageJms(objectMessage, object, vcMessagingServiceJms.getDelegate());
                 }
             } else {
-                ObjectMessage objectMessage = (ObjectMessage) getSession().createObjectMessage(object);
+                ObjectMessage objectMessage = (ObjectMessage) jmsSession.createObjectMessage(object);
                 int size = (serializedBytes != null) ? (serializedBytes.length) : (0);
                 String objectType = (serializedBytes != null) ? (object.getClass().getName()) : ("NULL");
                 vcMessagingServiceJms.getDelegate().onTraceEvent("MessageProducerSessionJms.createObjectMessage: (NOBLOB) size=" + size + ", type=" + objectType + ", elapsedTime = " + (System.currentTimeMillis() - t1) + " ms");

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -28,7 +28,12 @@ import cbit.vcell.message.VCMessageSelector;
 import cbit.vcell.message.VCMessageSession;
 import cbit.vcell.message.VCMessagingException;
 import cbit.vcell.message.VCQueueConsumer;
+import cbit.vcell.message.VCRpcRequest;
 import cbit.vcell.message.VCellQueue;
+import cbit.vcell.resource.PropertyLoader;
+
+import org.vcell.util.document.KeyValue;
+import org.vcell.util.document.User;
 
 /**
  * Pins the cost of a {@link MessageProducerSessionJms}: it opens a JMS connection when it is
@@ -159,6 +164,36 @@ public class MessageProducerSessionJmsTest {
 		} finally {
 			service.failConnections = false;
 			producerSession.close();
+		}
+	}
+
+	/**
+	 * sendRpcMessage builds its request message on a session of its own, so that forming a large
+	 * request does not touch the session the RPC is sent on (RpcService shares one producer
+	 * session across request threads). That session used to be a whole second
+	 * MessageProducerSessionJms -- a connection, session and temporary queue per RPC.
+	 */
+	@Test
+	public void anRpcOpensNoConnectionToBuildItsMessage() throws Exception {
+		String previous = System.getProperty(PropertyLoader.jmsBlobMessageUseMongo);
+		System.setProperty(PropertyLoader.jmsBlobMessageUseMongo, "false");
+		VCMessageSession producerSession = service.createProducerSession();
+		try {
+			int afterSessionOpened = service.connectionsOpened.get();
+
+			VCRpcRequest request = new VCRpcRequest(new User("testuser", new KeyValue("1")),
+					VCRpcRequest.RpcServiceType.TESTING_SERVICE, "aMethod", new Object[0]);
+			producerSession.sendRpcMessage(TEST_QUEUE, request, false, 60000L, null, null, null);
+
+			assertEquals(afterSessionOpened, service.connectionsOpened.get(),
+					"an RPC must not open a connection just to build its request message");
+		} finally {
+			producerSession.close();
+			if (previous == null) {
+				System.clearProperty(PropertyLoader.jmsBlobMessageUseMongo);
+			} else {
+				System.setProperty(PropertyLoader.jmsBlobMessageUseMongo, previous);
+			}
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #1842 — the last per-RPC connection in the `api` container.

`sendRpcMessage` created a whole second `MessageProducerSessionJms` (connection + session
+ temporary queue) purely to call `createObjectMessage`. Every legacy client RPC paid one
extra JMS connection.

## Forensics — why it was written that way

Tracked down with `git log --follow -p`, since `-S` can't see a line being commented out:

| when | commit | what |
|---|---|---|
| 2012-12-09 | `db18e35` "Bug 3381: fix Blob Message and extend to RPC messages" | introduced the temp session as `new MessageProducerSessionJms(session)` — **sharing** the caller's session, purely so BLOB messages could be formed |
| 2013 | `1c78fcd`, `ecf9b05` | modularisation adds the service argument |
| 2016-04-13 | `63a2879` "Bug 4668" (Frank Morgan) | switched it to an **independent** session, and did the same to `ConsumerContextJms` |

The reason for independence is visible in that 2016 diff: the same commit added
`tempMessageProducerSessionJms.close()` in the `finally`. Closing a *shared* session would
have closed the caller's own. So sharing wasn't found to be incorrect — the new
close-in-finally cleanup is what forced a separate session, and taking a whole connection
with it was incidental. The commented-out constructor, the `tmpQCnt` counter and the
`Thread.dumpStack()` calls in that same diff are leftovers from chasing leaked temporary
queues.

## Why the isolation is still worth keeping

`RpcService` creates **one** producer session at startup (`VCellApiMain:233`) and
`RpcRestlet` hands that same instance to every request thread, so the session
`sendRpcMessage` runs on is in concurrent use. Building a large request message —
serialize, possibly write a BLOB to disk or Mongo — off that session keeps it out of the
way. (The commented-out `/*synchronized*/` on the method signature is from the same
concern.)

A `Session` from the connection we already hold gives exactly that isolation for no new
connection: `Connection` is thread-safe, `Session` is not. The message is still built on
one session and sent by a producer on another — which this code has always done.

## Verification

`anRpcOpensNoConnectionToBuildItsMessage`. Control against `master`:

```
an RPC must not open a connection just to build its request message ==> expected: <4> but was: <5>
```

Only that test fails without the fix. `vcell-server` Fast group: 58 passed; `vcell-api`
compiles.

## Pre-existing issue this uncovered — NOT fixed here

`sendRpcMessage` is **not safe under concurrency**, independent of this change. One shared
producer session is used by all request threads for `createQueue`, `createProducer`,
`send`, `commit`, `createConsumer` and a blocking `receive` of up to the client timeout —
on a `javax.jms.Session`, which is not thread-safe. The commented-out `synchronized`
suggests this was noticed and backed out, presumably because serialising a multi-minute
blocking receive would have throttled all RPCs.

This change neither worsens nor fixes that: message construction moves *off* the shared
session, so if anything one fewer operation races. The real fix is a session per RPC call
off the shared connection (producer, reply queue, consumer and commit all on it), which is
a larger change to the most heavily used RPC path and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
