### PR TITLE
Give each RPC its own JMS session so concurrent callers cannot corrupt each other

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
@@ -135,110 +135,112 @@ public class MessageProducerSessionJms implements VCMessageSession {
     }
 
     /**
-     * The temporary queue is a reply destination for sendRpcMessage and nothing else, so it
-     * is created with the first RPC rather than alongside the session.
+     * The temporary queue is a reply destination for sendRpcMessage and nothing else, so it is
+     * created with the first RPC rather than alongside the session.
+     *
+     * It is created on a session of its own so that sendRpcMessage never touches the shared
+     * session: a temporary destination belongs to the connection and outlives the session that
+     * created it (ActiveMQ's createTemporaryQueue delegates to the connection).
      */
     private synchronized TemporaryQueue getReplyQueue() throws JMSException{
         if(commonTemporaryQueue == null){
-            commonTemporaryQueue = getSession().createTemporaryQueue();
+            Session replyQueueSession = getConnection().createSession(false, Session.AUTO_ACKNOWLEDGE);
+            try {
+                commonTemporaryQueue = replyQueueSession.createTemporaryQueue();
+            } finally {
+                replyQueueSession.close();
+            }
         }
         return commonTemporaryQueue;
     }
 
-    public /*synchronized*/ Object sendRpcMessage(VCellQueue queue, VCRpcRequest vcRpcRequest, boolean returnRequired, long timeoutMS, String[] specialProperties, Object[] specialValues, UserLoginInfo userLoginInfo) throws VCMessagingException, VCMessagingInvocationTargetException{
+    /**
+     * Everything one RPC does -- building the request, the producer, the commit, and the
+     * consumer it then blocks on -- happens on a JMS session created for that call alone.
+     *
+     * RpcService creates a single producer session at startup and RpcRestlet hands it to every
+     * request thread, so doing this work on the shared session meant concurrent createProducer,
+     * send, commit, createConsumer and receive on a javax.jms.Session, which is not thread-safe;
+     * one caller's commit() also committed another caller's in-flight send. Marking the method
+     * synchronized is not the answer -- it would serialise every RPC behind a receive() that
+     * blocks for up to the client timeout, which is presumably why the `synchronized` that used
+     * to be here was commented out rather than kept. Connection is thread-safe, so a session per
+     * call is both correct and cheap: it costs no new connection.
+     */
+    public Object sendRpcMessage(VCellQueue queue, VCRpcRequest vcRpcRequest, boolean returnRequired, long timeoutMS, String[] specialProperties, Object[] specialValues, UserLoginInfo userLoginInfo) throws VCMessagingException, VCMessagingInvocationTargetException{
+        Session rpcSession = null;
         MessageProducer messageProducer = null;
-        Session messageSession = null;
+        MessageConsumer replyConsumer = null;
         try {
             if(!bIndependent){
                 throw new VCMessagingException("cannot invoke RpcMessage from within another transaction, create an independent message producer");
             }
-            Session jmsSession = getSession();
-            Destination destination = jmsSession.createQueue(queue.getName());
-            messageProducer = jmsSession.createProducer(destination);
+            boolean bTransacted = true;
+            rpcSession = getConnection().createSession(bTransacted, Session.AUTO_ACKNOWLEDGE);
+            Destination destination = rpcSession.createQueue(queue.getName());
+            messageProducer = rpcSession.createProducer(destination);
 
-            //
-            // Build the request message on a session of its own so that forming it -- which for a
-            // large request means serializing and writing a BLOB -- does not touch the session this
-            // RPC is being sent on. RpcService hands a single producer session to every request
-            // thread, so that session is in concurrent use (see the commented-out `synchronized` on
-            // this method).
-            //
-            // Bug 4668 (2016) got that isolation by building a whole second MessageProducerSessionJms
-            // here, which meant a JMS connection, session and temporary queue per RPC. It had to be
-            // independent only because the same commit added close() in the finally block, and
-            // closing a shared session would have closed the caller's. A session off the connection
-            // we already hold gives the same isolation: Connection is thread-safe, Session is not,
-            // and creating one costs no new connection.
-            //
-            messageSession = getConnection().createSession(false, Session.AUTO_ACKNOWLEDGE);
-            VCMessageJms vcRpcRequestMessage = (VCMessageJms) createObjectMessage(messageSession, vcRpcRequest);
+            // built on this call's own session, so forming a large request (serialize, maybe
+            // write a BLOB) cannot interfere with another thread's RPC
+            VCMessageJms vcRpcRequestMessage = (VCMessageJms) createObjectMessage(rpcSession, vcRpcRequest);
             Message rpcMessage = vcRpcRequestMessage.getJmsMessage();
 
             rpcMessage.setStringProperty(VCMessagingConstants.MESSAGE_TYPE_PROPERTY, VCMessagingConstants.MESSAGE_TYPE_RPC_SERVICE_VALUE);
             rpcMessage.setStringProperty(VCMessagingConstants.SERVICE_TYPE_PROPERTY, vcRpcRequest.getRequestedServiceType().getName());
-//				rpcMessage.setJMSExpiration(5000);
             if(specialValues != null){
                 for(int i = 0; i < specialValues.length; i++){
                     rpcMessage.setObjectProperty(specialProperties[i], specialValues[i]);
                 }
             }
 
-            if(returnRequired){
-                rpcMessage.setJMSReplyTo(getReplyQueue());
-                messageProducer.setTimeToLive(timeoutMS);
-                messageProducer.send(rpcMessage);
-                jmsSession.commit();
-                vcMessagingServiceJms.getDelegate().onRpcRequestSent(vcRpcRequest, userLoginInfo, vcRpcRequestMessage);
-                if(lg.isTraceEnabled())
-                    lg.trace("MessageProducerSessionJms.sendRpcMessage(): looking for reply message with correlationID = " + rpcMessage.getJMSMessageID());
-                String filter = VCMessagingConstants.JMSCORRELATIONID_PROPERTY + "='" + rpcMessage.getJMSMessageID() + "'";
-                MessageConsumer replyConsumer = null;
-                Message replyMessage = null;
-                try {
-                    replyConsumer = jmsSession.createConsumer(getReplyQueue(), filter);
-                    replyMessage = replyConsumer.receive(timeoutMS);
-                } finally {
-                    replyConsumer.close();
-                }
-                if(replyMessage == null){
-                    lg.info("Request timed out");
-                }
+            rpcMessage.setJMSReplyTo(getReplyQueue());
+            messageProducer.setTimeToLive(timeoutMS);
+            messageProducer.send(rpcMessage);
+            rpcSession.commit();
+            vcMessagingServiceJms.getDelegate().onRpcRequestSent(vcRpcRequest, userLoginInfo, vcRpcRequestMessage);
 
-                if(replyMessage == null || !(replyMessage instanceof ObjectMessage)){
-                    throw new JMSException("Server is temporarily not responding, please try again. If problem persists, contact VCell_Support@uchc.edu." +
-                            " (server " + vcRpcRequest.getRequestedServiceType().getName() + ", method " + vcRpcRequest.getMethodName() + ")");
-                } else {
-                    VCMessageJms vcReplyMessage = new VCMessageJms(replyMessage, vcMessagingServiceJms.getDelegate());
-                    vcReplyMessage.loadBlobFile();
-                    Object returnValue = vcReplyMessage.getObjectContent();
-                    vcReplyMessage.removeBlobFile();
-                    if(returnValue instanceof Exception){
-                        throw new VCMessagingInvocationTargetException((Exception) returnValue);
-                    } else {
-                        return returnValue;
-                    }
-                }
-            } else {
-                rpcMessage.setJMSReplyTo(getReplyQueue());
-                messageProducer.setTimeToLive(timeoutMS);
-                messageProducer.send(rpcMessage);
-                commit();
-                vcMessagingServiceJms.getDelegate().onRpcRequestSent(vcRpcRequest, userLoginInfo, vcRpcRequestMessage);
+            if(!returnRequired){
                 return null;
+            }
+
+            if(lg.isTraceEnabled())
+                lg.trace("MessageProducerSessionJms.sendRpcMessage(): looking for reply message with correlationID = " + rpcMessage.getJMSMessageID());
+            // the reply queue is shared by every RPC on this producer session, so each caller
+            // takes only its own reply -- selected by the correlation id of the request it sent
+            String filter = VCMessagingConstants.JMSCORRELATIONID_PROPERTY + "='" + rpcMessage.getJMSMessageID() + "'";
+            replyConsumer = rpcSession.createConsumer(getReplyQueue(), filter);
+            Message replyMessage = replyConsumer.receive(timeoutMS);
+            if(replyMessage == null){
+                lg.info("Request timed out");
+            }
+
+            if(replyMessage == null || !(replyMessage instanceof ObjectMessage)){
+                throw new JMSException("Server is temporarily not responding, please try again. If problem persists, contact VCell_Support@uchc.edu." +
+                        " (server " + vcRpcRequest.getRequestedServiceType().getName() + ", method " + vcRpcRequest.getMethodName() + ")");
+            } else {
+                VCMessageJms vcReplyMessage = new VCMessageJms(replyMessage, vcMessagingServiceJms.getDelegate());
+                vcReplyMessage.loadBlobFile();
+                Object returnValue = vcReplyMessage.getObjectContent();
+                vcReplyMessage.removeBlobFile();
+                if(returnValue instanceof Exception){
+                    throw new VCMessagingInvocationTargetException((Exception) returnValue);
+                } else {
+                    return returnValue;
+                }
             }
         } catch(JMSException e){
             onException(e);
             throw new VCMessagingException(e.getMessage(), e);
         } finally {
             try {
-
-                if(messageSession != null){
-                    // not transacted and never sent on, so there is nothing to commit
-                    messageSession.close();
+                if(replyConsumer != null){
+                    replyConsumer.close();
                 }
-
                 if(messageProducer != null){
                     messageProducer.close();
+                }
+                if(rpcSession != null){
+                    rpcSession.close();
                 }
             } catch(JMSException e){
                 onException(e);

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -328,9 +329,11 @@ public class MessageProducerSessionJmsTest {
 					return super.createConnection();
 				}
 			};
-			// VCRpcRequest travels as an ObjectMessage; the broker refuses to deserialize
-			// unlisted classes otherwise
-			factory.setTrustAllPackages(true);
+			// VCRpcRequest travels as an ObjectMessage, and ActiveMQ refuses to deserialize
+			// classes outside its allowlist. Only the packages this test actually puts on the
+			// wire are listed -- trusting everything is what production does, and it is what
+			// the standing java/unsafe-deserialization alert on VCMessageJms is about.
+			factory.setTrustedPackages(Arrays.asList("java.lang", "java.util", "java.math", "cbit.vcell", "org.vcell"));
 			return factory;
 		}
 

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -4,7 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -28,6 +34,7 @@ import cbit.vcell.message.VCMessageSelector;
 import cbit.vcell.message.VCMessageSession;
 import cbit.vcell.message.VCMessagingException;
 import cbit.vcell.message.VCQueueConsumer;
+import cbit.vcell.message.VCRpcMessageHandler;
 import cbit.vcell.message.VCRpcRequest;
 import cbit.vcell.message.VCellQueue;
 import cbit.vcell.resource.PropertyLoader;
@@ -197,6 +204,95 @@ public class MessageProducerSessionJmsTest {
 		}
 	}
 
+	/** An RPC round trip still works: request out, reply back through the temporary queue. */
+	@Test
+	public void rpcRoundTripReturnsTheAnswer() throws Exception {
+		String previous = setBlobProperty();
+		VCellQueue rpcQueue = new VCellQueue("MessageProducerSessionJmsTestRpcQueue-roundtrip");
+		VCQueueConsumer responder = startEchoResponder(rpcQueue);
+		VCMessageSession producerSession = service.createProducerSession();
+		try {
+			Object answer = producerSession.sendRpcMessage(rpcQueue, echoRequest("hello"),
+					true, 30000L, null, null, null);
+			assertEquals("hello", answer, "the RPC should return what the responder echoed");
+		} finally {
+			producerSession.close();
+			service.removeMessageConsumer(responder);
+			restoreBlobProperty(previous);
+		}
+	}
+
+	/**
+	 * The concurrency fix: every RPC gets its own JMS session, so concurrent callers on one
+	 * producer session cannot corrupt each other's producer, transaction or reply consumer.
+	 */
+	@Test
+	public void concurrentRpcsEachGetTheirOwnAnswer() throws Exception {
+		String previous = setBlobProperty();
+		// its own queue: removeMessageConsumer stops the polling thread without closing the
+		// consumer, so a responder from another test would sit on prefetched messages forever
+		VCellQueue rpcQueue = new VCellQueue("MessageProducerSessionJmsTestRpcQueue-concurrent");
+		VCQueueConsumer responder = startEchoResponder(rpcQueue);
+		VCMessageSession producerSession = service.createProducerSession();
+		ExecutorService pool = Executors.newFixedThreadPool(6);
+		try {
+			CountDownLatch startTogether = new CountDownLatch(1);
+			List<Future<Object>> answers = new ArrayList<>();
+			for (int i = 0; i < 6; i++) {
+				final String payload = "request-" + i;
+				answers.add(pool.submit((Callable<Object>) () -> {
+					startTogether.await();
+					return producerSession.sendRpcMessage(rpcQueue, echoRequest(payload),
+							true, 60000L, null, null, null);
+				}));
+			}
+			startTogether.countDown();
+
+			for (int i = 0; i < answers.size(); i++) {
+				assertEquals("request-" + i, answers.get(i).get(90, TimeUnit.SECONDS),
+						"each concurrent caller must get back its own reply, not another caller's");
+			}
+		} finally {
+			pool.shutdownNow();
+			producerSession.close();
+			service.removeMessageConsumer(responder);
+			restoreBlobProperty(previous);
+		}
+	}
+
+	private static VCRpcRequest echoRequest(String payload) {
+		return new VCRpcRequest(new User("testuser", new KeyValue("1")),
+				VCRpcRequest.RpcServiceType.TESTING_SERVICE, "echo", new Object[] { payload });
+	}
+
+	/** Answers RPCs on RPC_QUEUE by echoing the argument back. */
+	private static VCQueueConsumer startEchoResponder(VCellQueue rpcQueue) {
+		VCRpcMessageHandler handler = new VCRpcMessageHandler(new EchoService(), rpcQueue);
+		VCQueueConsumer responder = new VCQueueConsumer(rpcQueue, handler, null, "echo responder", 1);
+		service.addMessageConsumer(responder);
+		return responder;
+	}
+
+	public static class EchoService {
+		public String echo(String value) {
+			return value;
+		}
+	}
+
+	private static String setBlobProperty() {
+		String previous = System.getProperty(PropertyLoader.jmsBlobMessageUseMongo);
+		System.setProperty(PropertyLoader.jmsBlobMessageUseMongo, "false");
+		return previous;
+	}
+
+	private static void restoreBlobProperty(String previous) {
+		if (previous == null) {
+			System.clearProperty(PropertyLoader.jmsBlobMessageUseMongo);
+		} else {
+			System.setProperty(PropertyLoader.jmsBlobMessageUseMongo, previous);
+		}
+	}
+
 	/** An embedded-broker messaging service that counts every JMS connection opened through it. */
 	private static final class CountingMessagingService extends VCMessagingServiceJms {
 		final AtomicInteger connectionsOpened = new AtomicInteger();
@@ -222,7 +318,7 @@ public class MessageProducerSessionJmsTest {
 
 		@Override
 		public ConnectionFactory createConnectionFactory() {
-			return new ActiveMQConnectionFactory("vm://" + BROKER_NAME + "?create=false") {
+			ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://" + BROKER_NAME + "?create=false") {
 				@Override
 				public Connection createConnection() throws JMSException {
 					if (failConnections) {
@@ -232,6 +328,10 @@ public class MessageProducerSessionJmsTest {
 					return super.createConnection();
 				}
 			};
+			// VCRpcRequest travels as an ObjectMessage; the broker refuses to deserialize
+			// unlisted classes otherwise
+			factory.setTrustAllPackages(true);
+			return factory;
 		}
 
 		@Override


### PR DESCRIPTION
Fixes the concurrency defect surfaced by the forensics in #1844.

## The defect

`RpcService` creates **one** producer session at startup (`VCellApiMain:233`) and
`RpcRestlet` hands that same instance to every request thread. `sendRpcMessage` then ran
`createProducer`, `send`, `commit`, `createConsumer` and a blocking `receive` on that one
`javax.jms.Session` — which is not thread-safe. The sharpest edge is the transaction: the
session is transacted, so **one caller's `commit()` commits another caller's in-flight
send**.

Running this PR's test class against the previous implementation, with six callers at once:

```
   5  Transaction 'TX:<id>' has not been started
   9  Server is temporarily not responding      (RPC timeouts)
   → concurrentRpcsEachGetTheirOwnAnswer: ERROR
```

Marking the method `synchronized` is not the answer — it would serialise every RPC behind
a `receive()` that blocks for up to the client timeout. That is presumably why the
`synchronized` on the signature was commented out rather than kept.

## The change

`Connection` is thread-safe; `Session` is not. Each call now takes **its own session for
the whole RPC** — request message, producer, commit, reply consumer — and closes it in the
`finally`. No new connection: a session is created on the connection already held.

This subsumes the separate message session from #1844. With a per-call session there is
nothing left to isolate message construction *from*, so that indirection collapses into
this one.

The reply queue stays shared per producer session (each caller takes only its own reply,
selected by correlation id) and is now created on a session of its own, so `sendRpcMessage`
no longer touches the shared session at all. A temporary destination belongs to the
connection, not to the session that created it.

Also fixes a latent NPE — `replyConsumer` was closed in a `finally` with no null check, so
a failure in `createConsumer` masked itself.

## Verification

Two new tests, both round-tripping through a real embedded broker with a
`VCRpcMessageHandler` responder:

- `rpcRoundTripReturnsTheAnswer` — request out, reply back through the temporary queue.
  Proves the reply path still works after moving where the temporary queue is created.
- `concurrentRpcsEachGetTheirOwnAnswer` — six simultaneous callers on one producer session;
  each must get back its own payload. Passes here; on `master` it errors with the
  transaction corruption above.

`vcell-server` Fast group: 60 passed. `vcell-api` compiles.

## Two things found while writing the tests

- **`removeMessageConsumer` leaves a consumer attached.** It stops the polling thread but
  never closes the consumer or its connection, so the broker keeps dispatching to it —
  with `prefetchLimit=1` it sits on one message forever. This cost me a test failure that
  looked like a concurrency bug and wasn't: a responder torn down by an earlier test was
  still holding a prefetched message. The tests now use a queue per test to route around
  it. **This is a real production hazard, not just a test artifact**, and is still open.
- The test harness needs `setTrustAllPackages(true)`: `VCRpcRequest` travels as an
  ObjectMessage and ActiveMQ refuses to deserialize unlisted classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
