### PR TITLE
Stop JMS test classes sharing ActiveMQ's global BrokerRegistry

### DIFF
--- a/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/JmsFailoverWatchdogTest.java
@@ -25,8 +25,10 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 @Tag("Fast")
+@ResourceLock("activemqBrokerRegistry")
 public class JmsFailoverWatchdogTest {
 
 	/**
@@ -38,6 +40,10 @@ public class JmsFailoverWatchdogTest {
 	@Test
 	public void attach_firesTerminalHandlerWhenFailoverGivesUp() throws Exception {
 		BrokerService broker = new BrokerService();
+		// never the ActiveMQ default ("localhost"): BrokerRegistry is JVM-global, and this test
+		// stops its broker on purpose, so a lookup elsewhere would otherwise fall through to
+		// whichever broker is still registered -- see issue #1852
+		broker.setBrokerName("JmsFailoverWatchdogTestBroker");
 		broker.setPersistent(false);
 		broker.setUseJmx(false);
 		broker.setUseShutdownHook(false);
@@ -85,7 +91,7 @@ public class JmsFailoverWatchdogTest {
 		// failed in CI). ActiveMQConnection exposes these callbacks, so both branches
 		// are driven deterministically with no timing involved.
 		ActiveMQConnection connection =
-				(ActiveMQConnection) new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false")
+				(ActiveMQConnection) new ActiveMQConnectionFactory("vm://JmsFailoverWatchdogTestVm?broker.persistent=false")
 						.createConnection();
 		ListAppender captured = ListAppender.attachTo(JmsFailoverWatchdog.class);
 		try {

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import cbit.vcell.message.VCDestination;
 import cbit.vcell.message.VCMessage;
@@ -55,6 +56,7 @@ import org.vcell.util.document.User;
  * hands it to the listener, and most listeners never send through it.
  */
 @Tag("Fast")
+@ResourceLock("activemqBrokerRegistry")
 public class MessageProducerSessionJmsTest {
 
 	private static final String BROKER_NAME = "MessageProducerSessionJmsTestBroker";

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/test/BlobMessageTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/test/BlobMessageTest.java
@@ -8,12 +8,14 @@ import cbit.vcell.mongodb.VCMongoDbDriver;
 import cbit.vcell.resource.PropertyLoader;
 import org.bouncycastle.util.Arrays;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Disabled
 @Tag("Fast")
+@ResourceLock("activemqBrokerRegistry")
 public class BlobMessageTest {
 
 	private static final int NUM_PRODUCERS = 2;


### PR DESCRIPTION
Fixes #1852.

The issue's diagnosis is correct and I could reproduce the mechanism locally — this adopts
both suggested fixes.

## Cause

The Fast group runs with class-level parallelism (`-Djunit.jupiter.execution.parallel.mode.classes.default=concurrent`
in `ci.yml`), so `JmsFailoverWatchdogTest`, `BlobMessageTest` and `MessageProducerSessionJmsTest`
share a JVM. ActiveMQ's `BrokerRegistry` is a **JVM-global singleton**, and a lookup for an
absent broker does not fail — it falls through to whichever broker *is* registered.

`JmsFailoverWatchdogTest` created its `BrokerService` without a name, taking ActiveMQ's
default of `localhost`, and stops that broker deliberately — surviving a broker going away
is the thing it tests. While it tore that down, lookups landed on the other test's broker:

```
WARN BrokerRegistry - Broker localhost not started so using MessageProducerSessionJmsTestBroker instead
```

As the issue notes, `MessageProducerSessionJmsTest` already renamed its own broker, but that
was never sufficient: the registry is shared regardless of naming.

## Changes

- **`@ResourceLock("activemqBrokerRegistry")`** on all three classes, so they serialise among
  themselves while everything else still parallelises. This follows the existing
  `@ResourceLock("vcellGlobalConfig")` convention already documented in `ci.yml`, and holds
  whatever the brokers are called.
- **`JmsFailoverWatchdogTest` names its broker explicitly** (`JmsFailoverWatchdogTestBroker`)
  and connects to `vm://JmsFailoverWatchdogTestVm`, so nothing is ever registered as
  `localhost`.

## Verification

Pass/fail is the wrong signal for this one — the failure depends on interleaving, and the
suite passed in every local run either way. So I measured the **mechanism**: the count of
registry-fallback warnings, running the Fast group with CI's own parallel flags.

| | fallback warnings | tests |
|---|---|---|
| without this change, run 1 | **2** | 62 pass |
| without this change, run 2 | **1** | 62 pass |
| with this change | **0** | 62 pass |

The coupling occurs on every run; only whether it bites is random. Zero fallbacks means the
classes no longer reach each other's brokers.

## Note on scope

The three JMS classes now serialise against each other only. Everything else in the shard
still runs concurrently, so the effect on wall-clock is limited to those classes — locally
the Fast group takes about the same time either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
