### PR TITLE
Give the simulated-outage test its own messaging service

### DIFF
--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -167,17 +167,24 @@ public class MessageProducerSessionJmsTest {
 	 */
 	@Test
 	public void aSendThatCannotOpenAConnectionThrows() throws Exception {
-		VCMessage message = service.createProducerSession().createTextMessage("never sent");
-
-		MessageProducerSessionJms producerSession = new MessageProducerSessionJms(service);
-		service.failConnections = true;
+		// Its own service instance, sharing only the broker. This test deliberately breaks
+		// connection creation, and doing that to the service every other test shares tore down
+		// connections their temporary reply destinations live on -- a later RPC then published
+		// to a deleted temp queue and waited out its whole timeout (issue #1855). failConnections
+		// is per-instance, so an isolated service cannot reach the shared one.
+		CountingMessagingService isolated = new CountingMessagingService();
+		VCMessageSession messageBuilder = isolated.createProducerSession();
+		MessageProducerSessionJms producerSession = new MessageProducerSessionJms(isolated);
 		try {
+			VCMessage message = messageBuilder.createTextMessage("never sent");
+			isolated.failConnections = true;
 			assertThrows(VCMessagingException.class,
 					() -> producerSession.sendQueueMessage(TEST_QUEUE, message, Boolean.FALSE, 60000L),
 					"a send that cannot open its connection must not report success");
 		} finally {
-			service.failConnections = false;
+			isolated.failConnections = false;
 			producerSession.close();
+			messageBuilder.close();   // was leaked into the shared service before
 		}
 	}
 

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -183,8 +183,32 @@ public class MessageProducerSessionJmsTest {
 					"a send that cannot open its connection must not report success");
 		} finally {
 			isolated.failConnections = false;
-			producerSession.close();
+			producerSession.close();  // never opened a connection -- the send failed at createConnection
 			messageBuilder.close();   // was leaked into the shared service before
+			// `isolated` itself is deliberately not close()d: both its sessions are closed above and
+			// it has no consumers, so close() would reclaim nothing -- it would only add its
+			// unconditional 4s Thread.sleep. The one thing an instance does leave behind, the daemon
+			// Timer built in the VCMessagingServiceJms constructor, is not cancelled by close() either.
+		}
+
+		// The actual regression from #1855: simulating the outage must leave the shared service
+		// untouched. An RPC is the sharp check, because it needs both a live connection and a live
+		// temporary reply queue -- dead reply destinations were what made a later test wait out its
+		// whole timeout. Asserting it here pins it deterministically instead of relying on a later
+		// test happening to run afterwards.
+		String previous = setBlobProperty();
+		VCellQueue afterOutageQueue = new VCellQueue("MessageProducerSessionJmsTestRpcQueue-afterOutage");
+		VCQueueConsumer responder = startEchoResponder(afterOutageQueue);
+		VCMessageSession sharedSession = service.createProducerSession();
+		try {
+			assertEquals("still alive",
+					sharedSession.sendRpcMessage(afterOutageQueue, echoRequest("still alive"),
+							true, 30000L, null, null, null),
+					"the shared service must still complete an RPC after the simulated outage");
+		} finally {
+			sharedSession.close();
+			service.removeMessageConsumer(responder);
+			restoreBlobProperty(previous);
 		}
 	}
 


### PR DESCRIPTION
Fixes #1855.

The issue's mechanism is right, and the defect is in my test rather than in the product.

## Cause

`aSendThatCannotOpenAConnectionThrows` set `failConnections` on the **static service shared by
every test method**. As the issue notes, the flag itself was reset in a `finally` — that was
never the bug. What survived was the damage: breaking connection creation on the shared
service tears down connections that later tests' temporary reply destinations live on, so a
subsequent RPC published to a temp queue that no longer existed, nobody consumed it, and the
caller waited out its full timeout.

```
ERROR - simulated broker outage
ERROR - Cannot publish to a deleted Destination: temp-queue://ID:runnervm...-24:1:1
ERROR - Server is temporarily not responding (server testing, method echo)
```

## Changes

- **The outage test builds its own `CountingMessagingService`**, sharing only the broker.
  `failConnections` is per-instance, so it cannot reach the shared service. This is suggestion
  (1) from the issue: the flag is a property of the fixture, not of the run.
- **Closes the producer session used to build the message.** It was created with
  `service.createProducerSession()` and never closed, leaking an open connection into the
  shared service's session list on every run — a second way this test dirtied shared state.

## Verification, and its limits

I could not reproduce this locally: 6 runs before the change and 4 after, all green, with the
failing signature (`deleted Destination`, `temporarily not responding`) absent throughout.
The full Fast group with CI's parallel flags is 62 green.

So this is verified **structurally, not by reproduction** — no test mutates the shared
service's connection behaviour any more. Worth stating plainly rather than claiming a fix I
watched fail and then pass.

One thing the local run did confirm: method order is not the missing ingredient. The outage
test already runs *before* the concurrent one locally (positions 2 and 6), so ordering was
right and only CI's timing window differs.

## On suggestion (3)

I looked at whether `VCMessagingServiceJms` leaves a failed connection's destinations
referenced, and I don't think it does: `getSession()` closes the connection if
`createSession` fails, `createConnection` failing leaves nothing behind, and
`createProducerSession()` only registers the session *after* `open()` succeeds. So I've
treated this as test-only rather than papering over a product weakness — happy to revisit if
you read it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
