### PR TITLE
Field viewer: 16-iteration default smoothing; discoverable enable flag in vmoptions

### DIFF
--- a/docker/build/installers/VCell.install4j
+++ b/docker/build/installers/VCell.install4j
@@ -138,6 +138,8 @@ java.desktop/sun.awt.image=ALL-UNNAMED
 -Dvcell.bioformatsJarDownloadURL=${compiler:bioformatsJarDownloadURL}
 -Dvcell.imagej.plugin.url=http://vcell.org/webstart
 -Dcom.apple.mrj.application.apple.menu.about.name=VCell_${compiler:Site}
+# set to true to enable the experimental browser-based 3D field viewer
+-Dvcell.fieldViewer.enabled=false
 -Dvcell.dummyvm=${compiler:sys.date}</content>
       </vmOptionsFile>
       <infoPlist>&lt;key&gt;LSEnvironment&lt;/key&gt;
@@ -177,6 +179,8 @@ java.desktop/sun.awt.image=ALL-UNNAMED
 -Dvcell.bioformatsJarFileName=${compiler:bioformatsJarFile}
 -Dvcell.bioformatsJarDownloadURL=${compiler:bioformatsJarDownloadURL}
 -Dvcell.imagej.plugin.url=http://vcell.org/webstart
+# set to true to enable the experimental browser-based 3D field viewer
+-Dvcell.fieldViewer.enabled=false
 -Dvcell.dummyvm=${compiler:sys.date}</content>
       </vmOptionsFile>
       <iconImageFiles>
@@ -212,6 +216,8 @@ java.desktop/sun.awt.image=ALL-UNNAMED
 -Dvcell.bioformatsJarDownloadURL=${compiler:bioformatsJarDownloadURL}
 -Dvcell.imagej.plugin.url=http://vcell.org/webstart
 -Xmx800M
+# set to true to enable the experimental browser-based 3D field viewer
+-Dvcell.fieldViewer.enabled=false
 -Dvcell.dummyvm=${compiler:sys.date}</content>
       </vmOptionsFile>
       <iconImageFiles>
@@ -246,6 +252,8 @@ java.desktop/sun.awt.image=ALL-UNNAMED
 -Dvcell.bioformatsJarFileName=${compiler:bioformatsJarFile}
 -Dvcell.bioformatsJarDownloadURL=${compiler:bioformatsJarDownloadURL}
 -Dvcell.imagej.plugin.url=http://vcell.org/webstart
+# set to true to enable the experimental browser-based 3D field viewer
+-Dvcell.fieldViewer.enabled=false
 -Dvcell.dummyvm=${compiler:sys.date}</content>
       </vmOptionsFile>
     </launcher>
@@ -277,6 +285,8 @@ java.desktop/sun.awt.image=ALL-UNNAMED
 -Dvcell.bioformatsJarFileName=${compiler:bioformatsJarFile}
 -Dvcell.bioformatsJarDownloadURL=${compiler:bioformatsJarDownloadURL}
 -Dvcell.imagej.plugin.url=http://vcell.org/webstart
+# set to true to enable the experimental browser-based 3D field viewer
+-Dvcell.fieldViewer.enabled=false
 -Dvcell.dummyvm=${compiler:sys.date}</content>
       </vmOptionsFile>
     </launcher>
@@ -308,6 +318,8 @@ java.desktop/sun.awt.image=ALL-UNNAMED
 -Dvcell.bioformatsJarFileName=${compiler:bioformatsJarFile}
 -Dvcell.bioformatsJarDownloadURL=${compiler:bioformatsJarDownloadURL}
 -Dvcell.imagej.plugin.url=http://vcell.org/webstart
+# set to true to enable the experimental browser-based 3D field viewer
+-Dvcell.fieldViewer.enabled=false
 -Dvcell.dummyvm=${compiler:sys.date}</content>
       </vmOptionsFile>
       <iconImageFiles>

--- a/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
@@ -74,12 +74,14 @@ public final class FieldViewerServer {
 	private static final String INDEX_HTML = "index.html";
 
 	/**
-	 * Smoothing parameters the client applies to the extracted boundary surface. These match
-	 * the reference pipeline in {@code org.vcell.vis.mapping.vcell.CartesianMeshVtkFileWriter}
-	 * (and pyvcell's {@code smooth_unstructured_grid_surface}) so the browser reproduces the
-	 * same smoothed membrane the desktop/VTK path produces.
+	 * Default smoothing parameters for the viewer's deformed display mesh. Feature angle and
+	 * pass band match the reference pipeline in
+	 * {@code org.vcell.vis.mapping.vcell.CartesianMeshVtkFileWriter} (and pyvcell's
+	 * {@code smooth_unstructured_grid_surface}); the iteration count is deliberately 16 where
+	 * the pyvcell/VisIt reference uses 12 — chosen by eye in the installed client as the better
+	 * default. The viewer's smoothing slider can still reach the 12-iteration reference.
 	 */
-	private static final int SINC_ITERATIONS = 12;
+	private static final int SINC_ITERATIONS = 16;
 	private static final double SINC_FEATURE_ANGLE = 120.0;
 	private static final double SINC_PASS_BAND = 0.05;
 

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -892,7 +892,7 @@ el.plotClose.addEventListener('click', () => { el.plotPanel.hidden = true; });
  * points by 26 units where the reference moves 0.45).
  */
 function smoothingFor(strength) {
-  const nom = state.nominalSinc ?? { iterations: 12, feature_angle: 120, pass_band: 0.05 };
+  const nom = state.nominalSinc ?? { iterations: 16, feature_angle: 120, pass_band: 0.05 };
   if (strength <= NOMINAL_STRENGTH) {
     return { iterations: Math.round(nom.iterations * (strength / NOMINAL_STRENGTH)), passBand: nom.pass_band };
   }


### PR DESCRIPTION
Two follow-ups from testing 8.0.9.01's field viewer in an installed alpha client (#1859):

1. **Default display smoothing: 16 iterations** (was 12). Feature angle and pass band still match the pyvcell/VisIt reference; the iteration count deliberately differs (the slider still reaches 12). The served `/grid` sinc block is the single source of nominal, so the slider marker and display-mesh statistics labels follow automatically. The bundle's golden-file test stays pinned at 12 — it verifies algorithm fidelity, not the viewer default.
2. **`-Dvcell.fieldViewer.enabled=false` written explicitly into all six installer `vmOptionsFile` blocks** with a one-line comment, so the flag is discoverable in `vmoptions.txt` instead of needing to be invented. CRLF endings of `VCell.install4j` audited (zero churn).

Verified: `vcell-client` compiles; headless harness renders with the 16-iteration nominal against the updated `/grid` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYqrC3BiB4JRsJoz7BXJF4