### PR TITLE
Close the consumer when removeMessageConsumer removes it

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/jms/ConsumerContextJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/ConsumerContextJms.java
@@ -23,8 +23,10 @@ public class ConsumerContextJms implements Runnable {
 	private Session jmsSession = null;
 	private Connection jmsConnection = null;
 	private MessageConsumer jmsMessageConsumer = null;
-	private boolean bProcessing = false;
-	private Thread thread = null;
+	// volatile: stop() and stopAndClose() run on a different thread from the polling loop,
+	// which must see the change promptly or it will keep calling receive() after close()
+	private volatile boolean bProcessing = false;
+	private volatile Thread thread = null;
 	private static Logger lg = LogManager.getLogger(ConsumerContextJms.class);
 	
 	public ConsumerContextJms(VCMessagingServiceJms vcMessagingServiceJms, VCMessagingConsumer consumer){
@@ -73,6 +75,12 @@ public class ConsumerContextJms implements Runnable {
 //						lg.info(toString()+"no message received within "+CONSUMER_POLLING_INTERVAL_MS+" ms");
 				}
 			} catch (JMSException e) {
+				if (!bProcessing || e instanceof javax.jms.IllegalStateException){
+					// close() unblocks a thread parked in receive(); that is shutdown, not a
+					// failure. Logging it as one and looping would spin on the closed consumer.
+					lg.debug(toString()+" consumer closed while polling", e);
+					break;
+				}
 				onException(e);
 			} catch (RollbackException e) {
 				lg.error(e.getMessage(),e);

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/ConsumerContextJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/ConsumerContextJms.java
@@ -102,6 +102,28 @@ public class ConsumerContextJms implements Runnable {
 		getThread().setDaemon(true);
 		getThread().start();
 	}
+	/**
+	 * Stop the polling thread and release the JMS resources behind it.
+	 *
+	 * stop() on its own only asks the thread to finish its current loop -- the MessageConsumer
+	 * stays registered with the broker, which keeps dispatching to it. With a prefetch limit
+	 * those messages then sit in a consumer nobody is reading and are not redelivered until
+	 * the connection dies.
+	 */
+	void stopAndClose(){
+		stop();
+		Thread consumerThread = getThread();
+		if (consumerThread != null && consumerThread != Thread.currentThread()){
+			try {
+				// the loop re-checks bProcessing once per receive() timeout
+				consumerThread.join(CONSUMER_POLLING_INTERVAL_MS*2);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		close();
+	}
+	
 	public void stop(){
 		if (bProcessing){
 			bProcessing=false;

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/VCMessagingServiceJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/VCMessagingServiceJms.java
@@ -187,16 +187,18 @@ public abstract class VCMessagingServiceJms implements VCMessagingService {
 
 	@Override
 	public void removeMessageConsumer(VCMessagingConsumer vcMessagingConsumer) {
+		ConsumerContextJms removed = null;
 		for (ConsumerContextJms context : consumerContexts){
 			if (context.getVCConsumer() == vcMessagingConsumer){
-				try {
-					context.stop();
-				} finally {
-					consumerContexts.remove(context);
-				}
-				return;
+				removed = context;
+				break;
 			}
 		}
+		if (removed == null){
+			return;
+		}
+		consumerContexts.remove(removed);
+		removed.stopAndClose();
 	}
 
 	@Override

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -294,6 +294,41 @@ public class MessageProducerSessionJmsTest {
 		}
 	}
 
+	/**
+	 * removeMessageConsumer used to stop the polling thread without closing the consumer, so the
+	 * broker went on dispatching to it: with prefetchLimit=1 a message would sit in a consumer
+	 * nobody was reading and was not redelivered until the connection died.
+	 */
+	@Test
+	public void removingAConsumerDoesNotStrandMessages() throws Exception {
+		VCellQueue queue = new VCellQueue("MessageProducerSessionJmsTestStrandedQueue");
+		VCQueueConsumer discarded = new VCQueueConsumer(queue, (m, s) -> { }, null, "discarded consumer", 1);
+		service.addMessageConsumer(discarded);
+		service.removeMessageConsumer(discarded);
+
+		int messageCount = 3;
+		CountDownLatch delivered = new CountDownLatch(messageCount);
+		VCQueueConsumer replacement = new VCQueueConsumer(queue, (m, s) -> delivered.countDown(),
+				null, "replacement consumer", 1);
+
+		VCMessageSession producerSession = service.createProducerSession();
+		try {
+			// sent while only the removed consumer could still be registered -- with a prefetch
+			// limit of one, a leaked consumer takes one of these and never gives it back
+			for (int i = 0; i < messageCount; i++) {
+				producerSession.sendQueueMessage(queue,
+						producerSession.createTextMessage("message " + i), Boolean.FALSE, 60000L);
+			}
+			service.addMessageConsumer(replacement);
+
+			assertTrue(delivered.await(20, TimeUnit.SECONDS),
+					"all " + messageCount + " messages should reach the replacement consumer; a removed "
+							+ "consumer must not still be holding one");
+		} finally {
+			producerSession.close();
+		}
+	}
+
 	/** An embedded-broker messaging service that counts every JMS connection opened through it. */
 	private static final class CountingMessagingService extends VCMessagingServiceJms {
 		final AtomicInteger connectionsOpened = new AtomicInteger();


### PR DESCRIPTION
Last of the JMS resource problems turned up while working through the export-progress
incident (#1837, #1838, #1839, #1842, #1844, #1845).

## The leak

`removeMessageConsumer` only called `stop()`, which asks the polling thread to finish its
current loop:

```java
if (context.getVCConsumer() == vcMessagingConsumer){
    try { context.stop(); } finally { consumerContexts.remove(context); }
    return;
}
```

The `MessageConsumer`, its session and its connection were left open. The broker therefore
went on dispatching to a consumer nobody was reading — and with a prefetch limit those
messages sit in its client-side buffer, undelivered and **not redelivered until the
connection dies**. Every VCell consumer is registered with an explicit prefetch limit
(`MessageConstants.PREFETCH_LIMIT_*`), so any removed consumer strands at least one message.

## The fix

`ConsumerContextJms.stopAndClose()` stops the thread, waits for it to leave its `receive()`
— bounded by two polling intervals, the same budget `VCMessagingServiceJms.close()` already
allows — and then closes the consumer, session and connection. `removeMessageConsumer` uses
it.

Finding the context first and mutating the list afterwards also removes a
remove-while-iterating that only worked because of the immediate `return`.

## Verification

`removingAConsumerDoesNotStrandMessages` registers a consumer, removes it, sends three
messages, then registers a replacement and requires all three to arrive. Control, with both
production files reverted to `master` and the test kept:

```
all 3 messages should reach the replacement consumer; a removed consumer must not
still be holding one ==> expected: <true> but was: <false>
```

Exactly one message stranded, as predicted by the prefetch limit of 1. `vcell-server` Fast
group: 61 passed.

## This one was not hypothetical

It cost a full debugging cycle on #1845. A responder torn down by an earlier test in the
same class was still holding a prefetched message, so a later test failed in a way that
looked exactly like the concurrency bug that PR was fixing — four concurrent callers passed,
six did not. Running the same test against `origin/master` first is what ruled out the
change under test and pointed here instead.

In production the same shape means a request silently stranded whenever a consumer is
removed and re-registered: no error, no redelivery, just one message that never gets a
reply until the connection is torn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
