### PR TITLE
3D field viewer: label each window with its run, let the canvas tile (#1859 item A)

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/data/PDEDataViewer.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/PDEDataViewer.java
@@ -1708,7 +1708,8 @@ private void openInBrowserViewer() {
 		// register the dataset before opening the browser, and hand over the reader this window already
 		// uses -- that is what lets one server serve several windows, local and remote alike
 		FieldViewerServer.register(simDataId,
-				((ClientPDEDataContext) dataContext).getDataManager().getVCDataManager(), mathDescription);
+				((ClientPDEDataContext) dataContext).getDataManager().getVCDataManager(), mathDescription,
+				displayNameForViewer());
 		int port = FieldViewerServer.start();
 		if (port < 0) {
 			DialogUtils.showErrorDialog(this, "Could not start the local field viewer server. See the log for details.");
@@ -1746,6 +1747,20 @@ private void openInBrowserViewer() {
 
 private static String urlEncode(String s) {
 	return java.net.URLEncoder.encode(s, java.nio.charset.StandardCharsets.UTF_8);
+}
+
+/**
+ * Human-readable name of the run for the 3D viewer's title, e.g. "model::app::sim". The data
+ * files carry only keys, so registration is the one moment anyone can attach a name.
+ */
+private String displayNameForViewer() {
+	SimulationModelInfo modelInfo = getSimulationModelInfo();
+	if (modelInfo != null && modelInfo.getSimulationName() != null) {
+		String context = modelInfo.getContextName();
+		return context == null ? modelInfo.getSimulationName()
+				: context + "::" + modelInfo.getSimulationName();
+	}
+	return getSimulation() == null ? null : getSimulation().getName();
 }
 
 

--- a/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
@@ -93,11 +93,15 @@ public final class FieldViewerServer {
 		final VCSimulationDataIdentifier vcdID;
 		final VCDataManager dataManager;
 		final SubdomainInfo subdomainInfo;
+		/** Human-readable name of the run, e.g. "model::app::sim"; may be null — the ID always exists, a name may not. */
+		final String simName;
 
-		DataSource(VCSimulationDataIdentifier vcdID, VCDataManager dataManager, SubdomainInfo subdomainInfo) {
+		DataSource(VCSimulationDataIdentifier vcdID, VCDataManager dataManager, SubdomainInfo subdomainInfo,
+				String simName) {
 			this.vcdID = vcdID;
 			this.dataManager = dataManager;
 			this.subdomainInfo = subdomainInfo;
+			this.simName = simName;
 		}
 	}
 
@@ -281,6 +285,10 @@ public final class FieldViewerServer {
 
 		StringBuilder sb = new StringBuilder(1024);
 		sb.append("{\"simId\":\"").append(jsonEscape(vcdID.getID())).append('"');
+		if (source.simName != null && !source.simName.isEmpty()) {
+			sb.append(",\"simName\":\"").append(jsonEscape(source.simName)).append('"');
+		}
+		sb.append(",\"jobIndex\":").append(vcdID.getJobIndex());
 		sb.append(",\"times\":");
 		appendDoubles(sb, times, times.length);
 		sb.append(",\"domains\":[");
@@ -455,16 +463,18 @@ public final class FieldViewerServer {
 	 * for that run, which is what keeps local and remote runs on one code path here.
 	 *
 	 * @param mathDesc supplies the domain names; the mesh carries subvolume numbers but not names
+	 * @param simName human-readable name for the run (registration is the only moment anyone holds
+	 *            it — the data files carry only keys); may be null
 	 */
 	public static void register(VCSimulationDataIdentifier vcdID, VCDataManager dataManager,
-			MathDescription mathDesc) throws MathException {
-		register(vcdID, dataManager, CartesianMeshBuilder.fromMathDescription(mathDesc));
+			MathDescription mathDesc, String simName) throws MathException {
+		register(vcdID, dataManager, CartesianMeshBuilder.fromMathDescription(mathDesc), simName);
 	}
 
 	/** For callers that already hold the domain naming and have no math description to hand. */
 	public static void register(VCSimulationDataIdentifier vcdID, VCDataManager dataManager,
-			SubdomainInfo subdomainInfo) {
-		dataSources.put(key(vcdID), new DataSource(vcdID, dataManager, subdomainInfo));
+			SubdomainInfo subdomainInfo, String simName) {
+		dataSources.put(key(vcdID), new DataSource(vcdID, dataManager, subdomainInfo, simName));
 		LG.debug("field viewer dataset registered: {}", vcdID.getID());
 	}
 

--- a/webapp-viewer/README.md
+++ b/webapp-viewer/README.md
@@ -67,3 +67,13 @@ scrub time — a time step costs about 5.7× less than shipping both.
   the drawing buffer to its 300×150 default.
 - Size the drawing buffer from the **box**, not the canvas: the canvas is still at its default until
   vtk takes it over.
+- **`vtkObjectManager` logs refusals, it does not throw.** A call can appear to succeed in JS while
+  doing nothing at all — watch the console for `is not permitted`. This makes capability probes
+  actively misleading unless they read the console.
+- **`renderer.addActor2D` is refused; `renderer.addViewProp` is not.** That is the route for 2D
+  props such as `vtkScalarBarActor`.
+- Probed 2026-08-07 and available through the standalone session: `vtkScalarBarActor`,
+  `vtkCubeAxesActor` (incl. `setBounds`/`setXTitle`/`setCamera`), `vtkPlane` + `vtkCutter`
+  (`setCutFunction`), `vtkColorTransferFunction`, `vtkLookupTable`, `vtkCellPicker` (incl. `pick`).
+  **`vtkOutlineFilter` has no registered constructor** — compiled into the `.wasm`, but absent from
+  the deserializer, which is the distinction that matters.

--- a/webapp-viewer/index.html
+++ b/webapp-viewer/index.html
@@ -13,6 +13,10 @@
     width/height 100% on it and installs a resize observer. A positioned, sized box keeps the
     geometry predictable either way.
   */
+  .run-title { width: 100%; max-width: 960px; display: flex; align-items: baseline; gap: 10px;
+               flex-wrap: wrap; min-height: 1.2em; }
+  .run-title .name { font-weight: 600; }
+  .run-title .id { font: 11px/1.4 ui-monospace, monospace; opacity: .6; }
   .canvas-box { position: relative; width: 100%; max-width: 960px; aspect-ratio: 4 / 3;
                 background: #12121a; border-radius: 6px; overflow: hidden; }
   .canvas-box canvas { display: block; width: 100%; height: 100%; cursor: grab; touch-action: none; }
@@ -29,6 +33,10 @@
 </style>
 </head>
 <body>
+
+<div class="run-title" id="runTitle" hidden>
+  <span class="name" id="runName"></span><span class="id" id="runId"></span>
+</div>
 
 <div class="canvas-box"><canvas id="canvas" tabindex="0"></canvas></div>
 

--- a/webapp-viewer/index.html
+++ b/webapp-viewer/index.html
@@ -17,7 +17,14 @@
                flex-wrap: wrap; min-height: 1.2em; }
   .run-title .name { font-weight: 600; }
   .run-title .id { font: 11px/1.4 ui-monospace, monospace; opacity: .6; }
+  /*
+    aspect-ratio names the preferred shape; the viewport clamps cap it so a viewer window that is
+    tiled small (several runs side by side) still shows its controls without scrolling. The buffer
+    is re-synced to the box on resize (see matchBufferToCanvas), so a clamped box is not a
+    stretched image.
+  */
   .canvas-box { position: relative; width: 100%; max-width: 960px; aspect-ratio: 4 / 3;
+                max-height: calc(100dvh - 170px); min-height: 160px; min-width: 240px;
                 background: #12121a; border-radius: 6px; overflow: hidden; }
   .canvas-box canvas { display: block; width: 100%; height: 100%; cursor: grab; touch-action: none; }
   .canvas-box canvas:active { cursor: grabbing; }

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -307,6 +307,24 @@ async function matchBufferToCanvas() {
   }
 }
 
+/**
+ * Re-sync the buffer when the window resizes. The box's viewport-height clamp means resizing can
+ * change its aspect ratio, and a buffer left at the old shape would draw stretched. Debounced:
+ * setSize allocates a new buffer, far too heavy to run per resize event.
+ */
+let resizeTimer = 0;
+window.addEventListener('resize', () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(async () => {
+    try {
+      await matchBufferToCanvas();
+      if (renderWindow) await renderWindow.render();
+    } catch (e) {
+      console.warn('resize re-render failed', e);
+    }
+  }, 150);
+});
+
 // ---------------------------------------------------------------------------
 // interaction
 // ---------------------------------------------------------------------------

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -29,6 +29,9 @@ const MIN_PASS_BAND = 0.005;
 const el = {
   canvas: document.getElementById('canvas'),
   box: document.querySelector('.canvas-box'),
+  runTitle: document.getElementById('runTitle'),
+  runName: document.getElementById('runName'),
+  runId: document.getElementById('runId'),
   dataControls: document.getElementById('dataControls'),
   variable: document.getElementById('variable'),
   time: document.getElementById('time'),
@@ -114,9 +117,25 @@ async function fetchJson(u, what) {
   return r.json();
 }
 
+/**
+ * Label the window and the page with what this run IS — several viewers tile on one screen, and
+ * an unlabeled one cannot be told from its neighbours. The name travels via /info rather than the
+ * URL because the server holds it for the dataset's lifetime, not just for the opening click.
+ * textContent, not innerHTML: the name is user-authored.
+ */
+function showRunTitle(info) {
+  const job = Number(info.jobIndex ?? state.dataset.job);
+  const name = (info.simName ?? info.simId) + (job > 0 ? ` · job ${job}` : '');
+  el.runName.textContent = name;
+  el.runId.textContent = info.simName ? info.simId : '';
+  el.runTitle.hidden = false;
+  document.title = `${name} — VCell 3D`;
+}
+
 async function loadInfo() {
   setStatus('asking the server what this run contains…');
   const info = await fetchJson(url('/info', {}), '/info');
+  showRunTitle(info);
   state.times = info.times ?? [];
   state.variables = (info.variables ?? []).map((v) => ({ name: v.name, domain: v.domain }));
   if (!state.variables.length) throw new Error(`run ${info.simId} exposes no volume variables`);


### PR DESCRIPTION
Implements item A of #1859 — the two small client-side follow-ups from the first installed-client test of the field viewer.

## (1) Simulation name and identifier

- `PDEDataViewer` builds a human-readable `model::app::sim` name (via `SimulationModelInfo`, falling back to the simulation's own name) and attaches it when registering the dataset with `FieldViewerServer` — registration is the only moment anyone holds a name; the data files carry only keys.
- `/info` now serves `simName` (when present) and `jobIndex` alongside `simId`.
- The viewer shows the name as a header above the canvas with the `SimID_…` identifier dimmed beside it, and mirrors it into the browser-tab title; `· job N` is appended only for parameter-scan jobs (N > 0). Rendered with `textContent` — sim names are user-authored.

## (7) Smaller canvas so several viewer windows tile

The culprit was the fixed 4/3 aspect ratio, not the 960px max-width: a viewer tiled into a half-screen window got a canvas tall enough to push its own controls below the fold. The canvas box is now clamped to the viewport height (`max-height: calc(100dvh - 170px)`, 160px floor), and a debounced window-resize handler re-syncs the vtk drawing buffer to the box — the clamp changes the box's aspect ratio, and a buffer left at the old shape would draw stretched. (vtk's own resize observer stays deliberately disabled; this is the viewer's hand-rolled handler, like the camera interaction.)

Also carries the vtk.wasm capability-probe notes in `webapp-viewer/README.md` (which classes the standalone session can actually construct — groundwork for item B).

## Testing

- `vcell-client` compiles clean; `viewer.js` passes `node --check`.
- `PDEDataViewer.java` is CRLF — diff audited, zero line-ending churn.
- Not exercised in a running client (needs the wasm bundle + a finished local sim with `-Dvcell.fieldViewer.enabled=true`); the feature remains off by default.

Closes nothing — #1859 stays open for items B–F; tick items (1) and (7) there on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYqrC3BiB4JRsJoz7BXJF4