### PR TITLE
Close the producer sendTopicMessage creates

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
@@ -293,15 +293,28 @@ public class MessageProducerSessionJms implements VCMessageSession {
         if(message instanceof VCMessageJms){
             VCMessageJms jmsMessage = (VCMessageJms) message;
             Session jmsSession = openSessionForSend();
+            MessageProducer messageProducer = null;
             try {
-                MessageProducer producer = jmsSession.createProducer(jmsSession.createTopic(topic.getName()));
-                producer.send(jmsMessage.getJmsMessage());
+                messageProducer = jmsSession.createProducer(jmsSession.createTopic(topic.getName()));
+                messageProducer.send(jmsMessage.getJmsMessage());
                 if(bIndependent){
                     jmsSession.commit();
                 }
                 vcMessagingServiceJms.getDelegate().onMessageSent(message, topic);
             } catch(JMSException e){
                 onException(e);
+            } finally {
+                // sendQueueMessage has always done this; without it every publish left a
+                // producer on the session. The callers here (SimDataServer's data and export
+                // events, SimulationStateMachine, StatusMessage) publish on sessions that live
+                // as long as the server, so the producers accumulated for the whole run.
+                if(messageProducer != null){
+                    try {
+                        messageProducer.close();
+                    } catch(JMSException e){
+                        lg.error(e.getMessage(), e);
+                    }
+                }
             }
         } else {
             throw new RuntimeException("must send a JMS message to a JMS messaging service");

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -20,6 +22,7 @@ import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
 import javax.jms.Session;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
@@ -38,6 +41,7 @@ import cbit.vcell.message.VCQueueConsumer;
 import cbit.vcell.message.VCRpcMessageHandler;
 import cbit.vcell.message.VCRpcRequest;
 import cbit.vcell.message.VCellQueue;
+import cbit.vcell.message.VCellTopic;
 import cbit.vcell.resource.PropertyLoader;
 
 import org.vcell.util.document.KeyValue;
@@ -326,6 +330,75 @@ public class MessageProducerSessionJmsTest {
 							+ "consumer must not still be holding one");
 		} finally {
 			producerSession.close();
+		}
+	}
+
+	/**
+	 * sendQueueMessage has always closed its producer in a finally; sendTopicMessage did not, so
+	 * every publish left one behind. The sessions that publish (SimDataServer's data and export
+	 * events, SimulationStateMachine, StatusMessage) live as long as the server, so the producers
+	 * accumulated for the whole run.
+	 */
+	@Test
+	public void sendTopicMessageDoesNotLeakProducers() throws Exception {
+		ProducerCountingService counting = new ProducerCountingService();
+		VCellTopic topic = new VCellTopic("MessageProducerSessionJmsTestTopic");
+		VCMessageSession producerSession = counting.createProducerSession();
+		try {
+			for (int i = 0; i < 5; i++) {
+				producerSession.sendTopicMessage(topic, producerSession.createTextMessage("message " + i));
+			}
+			assertEquals(0, counting.producersOpen.get(),
+					"every publish must close the producer it created");
+		} finally {
+			producerSession.close();
+		}
+	}
+
+	/**
+	 * Wraps the JMS objects in proxies so producers opened and closed can be counted in-process --
+	 * no broker bookkeeping, no timing, so the count is exact.
+	 */
+	private static final class ProducerCountingService extends VCMessagingServiceJms {
+		final AtomicInteger producersOpen = new AtomicInteger();
+
+		@Override
+		public ConnectionFactory createConnectionFactory() {
+			return new ActiveMQConnectionFactory("vm://" + BROKER_NAME + "?create=false") {
+				@Override
+				public Connection createConnection() throws JMSException {
+					return (Connection) countingProxy(Connection.class, super.createConnection());
+				}
+			};
+		}
+
+		@Override
+		public MessageConsumer createConsumer(Session jmsSession, VCDestination vcDestination,
+				VCMessageSelector vcSelector, int prefetchLimit) {
+			throw new UnsupportedOperationException("this service only produces");
+		}
+
+		private Object countingProxy(Class<?> iface, Object target) {
+			return Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] { iface },
+					(proxy, method, args) -> {
+						Object result;
+						try {
+							result = method.invoke(target, args);
+						} catch (InvocationTargetException e) {
+							throw e.getCause();
+						}
+						if ("createSession".equals(method.getName())) {
+							return countingProxy(Session.class, result);
+						}
+						if ("createProducer".equals(method.getName())) {
+							producersOpen.incrementAndGet();
+							return countingProxy(MessageProducer.class, result);
+						}
+						if ("close".equals(method.getName()) && target instanceof MessageProducer) {
+							producersOpen.decrementAndGet();
+						}
+						return result;
+					});
 		}
 	}
 


### PR DESCRIPTION
Last of the JMS resource problems found while working through the export-progress incident
(#1837, #1838, #1839, #1842, #1844, #1845, and the consumer-close PR this follows).

## The leak

`sendQueueMessage` has always closed its `MessageProducer` in a `finally`. `sendTopicMessage`
never did:

```java
MessageProducer producer = jmsSession.createProducer(jmsSession.createTopic(topic.getName()));
producer.send(jmsMessage.getJmsMessage());
if (bIndependent) { jmsSession.commit(); }
// ... and that was the end of the method
```

Every publish left a producer on the session.

## Why it matters

The sessions doing the publishing are long-lived, so nothing ever cleaned them up:

| caller | destination | session |
|---|---|---|
| `SimDataServer` — data events, **export events** | `ClientStatusTopic` | `createProducerSession()` at startup |
| `SimulationStateMachine` | `ServiceControlTopic` | long-lived |
| `StatusMessage.sendToClient` | `ClientStatusTopic` | caller's session |

One leaked producer per status update, for the life of the server — including every export
progress event, which is what made the original incident's message storm expensive in the
first place.

## Verification

`sendTopicMessageDoesNotLeakProducers` publishes five messages and requires the producer
count to return to zero. Control, with the production file reverted and the test kept:

```
every publish must close the producer it created ==> expected: <0> but was: <5>
```

Five publishes, five leaked producers.

The count is taken **in-process**, by wrapping the JMS objects in proxies that tally
`createProducer` against `close`, rather than querying the broker or turning on JMX. That is
deliberate: broker-side producer registration is asynchronous, and a count that depends on it
would be exactly the kind of racy assertion that passed locally and failed in CI earlier in
this series. This one is exact.

`vcell-server` Fast group: 62 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
