### PR TITLE
Bump Langevin solver to 1.4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,9 +193,9 @@
 		<solvers-vcell-mac.version>v0.0.44-dev4</solvers-vcell-mac.version>
 		<solvers-vcell-windows.version>v0.0.40</solvers-vcell-windows.version>
 		<solvers-vcell-linux.version>v0.0.44-dev4</solvers-vcell-linux.version>
-		<solvers-langevin-mac.version>1.4.11</solvers-langevin-mac.version>
-		<solvers-langevin-windows.version>1.4.11</solvers-langevin-windows.version>
-		<solvers-langevin-linux.version>1.4.11</solvers-langevin-linux.version>
+		<solvers-langevin-mac.version>1.4.12</solvers-langevin-mac.version>
+		<solvers-langevin-windows.version>1.4.12</solvers-langevin-windows.version>
+		<solvers-langevin-linux.version>1.4.12</solvers-langevin-linux.version>
 	</properties>
 
 


### PR DESCRIPTION
Bumps the Langevin solver from **1.4.11 to 1.4.12** for all three platforms.
[1.4.12](https://github.com/cam-center/LangevinNoVis01/releases/tag/1.4.12) was released today
and carries all three assets the build downloads.

## What's in it

Logging configuration is now final and immutable, fixing native-image logging. Per the
release notes, `log4j-core 2.24.0` shipped no GraalVM reachability metadata, so neither
`log4j2.xml` nor the plugin registry was bundled into the native executable — **logging was
unreliable in the shipped 1.4.11 binary**. 1.4.12 upgrades to log4j 2.25.1, removes the
programmatic `LoggingInit`, and pins a bundled configuration that cannot be redirected at
runtime.

So this is a fix worth taking rather than a routine bump, given VCell runs this solver as a
native binary and depends on its output.

## Verification (mac, end to end)

| | |
|---|---|
| assets present on 1.4.12 | `langevin-macos-universal`, `langevin-ubuntu-latest`, `langevin-windows-latest` — all HTTP 200 |
| build downloads | 110,139,624 bytes, md5 `6a01348bb4c5b8dd539dade041b476cc` |
| direct `curl` of the release asset | **identical** size and md5 |
| resulting binary | runs, and `-V` reports `1.4.12-0-g1c44c0c` |

## Gotcha for whoever bumps this next

My first attempt "passed" while proving nothing, so it is worth writing down:

- **The download plugin does not overwrite an existing `localsolvers/` file.** A version
  change is a no-op locally until you delete it — the build happily reports SUCCESS with the
  old binary in place.
- **A skipped run then seeds the plugin's cache slot for the _new_ URL with the _old_
  content.** The cache lives in `~/.m2/repository/.cache/download-maven-plugin/` keyed by
  md5 of the URL, so deleting only the `localsolvers/` file restores the stale binary from
  cache ("Got from cache") and still looks fine.

To pick up a new version locally, clear both. CI builds on clean runners, so release and CI
builds are unaffected — this only bites developers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg
