### PR TITLE
Field viewer: support 2D simulation results

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/data/PDEDataViewer.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/PDEDataViewer.java
@@ -1704,6 +1704,13 @@ private void openInBrowserViewer() {
 			DialogUtils.showWarningDialog(this, "These results cannot be viewed in 3D.");
 			return;
 		}
+		if (dataContext.getCartesianMesh() != null
+				&& dataContext.getCartesianMesh().getGeometryDimension() < 2) {
+			// the browser viewer renders 2D quads and 3D voxels; a 1D run has neither
+			DialogUtils.showWarningDialog(this,
+					"1D results are not supported by the 3D viewer; use the Plot button instead.");
+			return;
+		}
 		VCSimulationDataIdentifier simDataId = (VCSimulationDataIdentifier) dataContext.getVCDataIdentifier();
 		// register the dataset before opening the browser, and hand over the reader this window already
 		// uses -- that is what lets one server serve several windows, local and remote alike

--- a/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
@@ -71,6 +71,9 @@ public final class FieldViewerServer {
 	/** VTK_VOXEL: the cell type {@link CartesianMeshMapping} emits for 3D volume domains. */
 	private static final int VTK_VOXEL = 11;
 
+	/** VTK_QUAD: the in-plane cell type it emits for 2D volume domains. */
+	private static final int VTK_QUAD = 9;
+
 	private static final String INDEX_HTML = "index.html";
 
 	/**
@@ -350,10 +353,11 @@ public final class FieldViewerServer {
 		ex.getResponseHeaders().set("Cache-Control", "public, max-age=60");
 
 		List<VisPoint> points = visMesh.getPoints();
-		List<VisVoxel> voxels = visMesh.getVisVoxels();
+		Cells cells = new Cells(visMesh);
 
-		StringBuilder sb = new StringBuilder(32 * points.size() + 32 * voxels.size() + 512);
+		StringBuilder sb = new StringBuilder(32 * points.size() + 32 * cells.size() + 512);
 		sb.append("{\"geometryId\":\"").append(jsonEscape(geometryId(source, domain))).append('"');
+		sb.append(",\"dimension\":").append(cells.vtkCellType == VTK_QUAD ? 2 : 3);
 		sb.append(",\"numPoints\":").append(points.size());
 		sb.append(",\"points\":[");
 		for (int i = 0; i < points.size(); i++) {
@@ -363,10 +367,10 @@ public final class FieldViewerServer {
 			}
 			sb.append(p.getX()).append(',').append(p.getY()).append(',').append(p.getZ());
 		}
-		sb.append("],\"cellType\":").append(VTK_VOXEL);
+		sb.append("],\"cellType\":").append(cells.vtkCellType);
 		sb.append(",\"cells\":[");
-		for (int c = 0; c < voxels.size(); c++) {
-			List<Integer> idx = voxels.get(c).getPointIndices();
+		for (int c = 0; c < cells.size(); c++) {
+			List<Integer> idx = cells.pointIndices.get(c);
 			if (c > 0) {
 				sb.append(',');
 			}
@@ -408,17 +412,17 @@ public final class FieldViewerServer {
 			throw new IllegalArgumentException("missing required query parameter 'var'");
 		}
 		double time = parseTime(q, source);
-		List<VisVoxel> voxels = grid(source, domain).getVisVoxels();
+		Cells cells = new Cells(grid(source, domain));
 
-		// each cell carries the mesh's global index of the voxel it came from, which is the position
-		// of that cell's value in the solver's data array
+		// each cell carries the mesh's global index of the element it came from, which is the
+		// position of that cell's value in the solver's data array
 		SimDataBlock block = source.dataManager.getSimDataBlock(emptyOutputContext(), source.vcdID, varName, time);
 		double[] meshData = block.getData();
-		double[] values = new double[voxels.size()];
+		double[] values = new double[cells.size()];
 		double min = Double.POSITIVE_INFINITY;
 		double max = Double.NEGATIVE_INFINITY;
-		for (int c = 0; c < voxels.size(); c++) {
-			double value = meshData[voxels.get(c).getFiniteVolumeIndex().getGlobalIndex()];
+		for (int c = 0; c < cells.size(); c++) {
+			double value = meshData[cells.globalIndices[c]];
 			values[c] = value;
 			if (!Double.isNaN(value)) {
 				min = Math.min(min, value);
@@ -463,13 +467,13 @@ public final class FieldViewerServer {
 		if (cellParam == null || cellParam.isEmpty()) {
 			throw new IllegalArgumentException("missing required query parameter 'cell'");
 		}
-		List<VisVoxel> voxels = grid(source, domain).getVisVoxels();
+		Cells cells = new Cells(grid(source, domain));
 		int cell = Integer.parseInt(cellParam);
-		if (cell < 0 || cell >= voxels.size()) {
+		if (cell < 0 || cell >= cells.size()) {
 			throw new IllegalArgumentException("cell " + cell + " out of range; domain '" + domain
-					+ "' has " + voxels.size() + " cells");
+					+ "' has " + cells.size() + " cells");
 		}
-		int globalIndex = voxels.get(cell).getFiniteVolumeIndex().getGlobalIndex();
+		int globalIndex = cells.globalIndices[cell];
 
 		double[] times = source.dataManager.getDataSetTimes(source.vcdID);
 		if (times == null || times.length == 0) {
@@ -544,12 +548,7 @@ public final class FieldViewerServer {
 			final String dom = varDomains[v];
 			indices[v] = indicesByDomain.computeIfAbsent(dom, d -> {
 				try {
-					List<VisVoxel> voxels = grid(source, d).getVisVoxels();
-					int[] idx = new int[voxels.size()];
-					for (int c = 0; c < idx.length; c++) {
-						idx[c] = voxels.get(c).getFiniteVolumeIndex().getGlobalIndex();
-					}
-					return idx;
+					return new Cells(grid(source, d)).globalIndices.clone();
 				} catch (Exception e) {
 					throw new RuntimeException("building index set for domain '" + d + "'", e);
 				}
@@ -611,6 +610,48 @@ public final class FieldViewerServer {
 	 */
 	private static String geometryId(DataSource source, String domain) {
 		return source.vcdID.getID() + "/" + domain;
+	}
+
+	/**
+	 * The finite-volume cells of a mesh, uniformly for 2D and 3D. A 3D domain arrives as
+	 * {@link VisVoxel}s and a 2D one as in-plane {@link VisPolygon} quads — thrift types with no
+	 * common interface, and the one NOT produced is left null, which is how a 2D run used to 500
+	 * on {@code /grid}. Everything downstream (geometry, field values, time series, statistics)
+	 * needs only the point indices and the solver's global index, so that is the whole interface.
+	 */
+	private static final class Cells {
+		final int vtkCellType;
+		final List<List<Integer>> pointIndices;
+		final int[] globalIndices;
+
+		Cells(VisMesh visMesh) {
+			List<VisVoxel> voxels = visMesh.getVisVoxels();
+			List<org.vcell.vis.vismesh.thrift.VisPolygon> polygons = visMesh.getPolygons();
+			if (voxels != null && !voxels.isEmpty()) {
+				vtkCellType = VTK_VOXEL;
+				pointIndices = new ArrayList<>(voxels.size());
+				globalIndices = new int[voxels.size()];
+				for (int c = 0; c < voxels.size(); c++) {
+					pointIndices.add(voxels.get(c).getPointIndices());
+					globalIndices[c] = voxels.get(c).getFiniteVolumeIndex().getGlobalIndex();
+				}
+			} else if (polygons != null && !polygons.isEmpty()) {
+				vtkCellType = VTK_QUAD;
+				pointIndices = new ArrayList<>(polygons.size());
+				globalIndices = new int[polygons.size()];
+				for (int c = 0; c < polygons.size(); c++) {
+					pointIndices.add(polygons.get(c).getPointIndices());
+					globalIndices[c] = polygons.get(c).getFiniteVolumeIndex().getGlobalIndex();
+				}
+			} else {
+				throw new IllegalArgumentException("mesh has neither voxels nor polygons; "
+						+ "1D runs are not supported by the field viewer");
+			}
+		}
+
+		int size() {
+			return globalIndices.length;
+		}
 	}
 
 	// ---------------------------------------------------------------------

--- a/webapp-viewer/README.md
+++ b/webapp-viewer/README.md
@@ -98,6 +98,14 @@ scrub time — a time step costs about 5.7× less than shipping both.
   server-side next to the reader — never fetch every timestep to build one curve. The Stats button
   does the same for whole-domain min/mean/max per variable via `/stats` (one space-stats
   `TimeSeriesJobSpec` carrying all the variables at once).
+- **2D runs are first-class, through the same convention.** The server emits the mesh's
+  `VisPolygon` quads (`cellType` 9, `dimension: 2` in `/grid`) — reading `getVisVoxels()` on a 2D
+  mesh returns null (thrift optional), which is how 2D used to 500. The identical deform pipeline
+  smooths the domain OUTLINE: with `boundarySmoothingOn`, a flat regular interior is already a
+  Laplacian fixed point, so only the boundary polyline relaxes. The camera becomes top-down
+  parallel projection (drag pans, wheel scales — `dolly` does nothing under an ortho camera), the
+  slice row is hidden, and picking switches to a parallel-projection ray. 1D runs get a clear
+  dialog in the desktop client instead of a broken page.
 - `probe.html` is a scratch page for exactly these capability probes: point it at a suspect class,
   read the on-page result, and keep the console open for `is not permitted`.
 - **The scalar bar labels the lookup table's range, not the mapper's.** `mapper.setScalarRange`

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -70,6 +70,7 @@ const state = {
   selectedVar: '',
   selectedDomain: '',
   geometryId: '',
+  dimension: 3,
   bounds: null,
   sliceAxis: -1,
   slicePos: 50,
@@ -264,6 +265,9 @@ function buildPickIndex(geometry, bounds) {
     }
   }
   const d = [maxs[0] - mins[0], maxs[1] - mins[1], maxs[2] - mins[2]];
+  for (let a = 0; a < 3; a++) {
+    if (!(d[a] > 0)) d[a] = 1; // a 2D grid is flat along one axis: one unit-thick layer
+  }
   const o = [bounds[0], bounds[2], bounds[4]];
   const n = [0, 1, 2].map((a) => Math.max(1, Math.round((bounds[2 * a + 1] - bounds[2 * a]) / d[a])));
   const occ = new Map();
@@ -336,7 +340,11 @@ function castRay(origin, dir) {
   return -1;
 }
 
-/** Mouse position → world-space ray through the camera. Perspective camera, vertical FOV. */
+/**
+ * Mouse position → world-space ray through the camera. Perspective (vertical FOV) for 3D;
+ * parallel projection for the 2D top-down camera, where the ray origin shifts in-plane and the
+ * direction is the constant view direction.
+ */
 async function rayFromMouse(clientX, clientY) {
   const rect = el.canvas.getBoundingClientRect();
   const xN = ((clientX - rect.left) / rect.width) * 2 - 1;
@@ -344,7 +352,6 @@ async function rayFromMouse(clientX, clientY) {
   const P = await camera.getPosition();
   const F = await camera.getFocalPoint();
   const U = await camera.getViewUp();
-  const halfTan = Math.tan(((await camera.getViewAngle()) * Math.PI) / 360);
   const norm = (v) => {
     const l = Math.hypot(v[0], v[1], v[2]) || 1;
     return [v[0] / l, v[1] / l, v[2] / l];
@@ -354,6 +361,13 @@ async function rayFromMouse(clientX, clientY) {
   const right = norm(cross(fwd, U));
   const up = cross(right, fwd);
   const aspect = rect.width / rect.height;
+  if (state.dimension === 2) {
+    const ps = await camera.getParallelScale();
+    const origin = [0, 1, 2].map((a) =>
+      P[a] + right[a] * xN * aspect * ps + up[a] * yN * ps);
+    return { origin, dir: fwd };
+  }
+  const halfTan = Math.tan(((await camera.getViewAngle()) * Math.PI) / 360);
   const dir = norm([0, 1, 2].map((a) =>
     fwd[a] + right[a] * xN * aspect * halfTan + up[a] * yN * halfTan));
   return { origin: P, dir };
@@ -375,6 +389,7 @@ function boundsOf(geometry) {
 
 /** Builds the in-memory grid and points the pipeline at it. Re-run when the domain changes. */
 async function buildGrid(geometry, field) {
+  state.dimension = geometry.dimension ?? 3;
   const points = vtk.vtkPoints();
   await points.setNumberOfPoints(geometry.numPoints);
   const P = geometry.points;
@@ -524,7 +539,15 @@ async function buildScene(geometry, field) {
 
   sinc = vtk.vtkWindowedSincPolyDataFilter();
   await sinc.setInputConnection(await surfSource.getOutputPort());
-  await sinc.boundarySmoothingOff();
+  state.dimension = geometry.dimension ?? 3;
+  if (state.dimension === 2) {
+    // 2D: the quads ARE the display and the mesh's boundary edge is the domain outline — exactly
+    // what the convention smooths. A flat regular interior is already a Laplacian fixed point,
+    // so with boundary smoothing ON only the outline relaxes and the interior stays put.
+    await sinc.boundarySmoothingOn();
+  } else {
+    await sinc.boundarySmoothingOff();
+  }
   await sinc.featureEdgeSmoothingOff();
   await sinc.nonManifoldSmoothingOff();
   await sinc.normalizeCoordinatesOn();
@@ -598,6 +621,12 @@ async function buildScene(geometry, field) {
   // vtkRemoteSession, not on the standalone session we run. Interaction is driven directly against
   // the camera below.
   camera = await renderer.getActiveCamera();
+  if (state.dimension === 2) {
+    // top-down orthographic view of the z=0 plane; interaction becomes pan/zoom (no orbit)
+    await camera.parallelProjectionOn();
+    const sliceRow = el.sliceAxis.closest('.controls');
+    if (sliceRow) sliceRow.hidden = true;
+  }
   // The axes box needs the camera: its labels and fly-to-a-corner behaviour track the view. That
   // is exactly what an HTML fallback cannot fake, which is why this actor earns its keep.
   cubeAxes = vtk.vtkCubeAxesActor();
@@ -671,7 +700,7 @@ function attachTrackball() {
     const dy = e.clientY - lastY;
     lastX = e.clientX; lastY = e.clientY;
     dragDistance += Math.abs(dx) + Math.abs(dy);
-    if (dx || dy) void orbit(dx, dy);
+    if (dx || dy) void (state.dimension === 2 ? pan2d(dx, dy) : orbit(dx, dy));
     e.preventDefault();
   });
   const release = (e) => {
@@ -685,7 +714,8 @@ function attachTrackball() {
   el.canvas.addEventListener('pointercancel', release);
   el.canvas.addEventListener('pointerleave', () => { el.pickReadout.textContent = ''; });
   el.canvas.addEventListener('wheel', (e) => {
-    void dolly(e.deltaY < 0 ? 1.1 : 1 / 1.1);
+    const f = e.deltaY < 0 ? 1.1 : 1 / 1.1;
+    void (state.dimension === 2 ? zoom2d(f) : dolly(f));
     e.preventDefault();
   }, { passive: false });
 }
@@ -720,6 +750,41 @@ async function dolly(factor) {
   }
 }
 
+/** 2D drag: pan the top-down orthographic camera; the world under the cursor follows it. */
+async function pan2d(dx, dy) {
+  if (!camera || state.drawing) return;
+  state.drawing = true;
+  try {
+    const rect = el.canvas.getBoundingClientRect();
+    const worldPerPixel = (2 * (await camera.getParallelScale())) / rect.height;
+    const P = await camera.getPosition();
+    const F = await camera.getFocalPoint();
+    const mx = -dx * worldPerPixel;
+    const my = dy * worldPerPixel; // screen y grows downward; world y grows upward
+    await camera.setPosition(P[0] + mx, P[1] + my, P[2]);
+    await camera.setFocalPoint(F[0] + mx, F[1] + my, F[2]);
+    await renderWindow.render();
+  } catch (e) {
+    console.warn('pan failed', e);
+  } finally {
+    state.drawing = false;
+  }
+}
+
+/** 2D wheel: zoom by shrinking the parallel scale (dolly does nothing under an ortho camera). */
+async function zoom2d(factor) {
+  if (!camera || state.drawing) return;
+  state.drawing = true;
+  try {
+    await camera.setParallelScale((await camera.getParallelScale()) / factor);
+    await renderWindow.render();
+  } catch (e) {
+    console.warn('zoom failed', e);
+  } finally {
+    state.drawing = false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // picking (#1859 items 6 and 8)
 // ---------------------------------------------------------------------------
@@ -748,7 +813,7 @@ async function hoverPick(clientX, clientY) {
     }
     const v = state.fieldValues?.[cell];
     const c = cellCenter(cell);
-    const at = c ? ` @ (${c.map((x) => x.toFixed(1)).join(', ')})` : '';
+    const at = c ? ` @ (${c.slice(0, state.dimension === 2 ? 2 : 3).map((x) => x.toFixed(1)).join(', ')})` : '';
     el.pickReadout.textContent =
       v == null ? `no data${at}` : `${state.selectedVar} = ${v.toExponential(3)}${at}`;
   } catch (e) {
@@ -818,7 +883,7 @@ function renderPlot(series, center) {
     class: 'curve',
     points: times.map((t, i) => `${f.sx(t).toFixed(1)},${f.sy(values[i] ?? f.lo).toFixed(1)}`).join(' '),
   });
-  const at = center ? ` @ (${center.map((x) => x.toFixed(1)).join(', ')})` : '';
+  const at = center ? ` @ (${center.slice(0, state.dimension === 2 ? 2 : 3).map((x) => x.toFixed(1)).join(', ')})` : '';
   el.plotTitle.textContent = `${name}${at} · ${times.length} timepoints`;
   el.plotLegend.innerHTML = '';
   el.plotPanel.hidden = false;


### PR DESCRIPTION
Fixes the live-reported `viewer failed: /grid failed: 500 Internal Server Error` on 2D runs, by supporting 2D properly rather than hiding the button. **Stacked on #1866** (retargets to `master` when it merges).

**Root cause:** `CartesianMeshMapping` emits `VisPolygon` quads for 2D and leaves the thrift `visVoxels` list null; `/grid` read only voxels → NPE → 500.

**Server:** a small `Cells` accessor presents 3D voxels and 2D in-plane quads uniformly (point indices + solver global index is the whole interface — `VisPolygon` carries `FiniteVolumeIndex` exactly like `VisVoxel`), so `/grid` (now with `cellType: 9`, `dimension: 2`), `/field`, `/timeseries` and `/stats` all work for 2D through one path. 1D runs get a clear dialog in `PDEDataViewer` (their mesh has neither voxels nor polygons).

**Viewer — same convention, one dimension down:** the deformed-grid pipeline covers 2D as-is, with one switch: boundary smoothing ON — a flat regular interior is already a Laplacian fixed point, so only the domain **outline** relaxes and the write-back distorts exactly the boundary quads. Camera becomes top-down parallel projection with drag-pan and wheel-zoom (dolly is inert under an ortho camera), the slice row is hidden, picking switches to a parallel-projection ray over a one-layer occupancy index, and readouts drop the fake z.

Verified headless against a 48×48 2D mock: smoothed outline at nominal / staircase at 0, hover readout, click-to-plot, pan+zoom.

| 2D run, nominal smoothing (top-down ortho) | panned + zoomed, pick readout + time plot | smoothing 0 — raw outline |
|---|---|---|
| ![2d](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/c81443ca3da20af9d4724efe1a5a6d83e2c3a057/vd2-boot.png) | ![panzoom](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/c81443ca3da20af9d4724efe1a5a6d83e2c3a057/vd2-panzoom.png) | ![raw](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/c81443ca3da20af9d4724efe1a5a6d83e2c3a057/vd2-smooth0.png) |

Direction note, per discussion: this is a step toward the browser viewer eventually de-emphasizing the Java-based PDE viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYqrC3BiB4JRsJoz7BXJF4