### PR TITLE
3D field viewer: deformed-grid convention, annotations, cut plane, picking, time plots, statistics (#1859 items B–E)

### DIFF
--- a/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
@@ -8,15 +8,20 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.vcell.util.document.TSJobResultsNoStats;
+import org.vcell.util.document.TSJobResultsSpaceStats;
 import org.vcell.util.document.TimeSeriesJobSpec;
 import org.vcell.util.document.VCDataJobID;
 import org.vcell.vis.mapping.vcell.CartesianMeshMapping;
@@ -162,6 +167,7 @@ public final class FieldViewerServer {
 		s.createContext("/grid", wrap(FieldViewerServer::handleGrid));
 		s.createContext("/field", wrap(FieldViewerServer::handleField));
 		s.createContext("/timeseries", wrap(FieldViewerServer::handleTimeSeries));
+		s.createContext("/stats", wrap(FieldViewerServer::handleStats));
 		Path viewerRoot = staticRoot();
 		if (viewerRoot != null) {
 			// least-specific context: the data routes above still win, this catches the rest
@@ -485,6 +491,98 @@ public final class FieldViewerServer {
 		sb.append(",\"values\":");
 		appendDoubles(sb, timesAndValues[1], timesAndValues[1].length);
 		sb.append('}');
+		return sb.toString();
+	}
+
+	/**
+	 * {@code /stats?sim=<simKey>&job=<n>[&var=<a,b,c>]} — min, max and spatial mean per saved time
+	 * for the named volume variables (default: all of them), each computed over its own domain.
+	 * <p>
+	 * This is the aggregation the issue insists must NOT happen client-side: computing these curves
+	 * in the browser would mean pulling every timestep of every selected variable. One
+	 * {@link TimeSeriesJobSpec} with {@code calcSpaceStats} carries all the variables, so the
+	 * reduction runs next to the reader in a single pass.
+	 */
+	private static String handleStats(HttpExchange ex) throws Exception {
+		Map<String, String> q = query(ex);
+		DataSource source = sourceFor(q);
+		DataIdentifier[] ids = source.dataManager.getDataIdentifiers(emptyOutputContext(), source.vcdID);
+		Set<String> requested = null;
+		String varParam = q.get("var");
+		if (varParam != null && !varParam.isEmpty()) {
+			requested = new LinkedHashSet<>(Arrays.asList(varParam.split(",")));
+		}
+		List<DataIdentifier> chosen = new ArrayList<>();
+		for (DataIdentifier id : ids) {
+			if (!id.getVariableType().equals(cbit.vcell.math.VariableType.VOLUME)) {
+				continue;
+			}
+			if (requested == null || requested.contains(id.getName())) {
+				chosen.add(id);
+			}
+		}
+		if (chosen.isEmpty()) {
+			throw new IllegalArgumentException("no volume variables match " + varParam);
+		}
+		double[] times = source.dataManager.getDataSetTimes(source.vcdID);
+		if (times == null || times.length == 0) {
+			throw new IllegalArgumentException("run " + source.vcdID.getID() + " has no saved times");
+		}
+
+		// each variable's stats run over ITS domain's cells; domains repeat, so index once each
+		List<String> domains = readMesh(source).getVolumeDomainNames();
+		Map<String, int[]> indicesByDomain = new HashMap<>();
+		String[] names = new String[chosen.size()];
+		String[] varDomains = new String[chosen.size()];
+		int[][] indices = new int[chosen.size()][];
+		for (int v = 0; v < chosen.size(); v++) {
+			DataIdentifier id = chosen.get(v);
+			names[v] = id.getName();
+			varDomains[v] = id.getDomain() != null ? id.getDomain().getName() : domains.get(0);
+			final String dom = varDomains[v];
+			indices[v] = indicesByDomain.computeIfAbsent(dom, d -> {
+				try {
+					List<VisVoxel> voxels = grid(source, d).getVisVoxels();
+					int[] idx = new int[voxels.size()];
+					for (int c = 0; c < idx.length; c++) {
+						idx[c] = voxels.get(c).getFiniteVolumeIndex().getGlobalIndex();
+					}
+					return idx;
+				} catch (Exception e) {
+					throw new RuntimeException("building index set for domain '" + d + "'", e);
+				}
+			});
+		}
+
+		TimeSeriesJobSpec spec = new TimeSeriesJobSpec(names, indices, times[0], 1,
+				times[times.length - 1], true, false,
+				VCDataJobID.createVCDataJobID(source.vcdID.getOwner(), true));
+		TSJobResultsSpaceStats stats = (TSJobResultsSpaceStats) source.dataManager
+				.getTimeSeriesValues(emptyOutputContext(), source.vcdID, spec);
+		// on a uniform Cartesian grid the volume weighting is uniform; prefer weighted when present
+		double[][] means = stats.getWeightedMean() != null ? stats.getWeightedMean()
+				: stats.getUnweightedMean();
+
+		double[] statTimes = stats.getTimes();
+		StringBuilder sb = new StringBuilder(64 * statTimes.length * names.length + 512);
+		sb.append("{\"times\":");
+		appendDoubles(sb, statTimes, statTimes.length);
+		sb.append(",\"series\":[");
+		for (int v = 0; v < names.length; v++) {
+			if (v > 0) {
+				sb.append(',');
+			}
+			sb.append("{\"name\":\"").append(jsonEscape(names[v])).append('"');
+			sb.append(",\"domain\":\"").append(jsonEscape(varDomains[v])).append('"');
+			sb.append(",\"min\":");
+			appendDoubles(sb, stats.getMinimums()[v], statTimes.length);
+			sb.append(",\"max\":");
+			appendDoubles(sb, stats.getMaximums()[v], statTimes.length);
+			sb.append(",\"mean\":");
+			appendDoubles(sb, means[v], statTimes.length);
+			sb.append('}');
+		}
+		sb.append("]}");
 		return sb.toString();
 	}
 

--- a/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
@@ -16,6 +16,9 @@ import java.util.concurrent.Executors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.vcell.util.document.TSJobResultsNoStats;
+import org.vcell.util.document.TimeSeriesJobSpec;
+import org.vcell.util.document.VCDataJobID;
 import org.vcell.vis.mapping.vcell.CartesianMeshMapping;
 import org.vcell.vis.vcell.CartesianMeshBuilder;
 import org.vcell.vis.vcell.SubdomainInfo;
@@ -158,6 +161,7 @@ public final class FieldViewerServer {
 		s.createContext("/info", wrap(FieldViewerServer::handleInfo));
 		s.createContext("/grid", wrap(FieldViewerServer::handleGrid));
 		s.createContext("/field", wrap(FieldViewerServer::handleField));
+		s.createContext("/timeseries", wrap(FieldViewerServer::handleTimeSeries));
 		Path viewerRoot = staticRoot();
 		if (viewerRoot != null) {
 			// least-specific context: the data routes above still win, this catches the rest
@@ -426,6 +430,61 @@ public final class FieldViewerServer {
 		sb.append(",\"location\":\"cell\",\"values\":");
 		appendDoubles(sb, values, values.length);
 		sb.append(",\"range\":[").append(min).append(',').append(max).append("]}");
+		return sb.toString();
+	}
+
+	/**
+	 * {@code /timeseries?sim=<simKey>&job=<n>&domain=<name>&var=<name>&cell=<c>} — one variable's
+	 * full time course at one grid cell, for the viewer's click-to-plot.
+	 * <p>
+	 * The reduction happens HERE, next to the reader, through the same
+	 * {@link VCDataManager#getTimeSeriesValues} path the desktop's own time plots use — the design
+	 * the viewer must not replicate is fetching every timestep to the browser to build one curve.
+	 * The browser addresses the cell by its index in the served grid; this is where that maps to
+	 * the solver's global volume index.
+	 */
+	private static String handleTimeSeries(HttpExchange ex) throws Exception {
+		Map<String, String> q = query(ex);
+		DataSource source = sourceFor(q);
+		String domain = domainOf(q, source);
+		String varName = q.get("var");
+		if (varName == null || varName.isEmpty()) {
+			throw new IllegalArgumentException("missing required query parameter 'var'");
+		}
+		String cellParam = q.get("cell");
+		if (cellParam == null || cellParam.isEmpty()) {
+			throw new IllegalArgumentException("missing required query parameter 'cell'");
+		}
+		List<VisVoxel> voxels = grid(source, domain).getVisVoxels();
+		int cell = Integer.parseInt(cellParam);
+		if (cell < 0 || cell >= voxels.size()) {
+			throw new IllegalArgumentException("cell " + cell + " out of range; domain '" + domain
+					+ "' has " + voxels.size() + " cells");
+		}
+		int globalIndex = voxels.get(cell).getFiniteVolumeIndex().getGlobalIndex();
+
+		double[] times = source.dataManager.getDataSetTimes(source.vcdID);
+		if (times == null || times.length == 0) {
+			throw new IllegalArgumentException("run " + source.vcdID.getID() + " has no saved times");
+		}
+		TimeSeriesJobSpec spec = new TimeSeriesJobSpec(new String[] { varName },
+				new int[][] { { globalIndex } }, null, times[0], 1, times[times.length - 1],
+				VCDataJobID.createVCDataJobID(source.vcdID.getOwner(), true));
+		TSJobResultsNoStats results = (TSJobResultsNoStats) source.dataManager
+				.getTimeSeriesValues(emptyOutputContext(), source.vcdID, spec);
+		// row 0 is the times, row 1 the values at our single index
+		double[][] timesAndValues = results.getTimesAndValuesForVariable(varName);
+
+		StringBuilder sb = new StringBuilder(32 * timesAndValues[0].length + 256);
+		sb.append("{\"name\":\"").append(jsonEscape(varName)).append('"');
+		sb.append(",\"domain\":\"").append(jsonEscape(domain)).append('"');
+		sb.append(",\"cell\":").append(cell);
+		sb.append(",\"volumeIndex\":").append(globalIndex);
+		sb.append(",\"times\":");
+		appendDoubles(sb, timesAndValues[0], timesAndValues[0].length);
+		sb.append(",\"values\":");
+		appendDoubles(sb, timesAndValues[1], timesAndValues[1].length);
+		sb.append('}');
 		return sb.toString();
 	}
 

--- a/webapp-viewer/README.md
+++ b/webapp-viewer/README.md
@@ -72,6 +72,11 @@ scrub time — a time step costs about 5.7× less than shipping both.
   actively misleading unless they read the console.
 - **`renderer.addActor2D` is refused; `renderer.addViewProp` is not.** That is the route for 2D
   props such as `vtkScalarBarActor`.
+- **The scalar bar labels the lookup table's range, not the mapper's.** `mapper.setScalarRange`
+  alone never reaches the bar — it would label [0,1] under a correctly-colored surface. The viewer
+  therefore owns one `vtkLookupTable` (hue range flipped to blue-low→red-high, the desktop
+  convention) shared by mapper and bar, with `useLookupTableScalarRangeOn()` so the table's range
+  drives both. Verified with a monotonic ramp field: surface sweep and bar direction agree.
 - Probed 2026-08-07 and available through the standalone session: `vtkScalarBarActor`,
   `vtkCubeAxesActor` (incl. `setBounds`/`setXTitle`/`setCamera`), `vtkPlane` + `vtkCutter`
   (`setCutFunction`), `vtkColorTransferFunction`, `vtkLookupTable`, `vtkCellPicker` (incl. `pick`).

--- a/webapp-viewer/README.md
+++ b/webapp-viewer/README.md
@@ -72,10 +72,14 @@ scrub time — a time step costs about 5.7× less than shipping both.
   actively misleading unless they read the console.
 - **`renderer.addActor2D` is refused; `renderer.addViewProp` is not.** That is the route for 2D
   props such as `vtkScalarBarActor`.
-- **The cut plane slices the raw grid, not the smoothed surface.** `vtkCutter` passes cell data
-  through, so each cut polygon carries its source voxel's exact value; the boundary surface drops
-  to 25% opacity while a slice is shown, or it would hide it. Axis-aligned only, by design — an
-  interactive plane widget needs interactor infrastructure the standalone session lacks.
+- **The cut plane CROPS the volume; the slice caps the exposed face.** The surface mapper carries
+  a GPU clipping plane (`mapper.addClippingPlane`) that discards the half above the cut — this
+  works in the wasm build even though WebGL2 has no `gl_ClipDistance`, because VTK emulates
+  clipping in-shader. The cap is `vtkCutter` output from the raw grid: cell data passes through,
+  so each cut polygon carries its source voxel's exact value. Axis-aligned only, by design — an
+  interactive plane widget needs interactor infrastructure the standalone session lacks. When
+  judging whether a crop "worked" from a screenshot, orbit toward the REMOVED side: the kept
+  hemisphere looks whole from its own side by definition.
 - **The scalar bar labels the lookup table's range, not the mapper's.** `mapper.setScalarRange`
   alone never reaches the bar — it would label [0,1] under a correctly-colored surface. The viewer
   therefore owns one `vtkLookupTable` (hue range flipped to blue-low→red-high, the desktop

--- a/webapp-viewer/README.md
+++ b/webapp-viewer/README.md
@@ -92,7 +92,9 @@ scrub time — a time step costs about 5.7× less than shipping both.
   hover readout is an occupancy map + 3D-DDA ray walk over the Cartesian lattice — no round trip,
   no registry dependence. The walk applies the same crop keep-rule as the renderer, so picking the
   cut face reads the cap voxel. A click sends the picked cell to `/timeseries`, which reduces
-  server-side next to the reader — never fetch every timestep to build one curve.
+  server-side next to the reader — never fetch every timestep to build one curve. The Stats button
+  does the same for whole-domain min/mean/max per variable via `/stats` (one space-stats
+  `TimeSeriesJobSpec` carrying all the variables at once).
 - `probe.html` is a scratch page for exactly these capability probes: point it at a suspect class,
   read the on-page result, and keep the console open for `is not permitted`.
 - **The scalar bar labels the lookup table's range, not the mapper's.** `mapper.setScalarRange`

--- a/webapp-viewer/README.md
+++ b/webapp-viewer/README.md
@@ -72,6 +72,10 @@ scrub time — a time step costs about 5.7× less than shipping both.
   actively misleading unless they read the console.
 - **`renderer.addActor2D` is refused; `renderer.addViewProp` is not.** That is the route for 2D
   props such as `vtkScalarBarActor`.
+- **The cut plane slices the raw grid, not the smoothed surface.** `vtkCutter` passes cell data
+  through, so each cut polygon carries its source voxel's exact value; the boundary surface drops
+  to 25% opacity while a slice is shown, or it would hide it. Axis-aligned only, by design — an
+  interactive plane widget needs interactor infrastructure the standalone session lacks.
 - **The scalar bar labels the lookup table's range, not the mapper's.** `mapper.setScalarRange`
   alone never reaches the bar — it would label [0,1] under a correctly-colored surface. The viewer
   therefore owns one `vtkLookupTable` (hue range flipped to blue-low→red-high, the desktop

--- a/webapp-viewer/README.md
+++ b/webapp-viewer/README.md
@@ -88,6 +88,11 @@ scrub time — a time step costs about 5.7× less than shipping both.
   would round the cut edge off; it is also impossible here: `vtkClipDataSet`,
   `vtkTableBasedClipDataSet` and `vtkBoxClipDataSet` are compiled in but have **no registered
   constructor** (probed 2026-08-07), like `vtkOutlineFilter`.
+- **Picking is plain JS, not a VTK picker.** The browser holds the whole grid and field, so the
+  hover readout is an occupancy map + 3D-DDA ray walk over the Cartesian lattice — no round trip,
+  no registry dependence. The walk applies the same crop keep-rule as the renderer, so picking the
+  cut face reads the cap voxel. A click sends the picked cell to `/timeseries`, which reduces
+  server-side next to the reader — never fetch every timestep to build one curve.
 - `probe.html` is a scratch page for exactly these capability probes: point it at a suspect class,
   read the on-page result, and keep the console open for `is not permitted`.
 - **The scalar bar labels the lookup table's range, not the mapper's.** `mapper.setScalarRange`

--- a/webapp-viewer/README.md
+++ b/webapp-viewer/README.md
@@ -80,6 +80,16 @@ scrub time — a time step costs about 5.7× less than shipping both.
   interactive plane widget needs interactor infrastructure the standalone session lacks. When
   judging whether a crop "worked" from a screenshot, orbit toward the REMOVED side: the kept
   hemisphere looks whole from its own side by definition.
+- **The order is smooth-then-cut, and the cap rim follows the smoothing slider.** The cap stays
+  planar (flat, sharp cut — never smoothed), but its in-plane outline is trimmed to the smoothed
+  silhouette: `vtkClipPolyData` insideOut with a `vtkImplicitPolyDataDistance` built from the sinc
+  output (negative inside). Re-anchor the distance function (`setInput`) only when the smoothed
+  surface changes — it rebuilds its locator — not on every slider drag. Clip-the-grid-then-smooth
+  would round the cut edge off; it is also impossible here: `vtkClipDataSet`,
+  `vtkTableBasedClipDataSet` and `vtkBoxClipDataSet` are compiled in but have **no registered
+  constructor** (probed 2026-08-07), like `vtkOutlineFilter`.
+- `probe.html` is a scratch page for exactly these capability probes: point it at a suspect class,
+  read the on-page result, and keep the console open for `is not permitted`.
 - **The scalar bar labels the lookup table's range, not the mapper's.** `mapper.setScalarRange`
   alone never reaches the bar — it would label [0,1] under a correctly-colored surface. The viewer
   therefore owns one `vtkLookupTable` (hue range flipped to blue-low→red-high, the desktop

--- a/webapp-viewer/README.md
+++ b/webapp-viewer/README.md
@@ -72,22 +72,25 @@ scrub time — a time step costs about 5.7× less than shipping both.
   actively misleading unless they read the console.
 - **`renderer.addActor2D` is refused; `renderer.addViewProp` is not.** That is the route for 2D
   props such as `vtkScalarBarActor`.
-- **The cut plane CROPS the volume; the slice caps the exposed face.** The surface mapper carries
-  a GPU clipping plane (`mapper.addClippingPlane`) that discards the half above the cut — this
-  works in the wasm build even though WebGL2 has no `gl_ClipDistance`, because VTK emulates
-  clipping in-shader. The cap is `vtkCutter` output from the raw grid: cell data passes through,
-  so each cut polygon carries its source voxel's exact value. Axis-aligned only, by design — an
-  interactive plane widget needs interactor infrastructure the standalone session lacks. When
-  judging whether a crop "worked" from a screenshot, orbit toward the REMOVED side: the kept
-  hemisphere looks whole from its own side by definition.
-- **The order is smooth-then-cut, and the cap rim follows the smoothing slider.** The cap stays
-  planar (flat, sharp cut — never smoothed), but its in-plane outline is trimmed to the smoothed
-  silhouette: `vtkClipPolyData` insideOut with a `vtkImplicitPolyDataDistance` built from the sinc
-  output (negative inside). Re-anchor the distance function (`setInput`) only when the smoothed
-  surface changes — it rebuilds its locator — not on every slider drag. Clip-the-grid-then-smooth
-  would round the cut edge off; it is also impossible here: `vtkClipDataSet`,
-  `vtkTableBasedClipDataSet` and `vtkBoxClipDataSet` are compiled in but have **no registered
-  constructor** (probed 2026-08-07), like `vtkOutlineFilter`.
+- **The mesh IS the convention: one deformed grid, everything derives from it.** VCell's FV
+  display convention smooths the boundary VERTICES OF THE VOLUME MESH (raw boundary →
+  `vtkGeometryFilter` with `passThroughPointIds` → windowed sinc → `vtkVCellDeformGridToSurface`,
+  our custom write-back filter in the bundle, ≥ v1.2.0), so boundary cells are distorted
+  hexahedra reaching the smoothed surface. The shell is that mesh's boundary; the cut plane is
+  `vtkTableBasedClipDataSet` on that mesh — the cut face is flat and sharp, its rim lies on the
+  smoothed surface *because the cells reach it*, and every cut polygon carries its cell's value.
+  No cap, no trim, no GPU clipping planes, one actor. (History, so nobody re-walks it: a GPU-clip
+  + raw-grid-cap + implicit-distance-trim approach was built first and rejected in review — the
+  trim's per-cell chords can't follow the smoothed silhouette at nominal smoothing. When judging
+  a crop from a screenshot, orbit toward the REMOVED side; the kept hemisphere looks whole from
+  its own side by definition.)
+- **Two statistics families, both documented, neither hidden.** *Solver-grid* (`/stats`): uniform
+  voxel volumes, the solver's own bookkeeping, fast, reader-side; min/max exact; means carry the
+  known full-voxel distortion near membranes. *Display-mesh* (`vtkIntegrateAttributes` with
+  `divideAllCellDataByVolumeOn` over the deformed, possibly clipped mesh): self-consistent with
+  what is rendered; means carry the deformation convention instead. The two means converge as h→0
+  and their difference is a boundary-resolution diagnostic; min/max are identical by construction.
+  Label every displayed number with its family and, for display-mesh, the smoothing parameters.
 - **Picking is plain JS, not a VTK picker.** The browser holds the whole grid and field, so the
   hover readout is an occupancy map + 3D-DDA ray walk over the Cartesian lattice — no round trip,
   no registry dependence. The walk applies the same crop keep-rule as the renderer, so picking the

--- a/webapp-viewer/index.html
+++ b/webapp-viewer/index.html
@@ -89,6 +89,8 @@
   </select>
   <input id="slicePos" type="range" min="0" max="100" step="1" value="50" disabled>
   <span class="readout" id="sliceReadout"></span>
+  <span class="readout" id="cropStats"
+        title="display-mesh statistics: integrated over the smoothed (deformed) mesh shown on screen — self-consistent with the display; the /stats curves are solver-grid statistics (uniform voxel volumes, the solver's own bookkeeping); the two converge as the mesh refines"></span>
 </div>
 
 <div class="controls">

--- a/webapp-viewer/index.html
+++ b/webapp-viewer/index.html
@@ -39,6 +39,14 @@
   .status { font: 12px/1.4 ui-monospace, monospace; opacity: .7; }
   .status.err { color: #c0392b; opacity: 1; white-space: pre-wrap; }
   .readout.pick { flex: 0 1 auto; opacity: 1; color: #2a7; min-width: 12em; }
+  .plot-panel { width: 100%; max-width: 960px; border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+                border-radius: 6px; padding: 8px; }
+  .plot-head { display: flex; align-items: center; justify-content: space-between;
+               font: 12px/1.4 ui-monospace, monospace; margin-bottom: 4px; }
+  .plot-panel svg { display: block; width: 100%; height: 220px; }
+  .plot-panel .curve { fill: none; stroke: #2a7; stroke-width: 2; vector-effect: non-scaling-stroke; }
+  .plot-panel .axis { stroke: currentColor; stroke-opacity: .3; vector-effect: non-scaling-stroke; }
+  .plot-panel .lbl { font: 11px ui-monospace, monospace; fill: currentColor; fill-opacity: .7; }
 </style>
 </head>
 <body>
@@ -55,7 +63,15 @@
   <label for="time">Time</label>
   <input id="time" type="range" min="0" max="0" step="1" value="0" disabled>
   <span class="readout" id="dataReadout"></span>
-  <span class="readout pick" id="pickReadout" title="value under the mouse"></span>
+  <span class="readout pick" id="pickReadout" title="value under the mouse — click to plot over time"></span>
+</div>
+
+<div class="plot-panel" id="plotPanel" hidden>
+  <div class="plot-head">
+    <span id="plotTitle"></span>
+    <button id="plotClose" type="button">✕</button>
+  </div>
+  <svg id="plotSvg" viewBox="0 0 640 220" preserveAspectRatio="none" aria-label="time series plot"></svg>
 </div>
 
 <div class="controls">

--- a/webapp-viewer/index.html
+++ b/webapp-viewer/index.html
@@ -57,6 +57,18 @@
 </div>
 
 <div class="controls">
+  <label for="sliceAxis">Slice</label>
+  <select id="sliceAxis" disabled>
+    <option value="" selected>Off</option>
+    <option value="0">X</option>
+    <option value="1">Y</option>
+    <option value="2">Z</option>
+  </select>
+  <input id="slicePos" type="range" min="0" max="100" step="1" value="50" disabled>
+  <span class="readout" id="sliceReadout"></span>
+</div>
+
+<div class="controls">
   <label for="smoothing">Smoothing</label>
   <input id="smoothing" type="range" min="0" max="100" step="1" value="20" disabled>
   <span class="readout" id="smoothingReadout"></span>

--- a/webapp-viewer/index.html
+++ b/webapp-viewer/index.html
@@ -34,6 +34,7 @@
   .controls input[type=range] { flex: 0 0 200px; }
   .controls select { font: 12px ui-monospace, monospace; max-width: 260px; }
   .readout { flex: 1 1 auto; opacity: .8; }
+  .toggle { display: inline-flex; align-items: center; gap: 4px; white-space: nowrap; }
   .readout em { color: #2a7; font-style: normal; }
   .status { font: 12px/1.4 ui-monospace, monospace; opacity: .7; }
   .status.err { color: #c0392b; opacity: 1; white-space: pre-wrap; }
@@ -60,6 +61,8 @@
   <input id="smoothing" type="range" min="0" max="100" step="1" value="20" disabled>
   <span class="readout" id="smoothingReadout"></span>
   <button id="smoothingReset" type="button" disabled>Reset</button>
+  <label class="toggle"><input id="colorbar" type="checkbox" checked disabled> Color bar</label>
+  <label class="toggle"><input id="axes" type="checkbox" checked disabled> Axes</label>
 </div>
 
 <div class="status" id="status">loading…</div>

--- a/webapp-viewer/index.html
+++ b/webapp-viewer/index.html
@@ -38,6 +38,7 @@
   .readout em { color: #2a7; font-style: normal; }
   .status { font: 12px/1.4 ui-monospace, monospace; opacity: .7; }
   .status.err { color: #c0392b; opacity: 1; white-space: pre-wrap; }
+  .readout.pick { flex: 0 1 auto; opacity: 1; color: #2a7; min-width: 12em; }
 </style>
 </head>
 <body>
@@ -54,6 +55,7 @@
   <label for="time">Time</label>
   <input id="time" type="range" min="0" max="0" step="1" value="0" disabled>
   <span class="readout" id="dataReadout"></span>
+  <span class="readout pick" id="pickReadout" title="value under the mouse"></span>
 </div>
 
 <div class="controls">

--- a/webapp-viewer/index.html
+++ b/webapp-viewer/index.html
@@ -41,8 +41,11 @@
   .readout.pick { flex: 0 1 auto; opacity: 1; color: #2a7; min-width: 12em; }
   .plot-panel { width: 100%; max-width: 960px; border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
                 border-radius: 6px; padding: 8px; }
-  .plot-head { display: flex; align-items: center; justify-content: space-between;
+  .plot-head { display: flex; align-items: center; justify-content: space-between; gap: 10px;
                font: 12px/1.4 ui-monospace, monospace; margin-bottom: 4px; }
+  .plot-head .legend { display: inline-flex; gap: 12px; flex-wrap: wrap; flex: 1 1 auto; }
+  .plot-head .legend .swatch { display: inline-block; width: 10px; height: 10px; border-radius: 2px;
+                               margin-right: 4px; vertical-align: -1px; }
   .plot-panel svg { display: block; width: 100%; height: 220px; }
   .plot-panel .curve { fill: none; stroke: #2a7; stroke-width: 2; vector-effect: non-scaling-stroke; }
   .plot-panel .axis { stroke: currentColor; stroke-opacity: .3; vector-effect: non-scaling-stroke; }
@@ -62,6 +65,7 @@
   <select id="variable" disabled></select>
   <label for="time">Time</label>
   <input id="time" type="range" min="0" max="0" step="1" value="0" disabled>
+  <button id="statsBtn" type="button" disabled title="min / mean / max over space, per variable, over time">Stats</button>
   <span class="readout" id="dataReadout"></span>
   <span class="readout pick" id="pickReadout" title="value under the mouse — click to plot over time"></span>
 </div>
@@ -69,6 +73,7 @@
 <div class="plot-panel" id="plotPanel" hidden>
   <div class="plot-head">
     <span id="plotTitle"></span>
+    <span class="legend" id="plotLegend"></span>
     <button id="plotClose" type="button">✕</button>
   </div>
   <svg id="plotSvg" viewBox="0 0 640 220" preserveAspectRatio="none" aria-label="time series plot"></svg>

--- a/webapp-viewer/probe.html
+++ b/webapp-viewer/probe.html
@@ -32,6 +32,94 @@ try {
   for (const name of ['vtkContourTriangulator', 'vtkDelaunay2D']) {
     try { vtk[name](); log(`${name}: constructible`); } catch (e) { log(`${name}: FAILED — ${e?.message ?? e}`); }
   }
+  // --- deformed-grid feasibility probes ---
+  try {
+    log('session keys: ' + Object.keys(session).join(','));
+    log('runtime keys: ' + Object.keys(runtime).join(','));
+  } catch (e) { log('introspection failed: ' + e); }
+  try {
+    const gf = vtk.vtkGeometryFilter();
+    await gf.passThroughPointIdsOn();
+    log('vtkGeometryFilter.passThroughPointIdsOn: OK');
+  } catch (e) { log('passThroughPointIdsOn: FAILED — ' + (e?.message ?? e)); }
+  try {
+    // bulk readback: can we get a data array's contents without per-element calls?
+    const pts = vtk.vtkPoints();
+    await pts.setNumberOfPoints(3);
+    for (let i = 0; i < 3; i++) await pts.setPoint(i, i, 2 * i, 3 * i);
+    const candidates = [];
+    const dataObj = await pts.getData(); // vtkDataArray proxy?
+    for (const m of ['getState', 'get', 'toJSON', 'getValues', 'getArrays']) {
+      try {
+        const r = await (session[m]?.(pts) ?? Promise.reject());
+        candidates.push(`session.${m}: ${JSON.stringify(r).slice(0, 120)}`);
+      } catch { /* not available */ }
+    }
+    try {
+      const r = await dataObj.getValue(4); // element 4 = point 1 y = 2? sanity single-value
+      candidates.push(`dataArray.getValue(4)=${r}`);
+    } catch (e) { candidates.push('dataArray.getValue: refused'); }
+    log(candidates.length ? candidates.join(' | ') : 'no bulk readback candidates succeeded');
+  } catch (e) { log('bulk readback probe FAILED — ' + (e?.message ?? e)); }
+  try {
+    const pd = vtk.vtkPolyData();
+    const pts = vtk.vtkPoints();
+    await pts.setNumberOfPoints(4);
+    for (let i = 0; i < 4; i++) await pts.setPoint(i, i, i, 0);
+    const polys = vtk.vtkCellArray();
+    await polys.insertNextCell(4, [0, 1, 2, 3]);
+    await pd.setPoints(pts);
+    await pd.setPolys(polys);
+    const arr = vtk.vtkDoubleArray();
+    await arr.setNumberOfComponents(1);
+    await arr.setNumberOfTuples(1);
+    await arr.setTuple1(0, 42);
+    await (await pd.getCellData()).setScalars(arr);
+    let resetNote = 'cellArray.reset REFUSED';
+    try { await polys.reset(); await polys.insertNextCell(4, [0, 1, 2, 3]); resetNote = 'cellArray.reset OK'; } catch { /* keep note */ }
+    log(`vtkPolyData build: OK (${resetNote})`);
+  } catch (e) {
+    log(`vtkPolyData build: FAILED — ${e?.message ?? e}`);
+  }
+  for (const name of ['vtkTriangleFilter', 'vtkLinearSubdivisionFilter', 'vtkAdaptiveSubdivisionFilter']) {
+    try {
+      const f = vtk[name]();
+      if (name === 'vtkLinearSubdivisionFilter') await f.setNumberOfSubdivisions(2);
+      if (name === 'vtkAdaptiveSubdivisionFilter') await f.setMaximumEdgeLength(1);
+      log(`${name}: OK`);
+    } catch (e) {
+      log(`${name}: FAILED — ${e?.message ?? e}`);
+    }
+  }
+  // --- VTK-based statistics probes: filters + small-scalar readback ---
+  for (const name of ['vtkCellSizeFilter', 'vtkIntegrateAttributes', 'vtkArrayCalculator', 'vtkDescriptiveStatistics']) {
+    try { vtk[name](); log(`${name}: constructible`); } catch (e) { log(`${name}: FAILED — ${e?.message ?? e}`); }
+  }
+  try {
+    const a = vtk.vtkDoubleArray();
+    await a.setNumberOfComponents(1);
+    await a.setNumberOfTuples(3);
+    await a.setTuple1(0, 5); await a.setTuple1(1, -2); await a.setTuple1(2, 9);
+    const t1 = await a.getTuple1(1);
+    log(`dataArray.getTuple1(1) = ${JSON.stringify(t1)} (want -2)`);
+    let r;
+    try { r = await a.getRange(); } catch (e) { r = 'threw: ' + (e?.message ?? e); }
+    log(`dataArray.getRange() = ${JSON.stringify(r)} (want [-2,9])`);
+    let vr;
+    try { vr = await a.getValueRange(); } catch (e) { vr = 'threw'; }
+    log(`dataArray.getValueRange() = ${JSON.stringify(vr)}`);
+  } catch (e) { log('scalar readback probe FAILED — ' + (e?.message ?? e)); }
+  // 0003/0004 additions in vcell-vtk-wasm >= v1.2.0
+  try {
+    const d = vtk.vtkVCellDeformGridToSurface();
+    await d.setOriginalPointIdsArrayName('vtkOriginalPointIds');
+    log('vtkVCellDeformGridToSurface: OK (+setOriginalPointIdsArrayName)');
+  } catch (e) { log('vtkVCellDeformGridToSurface: FAILED — ' + (e?.message ?? e)); }
+  try {
+    const ia = vtk.vtkIntegrateAttributes();
+    await ia.divideAllCellDataByVolumeOn();
+    log('vtkIntegrateAttributes: OK (+divideAllCellDataByVolumeOn)');
+  } catch (e) { log('vtkIntegrateAttributes: FAILED — ' + (e?.message ?? e)); }
   // marshalled by the 0002 patch in vcell-vtk-wasm >= v1.1.0
   for (const name of ['vtkClipDataSet', 'vtkTableBasedClipDataSet']) {
     try {

--- a/webapp-viewer/probe.html
+++ b/webapp-viewer/probe.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>clip probe</title>
+<pre id="out">probing…</pre>
+<script src="vendor/vtk.umd.js"></script>
+<script type="module">
+const out = document.getElementById('out');
+const lines = [];
+const log = (s) => { lines.push(s); out.textContent = lines.join('\n'); };
+try {
+  const runtime = await window.vtkwasm.loadAsync({ url: 'assets/vtk-wasm/vcell-vtk-wasm32-emscripten.tar.gz' });
+  const session = runtime.createStandaloneSession();
+  const vtk = session.vtk;
+  try {
+    const clip = vtk.vtkClipPolyData();
+    const plane = vtk.vtkPlane();
+    await clip.setClipFunction(plane);
+    await clip.insideOutOn();
+    log('vtkClipPolyData: OK (+setClipFunction +insideOutOn)');
+  } catch (e) {
+    log(`vtkClipPolyData: FAILED — ${e?.message ?? e}`);
+  }
+  try {
+    const dist = vtk.vtkImplicitPolyDataDistance();
+    const sphere = vtk.vtkSphereSource();
+    await sphere.update();
+    await dist.setInput(await sphere.getOutput());
+    log('vtkImplicitPolyDataDistance: OK (+setInput with polydata proxy)');
+  } catch (e) {
+    log(`vtkImplicitPolyDataDistance: FAILED — ${e?.message ?? e}`);
+  }
+  for (const name of ['vtkContourTriangulator', 'vtkDelaunay2D']) {
+    try { vtk[name](); log(`${name}: constructible`); } catch (e) { log(`${name}: FAILED — ${e?.message ?? e}`); }
+  }
+  log('done');
+} catch (e) {
+  log('bootstrap failed: ' + (e?.message ?? e));
+}
+</script>

--- a/webapp-viewer/probe.html
+++ b/webapp-viewer/probe.html
@@ -32,6 +32,18 @@ try {
   for (const name of ['vtkContourTriangulator', 'vtkDelaunay2D']) {
     try { vtk[name](); log(`${name}: constructible`); } catch (e) { log(`${name}: FAILED — ${e?.message ?? e}`); }
   }
+  // marshalled by the 0002 patch in vcell-vtk-wasm >= v1.1.0
+  for (const name of ['vtkClipDataSet', 'vtkTableBasedClipDataSet']) {
+    try {
+      const clip = vtk[name]();
+      const plane = vtk.vtkPlane();
+      await clip.setClipFunction(plane);
+      await clip.insideOutOn();
+      log(`${name}: OK (+setClipFunction +insideOutOn)`);
+    } catch (e) {
+      log(`${name}: FAILED — ${e?.message ?? e}`);
+    }
+  }
   log('done');
 } catch (e) {
   log('bootstrap failed: ' + (e?.message ?? e));

--- a/webapp-viewer/scripts/fetch-vtk-wasm.mjs
+++ b/webapp-viewer/scripts/fetch-vtk-wasm.mjs
@@ -3,7 +3,7 @@
 // SAME-ORIGIN (GitHub release assets can't be fetched cross-origin from the browser — no CORS header).
 // The @kitware/vtk-wasm loader's loadAsync({url}) takes the .tar.gz and untars it in-browser
 // (DecompressionStream + untar), so we serve the .tar.gz as-is. Idempotent. Env:
-//   VTK_WASM_TAG     release tag in virtualcell/vcell-vtk-wasm (default v1.0.0)
+//   VTK_WASM_TAG     release tag in virtualcell/vcell-vtk-wasm (default v1.1.0)
 //   VTK_WASM_BUNDLE  use a local .tar.gz instead of downloading (offline/dev)
 import fs from 'node:fs';
 import path from 'node:path';
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const DEST = path.resolve(HERE, '../assets/vtk-wasm');   // served at assets/vtk-wasm/
-const TAG = process.env.VTK_WASM_TAG ?? 'v1.0.0';
+const TAG = process.env.VTK_WASM_TAG ?? 'v1.1.0';
 const ASSET = 'vcell-vtk-wasm32-emscripten.tar.gz';
 const TARGET = path.join(DEST, ASSET);
 const URL = `https://github.com/virtualcell/vcell-vtk-wasm/releases/download/${TAG}/${ASSET}`;

--- a/webapp-viewer/scripts/fetch-vtk-wasm.mjs
+++ b/webapp-viewer/scripts/fetch-vtk-wasm.mjs
@@ -3,7 +3,7 @@
 // SAME-ORIGIN (GitHub release assets can't be fetched cross-origin from the browser — no CORS header).
 // The @kitware/vtk-wasm loader's loadAsync({url}) takes the .tar.gz and untars it in-browser
 // (DecompressionStream + untar), so we serve the .tar.gz as-is. Idempotent. Env:
-//   VTK_WASM_TAG     release tag in virtualcell/vcell-vtk-wasm (default v1.1.0)
+//   VTK_WASM_TAG     release tag in virtualcell/vcell-vtk-wasm (default v1.2.0)
 //   VTK_WASM_BUNDLE  use a local .tar.gz instead of downloading (offline/dev)
 import fs from 'node:fs';
 import path from 'node:path';
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const DEST = path.resolve(HERE, '../assets/vtk-wasm');   // served at assets/vtk-wasm/
-const TAG = process.env.VTK_WASM_TAG ?? 'v1.1.0';
+const TAG = process.env.VTK_WASM_TAG ?? 'v1.2.0';
 const ASSET = 'vcell-vtk-wasm32-emscripten.tar.gz';
 const TARGET = path.join(DEST, ASSET);
 const URL = `https://github.com/virtualcell/vcell-vtk-wasm/releases/download/${TAG}/${ASSET}`;

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -37,6 +37,7 @@ const el = {
   sliceAxis: document.getElementById('sliceAxis'),
   slicePos: document.getElementById('slicePos'),
   sliceReadout: document.getElementById('sliceReadout'),
+  pickReadout: document.getElementById('pickReadout'),
   dataControls: document.getElementById('dataControls'),
   variable: document.getElementById('variable'),
   time: document.getElementById('time'),
@@ -58,6 +59,8 @@ const state = {
   bounds: null,
   sliceAxis: -1,
   slicePos: 50,
+  pick: null, // Cartesian occupancy index of the current grid, for mouse picking
+  fieldValues: null, // raw per-cell values of the shown field (nulls = blanked cells)
   nominalSinc: null,
   smoothing: NOMINAL_STRENGTH,
   ready: false,
@@ -232,6 +235,120 @@ async function applyFieldRange(field) {
   if (scalarBar) await scalarBar.setTitle(field.name);
 }
 
+/**
+ * Cartesian occupancy index for mouse picking, built once per geometry. The voxels are
+ * axis-aligned boxes on a regular lattice, so a pick is a 3D-DDA walk along the mouse ray —
+ * a few dozen lattice steps — not a test against every cell. Resolved entirely in JS: the
+ * browser already holds the grid and the field, so no round trip and no picker object.
+ */
+function buildPickIndex(geometry, bounds) {
+  const P = geometry.points;
+  const first = geometry.cells[0];
+  if (!first) return null;
+  let mins = [Infinity, Infinity, Infinity];
+  let maxs = [-Infinity, -Infinity, -Infinity];
+  for (const pi of first) {
+    for (let a = 0; a < 3; a++) {
+      mins[a] = Math.min(mins[a], P[3 * pi + a]);
+      maxs[a] = Math.max(maxs[a], P[3 * pi + a]);
+    }
+  }
+  const d = [maxs[0] - mins[0], maxs[1] - mins[1], maxs[2] - mins[2]];
+  const o = [bounds[0], bounds[2], bounds[4]];
+  const n = [0, 1, 2].map((a) => Math.max(1, Math.round((bounds[2 * a + 1] - bounds[2 * a]) / d[a])));
+  const occ = new Map();
+  const keyByCell = new Array(geometry.cells.length);
+  for (let c = 0; c < geometry.cells.length; c++) {
+    let cmin = [Infinity, Infinity, Infinity];
+    for (const pi of geometry.cells[c]) {
+      for (let a = 0; a < 3; a++) cmin[a] = Math.min(cmin[a], P[3 * pi + a]);
+    }
+    const i = [0, 1, 2].map((a) => Math.round((cmin[a] - o[a]) / d[a]));
+    const key = i[0] + n[0] * (i[1] + n[1] * i[2]);
+    occ.set(key, c);
+    keyByCell[c] = key;
+  }
+  return { o, d, n, occ, keyByCell };
+}
+
+/** Cell under the given ray, honoring the crop: cells above an active cut are not pickable. */
+function castRay(origin, dir) {
+  const pk = state.pick;
+  if (!pk) return -1;
+  const b = state.bounds;
+  // slab-clip the ray to the grid bounds
+  let t0 = 0;
+  let t1 = Infinity;
+  for (let a = 0; a < 3; a++) {
+    if (Math.abs(dir[a]) < 1e-12) {
+      if (origin[a] < b[2 * a] || origin[a] > b[2 * a + 1]) return -1;
+      continue;
+    }
+    let near = (b[2 * a] - origin[a]) / dir[a];
+    let far = (b[2 * a + 1] - origin[a]) / dir[a];
+    if (near > far) [near, far] = [far, near];
+    t0 = Math.max(t0, near);
+    t1 = Math.min(t1, far);
+  }
+  if (t0 > t1) return -1;
+  // crop plane: same keep-rule as the renderer (low side of the sliced axis survives)
+  let cropAxis = -1;
+  let cropPos = 0;
+  if (state.sliceAxis >= 0) {
+    cropAxis = state.sliceAxis;
+    const frac = 0.005 + 0.99 * (state.slicePos / 100);
+    cropPos = b[2 * cropAxis] + frac * (b[2 * cropAxis + 1] - b[2 * cropAxis]);
+  }
+  // Amanatides & Woo lattice walk
+  const eps = 1e-9;
+  const start = [0, 1, 2].map((a) => origin[a] + (t0 + eps) * dir[a]);
+  const i = [0, 1, 2].map((a) =>
+    Math.min(pk.n[a] - 1, Math.max(0, Math.floor((start[a] - pk.o[a]) / pk.d[a]))));
+  const step = dir.map((v) => (v > 0 ? 1 : -1));
+  const tDelta = [0, 1, 2].map((a) => Math.abs(pk.d[a] / (Math.abs(dir[a]) < 1e-12 ? Infinity : dir[a])));
+  const tMax = [0, 1, 2].map((a) => {
+    if (Math.abs(dir[a]) < 1e-12) return Infinity;
+    const edge = pk.o[a] + (i[a] + (step[a] > 0 ? 1 : 0)) * pk.d[a];
+    return t0 + (edge - start[a]) / dir[a];
+  });
+  for (let guard = pk.n[0] + pk.n[1] + pk.n[2] + 3; guard > 0; guard--) {
+    const cell = pk.occ.get(i[0] + pk.n[0] * (i[1] + pk.n[1] * i[2]));
+    if (cell !== undefined) {
+      if (cropAxis < 0) return cell;
+      const center = pk.o[cropAxis] + (i[cropAxis] + 0.5) * pk.d[cropAxis];
+      if (center <= cropPos) return cell;
+    }
+    const a = tMax[0] <= tMax[1] ? (tMax[0] <= tMax[2] ? 0 : 2) : (tMax[1] <= tMax[2] ? 1 : 2);
+    i[a] += step[a];
+    if (i[a] < 0 || i[a] >= pk.n[a] || tMax[a] > t1) return -1;
+    tMax[a] += tDelta[a];
+  }
+  return -1;
+}
+
+/** Mouse position → world-space ray through the camera. Perspective camera, vertical FOV. */
+async function rayFromMouse(clientX, clientY) {
+  const rect = el.canvas.getBoundingClientRect();
+  const xN = ((clientX - rect.left) / rect.width) * 2 - 1;
+  const yN = 1 - ((clientY - rect.top) / rect.height) * 2;
+  const P = await camera.getPosition();
+  const F = await camera.getFocalPoint();
+  const U = await camera.getViewUp();
+  const halfTan = Math.tan(((await camera.getViewAngle()) * Math.PI) / 360);
+  const norm = (v) => {
+    const l = Math.hypot(v[0], v[1], v[2]) || 1;
+    return [v[0] / l, v[1] / l, v[2] / l];
+  };
+  const cross = (u, v) => [u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2], u[0] * v[1] - u[1] * v[0]];
+  const fwd = norm([F[0] - P[0], F[1] - P[1], F[2] - P[2]]);
+  const right = norm(cross(fwd, U));
+  const up = cross(right, fwd);
+  const aspect = rect.width / rect.height;
+  const dir = norm([0, 1, 2].map((a) =>
+    fwd[a] + right[a] * xN * aspect * halfTan + up[a] * yN * halfTan));
+  return { origin: P, dir };
+}
+
 /** Axis-aligned bounds of the raw grid — the axes box frames the data, not the smoothed surface. */
 function boundsOf(geometry) {
   const b = [Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity];
@@ -282,6 +399,8 @@ async function buildGrid(geometry, field) {
     await (await actor.getProperty()).setColor(0.30, 0.65, 0.45);
   }
   state.bounds = boundsOf(geometry);
+  state.pick = buildPickIndex(geometry, state.bounds);
+  state.fieldValues = field ? field.values : null;
   if (cubeAxes) await cubeAxes.setBounds(...state.bounds);
   capTrimDirty = true; // new geometry, new smoothed surface
   await applySlice(); // a domain switch changes the bounds the slider position maps into
@@ -357,6 +476,7 @@ async function refreshSlice() {
 /** Same geometry, new values: rewrite the scalars in place rather than rebuilding the grid. */
 async function applyField(field) {
   if (!fieldArray) return;
+  state.fieldValues = field.values;
   await fieldArray.setName(field.name);
   await fieldArray.setNumberOfTuples(field.values.length);
   for (let i = 0; i < field.values.length; i++) await fieldArray.setTuple1(i, field.values[i] ?? 0);
@@ -504,17 +624,22 @@ function attachTrackball() {
   let dragging = false;
   let lastX = 0;
   let lastY = 0;
+  let dragDistance = 0;
   el.canvas.addEventListener('pointerdown', (e) => {
     if (e.button !== 0) return;
-    dragging = true; lastX = e.clientX; lastY = e.clientY;
+    dragging = true; lastX = e.clientX; lastY = e.clientY; dragDistance = 0;
     el.canvas.setPointerCapture(e.pointerId);
     e.preventDefault();
   });
   el.canvas.addEventListener('pointermove', (e) => {
-    if (!dragging) return;
+    if (!dragging) {
+      void hoverPick(e.clientX, e.clientY);
+      return;
+    }
     const dx = e.clientX - lastX;
     const dy = e.clientY - lastY;
     lastX = e.clientX; lastY = e.clientY;
+    dragDistance += Math.abs(dx) + Math.abs(dy);
     if (dx || dy) void orbit(dx, dy);
     e.preventDefault();
   });
@@ -525,6 +650,7 @@ function attachTrackball() {
   };
   el.canvas.addEventListener('pointerup', release);
   el.canvas.addEventListener('pointercancel', release);
+  el.canvas.addEventListener('pointerleave', () => { el.pickReadout.textContent = ''; });
   el.canvas.addEventListener('wheel', (e) => {
     void dolly(e.deltaY < 0 ? 1.1 : 1 / 1.1);
     e.preventDefault();
@@ -558,6 +684,44 @@ async function dolly(factor) {
     console.warn('dolly failed', e);
   } finally {
     state.drawing = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// picking (#1859 item 6)
+// ---------------------------------------------------------------------------
+
+/** Center coordinates of a picked cell, for the readouts. */
+function cellCenter(cell) {
+  const pk = state.pick;
+  const key = pk.keyByCell[cell];
+  if (key === undefined) return null;
+  const iz = Math.floor(key / (pk.n[0] * pk.n[1]));
+  const iy = Math.floor((key - iz * pk.n[0] * pk.n[1]) / pk.n[0]);
+  const ix = key % pk.n[0];
+  return [pk.o[0] + (ix + 0.5) * pk.d[0], pk.o[1] + (iy + 0.5) * pk.d[1], pk.o[2] + (iz + 0.5) * pk.d[2]];
+}
+
+let hoverBusy = false;
+async function hoverPick(clientX, clientY) {
+  if (!state.ready || !state.pick || hoverBusy) return;
+  hoverBusy = true;
+  try {
+    const { origin, dir } = await rayFromMouse(clientX, clientY);
+    const cell = castRay(origin, dir);
+    if (cell < 0) {
+      el.pickReadout.textContent = '';
+      return;
+    }
+    const v = state.fieldValues?.[cell];
+    const c = cellCenter(cell);
+    const at = c ? ` @ (${c.map((x) => x.toFixed(1)).join(', ')})` : '';
+    el.pickReadout.textContent =
+      v == null ? `no data${at}` : `${state.selectedVar} = ${v.toExponential(3)}${at}`;
+  } catch (e) {
+    console.warn('hover pick failed', e);
+  } finally {
+    hoverBusy = false;
   }
 }
 

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -1,10 +1,17 @@
 /**
  * VCell field viewer — see docs/3d-renderer-design.md.
  *
- * Runs VCell's finite-volume surface-smoothing pipeline entirely CLIENT-SIDE: build the raw
- * whole-voxel unstructured grid in memory from server-sent arrays → vtkGeometryFilter (extract the
- * boundary surface) → vtkWindowedSincPolyDataFilter (the faithful FV smoothing) → render via WebGL2,
- * through a custom VTK-compiled-to-WebAssembly bundle (virtualcell/vcell-vtk-wasm).
+ * Implements VCell's finite-volume DISPLAY CONVENTION entirely client-side: build the raw
+ * whole-voxel unstructured grid in memory from server-sent arrays, extract its boundary
+ * (vtkGeometryFilter, passing original point ids), smooth the boundary vertices
+ * (vtkWindowedSincPolyDataFilter, the faithful FV smoothing), then write the displaced positions
+ * BACK INTO THE GRID (vtkVCellDeformGridToSurface, our filter in the custom bundle) — yielding
+ * ONE unstructured mesh whose boundary cells are distorted hexahedra reaching the smoothed
+ * surface. The shell, the crop/cut face (vtkTableBasedClipDataSet) and the display-mesh
+ * statistics (vtkIntegrateAttributes) all derive from that one mesh, so geometry, mesh and
+ * statistics tell one consistent story. Solver-grid statistics (/stats, uniform voxel volumes)
+ * remain the reference analysis family; the two converge as the mesh refines. Rendered via
+ * WebGL2 through the custom VTK-to-WebAssembly bundle (virtualcell/vcell-vtk-wasm >= v1.2.0).
  *
  * Deliberately framework-free. The desktop client serves this page from its own loopback field
  * server, so page and data share an origin, and it must work with no network beyond that server.
@@ -37,6 +44,7 @@ const el = {
   sliceAxis: document.getElementById('sliceAxis'),
   slicePos: document.getElementById('slicePos'),
   sliceReadout: document.getElementById('sliceReadout'),
+  cropStats: document.getElementById('cropStats'),
   pickReadout: document.getElementById('pickReadout'),
   plotPanel: document.getElementById('plotPanel'),
   plotTitle: document.getElementById('plotTitle'),
@@ -76,8 +84,12 @@ const state = {
 
 // vtk handles, kept so controls can update the scene without rebuilding it
 let vtk = null;
-let geomFilter = null;
+let surfSource = null; // raw-boundary extractor feeding the smoother (passThroughPointIds on)
 let sinc = null;
+let deform = null; // vtkVCellDeformGridToSurface: writes the sinc'd points back into the grid
+let tableClip = null; // the cut plane, when active: clips the DEFORMED grid
+let geomFilter = null; // display boundary extractor (deformed or clipped-deformed grid)
+let integ = null; // vtkIntegrateAttributes for display-mesh statistics (null if unavailable)
 let mapper = null;
 let actor = null;
 let renderer = null;
@@ -87,15 +99,7 @@ let fieldArray = null;
 let lut = null;
 let scalarBar = null;
 let cubeAxes = null;
-let slicePlane = null;
 let clipPlane = null;
-let cutter = null;
-let sliceActor = null;
-let surfaceClipped = false;
-let capDist = null;
-let capTrim = null;
-/** True when the smoothed surface changed since the cap was last trimmed against it. */
-let capTrimDirty = true;
 
 const setStatus = (text, isError = false) => {
   el.status.textContent = text;
@@ -393,8 +397,10 @@ async function buildGrid(geometry, field) {
     await (await ug.getCellData()).setScalars(arr);
     fieldArray = arr;
   }
-  await geomFilter.setInputData(ug);
-  if (cutter) await cutter.setInputData(ug);
+  // the raw grid feeds the smoothing chain and the deform filter; everything the user sees
+  // (shell, crop, cut face) derives from the ONE deformed grid downstream of them
+  await surfSource.setInputData(ug);
+  await deform.setInputData(ug);
 
   if (field) {
     await mapper.setScalarModeToUseCellData();
@@ -408,74 +414,92 @@ async function buildGrid(geometry, field) {
   state.pick = buildPickIndex(geometry, state.bounds);
   state.fieldValues = field ? field.values : null;
   if (cubeAxes) await cubeAxes.setBounds(...state.bounds);
-  capTrimDirty = true; // new geometry, new smoothed surface
-  await applySlice(); // a domain switch changes the bounds the slider position maps into
+  await applyCrop(); // a domain switch changes the bounds the slider position maps into
   state.nominalSinc = geometry.sinc;
   previewSmoothing(state.smoothing);
 }
 
 /**
- * Position the cut and crop the volume at it. This is a CROP, not a floating cross-section: the
- * half above the plane is genuinely discarded (a GPU clipping plane on the surface mapper, so no
- * new geometry pipeline), and the slice actor caps the exposed face. The cap is cut from the RAW
- * grid — its purpose is the interior field, and the cutter passes cell data through, so each cut
- * polygon carries its source voxel's exact value. Its jagged voxel rim standing slightly proud of
- * the smoothed shell is honest: that is where the smoothing moved the boundary.
+ * Position the cut plane and crop the volume at it. The clip runs on the DEFORMED grid — the one
+ * mesh everything derives from — so the exposed cross-section is flat, its rim lies on the
+ * smoothed surface because the boundary cells themselves reach it (distorted hexahedra, VCell's
+ * FV display convention), and every cut polygon carries its cell's value. No cap, no trim, no
+ * second actor: the shell and the cut face are one boundary of one clipped mesh.
  */
-async function applySlice() {
-  if (!sliceActor) return;
+async function applyCrop() {
+  if (!tableClip) return;
   const axis = state.sliceAxis;
   if (axis < 0) {
-    await sliceActor.visibilityOff();
-    if (surfaceClipped) {
-      await mapper.removeAllClippingPlanes();
-      surfaceClipped = false;
-    }
+    await geomFilter.setInputConnection(await deform.getOutputPort());
     el.sliceReadout.textContent = '';
+    el.cropStats.textContent = '';
     return;
   }
   const b = state.bounds;
-  // inset from the ends: a plane exactly on the outermost voxel faces cuts a degenerate sliver
+  // inset from the ends: a plane exactly on the outermost faces clips a degenerate sliver
   const frac = 0.005 + 0.99 * (state.slicePos / 100);
   const pos = b[2 * axis] + frac * (b[2 * axis + 1] - b[2 * axis]);
   const origin = [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2];
   origin[axis] = pos;
+  // the clip keeps the side where the plane function is positive: -axis keeps everything below
+  // the cut, so the slider sweeps from almost-nothing (0) to the whole volume (100)
   const normal = [0, 0, 0];
-  normal[axis] = 1;
-  await slicePlane.setOrigin(...origin);
-  await slicePlane.setNormal(...normal);
-  // a clipping plane keeps the side its normal points toward, so -axis keeps everything below
-  // the cut; the slider sweeps from almost-nothing (0) to the whole volume (100)
   normal[axis] = -1;
   await clipPlane.setOrigin(...origin);
   await clipPlane.setNormal(...normal);
-  if (!surfaceClipped) {
-    await mapper.addClippingPlane(clipPlane);
-    surfaceClipped = true;
-  }
-  if (capTrimDirty) {
-    // re-anchor the trim to the smoothed surface as it is NOW; setInput rebuilds the distance
-    // locator, so this happens only when the surface changed, not on every slider drag
-    await sinc.update();
-    await capDist.setInput(await sinc.getOutput());
-    capTrimDirty = false;
-  }
-  await sliceActor.visibilityOn();
+  await geomFilter.setInputConnection(await tableClip.getOutputPort());
   el.sliceReadout.textContent = `${'xyz'[axis]} = ${pos.toFixed(2)}`;
 }
 
-/** Re-cut and re-render as the slider drags; in-flight guard, as for orbit. */
-let sliceInFlight = false;
-async function refreshSlice() {
-  if (!state.ready || sliceInFlight) return;
-  sliceInFlight = true;
+/** Re-crop and re-render as the slider drags; in-flight guard, as for orbit. */
+let cropInFlight = false;
+async function refreshCrop() {
+  if (!state.ready || cropInFlight) return;
+  cropInFlight = true;
   try {
-    await applySlice();
+    await applyCrop();
     await renderWindow.render();
+    await updateCropStats();
   } catch (e) {
-    setStatus('slice update failed: ' + (e?.message ?? e), true);
+    setStatus('crop update failed: ' + (e?.message ?? e), true);
   } finally {
-    sliceInFlight = false;
+    cropInFlight = false;
+  }
+}
+
+/**
+ * Display-mesh statistics of the cropped region (#1859 discussion): min/max from the clipped
+ * mesh's scalar range, volume-weighted mean from vtkIntegrateAttributes with
+ * DivideAllCellDataByVolume — integrated over the DEFORMED mesh, so the numbers are
+ * self-consistent with the geometry on screen and labeled as such. The solver-grid statistics
+ * (/stats, uniform voxel volumes, the solver's own bookkeeping) remain the reference family;
+ * near membranes the two differ by design and converge as the mesh refines.
+ */
+async function updateCropStats() {
+  if (!integ || state.sliceAxis < 0) return;
+  try {
+    await tableClip.update();
+    const clipped = await tableClip.getOutput();
+    const scalars = await (await clipped.getCellData()).getScalars();
+    const range = await scalars.getRange();
+    await integ.update();
+    const integrated = await (await integ.getOutput()).getCellData();
+    // integrated scalars are ∫f dV; "Volume" is ∫dV of the clipped smoothed mesh
+    const sumArr = (await integrated.getScalars()) ?? (await integrated.getArray(state.selectedVar));
+    const volArr = await integrated.getArray('Volume');
+    const integral = sumArr ? await sumArr.getTuple1(0) : null;
+    const volume = volArr ? await volArr.getTuple1(0) : null;
+    const mean = integral != null && volume ? integral / volume : null;
+    const p = smoothingFor(state.smoothing);
+    el.cropStats.textContent =
+      `display-mesh (cropped): min ${range[0].toExponential(3)} · `
+      + (mean != null && Number.isFinite(mean) ? `mean ${mean.toExponential(3)} · ` : '')
+      + `max ${range[1].toExponential(3)}`
+      + (volume != null && Number.isFinite(volume) ? ` · volume ${volume.toExponential(3)}` : '')
+      + ` (smoothing ${p.iterations} iters · pass-band ${formatPassBand(p.passBand)})`;
+  } catch (e) {
+    console.warn('display-mesh stats failed', e);
+    el.cropStats.textContent = '';
   }
 }
 
@@ -491,10 +515,15 @@ async function applyField(field) {
 }
 
 async function buildScene(geometry, field) {
-  geomFilter = vtk.vtkGeometryFilter();
+  // The deformed-grid convention (VCell FV display): extract the raw boundary, smooth its
+  // vertices, then write the displaced positions BACK INTO THE VOLUME GRID — boundary cells
+  // become distorted hexahedra reaching the smoothed surface, interior cells stay regular, and
+  // every downstream operation (shell, crop, cut face) derives from that one mesh.
+  surfSource = vtk.vtkGeometryFilter();
+  await surfSource.passThroughPointIdsOn(); // the write-back addresses grid points by original id
 
   sinc = vtk.vtkWindowedSincPolyDataFilter();
-  await sinc.setInputConnection(await geomFilter.getOutputPort());
+  await sinc.setInputConnection(await surfSource.getOutputPort());
   await sinc.boundarySmoothingOff();
   await sinc.featureEdgeSmoothingOff();
   await sinc.nonManifoldSmoothingOff();
@@ -503,8 +532,31 @@ async function buildScene(geometry, field) {
   await sinc.setFeatureAngle(geometry.sinc.feature_angle);
   await sinc.setPassBand(geometry.sinc.pass_band);
 
+  deform = vtk.vtkVCellDeformGridToSurface(); // our custom filter; bundle >= v1.2.0
+  await deform.setSourceConnection(await sinc.getOutputPort());
+
+  clipPlane = vtk.vtkPlane();
+  tableClip = vtk.vtkTableBasedClipDataSet();
+  await tableClip.setClipFunction(clipPlane);
+  await tableClip.setInputConnection(await deform.getOutputPort());
+
+  // display boundary extractor; applyCrop points it at the deformed grid or its clipped half
+  geomFilter = vtk.vtkGeometryFilter();
+
+  // display-mesh statistics of the cropped region; degrade quietly if the bundle lacks the filter
+  try {
+    integ = vtk.vtkIntegrateAttributes();
+    await integ.setInputConnection(await tableClip.getOutputPort());
+    // NB: DivideAllCellDataByVolume is a plain vtkSetMacro (no On/Off variants) and boolean
+    // setters marshal awkwardly — left at its default (off), so the integrated scalars are
+    // ∫f dV and the mean is computed in JS from them and the "Volume" array
+  } catch (e) {
+    integ = null;
+    console.warn('vtkIntegrateAttributes unavailable — display-mesh statistics disabled', e);
+  }
+
   // Surface normals so the mapper shades smoothly (Gouraud) instead of flat/faceted.
-  let surfacePort = await sinc.getOutputPort();
+  let surfacePort = await geomFilter.getOutputPort();
   try {
     const normals = vtk.vtkPolyDataNormals();
     await normals.setInputConnection(surfacePort);
@@ -532,37 +584,10 @@ async function buildScene(geometry, field) {
   await scalarBar.setHeight(0.72);
   await scalarBar.setPosition(0.9, 0.14);
 
-  // slice pipeline — built before buildGrid so the grid can be fed to the cutter; invisible and
-  // therefore never executed until a slice axis is chosen
-  slicePlane = vtk.vtkPlane();
-  clipPlane = vtk.vtkPlane();
-  cutter = vtk.vtkCutter();
-  await cutter.setCutFunction(slicePlane);
-  // Trim the cap to the SMOOTHED silhouette. The order is smooth-then-cut: the shell is smoothed
-  // first and cropped at the plane, and the cap — planar by construction, so the cut face stays
-  // flat and sharp — has its in-plane OUTLINE carved to match, via the smoothed surface turned
-  // into an implicit function (negative inside; insideOut keeps the inside). Clipping the volume
-  // first and smoothing after would round the cut edge off, which is exactly what is not wanted.
-  // (Grid-level clip filters have no registered constructor in this bundle anyway.)
-  capDist = vtk.vtkImplicitPolyDataDistance();
-  capTrim = vtk.vtkClipPolyData();
-  await capTrim.setInputConnection(await cutter.getOutputPort());
-  await capTrim.setClipFunction(capDist);
-  await capTrim.insideOutOn();
-  const sliceMapper = vtk.vtkPolyDataMapper();
-  await sliceMapper.setInputConnection(await capTrim.getOutputPort());
-  await sliceMapper.setLookupTable(lut); // same table as the surface and the bar
-  await sliceMapper.useLookupTableScalarRangeOn();
-  await sliceMapper.setScalarModeToUseCellData();
-  await sliceMapper.scalarVisibilityOn();
-  sliceActor = vtk.vtkActor({ mapper: sliceMapper });
-  await sliceActor.visibilityOff();
-
   await buildGrid(geometry, field);
 
   renderer = vtk.vtkRenderer({ background: [0.07, 0.07, 0.1] });
   await renderer.addActor(actor);
-  await renderer.addActor(sliceActor);
   await renderer.addViewProp(scalarBar); // addActor2D is refused by the invoker; addViewProp is the route
   await renderer.resetCamera();
   renderWindow = vtk.vtkRenderWindow({ canvasSelector: '#canvas' });
@@ -903,10 +928,10 @@ async function applySmoothing(strength) {
     const p = smoothingFor(strength);
     await sinc.setNumberOfIterations(p.iterations);
     await sinc.setPassBand(p.passBand);
-    await sinc.update();
-    capTrimDirty = true; // the surface the cap is trimmed against just moved
-    if (state.sliceAxis >= 0) await applySlice();
+    // the deform filter re-executes downstream at render, re-shaping the ONE mesh that the
+    // shell, the crop and the display-mesh statistics all derive from
     await renderWindow.render();
+    await updateCropStats();
     setStatus(`smoothing: ${p.iterations} iters · pass-band ${formatPassBand(p.passBand)} ✓ (${Math.round(performance.now() - t0)} ms)`);
   } catch (e) {
     setStatus('smoothing update failed: ' + (e?.message ?? e), true);
@@ -927,6 +952,7 @@ async function refreshField() {
   try {
     await applyField(await loadField());
     await renderWindow.render();
+    await updateCropStats(); // new values, same mesh
     setStatus(`${describe()} ✓ (${Math.round(performance.now() - t0)} ms)`);
   } catch (e) {
     setStatus('field update failed: ' + (e?.message ?? e), true);
@@ -991,11 +1017,11 @@ el.axes.addEventListener('change', () => void toggleProp(cubeAxes, el.axes.check
 el.sliceAxis.addEventListener('change', () => {
   state.sliceAxis = el.sliceAxis.value === '' ? -1 : Number(el.sliceAxis.value);
   el.slicePos.disabled = state.sliceAxis < 0;
-  void refreshSlice();
+  void refreshCrop();
 });
 el.slicePos.addEventListener('input', () => {
   state.slicePos = Number(el.slicePos.value);
-  void refreshSlice();
+  void refreshCrop();
 });
 
 el.smoothing.addEventListener('input', () => previewSmoothing(Number(el.smoothing.value)));

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -40,8 +40,10 @@ const el = {
   pickReadout: document.getElementById('pickReadout'),
   plotPanel: document.getElementById('plotPanel'),
   plotTitle: document.getElementById('plotTitle'),
+  plotLegend: document.getElementById('plotLegend'),
   plotSvg: document.getElementById('plotSvg'),
   plotClose: document.getElementById('plotClose'),
+  statsBtn: document.getElementById('statsBtn'),
   dataControls: document.getElementById('dataControls'),
   variable: document.getElementById('variable'),
   time: document.getElementById('time'),
@@ -756,14 +758,9 @@ async function plotPick(clientX, clientY) {
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
-/** Framework-free line plot: one polyline in an SVG, min/max labels, nothing else to maintain. */
-function renderPlot(series, center) {
-  const { times, values, name } = series;
-  const finite = values.filter((v) => v != null && Number.isFinite(v));
-  if (!times?.length || !finite.length) return;
-  let lo = Math.min(...finite);
-  let hi = Math.max(...finite);
-  if (hi - lo < 1e-300) { hi = lo + 1; }
+/** Fresh axes + scales in the plot SVG; both plot modes draw on top of this. */
+function plotFrame(times, lo, hi) {
+  if (hi - lo < 1e-300) hi = lo + 1;
   const W = 640;
   const H = 220;
   const M = { l: 8, r: 8, t: 8, b: 18 };
@@ -779,19 +776,81 @@ function renderPlot(series, center) {
   };
   mk('line', { class: 'axis', x1: M.l, y1: H - M.b, x2: W - M.r, y2: H - M.b });
   mk('line', { class: 'axis', x1: M.l, y1: M.t, x2: M.l, y2: H - M.b });
-  mk('polyline', {
-    class: 'curve',
-    points: times.map((t, i) => `${sx(t).toFixed(1)},${sy(values[i] ?? lo).toFixed(1)}`).join(' '),
-  });
   mk('text', { class: 'lbl', x: M.l + 4, y: M.t + 10 }, hi.toExponential(2));
   mk('text', { class: 'lbl', x: M.l + 4, y: H - M.b - 4 }, lo.toExponential(2));
   mk('text', { class: 'lbl', x: W - M.r - 4, y: H - 4, 'text-anchor': 'end' }, `t = ${times[times.length - 1]}`);
   mk('text', { class: 'lbl', x: M.l + 4, y: H - 4 }, `t = ${times[0]}`);
+  return { mk, sx, sy, lo };
+}
+
+/** Framework-free line plot: one polyline in an SVG, min/max labels, nothing else to maintain. */
+function renderPlot(series, center) {
+  const { times, values, name } = series;
+  const finite = values.filter((v) => v != null && Number.isFinite(v));
+  if (!times?.length || !finite.length) return;
+  const f = plotFrame(times, Math.min(...finite), Math.max(...finite));
+  f.mk('polyline', {
+    class: 'curve',
+    points: times.map((t, i) => `${f.sx(t).toFixed(1)},${f.sy(values[i] ?? f.lo).toFixed(1)}`).join(' '),
+  });
   const at = center ? ` @ (${center.map((x) => x.toFixed(1)).join(', ')})` : '';
   el.plotTitle.textContent = `${name}${at} · ${times.length} timepoints`;
+  el.plotLegend.innerHTML = '';
   el.plotPanel.hidden = false;
 }
 
+const SERIES_COLORS = ['#2a7', '#d70', '#07c', '#c2c', '#a33', '#578'];
+
+/**
+ * Item 9 (#1859): per-variable spatial min/max/mean over time — mean as a solid curve, the
+ * min-to-max envelope as a translucent band in the same color. One shared scale across all
+ * series, so the curves are directly comparable.
+ */
+function renderStatsPlot(stats) {
+  const { times, series } = stats;
+  if (!times?.length || !series?.length) return;
+  const finite = series.flatMap((s) => [...s.min, ...s.max]).filter((v) => v != null && Number.isFinite(v));
+  if (!finite.length) return;
+  const f = plotFrame(times, Math.min(...finite), Math.max(...finite));
+  series.forEach((s, k) => {
+    const color = SERIES_COLORS[k % SERIES_COLORS.length];
+    const fwd = times.map((t, i) => `${f.sx(t).toFixed(1)},${f.sy(s.min[i] ?? f.lo).toFixed(1)}`);
+    const back = [...times.keys()].reverse().map((i) => `${f.sx(times[i]).toFixed(1)},${f.sy(s.max[i] ?? f.lo).toFixed(1)}`);
+    f.mk('path', { d: `M${fwd.join('L')}L${back.join('L')}Z`, fill: color, 'fill-opacity': '0.15', stroke: 'none' });
+    f.mk('polyline', {
+      class: 'curve', stroke: color,
+      points: times.map((t, i) => `${f.sx(t).toFixed(1)},${f.sy(s.mean[i] ?? f.lo).toFixed(1)}`).join(' '),
+    });
+  });
+  el.plotTitle.textContent = `min / mean / max over space · ${times.length} timepoints`;
+  el.plotLegend.innerHTML = '';
+  series.forEach((s, k) => {
+    const item = document.createElement('span');
+    const swatch = document.createElement('span');
+    swatch.className = 'swatch';
+    swatch.style.background = SERIES_COLORS[k % SERIES_COLORS.length];
+    item.appendChild(swatch);
+    item.appendChild(document.createTextNode(s.name));
+    el.plotLegend.appendChild(item);
+  });
+  el.plotPanel.hidden = false;
+}
+
+async function plotStats() {
+  if (!state.ready || !state.dataset) return;
+  try {
+    // the server defaults to all volume variables; ask for a handful so the plot stays readable
+    const vars = state.variables.slice(0, SERIES_COLORS.length).map((v) => v.name);
+    setStatus(`fetching space statistics for ${vars.length} variable(s)…`);
+    const stats = await fetchJson(url('/stats', { var: vars.join(',') }), '/stats');
+    renderStatsPlot(stats);
+    setStatus(`${describe()} ✓`);
+  } catch (e) {
+    setStatus('stats failed: ' + (e?.message ?? e), true);
+  }
+}
+
+el.statsBtn.addEventListener('click', () => void plotStats());
 el.plotClose.addEventListener('click', () => { el.plotPanel.hidden = true; });
 
 // ---------------------------------------------------------------------------
@@ -987,6 +1046,7 @@ el.smoothingReset.addEventListener('click', () => {
     el.colorbar.disabled = false;
     el.axes.disabled = false;
     el.sliceAxis.disabled = false;
+    el.statsBtn.disabled = false;
     previewSmoothing(state.smoothing);
     setStatus(`rendered ${describe()} ✓ (${Math.round(performance.now() - t0)} ms) — drag to rotate, wheel to zoom`);
   } catch (e) {

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -79,8 +79,10 @@ let lut = null;
 let scalarBar = null;
 let cubeAxes = null;
 let slicePlane = null;
+let clipPlane = null;
 let cutter = null;
 let sliceActor = null;
+let surfaceClipped = false;
 
 const setStatus = (text, isError = false) => {
   el.status.textContent = text;
@@ -283,17 +285,22 @@ async function buildGrid(geometry, field) {
 }
 
 /**
- * Position the cut plane and the actors around it. The slice cuts the RAW grid, not the smoothed
- * surface: its purpose is the interior field, and the cutter passes cell data through, so each
- * cut polygon carries its source voxel's exact value. While a slice is shown the boundary surface
- * drops to 25% opacity — opaque, it would hide the slice entirely.
+ * Position the cut and crop the volume at it. This is a CROP, not a floating cross-section: the
+ * half above the plane is genuinely discarded (a GPU clipping plane on the surface mapper, so no
+ * new geometry pipeline), and the slice actor caps the exposed face. The cap is cut from the RAW
+ * grid — its purpose is the interior field, and the cutter passes cell data through, so each cut
+ * polygon carries its source voxel's exact value. Its jagged voxel rim standing slightly proud of
+ * the smoothed shell is honest: that is where the smoothing moved the boundary.
  */
 async function applySlice() {
   if (!sliceActor) return;
   const axis = state.sliceAxis;
   if (axis < 0) {
     await sliceActor.visibilityOff();
-    await (await actor.getProperty()).setOpacity(1);
+    if (surfaceClipped) {
+      await mapper.removeAllClippingPlanes();
+      surfaceClipped = false;
+    }
     el.sliceReadout.textContent = '';
     return;
   }
@@ -307,8 +314,16 @@ async function applySlice() {
   normal[axis] = 1;
   await slicePlane.setOrigin(...origin);
   await slicePlane.setNormal(...normal);
+  // a clipping plane keeps the side its normal points toward, so -axis keeps everything below
+  // the cut; the slider sweeps from almost-nothing (0) to the whole volume (100)
+  normal[axis] = -1;
+  await clipPlane.setOrigin(...origin);
+  await clipPlane.setNormal(...normal);
+  if (!surfaceClipped) {
+    await mapper.addClippingPlane(clipPlane);
+    surfaceClipped = true;
+  }
   await sliceActor.visibilityOn();
-  await (await actor.getProperty()).setOpacity(0.25);
   el.sliceReadout.textContent = `${'xyz'[axis]} = ${pos.toFixed(2)}`;
 }
 
@@ -382,6 +397,7 @@ async function buildScene(geometry, field) {
   // slice pipeline — built before buildGrid so the grid can be fed to the cutter; invisible and
   // therefore never executed until a slice axis is chosen
   slicePlane = vtk.vtkPlane();
+  clipPlane = vtk.vtkPlane();
   cutter = vtk.vtkCutter();
   await cutter.setCutFunction(slicePlane);
   const sliceMapper = vtk.vtkPolyDataMapper();

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -38,6 +38,10 @@ const el = {
   slicePos: document.getElementById('slicePos'),
   sliceReadout: document.getElementById('sliceReadout'),
   pickReadout: document.getElementById('pickReadout'),
+  plotPanel: document.getElementById('plotPanel'),
+  plotTitle: document.getElementById('plotTitle'),
+  plotSvg: document.getElementById('plotSvg'),
+  plotClose: document.getElementById('plotClose'),
   dataControls: document.getElementById('dataControls'),
   variable: document.getElementById('variable'),
   time: document.getElementById('time'),
@@ -647,6 +651,8 @@ function attachTrackball() {
     if (!dragging) return;
     dragging = false;
     try { el.canvas.releasePointerCapture(e.pointerId); } catch { /* already released */ }
+    // a press that never really moved is a pick, not an orbit
+    if (dragDistance < 4) void plotPick(e.clientX, e.clientY);
   };
   el.canvas.addEventListener('pointerup', release);
   el.canvas.addEventListener('pointercancel', release);
@@ -688,7 +694,7 @@ async function dolly(factor) {
 }
 
 // ---------------------------------------------------------------------------
-// picking (#1859 item 6)
+// picking (#1859 items 6 and 8)
 // ---------------------------------------------------------------------------
 
 /** Center coordinates of a picked cell, for the readouts. */
@@ -724,6 +730,69 @@ async function hoverPick(clientX, clientY) {
     hoverBusy = false;
   }
 }
+
+/**
+ * Click → time course at the picked cell. The series comes from /timeseries, which reduces
+ * server-side next to the reader — fetching every timestep to build one curve is the design
+ * explicitly ruled out in #1859.
+ */
+async function plotPick(clientX, clientY) {
+  if (!state.ready || !state.pick || !state.dataset) return;
+  try {
+    const { origin, dir } = await rayFromMouse(clientX, clientY);
+    const cell = castRay(origin, dir);
+    if (cell < 0) return;
+    const c = cellCenter(cell);
+    setStatus(`fetching time series for ${state.selectedVar} at cell ${cell}…`);
+    const series = await fetchJson(
+      url('/timeseries', { domain: state.selectedDomain, var: state.selectedVar, cell: String(cell) }),
+      '/timeseries');
+    renderPlot(series, c);
+    setStatus(`${describe()} ✓`);
+  } catch (e) {
+    setStatus('time-series pick failed: ' + (e?.message ?? e), true);
+  }
+}
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** Framework-free line plot: one polyline in an SVG, min/max labels, nothing else to maintain. */
+function renderPlot(series, center) {
+  const { times, values, name } = series;
+  const finite = values.filter((v) => v != null && Number.isFinite(v));
+  if (!times?.length || !finite.length) return;
+  let lo = Math.min(...finite);
+  let hi = Math.max(...finite);
+  if (hi - lo < 1e-300) { hi = lo + 1; }
+  const W = 640;
+  const H = 220;
+  const M = { l: 8, r: 8, t: 8, b: 18 };
+  const sx = (t) => M.l + ((t - times[0]) / (times[times.length - 1] - times[0] || 1)) * (W - M.l - M.r);
+  const sy = (v) => H - M.b - ((v - lo) / (hi - lo)) * (H - M.t - M.b);
+  el.plotSvg.innerHTML = '';
+  const mk = (tag, attrs, text) => {
+    const n = document.createElementNS(SVG_NS, tag);
+    for (const [k, v] of Object.entries(attrs)) n.setAttribute(k, v);
+    if (text != null) n.textContent = text;
+    el.plotSvg.appendChild(n);
+    return n;
+  };
+  mk('line', { class: 'axis', x1: M.l, y1: H - M.b, x2: W - M.r, y2: H - M.b });
+  mk('line', { class: 'axis', x1: M.l, y1: M.t, x2: M.l, y2: H - M.b });
+  mk('polyline', {
+    class: 'curve',
+    points: times.map((t, i) => `${sx(t).toFixed(1)},${sy(values[i] ?? lo).toFixed(1)}`).join(' '),
+  });
+  mk('text', { class: 'lbl', x: M.l + 4, y: M.t + 10 }, hi.toExponential(2));
+  mk('text', { class: 'lbl', x: M.l + 4, y: H - M.b - 4 }, lo.toExponential(2));
+  mk('text', { class: 'lbl', x: W - M.r - 4, y: H - 4, 'text-anchor': 'end' }, `t = ${times[times.length - 1]}`);
+  mk('text', { class: 'lbl', x: M.l + 4, y: H - 4 }, `t = ${times[0]}`);
+  const at = center ? ` @ (${center.map((x) => x.toFixed(1)).join(', ')})` : '';
+  el.plotTitle.textContent = `${name}${at} · ${times.length} timepoints`;
+  el.plotPanel.hidden = false;
+}
+
+el.plotClose.addEventListener('click', () => { el.plotPanel.hidden = true; });
 
 // ---------------------------------------------------------------------------
 // smoothing

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -32,6 +32,8 @@ const el = {
   runTitle: document.getElementById('runTitle'),
   runName: document.getElementById('runName'),
   runId: document.getElementById('runId'),
+  colorbar: document.getElementById('colorbar'),
+  axes: document.getElementById('axes'),
   dataControls: document.getElementById('dataControls'),
   variable: document.getElementById('variable'),
   time: document.getElementById('time'),
@@ -50,6 +52,7 @@ const state = {
   selectedVar: '',
   selectedDomain: '',
   geometryId: '',
+  bounds: null,
   nominalSinc: null,
   smoothing: NOMINAL_STRENGTH,
   ready: false,
@@ -67,6 +70,9 @@ let renderer = null;
 let renderWindow = null;
 let camera = null;
 let fieldArray = null;
+let lut = null;
+let scalarBar = null;
+let cubeAxes = null;
 
 const setStatus = (text, isError = false) => {
   el.status.textContent = text;
@@ -198,6 +204,34 @@ const describe = () =>
 // scene
 // ---------------------------------------------------------------------------
 
+/**
+ * Point the mapper, the lookup table and the color bar at one field together. The scalar bar
+ * labels the LUT's range — mapper.setScalarRange alone never reaches it, and a bar labelling
+ * [0,1] under a differently-colored surface is silently wrong, so the two update as one.
+ */
+async function applyFieldRange(field) {
+  await mapper.setScalarRange(field.range[0], field.range[1]);
+  if (lut) {
+    await lut.setTableRange(field.range[0], field.range[1]);
+    await lut.build();
+  }
+  if (scalarBar) await scalarBar.setTitle(field.name);
+}
+
+/** Axis-aligned bounds of the raw grid — the axes box frames the data, not the smoothed surface. */
+function boundsOf(geometry) {
+  const b = [Infinity, -Infinity, Infinity, -Infinity, Infinity, -Infinity];
+  const P = geometry.points;
+  for (let i = 0; i < geometry.numPoints; i++) {
+    for (let a = 0; a < 3; a++) {
+      const v = P[3 * i + a];
+      if (v < b[2 * a]) b[2 * a] = v;
+      if (v > b[2 * a + 1]) b[2 * a + 1] = v;
+    }
+  }
+  return b;
+}
+
 /** Builds the in-memory grid and points the pipeline at it. Re-run when the domain changes. */
 async function buildGrid(geometry, field) {
   const points = vtk.vtkPoints();
@@ -227,11 +261,13 @@ async function buildGrid(geometry, field) {
   if (field) {
     await mapper.setScalarModeToUseCellData();
     await mapper.scalarVisibilityOn(); // no-arg form; the boolean setter marshals awkwardly
-    await mapper.setScalarRange(field.range[0], field.range[1]);
+    await applyFieldRange(field);
   } else {
     // no field → solid surface (via the property method; actor.property.color is a no-op)
     await (await actor.getProperty()).setColor(0.30, 0.65, 0.45);
   }
+  state.bounds = boundsOf(geometry);
+  if (cubeAxes) await cubeAxes.setBounds(...state.bounds);
   state.nominalSinc = geometry.sinc;
   previewSmoothing(state.smoothing);
 }
@@ -243,7 +279,7 @@ async function applyField(field) {
   await fieldArray.setNumberOfTuples(field.values.length);
   for (let i = 0; i < field.values.length; i++) await fieldArray.setTuple1(i, field.values[i] ?? 0);
   await fieldArray.modified();
-  await mapper.setScalarRange(field.range[0], field.range[1]);
+  await applyFieldRange(field);
 }
 
 async function buildScene(geometry, field) {
@@ -270,12 +306,29 @@ async function buildScene(geometry, field) {
 
   mapper = vtk.vtkPolyDataMapper();
   await mapper.setInputConnection(surfacePort);
+  // Own the lookup table rather than borrowing the mapper's implicit one, so the surface and the
+  // color bar read the same table and cannot disagree about what color means what value.
+  lut = vtk.vtkLookupTable();
+  // low→high as blue→red, the direction the desktop results viewer already taught users;
+  // VTK's default rainbow runs the other way
+  await lut.setHueRange(0.66667, 0.0);
+  await mapper.setLookupTable(lut);
+  await mapper.useLookupTableScalarRangeOn(); // no-arg form, as for scalarVisibilityOn
   actor = vtk.vtkActor({ mapper });
+
+  scalarBar = vtk.vtkScalarBarActor();
+  await scalarBar.setLookupTable(lut);
+  // the default bar spans most of the viewport and auto-scales its text to match — huge; keep it
+  // a slim strip on the right edge
+  await scalarBar.setWidth(0.08);
+  await scalarBar.setHeight(0.72);
+  await scalarBar.setPosition(0.9, 0.14);
 
   await buildGrid(geometry, field);
 
   renderer = vtk.vtkRenderer({ background: [0.07, 0.07, 0.1] });
   await renderer.addActor(actor);
+  await renderer.addViewProp(scalarBar); // addActor2D is refused by the invoker; addViewProp is the route
   await renderer.resetCamera();
   renderWindow = vtk.vtkRenderWindow({ canvasSelector: '#canvas' });
   await renderWindow.addRenderer(renderer);
@@ -285,6 +338,15 @@ async function buildScene(geometry, field) {
   // vtkRemoteSession, not on the standalone session we run. Interaction is driven directly against
   // the camera below.
   camera = await renderer.getActiveCamera();
+  // The axes box needs the camera: its labels and fly-to-a-corner behaviour track the view. That
+  // is exactly what an HTML fallback cannot fake, which is why this actor earns its keep.
+  cubeAxes = vtk.vtkCubeAxesActor();
+  await cubeAxes.setBounds(...state.bounds);
+  await cubeAxes.setCamera(camera);
+  await cubeAxes.setXTitle('X');
+  await cubeAxes.setYTitle('Y');
+  await cubeAxes.setZTitle('Z');
+  await renderer.addViewProp(cubeAxes);
   attachTrackball();
   await renderWindow.render();
 }
@@ -508,6 +570,21 @@ el.variable.addEventListener('change', () => {
     void refreshField();
   }
 });
+/** Show/hide an annotation prop. visibilityOn/Off: the boolean setter marshals awkwardly. */
+async function toggleProp(prop, on) {
+  if (!prop || !state.ready) return;
+  try {
+    if (on) await prop.visibilityOn();
+    else await prop.visibilityOff();
+    await renderWindow.render();
+  } catch (e) {
+    console.warn('toggling annotation failed', e);
+  }
+}
+
+el.colorbar.addEventListener('change', () => void toggleProp(scalarBar, el.colorbar.checked));
+el.axes.addEventListener('change', () => void toggleProp(cubeAxes, el.axes.checked));
+
 el.smoothing.addEventListener('input', () => previewSmoothing(Number(el.smoothing.value)));
 el.smoothing.addEventListener('change', () => void applySmoothing(Number(el.smoothing.value)));
 el.smoothingReset.addEventListener('click', () => {
@@ -553,6 +630,8 @@ el.smoothingReset.addEventListener('click', () => {
     el.variable.disabled = false;
     el.time.disabled = state.times.length < 2;
     el.smoothing.disabled = false;
+    el.colorbar.disabled = false;
+    el.axes.disabled = false;
     previewSmoothing(state.smoothing);
     setStatus(`rendered ${describe()} ✓ (${Math.round(performance.now() - t0)} ms) — drag to rotate, wheel to zoom`);
   } catch (e) {

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -83,6 +83,10 @@ let clipPlane = null;
 let cutter = null;
 let sliceActor = null;
 let surfaceClipped = false;
+let capDist = null;
+let capTrim = null;
+/** True when the smoothed surface changed since the cap was last trimmed against it. */
+let capTrimDirty = true;
 
 const setStatus = (text, isError = false) => {
   el.status.textContent = text;
@@ -279,6 +283,7 @@ async function buildGrid(geometry, field) {
   }
   state.bounds = boundsOf(geometry);
   if (cubeAxes) await cubeAxes.setBounds(...state.bounds);
+  capTrimDirty = true; // new geometry, new smoothed surface
   await applySlice(); // a domain switch changes the bounds the slider position maps into
   state.nominalSinc = geometry.sinc;
   previewSmoothing(state.smoothing);
@@ -322,6 +327,13 @@ async function applySlice() {
   if (!surfaceClipped) {
     await mapper.addClippingPlane(clipPlane);
     surfaceClipped = true;
+  }
+  if (capTrimDirty) {
+    // re-anchor the trim to the smoothed surface as it is NOW; setInput rebuilds the distance
+    // locator, so this happens only when the surface changed, not on every slider drag
+    await sinc.update();
+    await capDist.setInput(await sinc.getOutput());
+    capTrimDirty = false;
   }
   await sliceActor.visibilityOn();
   el.sliceReadout.textContent = `${'xyz'[axis]} = ${pos.toFixed(2)}`;
@@ -400,8 +412,19 @@ async function buildScene(geometry, field) {
   clipPlane = vtk.vtkPlane();
   cutter = vtk.vtkCutter();
   await cutter.setCutFunction(slicePlane);
+  // Trim the cap to the SMOOTHED silhouette. The order is smooth-then-cut: the shell is smoothed
+  // first and cropped at the plane, and the cap — planar by construction, so the cut face stays
+  // flat and sharp — has its in-plane OUTLINE carved to match, via the smoothed surface turned
+  // into an implicit function (negative inside; insideOut keeps the inside). Clipping the volume
+  // first and smoothing after would round the cut edge off, which is exactly what is not wanted.
+  // (Grid-level clip filters have no registered constructor in this bundle anyway.)
+  capDist = vtk.vtkImplicitPolyDataDistance();
+  capTrim = vtk.vtkClipPolyData();
+  await capTrim.setInputConnection(await cutter.getOutputPort());
+  await capTrim.setClipFunction(capDist);
+  await capTrim.insideOutOn();
   const sliceMapper = vtk.vtkPolyDataMapper();
-  await sliceMapper.setInputConnection(await cutter.getOutputPort());
+  await sliceMapper.setInputConnection(await capTrim.getOutputPort());
   await sliceMapper.setLookupTable(lut); // same table as the surface and the bar
   await sliceMapper.useLookupTableScalarRangeOn();
   await sliceMapper.setScalarModeToUseCellData();
@@ -589,6 +612,8 @@ async function applySmoothing(strength) {
     await sinc.setNumberOfIterations(p.iterations);
     await sinc.setPassBand(p.passBand);
     await sinc.update();
+    capTrimDirty = true; // the surface the cap is trimmed against just moved
+    if (state.sliceAxis >= 0) await applySlice();
     await renderWindow.render();
     setStatus(`smoothing: ${p.iterations} iters · pass-band ${formatPassBand(p.passBand)} ✓ (${Math.round(performance.now() - t0)} ms)`);
   } catch (e) {

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -34,6 +34,9 @@ const el = {
   runId: document.getElementById('runId'),
   colorbar: document.getElementById('colorbar'),
   axes: document.getElementById('axes'),
+  sliceAxis: document.getElementById('sliceAxis'),
+  slicePos: document.getElementById('slicePos'),
+  sliceReadout: document.getElementById('sliceReadout'),
   dataControls: document.getElementById('dataControls'),
   variable: document.getElementById('variable'),
   time: document.getElementById('time'),
@@ -53,6 +56,8 @@ const state = {
   selectedDomain: '',
   geometryId: '',
   bounds: null,
+  sliceAxis: -1,
+  slicePos: 50,
   nominalSinc: null,
   smoothing: NOMINAL_STRENGTH,
   ready: false,
@@ -73,6 +78,9 @@ let fieldArray = null;
 let lut = null;
 let scalarBar = null;
 let cubeAxes = null;
+let slicePlane = null;
+let cutter = null;
+let sliceActor = null;
 
 const setStatus = (text, isError = false) => {
   el.status.textContent = text;
@@ -257,6 +265,7 @@ async function buildGrid(geometry, field) {
     fieldArray = arr;
   }
   await geomFilter.setInputData(ug);
+  if (cutter) await cutter.setInputData(ug);
 
   if (field) {
     await mapper.setScalarModeToUseCellData();
@@ -268,8 +277,54 @@ async function buildGrid(geometry, field) {
   }
   state.bounds = boundsOf(geometry);
   if (cubeAxes) await cubeAxes.setBounds(...state.bounds);
+  await applySlice(); // a domain switch changes the bounds the slider position maps into
   state.nominalSinc = geometry.sinc;
   previewSmoothing(state.smoothing);
+}
+
+/**
+ * Position the cut plane and the actors around it. The slice cuts the RAW grid, not the smoothed
+ * surface: its purpose is the interior field, and the cutter passes cell data through, so each
+ * cut polygon carries its source voxel's exact value. While a slice is shown the boundary surface
+ * drops to 25% opacity — opaque, it would hide the slice entirely.
+ */
+async function applySlice() {
+  if (!sliceActor) return;
+  const axis = state.sliceAxis;
+  if (axis < 0) {
+    await sliceActor.visibilityOff();
+    await (await actor.getProperty()).setOpacity(1);
+    el.sliceReadout.textContent = '';
+    return;
+  }
+  const b = state.bounds;
+  // inset from the ends: a plane exactly on the outermost voxel faces cuts a degenerate sliver
+  const frac = 0.005 + 0.99 * (state.slicePos / 100);
+  const pos = b[2 * axis] + frac * (b[2 * axis + 1] - b[2 * axis]);
+  const origin = [(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2];
+  origin[axis] = pos;
+  const normal = [0, 0, 0];
+  normal[axis] = 1;
+  await slicePlane.setOrigin(...origin);
+  await slicePlane.setNormal(...normal);
+  await sliceActor.visibilityOn();
+  await (await actor.getProperty()).setOpacity(0.25);
+  el.sliceReadout.textContent = `${'xyz'[axis]} = ${pos.toFixed(2)}`;
+}
+
+/** Re-cut and re-render as the slider drags; in-flight guard, as for orbit. */
+let sliceInFlight = false;
+async function refreshSlice() {
+  if (!state.ready || sliceInFlight) return;
+  sliceInFlight = true;
+  try {
+    await applySlice();
+    await renderWindow.render();
+  } catch (e) {
+    setStatus('slice update failed: ' + (e?.message ?? e), true);
+  } finally {
+    sliceInFlight = false;
+  }
 }
 
 /** Same geometry, new values: rewrite the scalars in place rather than rebuilding the grid. */
@@ -324,10 +379,25 @@ async function buildScene(geometry, field) {
   await scalarBar.setHeight(0.72);
   await scalarBar.setPosition(0.9, 0.14);
 
+  // slice pipeline — built before buildGrid so the grid can be fed to the cutter; invisible and
+  // therefore never executed until a slice axis is chosen
+  slicePlane = vtk.vtkPlane();
+  cutter = vtk.vtkCutter();
+  await cutter.setCutFunction(slicePlane);
+  const sliceMapper = vtk.vtkPolyDataMapper();
+  await sliceMapper.setInputConnection(await cutter.getOutputPort());
+  await sliceMapper.setLookupTable(lut); // same table as the surface and the bar
+  await sliceMapper.useLookupTableScalarRangeOn();
+  await sliceMapper.setScalarModeToUseCellData();
+  await sliceMapper.scalarVisibilityOn();
+  sliceActor = vtk.vtkActor({ mapper: sliceMapper });
+  await sliceActor.visibilityOff();
+
   await buildGrid(geometry, field);
 
   renderer = vtk.vtkRenderer({ background: [0.07, 0.07, 0.1] });
   await renderer.addActor(actor);
+  await renderer.addActor(sliceActor);
   await renderer.addViewProp(scalarBar); // addActor2D is refused by the invoker; addViewProp is the route
   await renderer.resetCamera();
   renderWindow = vtk.vtkRenderWindow({ canvasSelector: '#canvas' });
@@ -585,6 +655,16 @@ async function toggleProp(prop, on) {
 el.colorbar.addEventListener('change', () => void toggleProp(scalarBar, el.colorbar.checked));
 el.axes.addEventListener('change', () => void toggleProp(cubeAxes, el.axes.checked));
 
+el.sliceAxis.addEventListener('change', () => {
+  state.sliceAxis = el.sliceAxis.value === '' ? -1 : Number(el.sliceAxis.value);
+  el.slicePos.disabled = state.sliceAxis < 0;
+  void refreshSlice();
+});
+el.slicePos.addEventListener('input', () => {
+  state.slicePos = Number(el.slicePos.value);
+  void refreshSlice();
+});
+
 el.smoothing.addEventListener('input', () => previewSmoothing(Number(el.smoothing.value)));
 el.smoothing.addEventListener('change', () => void applySmoothing(Number(el.smoothing.value)));
 el.smoothingReset.addEventListener('click', () => {
@@ -632,6 +712,7 @@ el.smoothingReset.addEventListener('click', () => {
     el.smoothing.disabled = false;
     el.colorbar.disabled = false;
     el.axes.disabled = false;
+    el.sliceAxis.disabled = false;
     previewSmoothing(state.smoothing);
     setStatus(`rendered ${describe()} ✓ (${Math.round(performance.now() - t0)} ms) — drag to rotate, wheel to zoom`);
   } catch (e) {


### PR DESCRIPTION
Implements items B–E of #1859 on top of #1860 (merged): color bar, tick-labeled axes, the orthogonal cut plane, value-under-mouse picking, time-series at a picked point, and statistics. All viewer changes in `webapp-viewer/`; the field server (`FieldViewerServer`) gains `/timeseries` and `/stats`; the custom wasm bundle advances to **v1.2.0**.

## The deformed-grid convention (the design center of this PR)

VCell's FV display convention: the solution lives on a regular Cartesian grid with an implicit boundary; for display, the boundary **vertices of the volume mesh** are smoothed (windowed sinc, reference parameters), yielding one unstructured grid whose boundary cells are **distorted hexahedra** reaching the smoothed surface. The viewer builds exactly that — raw boundary (`vtkGeometryFilter`, `passThroughPointIds`) → sinc → `vtkVCellDeformGridToSurface` (our custom write-back filter, [vcell-vtk-wasm#2](https://github.com/virtualcell/vcell-vtk-wasm/pull/2)) — and derives **everything from the one mesh**: the shell is its boundary; the cut plane is `vtkTableBasedClipDataSet` on it; display-mesh statistics integrate over it. Geometry, mesh and statistics tell one story, at any smoothing setting (default = the reference parameters).

*Design history, for the record:* an earlier iteration smoothed only the extracted surface and patched the cut face against it (GPU clip + raw-grid cap + implicit-distance trim). Review correctly rejected it — the volume elements being cut were still right hexahedra, so the cut rim degenerated to a shaved staircase. That approach is fully removed; this section describes the only implementation in the PR.

## Cut plane — a crop of the deformed grid

Axis dropdown + position slider. The cut face is **flat and sharp** (never smoothed — the order is deform-then-clip); its rim lies on the smoothed surface **because the boundary cells reach it**; every cut polygon carries its cell's exact value through the clip. At smoothing 0 the rim honestly reverts to the raw staircase; at nominal and above it follows the smoothed silhouette — verified at 48³ resolution against the exact shots that condemned the previous approach.

| face-on Z crop, nominal smoothing | X crop orbited toward the cut | smoothing 0 — raw staircase, consistently |
|---|---|---|
| ![nominal](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/1bbedf385e1925c505d5edca743fd894a48dc3cc/deform48b-crop-z50-nominal.png) | ![orbit](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/1bbedf385e1925c505d5edca743fd894a48dc3cc/deform48b-crop-x45-orbit.png) | ![raw](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/1bbedf385e1925c505d5edca743fd894a48dc3cc/deform48b-crop-smooth0.png) |

## Color bar and tick-labeled axes (items 2, 3)

`vtkScalarBarActor` + `vtkCubeAxesActor` via `addViewProp` (`addActor2D` is refused by the invoker), each with a default-on checkbox. The viewer owns one `vtkLookupTable` shared by surface and bar (`useLookupTableScalarRangeOn`) — the bar labels the LUT's range, which `mapper.setScalarRange` alone never reaches — with hue flipped to blue-low→red-high to match the desktop. Verified with a monotonic ramp field: surface sweep and bar direction/labels agree.

| annotated scene | ramp verification |
|---|---|
| ![annotated](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/6f652d0d6d3e6fa66e19013f9c5b77467aa1b3a1/annot-full.png) | ![ramp](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/6f652d0d6d3e6fa66e19013f9c5b77467aa1b3a1/annot-ramp.png) |

## Picking and time series (items 6, 8)

Hover resolves in **plain JS** — occupancy map + 3D-DDA over the Cartesian lattice, no round trip, no picker object — honoring the crop's keep-rule (picking the cut face reads the cap cell). A press that moves < 4 px plots the picked cell's full time course via the new `/timeseries` endpoint, which maps the cell to the solver's global volume index and reduces server-side through the same `VCDataManager.getTimeSeriesValues` path as the desktop's own plots — the data crosses the wire once, already reduced. Known caveat: the pick walks the regular lattice, so within the boundary band it can disagree with the deformed geometry by less than a cell; noted for a follow-up.

![pick and plot](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/9c0afb91f543373f7a0d7df7192b9b58b005dd39/pick-plot.png)

## Statistics — two documented families (item 9 + design discussion)

- **Solver-grid** (`/stats`, Java, reader-side): one space-stats `TimeSeriesJobSpec` carrying all requested variables, each reduced over its own domain — uniform voxel volumes, the solver's own bookkeeping, serving the min/mean/max **time curves** (Stats button → mean curves + min–max envelopes, shared scale, legend). Fast; min/max exact; means carry the known full-voxel distortion near membranes.
- **Display-mesh** (new, wasm): when a crop is active, a live readout shows **min · volume-weighted mean · max · volume of the cropped region**, integrated by `vtkIntegrateAttributes` over the deformed (clipped) mesh — self-consistent with the geometry on screen, labeled with family + smoothing parameters. Sanity: the cropped half-ellipsoid's volume matches the analytic value to 4 digits.

Min/max are identical between families by construction; the two means differ near membranes by design — the delta is a boundary-resolution diagnostic — and converge as the mesh refines. Documented in `webapp-viewer/README.md`.

![stats plot](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/9c0afb91f543373f7a0d7df7192b9b58b005dd39/stats-stats.png)

## Bundle: vcell-vtk-wasm v1.1.0 → v1.2.0

- v1.1.0 ([#1](https://github.com/virtualcell/vcell-vtk-wasm/pull/1)): marshalled `vtkClipDataSet`/`vtkTableBasedClipDataSet`.
- v1.2.0 ([#2](https://github.com/virtualcell/vcell-vtk-wasm/pull/2)): adds `vtkVCellDeformGridToSurface` (the write-back must live in the bundle — the session has no bulk data readback) and marshals `vtkCellSizeFilter`/`vtkIntegrateAttributes`. Both released through the build + golden-test gate; the fetch script pins v1.2.0; `probe.html` (committed) verifies the roster on every bump.

## Verification

All features exercised headless against a mock field server at 18³ and 48³ (screenshots above are real renders of this branch): annotations, ramp-field color consistency, crop across the smoothing range including the rim-fidelity comparison, picking (incl. crop-aware cap picks), time-series plot, stats curves, cropped-region stats with analytic volume check. The Java endpoints compile and ride the same data paths as the desktop's plots; live-client exercise still to come via the usual `-Dvcell.fieldViewer.enabled=true` route.

On merge, tick items (2), (3), (4), (6), (8), (9) in #1859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYqrC3BiB4JRsJoz7BXJF4
