### PR TITLE
Ship the 3D field viewer's web content in the installers

### DIFF
--- a/.github/workflows/CI-full.yml
+++ b/.github/workflows/CI-full.yml
@@ -181,6 +181,7 @@ jobs:
             needs_maven: true
             needs_secrets: false
             needs_installer_secrets: true
+            needs_vtk_wasm: true
           - name: admin
             dockerfile: docker/build/Dockerfile-admin-dev
             context: .
@@ -232,6 +233,14 @@ jobs:
         cd ..
         sudo tar -xvf deploy/deploy_dir_2025_03_18.tar
         sudo chmod 777 -R deploy
+
+    # The 3D field viewer's wasm bundle is a pinned release asset, not a repo file, and only the
+    # clientgen image ships it. Fetching it here rather than in the maven build keeps a 12 MB
+    # download off every developer's machine for a feature that is disabled by default; developers
+    # who want the viewer locally run the same script themselves (see webapp-viewer/README.md).
+    - name: fetch vtk.wasm bundle for the field viewer
+      if: ${{ matrix.image.needs_vtk_wasm }}
+      run: node webapp-viewer/scripts/fetch-vtk-wasm.mjs
 
     - name: Pre-build step
       if: ${{ matrix.image.pre_build }}

--- a/docker/build/Dockerfile-clientgen-dev
+++ b/docker/build/Dockerfile-clientgen-dev
@@ -38,6 +38,20 @@ COPY ./vcell-client/target/vcell-client-0.0.1-SNAPSHOT.jar \
     ./vcell-client/target/maven-jars/*.jar \
     /vcellclient/vcell-client/target/maven-jars/
 
+#
+# The 3D field viewer's web content, served by the client's own loopback field server from
+# <installDir>/webviewer. webapp-viewer has no build step — the source directory is the deployable —
+# so only what the browser actually loads is copied; the fetch script and package.json stay behind.
+#
+# assets/ holds the vtk.wasm bundle, which is gitignored and downloaded by CI before this image is
+# built. If that step did not run, this COPY fails and the image build stops — which is the point:
+# an installer that shipped the page without the bundle would 404 at the moment a user clicks
+# "View in 3D".
+#
+COPY ./webapp-viewer/index.html ./webapp-viewer/viewer.js /vcellclient/webviewer/
+COPY ./webapp-viewer/vendor    /vcellclient/webviewer/vendor
+COPY ./webapp-viewer/assets    /vcellclient/webviewer/assets
+
 COPY ./docker/build/installers /config/
 
 WORKDIR /config

--- a/docker/build/installers/VCell.install4j
+++ b/docker/build/installers/VCell.install4j
@@ -19,6 +19,7 @@
       <variable name="vcellLocalSolversDirPath" value="${compiler:mavenRootDir}/localsolvers" />
       <variable name="vcellLicenseFilePath" value="${compiler:mavenRootDir}/thirdpartylicenses.txt" />
       <variable name="vcellbngPerlPath" value="${compiler:mavenRootDir}/bionetgen" />
+      <variable name="vcellWebViewerPath" value="${compiler:mavenRootDir}/webviewer" />
     </variables>
     <codeSigning macEnabled="true" macPkcs12File="${compiler:macKeystore}" windowsEnabled="true" windowsPkcs12File="${compiler:winKeystore}">
       <macAdditionalBinaries>
@@ -56,6 +57,7 @@
       <mountPoint id="1473" location="resources" />
       <mountPoint id="1474" location="localsolvers" />
       <mountPoint id="1750" location="bionetgen" />
+      <mountPoint id="3200" location="webviewer" />
       <mountPoint id="1348" root="1114" location="nativelibs" />
       <mountPoint id="1349" root="1114" location="nativelibs/mac64" />
       <mountPoint id="1342" root="1114" location="localsolvers" />
@@ -81,6 +83,7 @@
       <dirEntry mountPoint="719" file="${compiler:vcellLibSourcePath}" subDirectory="maven-jars" />
       <fileEntry mountPoint="1473" file="${compiler:vcellLicenseFilePath}" />
       <dirEntry mountPoint="1750" file="${compiler:vcellbngPerlPath}" />
+      <dirEntry mountPoint="3200" file="${compiler:vcellWebViewerPath}" />
       <dirEntry mountPoint="1349" file="${compiler:vcellNativeLibsDirSourcePath}/mac64" />
       <dirEntry mountPoint="1353" file="${compiler:vcellLocalSolversDirPath}/mac64" fileMode="755" overrideFileMode="true" />
       <dirEntry mountPoint="1355" file="${compiler:vcellNativeLibsDirSourcePath}/win64" />

--- a/webapp-viewer/scripts/fetch-vtk-wasm.mjs
+++ b/webapp-viewer/scripts/fetch-vtk-wasm.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Build-time fetch of VCell's VTK.wasm bundle into webapp-ng's assets, so the field viewer loads it
+// Build-time fetch of VCell's VTK.wasm bundle into webapp-viewer's assets, so the field viewer loads it
 // SAME-ORIGIN (GitHub release assets can't be fetched cross-origin from the browser — no CORS header).
 // The @kitware/vtk-wasm loader's loadAsync({url}) takes the .tar.gz and untars it in-browser
 // (DecompressionStream + untar), so we serve the .tar.gz as-is. Idempotent. Env:


### PR DESCRIPTION
Closes the packaging gap tracked in #1851. Stacked on #1829 — **base is `vtk/field-viewer`**, so the diff here is just the four files below; retarget to `master` once #1829 lands.

`FieldViewerServer` already serves the viewer page from `<installDir>/webviewer`, but nothing ever put content there. On an installed client the directory is absent, so "View in 3D" opens a page that cannot load. This ships it.

## The three pieces

| file | change |
|---|---|
| `VCell.install4j` | a `webviewer` mount point, a source-path variable, a `dirEntry` (3 lines) |
| `Dockerfile-clientgen-dev` | copy the content to `/vcellclient/webviewer` |
| `CI-full.yml` | fetch the wasm bundle before that image builds |

**`site_deploy.yml` needs no change** — worth stating, because #1851 originally claimed otherwise. It stages nothing: it pulls the prebuilt `vcell-clientgen` image and runs `build_installers.sh` inside it, where `mavenRootDir=/vcellclient` refers to paths baked into the image. So everything an installer ships is `COPY`d in when CI-full builds clientgen.

## Two things a reviewer should check

**`maven-jars` is the wrong template**, and it is the obvious one to reach for. Its `mountPoint="719"` is `lib`, not the install root. `bionetgen` is the right precedent: a rootless mount point, relative to the install root, which is what `-Dvcell.installDir=${launcher:sys.launcherDirectory}` resolves to and what `staticRoot()` looks under.

**Why the fetch is in CI rather than the maven build.** The `localsolvers` precedent argues for a `download-maven-plugin` execution, and that would work — but solvers are downloaded because developers actually run them locally, whereas this bundle is only needed to build an installer. Putting it in maven would impose a 12 MB download on every developer for a feature that is off by default. Developers who want the viewer locally already run the same script themselves.

## Verified

Both claims in the Dockerfile comment were checked with real docker builds, not reasoned about:

- The copy produces exactly `index.html`, `viewer.js`, `vendor/vtk.umd.js` and `assets/vtk-wasm/*.tar.gz` — **12 MB**, with the fetch script, `package.json` and `README` left behind.
- With `assets/` absent (a skipped fetch), the build **fails** with `"/webapp-viewer/assets": not found` rather than silently producing an installer whose viewer 404s.

## What this does not do, and the risk it adds

The feature stays behind `vcell.fieldViewer.enabled`, still defaulting to **false**, so this changes nothing a user sees. It does not pre-seed the flag in the install4j vmoptions templates; testers still add the line themselves.

The real cost is that **the release build gains a network dependency**: the bundle is fetched from the pinned `virtualcell/vcell-vtk-wasm` `v1.0.0` release, and clientgen blocks release. If that release is unreachable, the release build fails. That is the argument for merging this early in a cycle rather than next to a release. It also adds ~12 MB to all five media, and the `.tar.gz` will not compress further under install4j's LZMA.

Note this cannot be fully exercised outside a real `site_deploy` run — the installer build needs the install4j license and both code-signing keystores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)