### PR TITLE
Timestamp temp-queue advisories so the next #1863 flake is decidable

### DIFF
--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -262,8 +262,10 @@ public class MessageProducerSessionJmsTest {
 		VCQueueConsumer responder = startEchoResponder(rpcQueue);
 		VCMessageSession producerSession = service.createProducerSession();
 		try {
+			System.out.println("TEMPQ-ADVISORY " + java.time.Instant.now() + " RPC-SEND  roundtrip");
 			Object answer = producerSession.sendRpcMessage(rpcQueue, echoRequest("hello"),
 					true, 30000L, null, null, null);
+			System.out.println("TEMPQ-ADVISORY " + java.time.Instant.now() + " RPC-DONE  roundtrip");
 			assertEquals("hello", answer, "the RPC should return what the responder echoed");
 		} finally {
 			producerSession.close();
@@ -489,8 +491,9 @@ public class MessageProducerSessionJmsTest {
 			}
 			DestinationInfo info = (DestinationInfo) data;
 			boolean removed = info.getOperationType() == DestinationInfo.REMOVE_OPERATION_TYPE;
-			String line = String.format("TEMPQ-ADVISORY %-6s %s  requested-by-connection=%s",
-					removed ? "REMOVE" : "ADD", info.getDestination(), info.getConnectionId());
+			String line = String.format("TEMPQ-ADVISORY %s %-6s %s  requested-by-connection=%s",
+					java.time.Instant.now(), removed ? "REMOVE" : "ADD",
+					info.getDestination(), info.getConnectionId());
 			events.add(line);
 			System.out.println(line);
 			if (removed) {


### PR DESCRIPTION
Refs #1863. Diagnostic only — no production code touched.

Follow-up to #1865, which captured its first failure. That record answered one question and
raised a sharper one; this makes the next occurrence decide it.

## What the first captured failure showed

```
TEMPQ-ADVISORY ADD    temp-queue://…-24:1:1  requested-by-connection=…-24:1
… reply attempt → Cannot publish to a deleted Destination: …-24:1:1
… (+30s) Server is temporarily not responding
TEMPQ-ADVISORY REMOVE temp-queue://…-24:1:1  requested-by-connection=…-24:1
   thread ForkJoinPool-1-worker-2 at ConsumerContextJms.close(…:180)
```

**Settled:** the REMOVE was requested by the queue's *own* connection (`-24:1` owns `-24:1:1`),
during teardown. Nothing foreign deleted it, and no connection reached across to another's
queue. That was the discriminating question set before the run, and it supports the reading
that there is no corresponding production path.

**Unsettled:** the advisory arrived *after* the 30 s timeout. Without timestamps there was no
way to tell whether the removal happened late, or the notification was merely delivered late —
and those imply opposite causes.

## What this adds

Timestamps on every advisory, plus start/finish markers around the round-trip RPC. That gives
the calibration the last log lacked — locally, advisory delivery latency is **~1 ms**:

```
14:55:23.857  RPC-SEND  roundtrip
14:55:23.858  ADD     …-24:1:1
14:55:23.861  RPC-DONE  roundtrip
14:55:23.861  REMOVE  …-24:1:1
```

So next time the record is decisive:

- REMOVE tens of seconds **after** the error ⇒ the queue was still alive when the reply was
  refused, making `Cannot publish to a deleted Destination` a **client-side false negative**.
  That would implicate `ActiveMQConnection.isDeleted()`, which answers from the connection's own
  advisory-populated set of temp destinations — a connection that has not yet learned about
  another connection's temp queue reports it as deleted, and `ConsumerContextJms` creates
  exactly such a connection per message.
- REMOVE **at** the error ⇒ something really is closing the owning session early, and that is a
  different hunt.

## What I deliberately did not do

Ship a fix for the client-side theory. `ActiveMQConnectionFactory.setWatchTopicAdvisories(false)`
would remove that failure mode in one line, but a 25-iteration probe could not reproduce it
locally — 0 failures with advisory-watching both on and off, where propagation is instant. This
test has already absorbed three rounds of plausible-but-wrong reasoning (#1852, #1855, and the
three mechanisms probed and disproved in #1863); a fourth speculative fix is not worth it when
one more real occurrence will settle it.

`vcell-server` Fast group: 62 green, including with CI's parallel flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg