### PR TITLE
Stop the ActiveMQ client declaring live temporary queues deleted

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/jms/activeMQ/VCMessagingServiceActiveMQ.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/activeMQ/VCMessagingServiceActiveMQ.java
@@ -28,6 +28,20 @@ public class VCMessagingServiceActiveMQ extends VCMessagingServiceJms implements
 		//return new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false&broker.useJmx=false&create=false");
 		ActiveMQConnectionFactory activeMQConnectionFactory = new ActiveMQConnectionFactory(jmsUrl(jmshost, jmsport ));
 		activeMQConnectionFactory.setTrustAllPackages(true);
+		// Do not let the client second-guess whether a temporary destination exists.
+		//
+		// ActiveMQConnection.isDeleted() answers from the connection's OWN advisory-populated
+		// set of temp destinations, not from the broker, and refuses to publish to anything
+		// missing from it. A connection that has not yet received the advisory for someone
+		// else's reply queue therefore reports it as deleted while it is alive. Since
+		// ConsumerContextJms opens a connection per message, an RPC reply is published from a
+		// connection that may be milliseconds old -- measured in CI, a reply was refused 3.4ms
+		// after the queue was created, and the genuine removal advisory arrived 60s later at
+		// teardown. The caller then waits out its whole timeout for a reply that was never sent.
+		//
+		// With advisory watching off, isDeleted() always returns false and the broker decides,
+		// which is the correct authority. See docs/MESSAGING.md and issue #1863.
+		activeMQConnectionFactory.setWatchTopicAdvisories(false);
 		return activeMQConnectionFactory;
 	}
 	

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -421,12 +421,20 @@ public class MessageProducerSessionJmsTest {
 
 		@Override
 		public ConnectionFactory createConnectionFactory() {
-			return new ActiveMQConnectionFactory("vm://" + BROKER_NAME + "?create=false") {
+			ActiveMQConnectionFactory factory =
+					new ActiveMQConnectionFactory("vm://" + BROKER_NAME + "?create=false") {
 				@Override
 				public Connection createConnection() throws JMSException {
 					return (Connection) countingProxy(Connection.class, super.createConnection());
 				}
 			};
+			// Mirror production (VCMessagingServiceActiveMQ): without this the client answers
+			// "is this temp queue deleted?" from its own advisory state and can refuse to
+			// publish to a live reply queue it has not heard about yet -- issue #1863. The test
+			// harness has to carry the same setting, or it exercises a configuration that no
+			// longer ships. Explicitly subscribing to the advisory topic (below) still works.
+			factory.setWatchTopicAdvisories(false);
+			return factory;
 		}
 
 		@Override
@@ -568,6 +576,12 @@ public class MessageProducerSessionJmsTest {
 			// wire are listed -- trusting everything is what production does, and it is what
 			// the standing java/unsafe-deserialization alert on VCMessageJms is about.
 			factory.setTrustedPackages(Arrays.asList("java.lang", "java.util", "java.math", "cbit.vcell", "org.vcell"));
+			// Mirror production (VCMessagingServiceActiveMQ): without this the client answers
+			// "is this temp queue deleted?" from its own advisory state and can refuse to
+			// publish to a live reply queue it has not heard about yet -- issue #1863. The test
+			// harness has to carry the same setting, or it exercises a configuration that no
+			// longer ships. Explicitly subscribing to the advisory topic (below) still works.
+			factory.setWatchTopicAdvisories(false);
 			return factory;
 		}
 

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/activeMQ/VCMessagingServiceActiveMQTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/activeMQ/VCMessagingServiceActiveMQTest.java
@@ -1,0 +1,105 @@
+package cbit.vcell.message.jms.activeMQ;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Session;
+import javax.jms.TemporaryQueue;
+
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+/**
+ * Pins the reason the production connection factory disables advisory watching.
+ *
+ * ActiveMQConnection.isDeleted() does not ask the broker — it answers from the connection's own
+ * advisory-populated set of temp destinations, and callers refuse to publish to anything absent
+ * from it. A connection that has not yet learned about another connection's reply queue reports
+ * it as deleted while it is alive, and the RPC caller then waits out its full timeout (#1863).
+ *
+ * The race itself is timing-dependent and does not reproduce on an unloaded machine, so this
+ * pins the mechanism rather than the race: with watching off, the answer is unconditional.
+ */
+@Tag("Fast")
+@ResourceLock("activemqBrokerRegistry")
+public class VCMessagingServiceActiveMQTest {
+
+	private static final String BROKER = "VCMessagingServiceActiveMQTestBroker";
+	private static BrokerService broker;
+
+	@BeforeAll
+	public static void startBroker() throws Exception {
+		broker = new BrokerService();
+		broker.setBrokerName(BROKER);
+		broker.setPersistent(false);
+		broker.setUseJmx(false);
+		broker.setUseShutdownHook(false);
+		broker.start();
+		broker.waitUntilStarted();
+	}
+
+	@AfterAll
+	public static void stopBroker() throws Exception {
+		if (broker != null) {
+			broker.stop();
+			broker.waitUntilStopped();
+		}
+	}
+
+	/** The production factory must not watch advisories, or replies can be spuriously refused. */
+	@Test
+	public void productionFactoryDoesNotWatchTopicAdvisories() {
+		VCMessagingServiceActiveMQ service = new VCMessagingServiceActiveMQ();
+		service.setConfiguration(new cbit.vcell.message.SimpleMessagingDelegate(), "localhost", 61616);
+		ConnectionFactory factory = service.createConnectionFactory();
+		assertFalse(((ActiveMQConnectionFactory) factory).isWatchTopicAdvisories(),
+				"watching advisories lets a connection call a live temp queue 'deleted' (#1863)");
+	}
+
+	/**
+	 * The behaviour that setting controls: a connection that knows nothing about a temporary
+	 * queue must not claim it is deleted.
+	 */
+	@Test
+	public void aConnectionThatNeverSawTheAdvisoryMustNotCallTheQueueDeleted() throws Exception {
+		ActiveMQConnectionFactory ownerFactory =
+				new ActiveMQConnectionFactory("vm://" + BROKER + "?create=false");
+		Connection owner = ownerFactory.createConnection();
+		owner.start();
+		try {
+			Session ownerSession = owner.createSession(false, Session.AUTO_ACKNOWLEDGE);
+			TemporaryQueue foreign = ownerSession.createTemporaryQueue();
+
+			ActiveMQConnectionFactory replierFactory =
+					new ActiveMQConnectionFactory("vm://" + BROKER + "?create=false");
+			replierFactory.setWatchTopicAdvisories(false);   // what production now does
+			ActiveMQConnection replier = (ActiveMQConnection) replierFactory.createConnection();
+			replier.start();
+			try {
+				assertFalse(replier.isDeleted((ActiveMQDestination) foreign),
+						"with advisory watching off the client must defer to the broker, "
+								+ "never declare another connection's live queue deleted");
+			} finally {
+				replier.close();
+			}
+
+			// and the converse: with watching on, the answer depends on advisory state, which is
+			// exactly the fragility being removed -- assert only that the setting is honoured
+			ActiveMQConnectionFactory watchingFactory =
+					new ActiveMQConnectionFactory("vm://" + BROKER + "?create=false");
+			assertTrue(watchingFactory.isWatchTopicAdvisories(),
+					"ActiveMQ's default is to watch advisories, which is why this must be set explicitly");
+		} finally {
+			owner.close();
+		}
+	}
+}


### PR DESCRIPTION
Closes #1863. **This is a production defect, not a test defect.**

## The evidence

The advisory instrumentation from #1865 captured a run and settled it. Timestamps from the CI
log:

```
16:20:56.4994  TEMPQ-ADVISORY ADD    temp-queue://…-32:1:1     ← reply queue created
16:20:56.5028  Cannot publish to a deleted Destination: …-32:1:1   ← refused 3.4 ms later
16:21:56.4812  Server is temporarily not responding               ← caller's full 60 s timeout
16:21:56.4877  TEMPQ-ADVISORY REMOVE temp-queue://…-32:1:1     ← genuine removal, at teardown
```

The queue was created 3.4 ms before the reply was refused and genuinely removed 60 s after. **It
was alive the whole time** — the "deleted destination" error is false.

## Why

`ActiveMQConnection.isDeleted()` does not ask the broker. It answers
`!activeTempDestinations.contains(dest)`, and that set is filled by the connection's own advisory
consumer. A connection that has not yet received the advisory for *another* connection's reply
queue therefore reports it as deleted. `ConsumerContextJms` opens a connection per message, so an
RPC reply is published from a connection that may be milliseconds old — which is how a 3.4 ms-old
queue gets called deleted, and why the caller then waits out its entire timeout for a reply
nobody sent.

## Scope — this reaches production

`RestDatabaseService` creates a producer session **per request**, so every one of its RPCs mints
a fresh reply queue and sits in exactly this window. `RpcService` is less exposed only because its
session is process-lifetime, so its queue is long-established after the first call.

I should also flag that #1842 (lazy connection open) plausibly **widened** the window: it moved
connection creation out of the per-message session's constructor and into the listener,
immediately before the send, leaving less time for the advisory to arrive.

## The fix

`setWatchTopicAdvisories(false)` on the production connection factory. `isDeleted()` then always
returns false and the broker decides — which is the only authority that actually knows. It also
removes a chunk of advisory traffic.

## Testing

The race is timing-dependent and does not reproduce unloaded (a 25-iteration probe saw zero
failures either way), so the test pins the **mechanism**, not the race:

- the production factory must not watch advisories — reverting the fix fails this;
- a connection that never saw the advisory must not call a live queue deleted.

`vcell-server` Fast group: 64 green, including with CI's parallel flags.

## Note on the three earlier rounds

#1852 (shared broker registry) and #1855 (shared static fixture) were real and independently
worth fixing, but neither was this. Three further mechanisms were probed and disproved before the
instrumentation was added — the queue outliving its creating session, consumer churn, and a
publishing connection closing. Adding the advisory recorder rather than guessing a fourth time is
what produced the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg