### PR TITLE
Mint every SED-ML id from one document-wide allocator

### DIFF
--- a/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
+++ b/vcell-core/src/main/java/org/vcell/sedml/SEDMLExporter.java
@@ -100,7 +100,14 @@ public class SEDMLExporter {
 
     /** Application to the SED-ML id it was exported under; see {@link #getSimContextId}. */
     private final Map<SimulationContext, String> simContextIdMap = new LinkedHashMap<>();
-    private final Set<String> usedSimContextIds = new LinkedHashSet<>();
+
+    /**
+     * Every SId this exporter has minted into the current document; see {@link #uniqueId}.
+     */
+    private final Set<String> usedSedmlIds = new LinkedHashSet<>();
+
+    /** The 'time' data generator minted for each task, so outputs can reference it without re-deriving its id. */
+    private final Map<SId, SId> timeDataGeneratorIdByTask = new LinkedHashMap<>();
 
     /**
      * Ids the current application's SBML gave an {@code <initialAssignment>} rather than an
@@ -196,6 +203,9 @@ public class SEDMLExporter {
                                           boolean bRoundTripSBMLValidation, Predicate<SimulationContext> simContextExportFilter) {
         SedML sedml = this.sedmlModel.getSedML();
         this.modelFilePathStrAbsoluteList.clear();
+        this.simContextIdMap.clear();
+        this.usedSedmlIds.clear();
+        this.timeDataGeneratorIdByTask.clear();
         try {
 
             if (modelFormat == ModelFormat.VCML) {
@@ -208,6 +218,7 @@ public class SEDMLExporter {
                 String modelFileNameAbs = Paths.get(savePath, modelFileNameRel).toString();
                 XmlUtil.writeXMLStringToFile(vcmlString, modelFileNameAbs, false);
                 this.modelFilePathStrAbsoluteList.add(modelFileNameRel);
+                this.reserveSimContextIds(this.vcBioModel.getSimulationContexts());
                 for (int i = 0; i < this.vcBioModel.getSimulationContexts().length; i++) {
                     this.writeModelVCML(modelFileNameRel, this.vcBioModel.getSimulationContext(i));
                     this.sedmlRecorder.addTaskRecord(this.vcBioModel.getSimulationContext(i).getName(), TaskType.SIMCONTEXT, TaskResult.SUCCEEDED, null);
@@ -239,6 +250,7 @@ public class SEDMLExporter {
                 if (simContexts.length == 0) {
                     this.sedmlRecorder.addTaskRecord(this.vcBioModel.getName(), TaskType.MODEL, TaskResult.FAILED, new Exception("Model has no Applications"));
                 } else {
+                    this.reserveSimContextIds(simContexts);
                     int simContextCnt = 0;    // for model count, task subcount
                     for (SimulationContext simContext : simContexts) {
                         // Export the application itself to SBML, with default values (overrides will become model changes or repeated tasks)
@@ -288,6 +300,33 @@ public class SEDMLExporter {
     }
 
     /**
+     * Mint an SId that no other object in this document uses.
+     * <p>
+     * SED-ML SIds share one namespace across every kind of object, but the ids here are built from
+     * several independent recipes — application names, simulation names, mangled variable names,
+     * per-kind counters — so nothing stops two of them landing on the same string. A BioModel with
+     * an application <em>and</em> a simulation both named {@code compartmental} produced a document
+     * with {@code <model id="compartmental">} and {@code <uniformTimeCourse id="compartmental">},
+     * which is invalid. Routing every mint through here makes that impossible by construction.
+     * <p>
+     * A free {@code base} is returned unchanged, so ids only move where they previously collided.
+     * {@code kindTag} names the kind of object being identified, so a disambiguated id still reads
+     * as what it is ({@code compartmental_sim0}).
+     */
+    private String uniqueId(String base, String kindTag) {
+        String candidate = base;
+        int collisionCount = 0;
+        while (!this.usedSedmlIds.add(candidate)) {
+            candidate = base + "_" + kindTag + collisionCount++;
+        }
+        return candidate;
+    }
+
+    private SId uniqueSId(String base, String kindTag) {
+        return new SId(this.uniqueId(base, kindTag));
+    }
+
+    /**
      * The SED-ML id for an application, unique across the exported document.
      * <p>
      * {@link TokenMangler#mangleToSName} replaces every non-alphanumeric character with an
@@ -296,20 +335,23 @@ public class SEDMLExporter {
      * it, so without disambiguation the second application overwrites the first application's SBML
      * file and re-uses its model id — leaving that application's data generators pointing at another
      * application's parameters, and silently shipping the wrong model in the archive.
-     * <p>
-     * The suffix is {@code _app<n>} rather than {@code _<n>} to stay clear of the ids given to
-     * override-derived models, which are {@code <simContextId>_<overrideCount>}.
      */
     private String getSimContextId(SimulationContext simContext) {
-        return this.simContextIdMap.computeIfAbsent(simContext, sc -> {
-            String base = TokenMangler.mangleToSName(sc.getName());
-            String candidate = base;
-            int collisionCount = 0;
-            while (!this.usedSimContextIds.add(candidate)) {
-                candidate = base + "_app" + collisionCount++;
-            }
-            return candidate;
-        });
+        return this.simContextIdMap.computeIfAbsent(simContext,
+                sc -> this.uniqueId(TokenMangler.mangleToSName(sc.getName()), "app"));
+    }
+
+    /**
+     * Claim the id of every application before exporting anything else.
+     * <p>
+     * Applications are exported one at a time, so without this an application's id could be taken
+     * first by a simulation of an earlier application. Applications get first refusal because their
+     * id also names the SBML file written for them.
+     */
+    private void reserveSimContextIds(SimulationContext[] simContexts) {
+        for (SimulationContext simContext : simContexts) {
+            this.getSimContextId(simContext);
+        }
     }
 
     private void writeModelVCML(String filePathStrRelative, SimulationContext simContext) {
@@ -380,12 +422,26 @@ public class SEDMLExporter {
         }
     }
 
+    /**
+     * The 'time' data generator for a task, looked up by the id it was actually given rather than
+     * by rebuilding that id here — the allocator is free to move it, and outputs are meaningless
+     * without an x axis.
+     */
+    private DataGenerator findTimeDataGenerator(SId taskRef, SimulationContext simContext) {
+        SId timeDataGenId = this.timeDataGeneratorIdByTask.get(taskRef);
+        DataGenerator dgTime = timeDataGenId == null ? null : this.sedmlModel.findDataGeneratorById(timeDataGenId);
+        if (dgTime == null) {
+            throw new RuntimeException("DataGenerator referring time could not be found (sim context: '" + simContext.getName() + "')");
+        }
+        return dgTime;
+    }
+
     private void createSedMLOutputs(SimulationContext simContext, Simulation vcSimulation, List<DataGenerator> dataGeneratorsOfSim, SId taskRef) {
         // add output to sedml Model : 1 plot2d for each non-spatial simulation with all vars (species/output functions) vs time (1 curve per var)
         // ignoring output for spatial deterministic (spatial stochastic is not exported to SEDML) and non-spatial stochastic applications with histogram
         if (!(simContext.getGeometry().getDimension() > 0)) {
-            String plot2dId = "plot2d_" + TokenMangler.mangleToSName(vcSimulation.getName());
-            String reportId = "report_" + TokenMangler.mangleToSName(vcSimulation.getName());
+            String plot2dId = this.uniqueId("plot2d_" + TokenMangler.mangleToSName(vcSimulation.getName()), "plot");
+            String reportId = this.uniqueId("report_" + TokenMangler.mangleToSName(vcSimulation.getName()), "report");
             //								String reportId = "__plot__" + plot2dId;
             String plotName = simContext.getName() + "_" + vcSimulation.getName() + "_plot";
             Plot2D sedmlPlot2d = new Plot2D(new SId(plot2dId), plotName);
@@ -393,10 +449,9 @@ public class SEDMLExporter {
 
             sedmlPlot2d.setNotes(this.createNotesElement("Plot of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
             sedmlReport.setNotes(this.createNotesElement("Report of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
-            DataGenerator dgTime = this.sedmlModel.findDataGeneratorById(new SId(DATA_GENERATOR_TIME_NAME + "_" + taskRef.string()));
-            if (null == dgTime) throw new RuntimeException("DataGenerator referring time could not be found (sim context: '" + simContext.getName() + "')");
+            DataGenerator dgTime = this.findTimeDataGenerator(taskRef, simContext);
             SId xDataRef = dgTime.getId();
-            SId xDatasetXId = new SId("__data_set__" + plot2dId + dgTime.getIdAsString());
+            SId xDatasetXId = this.uniqueSId("__data_set__" + plot2dId + dgTime.getIdAsString(), "dataSet");
             DataSet dataSet = new DataSet(xDatasetXId, DATA_GENERATOR_TIME_NAME, "time", xDataRef);    // id, name, label, data generator reference
             sedmlReport.addDataSet(dataSet);
 
@@ -408,8 +463,8 @@ public class SEDMLExporter {
                 if (dg.getId().equals(xDataRef)) {
                     continue;
                 }
-                SId curveId = new SId("curve_" + plot2dId + "_" + dg.getIdAsString());
-                SId datasetYId = new SId("__data_set__" + plot2dId + dg.getIdAsString());
+                SId curveId = this.uniqueSId("curve_" + plot2dId + "_" + dg.getIdAsString(), "curve");
+                SId datasetYId = this.uniqueSId("__data_set__" + plot2dId + dg.getIdAsString(), "dataSet");
                 Curve curve = new Curve(curveId, dg.getName(), xDataRef, dg.getId());
                 sedmlPlot2d.addCurve(curve);
                 //									// id, name, label, dataRef
@@ -425,18 +480,17 @@ public class SEDMLExporter {
         } else {        // spatial deterministic
             if (simContext.getApplicationType().equals(Application.NETWORK_DETERMINISTIC)) {    // we ignore spatial stochastic (Smoldyn)
                 // TODO: add curves/surfaces to the plots
-                SId plot3dId = new SId("plot3d_" + TokenMangler.mangleToSName(vcSimulation.getName()));
-                SId reportId = new SId("report_" + TokenMangler.mangleToSName(vcSimulation.getName()));
+                SId plot3dId = this.uniqueSId("plot3d_" + TokenMangler.mangleToSName(vcSimulation.getName()), "plot");
+                SId reportId = this.uniqueSId("report_" + TokenMangler.mangleToSName(vcSimulation.getName()), "report");
                 String plotName = simContext.getName() + "plots";
                 Plot3D sedmlPlot3d = new Plot3D(plot3dId, plotName);
                 Report sedmlReport = new Report(reportId, plotName);
 
                 sedmlPlot3d.setNotes(this.createNotesElement("Plot of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
                 sedmlReport.setNotes(this.createNotesElement("Report of all variables and output functions from application '" + simContext.getName() + "' ; simulation '" + vcSimulation.getName() + "' in VCell model"));
-                DataGenerator dgTime = this.sedmlModel.findDataGeneratorById(new SId(DATA_GENERATOR_TIME_NAME + "_" + taskRef.string()));
-                if (null == dgTime) throw new RuntimeException("DataGenerator referring time could not be found (sim context: '" + simContext.getName() + "')");
+                DataGenerator dgTime = this.findTimeDataGenerator(taskRef, simContext);
                 SId xDataRef = dgTime.getId();
-                SId xDatasetXId = new SId("__data_set__" + plot3dId.string() + dgTime.getIdAsString());
+                SId xDatasetXId = this.uniqueSId("__data_set__" + plot3dId.string() + dgTime.getIdAsString(), "dataSet");
                 DataSet dataSet = new DataSet(xDatasetXId, DATA_GENERATOR_TIME_NAME, "time", xDataRef);    // id, name, label, data generator reference
                 sedmlReport.addDataSet(dataSet);
 
@@ -448,8 +502,8 @@ public class SEDMLExporter {
                     if (dg.getId().equals(xDataRef)) {
                         continue;
                     }
-                    SId curveId = new SId("curve_" + plot3dId.string() + "_" + dg.getIdAsString());
-                    SId datasetYId = new SId("__data_set__" + plot3dId.string() + dg.getIdAsString());
+                    SId curveId = this.uniqueSId("curve_" + plot3dId.string() + "_" + dg.getIdAsString(), "curve");
+                    SId datasetYId = this.uniqueSId("__data_set__" + plot3dId.string() + dg.getIdAsString(), "dataSet");
 
                     DataSet yDataSet = new DataSet(datasetYId, dg.getName(), dg.getIdAsString(), dg.getId());
                     sedmlReport.addDataSet(yDataSet);
@@ -465,8 +519,9 @@ public class SEDMLExporter {
         List<DataGenerator> dataGeneratorsOfSim = new ArrayList<>();
         for (SId taskRef : dataGeneratorTasksSet) {
             // add one DataGenerator for 'time'
-            SId timeDataGenId = new SId(DATA_GENERATOR_TIME_NAME + "_" + taskRef.string());
-            SId timeVarId = new SId(DATA_GENERATOR_TIME_SYMBOL + "_" + taskRef.string());
+            SId timeDataGenId = this.uniqueSId(DATA_GENERATOR_TIME_NAME + "_" + taskRef.string(), "dataGen");
+            this.timeDataGeneratorIdByTask.put(taskRef, timeDataGenId);
+            SId timeVarId = this.uniqueSId(DATA_GENERATOR_TIME_SYMBOL + "_" + taskRef.string(), "var");
             Variable timeVar = new Variable(timeVarId, DATA_GENERATOR_TIME_SYMBOL, taskRef, VariableSymbol.TIME);
             ASTNode math = Libsedml.parseFormulaString(timeVarId.string());
             DataGenerator timeDataGen = new DataGenerator(timeDataGenId, timeDataGenId.string(), math);
@@ -488,11 +543,11 @@ public class SEDMLExporter {
                 }
             }
             for (String varName : varNamesList) {
-                SId varId = new SId(TokenMangler.mangleToSName(varName) + "_" + taskRef.string());
+                SId varId = this.uniqueSId(TokenMangler.mangleToSName(varName) + "_" + taskRef.string(), "var");
                 String xPathForSpecies = sbmlString != null ? this.sbmlSupport.getXPathForSpecies(varName) : VCMLSupport.getXPathForSpeciesContextSpec(simContext.getName(), varName);
                 Variable sedmlVar = new Variable(varId, varName, taskRef, xPathForSpecies);
                 ASTNode varMath = Libsedml.parseFormulaString(varId.string());
-                SId dataGenId = new SId(dataGenIdPrefix + "_" + TokenMangler.mangleToSName(varName)); //"dataGen_" + varCount; - old code
+                SId dataGenId = this.uniqueSId(dataGenIdPrefix + "_" + TokenMangler.mangleToSName(varName), "dataGen"); //"dataGen_" + varCount; - old code
                 DataGenerator dataGen = new DataGenerator(dataGenId, varName, varMath);
                 dataGen.addVariable(sedmlVar);
                 dataGeneratorsOfSim.add(dataGen);
@@ -521,11 +576,11 @@ public class SEDMLExporter {
                 }
             }
             for (String varName : varNamesList) {
-                SId varId = new SId(TokenMangler.mangleToSName(varName) + "_" + taskRef.string());
+                SId varId = this.uniqueSId(TokenMangler.mangleToSName(varName) + "_" + taskRef.string(), "var");
                 String xPathForSpecies = sbmlString != null ? this.sbmlSupport.getXPathForGlobalParameter(varName) : VCMLSupport.getXPathForOutputFunction(simContext.getName(), varName);
                 Variable sedmlVar = new Variable(varId, varName, taskRef, xPathForSpecies);
                 ASTNode varMath = Libsedml.parseFormulaString(varId.string());
-                SId dataGenId = new SId(dataGenIdPrefix + "_" + TokenMangler.mangleToSName(varName)); //"dataGen_" + varCount; - old code
+                SId dataGenId = this.uniqueSId(dataGenIdPrefix + "_" + TokenMangler.mangleToSName(varName), "dataGen"); //"dataGen_" + varCount; - old code
                 DataGenerator dataGen = new DataGenerator(dataGenId, varName, varMath);
                 dataGen.addVariable(sedmlVar);
                 dataGeneratorsOfSim.add(dataGen);
@@ -548,7 +603,7 @@ public class SEDMLExporter {
         TimeBounds vcSimTimeBounds = simTaskDesc.getTimeBounds();
         double startingTime = vcSimTimeBounds.getStartingTime();
         String simName = simTaskDesc.getSimulation().getName();
-        UniformTimeCourse utcSim = new UniformTimeCourse(new SId(TokenMangler.mangleToSName(simName)), simName, startingTime, startingTime,
+        UniformTimeCourse utcSim = new UniformTimeCourse(this.uniqueSId(TokenMangler.mangleToSName(simName), "sim"), simName, startingTime, startingTime,
                 vcSimTimeBounds.getEndingTime(), (int) simTaskDesc.getExpectedNumTimePoints(), sedmlAlgorithm);
 
         boolean enableAbsoluteErrorTolerance;        // --------- deal with error tolerance
@@ -697,7 +752,7 @@ public class SEDMLExporter {
             throws ExpressionException, MappingException {
         if (mathOverrides == null || !mathOverrides.hasOverrides()) {
             // no math overrides, add basic task.
-            SId taskId = new SId("tsk_" + simContextCnt + "_" + this.simCount);
+            SId taskId = this.uniqueSId("tsk_" + simContextCnt + "_" + this.simCount, "tsk");
             Task sedmlTask = new Task(taskId, vcSimulation.getName(), new SId(simContextId), utcSim.getId());
             dataGeneratorTasksSet.add(sedmlTask.getId());
             this.sedmlModel.getSedML().addTask(sedmlTask);
@@ -760,7 +815,7 @@ public class SEDMLExporter {
         if (!unscannedParamHash.isEmpty() && scannedParamHash.isEmpty()) {
             // only parameters with simple overrides (numeric/expression) no scans
             // create new model with change for each parameter that has override; add simple task
-            SId overriddenSimContextId = new SId(simContextId + "_" + this.overrideCount);
+            SId overriddenSimContextId = this.uniqueSId(simContextId + "_" + this.overrideCount, "model");
             String overriddenSimContextName = simContextName + " modified";
             Model sedModel = new Model(overriddenSimContextId, overriddenSimContextName, languageURN, "#" + simContextId);
             this.overrideCount++;
@@ -792,7 +847,7 @@ public class SEDMLExporter {
                     Expression expr = new Expression(unscannedParamExpr);
                     String[] exprSymbols = expr.getSymbols();
                     for (String symbol : exprSymbols) {
-                        SId varName = new SId(overriddenSimContextId.string() + "_" + symbol + "_" + variableCount);
+                        SId varName = this.uniqueSId(overriddenSimContextId.string() + "_" + symbol + "_" + variableCount, "var");
                         Variable sedmlVar = new Variable(varName, varName.string(), symbolToTargetMap.get(symbol).toString(), overriddenSimContextId);
                         expr.substituteInPlace(new Expression(symbol), new Expression(varName.string()));
                         computeChange.addVariable(sedmlVar);
@@ -805,13 +860,13 @@ public class SEDMLExporter {
             }
             this.sedmlModel.getSedML().addModel(sedModel);
 
-            SId taskId = new SId("tsk_" + simContextCnt + "_" + this.simCount);
+            SId taskId = this.uniqueSId("tsk_" + simContextCnt + "_" + this.simCount, "tsk");
             Task sedmlTask = new Task(taskId, vcSimulation.getName(), sedModel.getId(), utcSim.getId());
             dataGeneratorTasksSet.add(sedmlTask.getId());
             this.sedmlModel.getSedML().addTask(sedmlTask);
         } else if (!scannedParamHash.isEmpty() && unscannedParamHash.isEmpty()) {
             // only parameters with scans
-            SId taskId = new SId("tsk_" + simContextCnt + "_" + this.simCount);
+            SId taskId = this.uniqueSId("tsk_" + simContextCnt + "_" + this.simCount, "tsk");
             Task sedmlTask = new Task(taskId, vcSimulation.getName(), new SId(simContextId), utcSim.getId());
             dataGeneratorTasksSet.add(sedmlTask.getId());
             this.sedmlModel.getSedML().addTask(sedmlTask);
@@ -819,8 +874,8 @@ public class SEDMLExporter {
             int repeatedTaskIndex = 0;
             SId ownerTaskId = taskId;
             for (String scannedConstName : scannedConstantsNames) {
-                SId repeatedTaskId = new SId("repTsk_" + simContextCnt + "_" + this.simCount + "_" + repeatedTaskIndex);
-                SId rangeId = new SId("range_" + simContextCnt + "_" + this.simCount + "_" + scannedConstName);
+                SId repeatedTaskId = this.uniqueSId("repTsk_" + simContextCnt + "_" + this.simCount + "_" + repeatedTaskIndex, "repTsk");
+                SId rangeId = this.uniqueSId("range_" + simContextCnt + "_" + this.simCount + "_" + scannedConstName, "range");
                 RepeatedTask rt = this.createSedMLRepeatedTask(rangeId, l2gMap, simContext, dataGeneratorTasksSet, mathOverrides, ownerTaskId, scannedConstName, repeatedTaskId, new SId(simContextId));
                 ownerTaskId = repeatedTaskId;
                 repeatedTaskIndex++;
@@ -833,12 +888,12 @@ public class SEDMLExporter {
             List<RepeatedTask> repeatedTasksList = new ArrayList<>();
 
             // create new model with change for each unscanned parameter that has override
-            SId overriddenSimContextId = new SId(simContextId + "_" + this.overrideCount);
+            SId overriddenSimContextId = this.uniqueSId(simContextId + "_" + this.overrideCount, "model");
             String overriddenSimContextName = simContextName + " modified";
             Model sedModel = new Model(overriddenSimContextId, overriddenSimContextName, languageURN, "#" + simContextId);
             this.overrideCount++;
 
-            SId taskId = new SId("tsk_" + simContextCnt + "_" + this.simCount);
+            SId taskId = this.uniqueSId("tsk_" + simContextCnt + "_" + this.simCount, "tsk");
             Task sedmlTask = new Task(taskId, vcSimulation.getName(), overriddenSimContextId, utcSim.getId());
             dataGeneratorTasksSet.add(sedmlTask.getId());
             this.sedmlModel.getSedML().addTask(sedmlTask);
@@ -848,8 +903,8 @@ public class SEDMLExporter {
             int variableCount = 0;
             SId ownerTaskId = taskId;
             for (String scannedConstName : scannedConstantsNames) {
-                SId repeatedTaskId = new SId("repTsk_" + simContextCnt + "_" + this.simCount + "_" + repeatedTaskIndex);
-                SId rangeId = new SId("range_" + simContextCnt + "_" + this.simCount + "_" + scannedConstName);
+                SId repeatedTaskId = this.uniqueSId("repTsk_" + simContextCnt + "_" + this.simCount + "_" + repeatedTaskIndex, "repTsk");
+                SId rangeId = this.uniqueSId("range_" + simContextCnt + "_" + this.simCount + "_" + scannedConstName, "range");
                 RepeatedTask rt = this.createSedMLRepeatedTask(rangeId, l2gMap, simContext, dataGeneratorTasksSet, mathOverrides, ownerTaskId, scannedConstName, repeatedTaskId, overriddenSimContextId);
                 ownerTaskId = repeatedTaskId;
                 repeatedTaskIndex++;
@@ -906,7 +961,7 @@ public class SEDMLExporter {
                             SetValue setValue = new SetValue(target, rangeId, overriddenSimContextId);    // @TODO: we have no range??
                             Expression expr = new Expression(unscannedParamExpr);
                             for (String symbol : symbols) {
-                                SId symbolName = new SId(rangeId.string() + "_" + symbol + "_" + variableCount);
+                                SId symbolName = this.uniqueSId(rangeId.string() + "_" + symbol + "_" + variableCount, "var");
                                 Variable sedmlVar = new Variable(symbolName, symbolName.string(), symbolToTargetMap.get(symbol).toString(), overriddenSimContextId);    // sbmlSupport.getXPathForSpecies(symbol));
                                 setValue.addVariable(sedmlVar);
                                 expr.substituteInPlace(new Expression(symbol), new Expression(symbolName.string()));
@@ -923,7 +978,7 @@ public class SEDMLExporter {
                         ComputeChange computeChange = new ComputeChange(targetXpath);
                         Expression expr = new Expression(unscannedParamExpr);
                         for (String symbol : exprSymbols) {
-                            SId varName = new SId(overriddenSimContextId.string() + "_" + symbol + "_" + variableCount);
+                            SId varName = this.uniqueSId(overriddenSimContextId.string() + "_" + symbol + "_" + variableCount, "var");
                             Variable sedmlVar = new Variable(varName, varName.string(), symbolToTargetMap.get(symbol).toString(), overriddenSimContextId);
                             expr.substituteInPlace(new Expression(symbol), new Expression(varName.string()));
                             computeChange.addVariable(sedmlVar);
@@ -1003,7 +1058,7 @@ public class SEDMLExporter {
                 r = new UniformRange(rangeId, 1, 2, constantArraySpec.getNumValues(), type);
                 rt.addRange(r);
                 // now make a FunctionalRange with expressions
-                FunctionalRange fr = new FunctionalRange(new SId("fr_" + rangeId.string()), rangeId);
+                FunctionalRange fr = new FunctionalRange(this.uniqueSId("fr_" + rangeId.string(), "range"), rangeId);
                 Expression expMin = constantArraySpec.getMinValue();
                 expMin = this.adjustIfRateParam(vcSim, ste, expMin);
                 Expression expMax = constantArraySpec.getMaxValue();
@@ -1037,7 +1092,7 @@ public class SEDMLExporter {
             r = new VectorRange(rangeId, values);
             rt.addRange(r);
             // now make a FunctionalRange with expressions
-            FunctionalRange fr = new FunctionalRange(new SId("fr_" + rangeId.string()), rangeId);
+            FunctionalRange fr = new FunctionalRange(this.uniqueSId("fr_" + rangeId.string(), "range"), rangeId);
             expFact = Expression.mult(new Expression(rangeId.string()), expFact);
             expFact = this.adjustIfRateParam(vcSim, ste, expFact);
             this.createFunctionalRangeElements(fr, expFact, simContext, l2gMap, modelReferenceId);
@@ -1054,7 +1109,7 @@ public class SEDMLExporter {
             if (symbol.equals(fr.getRange().string())) continue;
             SymbolTableEntry entry = getSymbolTableEntryForModelEntity(msm, symbol);
             XPathTarget target = this.getTargetAttributeXPath(entry, l2gMap, simContext);
-            SId symbolName = new SId(fr.getRange().string() + "_" + symbol);
+            SId symbolName = this.uniqueSId(fr.getRange().string() + "_" + symbol, "var");
             Variable sedmlVar = new Variable(symbolName, symbolName.string(), target.toString(), modelReferenceId);    // sbmlSupport.getXPathForSpecies(symbol));
             fr.addVariable(sedmlVar);
             func.substituteInPlace(new Expression(symbol), new Expression(symbolName.string()));

--- a/vcell-core/src/test/java/org/vcell/sbml/SEDMLExporterSBMLTest.java
+++ b/vcell-core/src/test/java/org/vcell/sbml/SEDMLExporterSBMLTest.java
@@ -156,7 +156,11 @@ public class SEDMLExporterSBMLTest extends SEDMLExporterCommon {
 
 
 		// SEDML Validator Errors
-		faults.put("biomodel_82065439.vcml", SEDML_FAULT.OMEX_PARSER_ERRORS);  //  NON_UNIQUE_IDS:    Each identified SED object must have a unique id. Multiple objects have the following ids:",[["compartmental"]]
+		// biosimulators-utils 0.2.3 validates every repeatedTask setValue target against the LAST model in the
+		// document instead of the one the change references (sedml/validation.py:509 passes a leaked `model`
+		// loop variable, not `change.model`), so these XPaths are reported against a model they never named.
+		// The archive is correct - the parameters resolve against their own model sources. Remove once fixed upstream.
+		faults.put("biomodel_28625786.vcml", SEDML_FAULT.OMEX_PARSER_ERRORS);  //  XPATH_BAD:  XPath `/sbml:sbml/sbml:model/sbml:listOfParameters/sbml:parameter[@id='Km_PKA_activates_Raf']/@value` does not match any elements of model `simple_1`.
 		faults.put("biomodel_220138948.vcml",SEDML_FAULT.OMEX_VALIDATION_ERRORS);  //  XPATH_BAD:  XPath `/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='OAT1']/@initialConcentration` does not match any elements of model `_0D`.
 		faults.put("biomodel_31523791.vcml", SEDML_FAULT.OMEX_PARSER_ERRORS);      //  XPATH_BAD:  XPath `/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='cAMP_Intracellular']/@initialConcentration` does not match any elements of model `Dose_response`.
 		faults.put("biomodel_34855932.vcml", SEDML_FAULT.OMEX_PARSER_ERRORS);      //  XPATH_BAD:  XPath `/sbml:sbml/sbml:model/sbml:listOfParameters/sbml:parameter[@id='Kf_GPCR_to_ICSC']/@value` does not match any elements of model `cell5`


### PR DESCRIPTION
Last of the nightly `SEDML_SBML_IT` failures. `biomodel_28625786` has an **application** and a **simulation** both named `compartmental`, so the exported archive carried

```xml
<model id="compartmental" name="compartmental" .../>
<uniformTimeCourse id="compartmental" name="compartmental" .../>
```

which the OMEX validator rejects: *"Each identified SED object must have a unique id. Multiple objects have the following ids: [compartmental]"*.

## Why the previous fix didn't cover it

SED-ML SIds share **one namespace across every kind of object**, but `SEDMLExporter` built them from several independent recipes — application names, simulation names, mangled variable names, per-kind counters — with no check that two hadn't landed on the same string. #1840 added a uniqueness guard *within the application namespace only*; simulation ids were still minted unguarded in `createSedMLSim`.

Rather than repeat that guard per kind, every mint now goes through one allocator:

```java
private String uniqueId(String base, String kindTag) {
    String candidate = base;
    int collisionCount = 0;
    while (!this.usedSedmlIds.add(candidate)) {
        candidate = base + "_" + kindTag + collisionCount++;
    }
    return candidate;
}
```

A free `base` is returned unchanged, so **ids move only where they previously collided** — a correct archive is unaffected. Applications are reserved up front (`reserveSimContextIds`) so they keep first refusal on their name, which matters because an application's id also names the SBML file written for it. `#1840`'s `_app<n>` is now one case of the general `_<kind><n>`.

For `biomodel_28625786` the entire id diff against master is one line:

```
duplicate ids NEW: NONE
compartmental model : ['compartmental', 'compartmental_0', 'compartmental_1']
compartmental sim   : [('compartmental_sim0', 'compartmental')]
ids removed vs master: []
ids added   vs master: ['compartmental_sim0']
```

## Latent collisions this also closes

Neither had been hit by a test yet:

- **Override-derived models** are `<simContextId>_<overrideCount>`, which can land on another application's mangled id. This very model has applications `simple_1` and `simple_1.5` → `simple_1_5`; a sixth override variant of `simple_1` would have collided.
- **Data generator ids** are `dataGen_<task>_<mangled var>`, and `TokenMangler.mangleToSName` is many-to-one — species `a.b` and `a-b` both mangle to `a_b`.

The 'time' data generator is now looked up by the id it was actually given rather than by rebuilding that id at the use site, since the allocator is free to move it.

## Test expectations

**`biomodel_82065439` had the same duplicate-`compartmental` fault recorded and now round-trips cleanly**, so it failed with *"passed SEDML Round trip, but knownSEDMLFault was set"* — entry removed. (This is the usual signal on this suite: a fix surfaces as a failure.)

**`biomodel_28625786` still fails, on a validator bug rather than on the archive**, and is recorded as a known fault with the diagnosis inline. `biosimulators-utils` 0.2.3 checks every `repeatedTask` `setValue` target against the **last model in the document** instead of the one the change references — `sedml/validation.py:509` passes a leaked `model` loop variable where it means `change.model`. Here that lands on `HPC_070907`; species targets happen to exist there so they pass, the kinetic parameters do not, and the errors are then reported against models (`simple_1`, `simple_1_5`) that were never searched. Verified with lxml that those parameters *do* resolve against their own model sources:

```
<parameter constant="true" id="Km_PKA_activates_Raf" units="Unit_umol_l_1" value="0.5"/>
```

0.2.3 is the latest release on PyPI, so there's nothing to upgrade to; the entry comes out when the upstream fix lands.

## Testing

PR CI cannot exercise this — `SEDML_SBML_IT` runs only in `regression.yml`, and these models sit behind `test.include.slow`. Locally:

```bash
mvn -o test -pl vcell-core -Dgroups=SEDML_SBML_IT -Dtest=SEDMLExporterSBMLTest \
    -Dtest.include.slow=true -Dtest.only=biomodel_28625786,biomodel_82065439,biomodel_220138948
```

The duplicate-id error is gone; `biomodel_82065439` now passes outright. **The full 264-model group is still running** — any other model whose fault this resolves will announce itself the same way, and I'll push a follow-up commit if more turn up before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvqmME7MkRUNEYje5HpiLt
