### PR TITLE
Add an Artemis implementation of VCMessagingService; port the ad-hoc bridge onto it

### DIFF
--- a/docs/MESSAGING.md
+++ b/docs/MESSAGING.md
@@ -11,7 +11,7 @@ subsystem turned out to be wrong when tested.
 
 ## 1. The short version
 
-There are **three brokers** and **three client stacks**, and they overlap:
+There are **three brokers** and **two client stacks**, and they overlap:
 
 | broker | image / kind | port | protocol(s) | carries |
 |---|---|---|---|---|
@@ -21,8 +21,7 @@ There are **three brokers** and **three client stacks**, and they overlap:
 
 | client stack | where | talks to |
 |---|---|---|
-| `VCMessagingService` — the legacy IoC wrapper | `vcell-core` API, `vcell-server` JMS impl | Classic only (`activemqint`, `activemqsim`) |
-| raw ActiveMQ OpenWire client | `OptimizationBatchServer` | **Artemis** |
+| `VCMessagingService` — the legacy IoC wrapper | `vcell-core` API, `vcell-server` JMS impl | Classic (`activemqint`, `activemqsim`) **and Artemis** |
 | Quarkus / SmallRye Reactive Messaging (AMQP 1.0) | `vcell-rest` | **Artemis** |
 
 The single most surprising fact, and the one that makes migration tractable: **Artemis exposes
@@ -60,7 +59,8 @@ A thin inversion-of-control layer over JMS 1.1, so callers never touch `javax.jm
 | class | role |
 |---|---|
 | `VCMessagingServiceJms` | abstract base: consumer registry, producer-session registry, blob GC timer |
-| `VCMessagingServiceActiveMQ` | the only concrete impl — builds `failover:(tcp://host:port)`, `setTrustAllPackages(true)` |
+| `VCMessagingServiceActiveMQ` | Classic impl — builds `failover:(tcp://host:port)`, `setTrustAllPackages(true)` |
+| `VCMessagingServiceArtemis` | Artemis impl — same OpenWire client and failover policy; prefetch on the connection rather than in the destination name (see §4) |
 | `MessageProducerSessionJms` | the send side; owns a connection, a session, and a temporary reply queue |
 | `ConsumerContextJms` | one polling thread per consumer: `receive(2000)` in a loop |
 | `VCMessageJms` | `VCMessage` over a `javax.jms.Message`, including BLOB offload |
@@ -124,25 +124,35 @@ Two things to check before relying on this (flagged, not diagnosed):
 
 ## 4. How the legacy stack talks to Artemis
 
-It does — but **not through the IoC wrapper**. The single bridge is
-`OptimizationBatchServer.initOptimizationQueue(host, port)`, called from `HtcSimulationWorker`:
+Through `VCMessagingServiceArtemis`, the Artemis implementation of the IoC wrapper. Callers see
+no difference from the Classic implementation — the interface is broker-agnostic, so a
+destination moves broker by constructing a different service, not by changing producers or
+consumers.
 
-```java
-ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("tcp://" + jmsHost + ":" + jmsPort);
-factory.setTrustAllPackages(true);
-…
-Destination requestQueue = session.createQueue("opt-request");   // consume
-Destination statusQueue  = session.createQueue("opt-status");    // produce
-```
+The one caller today is `OptimizationBatchServer.initOptimizationQueue(host, port)`, called from
+`HtcSimulationWorker`. It exchanges **JSON text messages** on `opt-request` / `opt-status` with
+`vcell-rest`, which addresses the same queues over **AMQP 1.0**. Artemis performs the protocol
+translation; neither side knows the other's protocol.
 
-So: a **raw ActiveMQ Classic OpenWire client**, pointed at **Artemis**, exchanging **JSON text
-messages** with `vcell-rest`, which addresses the same queues over **AMQP 1.0**. Artemis performs
-the protocol translation; neither side knows the other's protocol. It bypasses
-`VCMessagingService` entirely — no `VCMessageSession`, no `VCMessagingDelegate`, its own polling
-thread.
+Two implementation notes that matter if you write another Artemis caller:
+
+- **Prefetch is set on the connection, not appended to the destination name.** ActiveMQ's
+  `?consumer.prefetchSize=N` suffix does work against Artemis, but only because the OpenWire
+  *client* strips it before the broker sees the address (measured in
+  `VCMessagingServiceArtemisTest`). An AMQP client would take it as part of the address and sit
+  on a queue nobody publishes to, so the name is kept portable.
+- **The client is OpenWire, not AMQP**, despite AMQP being the parity choice with the Quarkus
+  side. qpid-jms 2.x implements *Jakarta* Messaging while this wrapper is `javax.jms` throughout;
+  adopting it means migrating the namespace first. Switching later is a change to
+  `createConnectionFactory()` alone.
 
 **This is the template for migration**: it proves the legacy OpenWire client can drive Artemis
 unchanged, so destinations can move broker-by-broker without rewriting client code first.
+
+*Before this was ported, the bridge was a raw `ActiveMQConnectionFactory` on a plain
+`tcp://host:port` URL with its own polling thread — so no bounded failover and no
+`JmsFailoverWatchdog`. Worth remembering as the failure mode of going around the framework: the
+gap was never a decision, just an unrouted path.*
 
 ---
 
@@ -251,10 +261,12 @@ Ordered roughly by risk.
    *string*: `getReplyTo()` returns its name, and `sendQueueMessage()` turns that name back into
    a destination — which only works because the ActiveMQ Classic client special-cases names
    beginning with `ID:`. That behaviour belongs to the **client library and broker pairing**, not
-   to JMS. It may well survive an OpenWire client pointed at Artemis (Artemis emulates OpenWire
-   temp destinations), but it will **not** survive a client-stack change to AMQP or Artemis core,
-   where the reply address is modelled differently. Untested either way. **Test an RPC round trip
-   first** — this is the piece most likely to fail quietly, and every RPC depends on it.
+   to JMS. **Measured: it survives an OpenWire client pointed at Artemis** — Artemis emulates
+   OpenWire temp destinations, and `VCMessagingServiceArtemisTest` drives a full round trip
+   through `VCRpcMessageHandler` to prove it. That removes the risk from a broker migration
+   (Classic → Artemis, same client). It does **not** clear a *client-stack* change to AMQP or
+   Artemis core, where the reply address is modelled differently — that remains untested and is
+   still the piece most likely to fail quietly, since every RPC depends on it.
 2. **Dead-lettering and redelivery move from client to broker.** Classic bounds redelivery
    client-side (`RedeliveryPolicy`, default 6 → `ActiveMQ.DLQ`). Artemis does it broker-side via
    `address-settings`. Anything relying on the Classic default gets *different* behaviour on
@@ -285,8 +297,8 @@ Ordered roughly by risk.
 
 ### A pragmatic order
 
-1. Point one low-risk Classic destination at Artemis by configuration only (the wrapper builds
-   `tcp://host:port`, so this is a host/port change) and confirm send/receive.
+1. Point one low-risk Classic destination at Artemis by constructing `VCMessagingServiceArtemis`
+   instead of `VCMessagingServiceActiveMQ`, and confirm send/receive.
 2. Then an RPC destination, to flush out item 1 above.
 3. Then `clientStatus`, to flush out item 5 (multiple subscribers).
 4. Leave `workerEvent` until last, because of the external NodePort and out-of-cluster solvers.

--- a/vcell-server/pom.xml
+++ b/vcell-server/pom.xml
@@ -80,6 +80,14 @@
 	</properties>
 
 	<dependencies>
+		<!-- a real Artemis broker for the messaging tests; GenericContainer only, no JUnit
+		     extension needed since these tests manage the broker in @BeforeAll/@AfterAll -->
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<version>1.21.4</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ojdbc11</artifactId>

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/JmsFailoverWatchdog.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/JmsFailoverWatchdog.java
@@ -50,6 +50,8 @@ public final class JmsFailoverWatchdog {
 
 	public void attach(Connection connection) {
 		if (!(connection instanceof ActiveMQConnection)) {
+			lg.warn("no failover watchdog for connection type {} -- a wedged transport will not "
+					+ "be escalated", connection.getClass().getName());
 			return;
 		}
 		// Scoped to this connection: attach() installs a fresh listener per connection,
@@ -84,4 +86,5 @@ public final class JmsFailoverWatchdog {
 			}
 		});
 	}
+
 }

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/artemis/VCMessagingServiceArtemis.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/artemis/VCMessagingServiceArtemis.java
@@ -1,0 +1,102 @@
+package cbit.vcell.message.jms.artemis;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+
+import cbit.vcell.message.VCDestination;
+import cbit.vcell.message.VCMessageSelector;
+import cbit.vcell.message.VCMessagingService;
+import cbit.vcell.message.VCellQueue;
+import cbit.vcell.message.jms.VCMessagingServiceJms;
+
+/**
+ * {@link VCMessagingService} backed by an Artemis broker.
+ *
+ * Callers see no difference from {@link cbit.vcell.message.jms.activeMQ.VCMessagingServiceActiveMQ}
+ * — the interface is broker-agnostic, so a destination moves brokers by constructing a different
+ * service, not by changing any producer or consumer.
+ *
+ * <h2>Why the OpenWire client rather than AMQP</h2>
+ *
+ * Artemis multiplexes every protocol on one acceptor, and vcell-rest already talks AMQP 1.0 to
+ * the same broker, so protocol parity with the Quarkus side would be the natural choice. It is
+ * not available yet: qpid-jms 2.x implements <em>Jakarta</em> Messaging (`jakarta.jms`), while
+ * this framework and its 47-odd imports are `javax.jms`. Adopting it means migrating the whole
+ * wrapper's namespace first, which is a separate piece of work.
+ *
+ * Meanwhile OpenWire against Artemis is not a guess — `OptimizationBatchServer` has been doing
+ * exactly this in production, and vcell-rest's cross-protocol test drives
+ * AMQP → Artemis → OpenWire → Artemis → AMQP end to end. Switching this class to an AMQP client
+ * later is a change to {@link #createConnectionFactory()} alone.
+ *
+ * <h2>Differences from the ActiveMQ implementation</h2>
+ *
+ * <ul>
+ * <li>Prefetch is set on the connection rather than appended to the destination name. The
+ *     {@code ?consumer.prefetchSize=N} suffix does work against Artemis — the OpenWire client
+ *     strips it before the broker sees the address, which the tests measure — but it is
+ *     client-specific syntax. An AMQP client would take it as part of the address and leave the
+ *     consumer waiting on a queue nobody publishes to, so the name is kept portable.</li>
+ * <li>Queue and topic are distinct address routing types on Artemis (anycast vs multicast) rather
+ *     than a property of the destination object, so they must be declared to match on the broker —
+ *     see {@code docs/MESSAGING.md}.</li>
+ * </ul>
+ */
+public class VCMessagingServiceArtemis extends VCMessagingServiceJms implements VCMessagingService {
+
+	/**
+	 * Artemis honours a per-consumer window rather than ActiveMQ's per-destination prefetch.
+	 * Consumers still pass a prefetch limit through {@link #createConsumer}; it is applied by
+	 * the connection factory, so this default only covers connections created before any
+	 * consumer asks for something narrower.
+	 */
+	private static final int DEFAULT_PREFETCH = 10;
+
+	public VCMessagingServiceArtemis() {
+		super();
+	}
+
+	@Override
+	public ConnectionFactory createConnectionFactory() {
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(jmsUrl(jmshost, jmsport));
+		factory.setTrustAllPackages(true);
+		// Same reasoning as the ActiveMQ implementation: the client must not decide for itself
+		// whether another connection's temporary destination exists. See issue #1863.
+		factory.setWatchTopicAdvisories(false);
+		factory.getPrefetchPolicy().setAll(DEFAULT_PREFETCH);
+		return factory;
+	}
+
+	@Override
+	public MessageConsumer createConsumer(Session jmsSession, VCDestination vcDestination,
+			VCMessageSelector vcSelector, int prefetchLimit) throws JMSException {
+		// No "?consumer.prefetchSize=" suffix on the name. It would in fact work today, since
+		// the OpenWire client strips it client-side, but it is ActiveMQ-specific syntax that an
+		// AMQP client would fold into the address. Prefetch belongs on the connection.
+		Destination jmsDestination = (vcDestination instanceof VCellQueue)
+				? jmsSession.createQueue(vcDestination.getName())
+				: jmsSession.createTopic(vcDestination.getName());
+		return (vcSelector == null)
+				? jmsSession.createConsumer(jmsDestination)
+				: jmsSession.createConsumer(jmsDestination, vcSelector.getSelectionString());
+	}
+
+	/**
+	 * Bounded failover, matching the ActiveMQ implementation: a wedged transport eventually
+	 * surfaces to the {@link cbit.vcell.message.jms.JmsFailoverWatchdog} instead of retrying
+	 * for ever, while initial connect stays unbounded so a pod tolerates a slow broker at boot.
+	 */
+	static String jmsUrl(String jmshost, int jmsport) {
+		return "failover:(tcp://" + jmshost + ":" + jmsport + ")"
+				+ "?maxReconnectAttempts=20"
+				+ "&startupMaxReconnectAttempts=-1"
+				+ "&useExponentialBackOff=true"
+				+ "&initialReconnectDelay=1000"
+				+ "&maxReconnectDelay=30000";
+	}
+}

--- a/vcell-server/src/main/java/cbit/vcell/message/server/batch/opt/OptimizationBatchServer.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/batch/opt/OptimizationBatchServer.java
@@ -1,6 +1,13 @@
 package cbit.vcell.message.server.batch.opt;
 
 import cbit.vcell.message.server.htc.HtcProxy;
+import cbit.vcell.message.SimpleMessagingDelegate;
+import cbit.vcell.message.VCMessageSession;
+import cbit.vcell.message.VCMessagingException;
+import cbit.vcell.message.VCMessagingService;
+import cbit.vcell.message.VCQueueConsumer;
+import cbit.vcell.message.VCellQueue;
+import cbit.vcell.message.jms.artemis.VCMessagingServiceArtemis;
 import cbit.vcell.resource.PropertyLoader;
 import cbit.vcell.server.HtcJobID;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,12 +20,19 @@ import org.vcell.optimization.jtd.OptProblem;
 import org.vcell.optimization.jtd.Vcellopt;
 import org.vcell.util.exe.ExecutableException;
 
-import javax.jms.*;
-import org.apache.activemq.ActiveMQConnectionFactory;
 
 import java.io.*;
 
 public class OptimizationBatchServer {
+
+    private static final VCellQueue OPT_REQUEST_QUEUE = new VCellQueue("opt-request");
+    private static final VCellQueue OPT_STATUS_QUEUE = new VCellQueue("opt-status");
+    /** status updates are only useful while the caller is still waiting */
+    private static final long STATUS_TIME_TO_LIVE_MS = 3600_000L;
+
+    private VCMessagingService optMessagingService;
+    private VCMessageSession optStatusSession;
+
 
     private final static Logger lg = LogManager.getLogger(OptimizationBatchServer.class);
     private HtcProxy.HtcProxyFactory htcProxyFactory = null;
@@ -36,52 +50,55 @@ public class OptimizationBatchServer {
      * Receives submit/stop commands as JSON text messages, dispatches to SLURM, and sends status updates
      * back on "opt-status".
      */
+    /**
+     * Listen for optimization requests on the Artemis broker.
+     *
+     * This used to hand-roll its own JMS: a raw ActiveMQConnectionFactory on a plain
+     * "tcp://host:port" URL, its own daemon thread, and a while(true) receive loop. That worked,
+     * but it sat outside {@link VCMessagingService} and so inherited none of its policy -- no
+     * bounded failover URL, no {@link cbit.vcell.message.jms.JmsFailoverWatchdog}, no delegate,
+     * no shared connection handling. Nobody decided the optimization path should be less
+     * resilient than everything else; it simply was not routed through the place that decides.
+     *
+     * Going through VCMessagingServiceArtemis gets all of that, and the request/reply shape is
+     * unchanged on the wire: JSON text on "opt-request" and "opt-status", which is what
+     * vcell-rest publishes and consumes over AMQP 1.0 on the same addresses.
+     */
     public void initOptimizationQueue(String jmsHost, int jmsPort) {
-        Thread optQueueThread = new Thread(() -> {
-            ObjectMapper objectMapper = new ObjectMapper();
+        VCMessagingServiceArtemis messagingService = new VCMessagingServiceArtemis();
+        messagingService.setConfiguration(new SimpleMessagingDelegate(), jmsHost, jmsPort);
+        initOptimizationQueue(messagingService);
+    }
+
+    /** Package-visible so tests can supply a service pointed at a broker container. */
+    void initOptimizationQueue(VCMessagingService messagingService) {
+        this.optMessagingService = messagingService;
+        this.optStatusSession = messagingService.createProducerSession();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        VCQueueConsumer consumer = new VCQueueConsumer(OPT_REQUEST_QUEUE, (vcMessage, session) -> {
+            String json = vcMessage.getTextContent();
+            if (json == null) {
+                lg.warn("optimization request had no text content, ignoring");
+                return;
+            }
             try {
-                ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(
-                        "tcp://" + jmsHost + ":" + jmsPort);
-                connectionFactory.setTrustAllPackages(true);
-                Connection connection = connectionFactory.createConnection();
-                connection.start();
-
-                Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-                Destination requestQueue = session.createQueue("opt-request");
-                Destination statusQueue = session.createQueue("opt-status");
-                MessageConsumer consumer = session.createConsumer(requestQueue);
-                MessageProducer producer = session.createProducer(statusQueue);
-
-                lg.info("Optimization JMS queue listener started on opt-request");
-
-                while (true) {
-                    Message message = consumer.receive(2000); // 2 second poll
-                    if (message == null) continue;
-
-                    if (message instanceof TextMessage textMessage) {
-                        try {
-                            String json = textMessage.getText();
-                            OptRequestMessage request = objectMapper.readValue(json, OptRequestMessage.class);
-                            lg.info("Received optimization request: command={}, jobId={}", request.command, request.jobId);
-
-                            if ("submit".equals(request.command)) {
-                                handleSubmitRequest(request, session, producer, objectMapper);
-                            } else if ("stop".equals(request.command)) {
-                                handleStopRequest(request);
-                            } else {
-                                lg.warn("Unknown optimization command: {}", request.command);
-                            }
-                        } catch (Exception e) {
-                            lg.error("Error processing optimization request: {}", e.getMessage(), e);
-                        }
-                    }
+                OptRequestMessage request = objectMapper.readValue(json, OptRequestMessage.class);
+                lg.info("Received optimization request: command={}, jobId={}", request.command, request.jobId);
+                if ("submit".equals(request.command)) {
+                    handleSubmitRequest(request, objectMapper);
+                } else if ("stop".equals(request.command)) {
+                    handleStopRequest(request);
+                } else {
+                    lg.warn("Unknown optimization command: {}", request.command);
                 }
             } catch (Exception e) {
-                lg.error("Optimization JMS queue listener failed: {}", e.getMessage(), e);
+                lg.error("Error processing optimization request: {}", e.getMessage(), e);
             }
-        }, "optQueueListener");
-        optQueueThread.setDaemon(true);
-        optQueueThread.start();
+        }, null, "optQueueListener", 1);
+
+        messagingService.addMessageConsumer(consumer);
+        lg.info("Optimization queue listener started on {}", OPT_REQUEST_QUEUE.getName());
     }
 
     /**
@@ -97,8 +114,7 @@ public class OptimizationBatchServer {
         return file;
     }
 
-    private void handleSubmitRequest(OptRequestMessage request, Session session,
-                                     MessageProducer producer, ObjectMapper objectMapper) {
+    private void handleSubmitRequest(OptRequestMessage request, ObjectMapper objectMapper) {
         try {
             // Validate jobId is numeric (database key) to prevent injection in file names
             Long.parseLong(request.jobId);
@@ -126,14 +142,14 @@ public class OptimizationBatchServer {
             lg.info("Submitted SLURM job {} for optimization jobId={}", htcJobID, request.jobId);
 
             // Send QUEUED status back with htcJobId
-            sendStatusMessage(session, producer, objectMapper,
+            sendStatusMessage(objectMapper,
                     request.jobId, OptJobStatus.QUEUED, null, htcJobID.toDatabase());
         } catch (Exception e) {
             lg.error("Failed to submit optimization job {}: {}", request.jobId, e.getMessage(), e);
             try {
-                sendStatusMessage(session, producer, objectMapper,
+                sendStatusMessage(objectMapper,
                         request.jobId, OptJobStatus.FAILED, e.getMessage(), null);
-            } catch (JMSException jmsEx) {
+            } catch (VCMessagingException jmsEx) {
                 lg.error("Failed to send FAILED status for job {}: {}", request.jobId, jmsEx.getMessage(), jmsEx);
             }
         }
@@ -162,18 +178,18 @@ public class OptimizationBatchServer {
         }
     }
 
-    private void sendStatusMessage(Session session, MessageProducer producer, ObjectMapper objectMapper,
+    private void sendStatusMessage(ObjectMapper objectMapper,
                                    String jobId, OptJobStatus status, String statusMessage, String htcJobId)
-            throws JMSException {
+            throws VCMessagingException {
         try {
             OptStatusMessage statusMsg = new OptStatusMessage(jobId, status, statusMessage, htcJobId);
             String json = objectMapper.writeValueAsString(statusMsg);
-            TextMessage textMessage = session.createTextMessage(json);
-            producer.send(textMessage);
+            optStatusSession.sendQueueMessage(OPT_STATUS_QUEUE, optStatusSession.createTextMessage(json),
+                    Boolean.FALSE, STATUS_TIME_TO_LIVE_MS);
             lg.info("Sent optimization status: jobId={}, status={}", jobId, status);
         } catch (Exception e) {
             lg.error("Failed to send status message for job {}: {}", jobId, e.getMessage(), e);
-            throw new JMSException("Failed to serialize status message: " + e.getMessage());
+            throw new VCMessagingException("Failed to serialize status message: " + e.getMessage(), e);
         }
     }
 

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/artemis/VCMessagingServiceArtemisTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/artemis/VCMessagingServiceArtemisTest.java
@@ -1,0 +1,234 @@
+package cbit.vcell.message.jms.artemis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+import javax.jms.Destination;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import cbit.vcell.message.SimpleMessagingDelegate;
+import cbit.vcell.message.VCMessage;
+import cbit.vcell.message.VCMessageSession;
+import cbit.vcell.message.VCQueueConsumer;
+import cbit.vcell.message.VCTopicConsumer;
+import cbit.vcell.message.VCellQueue;
+import cbit.vcell.message.VCellTopic;
+
+/**
+ * Exercises {@link VCMessagingServiceArtemis} against a real Artemis broker in a container —
+ * the same image vcell-rest's cross-protocol test uses, with both AMQP (5672) and OpenWire
+ * (61616) exposed.
+ *
+ * A real broker rather than an embedded one because the interesting failures here are broker
+ * semantics, not plumbing: anycast vs multicast routing, whether a destination-URI suffix is
+ * honoured or silently becomes part of the address name, and whether an OpenWire producer and
+ * an AMQP consumer actually meet on the same address.
+ */
+@Tag("Fast")
+public class VCMessagingServiceArtemisTest {
+
+	private static final String IMAGE = "quay.io/artemiscloud/activemq-artemis-broker:1.0.25";
+	private static GenericContainer<?> artemis;
+	private static VCMessagingServiceArtemis service;
+
+	@BeforeAll
+	public static void startBroker() {
+		Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(),
+				"needs Docker for the Artemis broker container");
+		artemis = new GenericContainer<>(IMAGE)
+				.withExposedPorts(5672, 61616)
+				.withEnv("AMQ_USER", "guest")
+				.withEnv("AMQ_PASSWORD", "guest")
+				.waitingFor(Wait.forListeningPort());
+		artemis.start();
+
+		service = new VCMessagingServiceArtemis();
+		service.setConfiguration(new SimpleMessagingDelegate(),
+				artemis.getHost(), artemis.getMappedPort(61616));
+	}
+
+	@AfterAll
+	public static void stopBroker() throws Exception {
+		if (service != null) {
+			service.close();
+		}
+		if (artemis != null) {
+			artemis.stop();
+		}
+	}
+
+	/** The framework's basic contract: a queue message reaches a registered consumer. */
+	@Test
+	public void queueMessageReachesItsConsumer() throws Exception {
+		VCellQueue queue = new VCellQueue("artemis.test.queue");
+		CountDownLatch delivered = new CountDownLatch(1);
+		List<String> received = Collections.synchronizedList(new ArrayList<>());
+
+		VCQueueConsumer consumer = new VCQueueConsumer(queue, (vcMessage, session) -> {
+			received.add(vcMessage.getTextContent());
+			delivered.countDown();
+		}, null, "artemis queue consumer", 1);
+		service.addMessageConsumer(consumer);
+
+		VCMessageSession producer = service.createProducerSession();
+		try {
+			producer.sendQueueMessage(queue, producer.createTextMessage("over artemis"), Boolean.FALSE, 60000L);
+			assertTrue(delivered.await(30, TimeUnit.SECONDS), "queue message should reach the consumer");
+			assertEquals("over artemis", received.get(0));
+		} finally {
+			producer.close();
+			service.removeMessageConsumer(consumer);
+		}
+	}
+
+	/**
+	 * Topics are multicast addresses on Artemis, and every subscriber must get its own copy.
+	 * Getting this wrong is silent — a topic routed anycast delivers to one subscriber only.
+	 */
+	@Test
+	public void topicMessageReachesEverySubscriber() throws Exception {
+		VCellTopic topic = new VCellTopic("artemis.test.topic");
+		CountDownLatch both = new CountDownLatch(2);
+
+		VCTopicConsumer first = new VCTopicConsumer(topic, (m, s) -> both.countDown(), null, "sub one", 1);
+		VCTopicConsumer second = new VCTopicConsumer(topic, (m, s) -> both.countDown(), null, "sub two", 1);
+		service.addMessageConsumer(first);
+		service.addMessageConsumer(second);
+
+		VCMessageSession producer = service.createProducerSession();
+		try {
+			producer.sendTopicMessage(topic, producer.createTextMessage("broadcast"));
+			assertTrue(both.await(30, TimeUnit.SECONDS),
+					"both subscribers must receive it — a topic routed anycast would deliver to one");
+		} finally {
+			producer.close();
+			service.removeMessageConsumer(first);
+			service.removeMessageConsumer(second);
+		}
+	}
+
+	/** Selectors must still filter, since RPC replies depend on correlation-id selection. */
+	@Test
+	public void selectorsFilterOnArtemis() throws Exception {
+		VCellQueue queue = new VCellQueue("artemis.test.selector");
+		Connection connection = service.createConnectionFactory().createConnection();
+		connection.start();
+		try {
+			Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+			Destination destination = session.createQueue(queue.getName());
+			MessageProducer producer = session.createProducer(destination);
+			for (String id : new String[] { "wanted", "unwanted" }) {
+				TextMessage m = session.createTextMessage("payload-" + id);
+				m.setJMSCorrelationID(id);
+				producer.send(m);
+			}
+			MessageConsumer selective =
+					session.createConsumer(destination, "JMSCorrelationID='wanted'");
+			TextMessage got = (TextMessage) selective.receive(20000);
+			assertNotNull(got, "the selector should match the 'wanted' message");
+			assertEquals("payload-wanted", got.getText());
+		} finally {
+			connection.close();
+		}
+	}
+
+	/**
+	 * ActiveMQ's "?consumer.prefetchSize=N" destination suffix is parsed and stripped by the
+	 * OpenWire *client*, so against Artemis it still resolves to the plain address — measured
+	 * here, not assumed (an earlier version of this test asserted the opposite and was wrong).
+	 *
+	 * It works, but it is client-specific syntax that an AMQP client would not interpret: the
+	 * suffix would then become part of the address and the consumer would sit on a queue nobody
+	 * publishes to. {@link VCMessagingServiceArtemis} therefore sets prefetch on the connection
+	 * factory instead, so the destination name stays portable across clients.
+	 */
+	@Test
+	public void theActiveMQPrefetchSuffixIsClientSideSugar() throws Exception {
+		Connection connection = service.createConnectionFactory().createConnection();
+		connection.start();
+		try {
+			Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+			String plain = "artemis.test.prefetch";
+			MessageProducer producer = session.createProducer(session.createQueue(plain));
+			producer.send(session.createTextMessage("sent to the plain address"));
+
+			MessageConsumer suffixed = session.createConsumer(
+					session.createQueue(plain + "?consumer.prefetchSize=1"));
+			TextMessage got = (TextMessage) suffixed.receive(20000);
+			assertNotNull(got,
+					"the OpenWire client strips the suffix, so this resolves to the plain address");
+			assertEquals("sent to the plain address", got.getText());
+			assertEquals(plain, ((javax.jms.Queue) got.getJMSDestination()).getQueueName(),
+					"the broker only ever saw the plain address name");
+		} finally {
+			connection.close();
+		}
+	}
+
+	/**
+	 * The interop that matters for the migration: a message published through the IoC framework
+	 * must be readable by a consumer that is not using the framework — here a raw OpenWire
+	 * client standing in for the other side of a shared destination.
+	 */
+	@Test
+	public void aMessageSentThroughTheFrameworkIsReadableByAPlainClient() throws Exception {
+		VCellQueue queue = new VCellQueue("artemis.test.interop");
+		VCMessageSession producer = service.createProducerSession();
+		ActiveMQConnectionFactory plainFactory = new ActiveMQConnectionFactory(
+				"tcp://" + artemis.getHost() + ":" + artemis.getMappedPort(61616));
+		plainFactory.setTrustAllPackages(true);
+		Connection plain = plainFactory.createConnection();
+		plain.start();
+		try {
+			VCMessage message = producer.createTextMessage("{\"command\":\"submit\"}");
+			producer.sendQueueMessage(queue, message, Boolean.FALSE, 60000L);
+
+			Session session = plain.createSession(false, Session.AUTO_ACKNOWLEDGE);
+			MessageConsumer consumer = session.createConsumer(session.createQueue(queue.getName()));
+			TextMessage got = (TextMessage) consumer.receive(30000);
+			assertNotNull(got, "a plain client must be able to read what the framework sent");
+			assertEquals("{\"command\":\"submit\"}", got.getText(),
+					"JSON text survives the framework unchanged -- portable payloads are what "
+							+ "make a destination shareable with the AMQP side");
+		} finally {
+			producer.close();
+			plain.close();
+		}
+	}
+
+	/**
+	 * The policy the optimization bridge previously lacked: it connected with a plain
+	 * "tcp://host:port" URL, so a wedged transport could never escalate to the failover
+	 * watchdog. Routing it through this service is what restores that.
+	 */
+	@Test
+	public void theServiceUsesABoundedFailoverUrl() {
+		String url = VCMessagingServiceArtemis.jmsUrl("broker.example", 61616);
+		assertTrue(url.startsWith("failover:("),
+				"a plain tcp:// URL cannot escalate a wedged transport -- that was the gap");
+		assertTrue(url.contains("maxReconnectAttempts=20"), "reconnects must be bounded");
+		assertTrue(url.contains("startupMaxReconnectAttempts=-1"),
+				"initial connect stays unbounded so a pod tolerates a slow broker at boot");
+	}
+}

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/artemis/VCMessagingServiceArtemisTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/artemis/VCMessagingServiceArtemisTest.java
@@ -31,9 +31,16 @@ import cbit.vcell.message.SimpleMessagingDelegate;
 import cbit.vcell.message.VCMessage;
 import cbit.vcell.message.VCMessageSession;
 import cbit.vcell.message.VCQueueConsumer;
+import cbit.vcell.message.VCRpcMessageHandler;
+import cbit.vcell.message.VCRpcRequest;
 import cbit.vcell.message.VCTopicConsumer;
 import cbit.vcell.message.VCellQueue;
 import cbit.vcell.message.VCellTopic;
+
+import org.vcell.util.document.KeyValue;
+import org.vcell.util.document.User;
+
+import cbit.vcell.resource.PropertyLoader;
 
 /**
  * Exercises {@link VCMessagingServiceArtemis} against a real Artemis broker in a container —
@@ -214,6 +221,50 @@ public class VCMessagingServiceArtemisTest {
 		} finally {
 			producer.close();
 			plain.close();
+		}
+	}
+
+	/**
+	 * The highest-risk item on the migration list, and until now untested either way
+	 * (`docs/MESSAGING.md` §7.1): the RPC pattern round-trips a temporary reply queue through a
+	 * *string* — `getReplyTo()` returns its name and `sendQueueMessage()` turns that name back
+	 * into a destination. That works on Classic only because the client special-cases names
+	 * beginning with {@code ID:}. It is a property of the client/broker pairing, not of JMS, so
+	 * whether it survives against Artemis is a question the code cannot answer by inspection.
+	 *
+	 * It does survive, with the OpenWire client — Artemis emulates OpenWire temp destinations.
+	 * This says nothing about an AMQP or Artemis-core client, where the reply address is modelled
+	 * differently; that remains the open risk.
+	 */
+	@Test
+	public void rpcRoundTripSurvivesTheTempQueueNameRoundTrip() throws Exception {
+		String previousBlobProperty = System.getProperty(PropertyLoader.jmsBlobMessageUseMongo);
+		System.setProperty(PropertyLoader.jmsBlobMessageUseMongo, "false");
+		VCellQueue rpcQueue = new VCellQueue("artemis.test.rpc");
+		VCRpcMessageHandler handler = new VCRpcMessageHandler(new EchoService(), rpcQueue);
+		VCQueueConsumer responder = new VCQueueConsumer(rpcQueue, handler, null, "echo responder", 1);
+		service.addMessageConsumer(responder);
+		VCMessageSession producer = service.createProducerSession();
+		try {
+			VCRpcRequest request = new VCRpcRequest(new User("testuser", new KeyValue("1")),
+					VCRpcRequest.RpcServiceType.TESTING_SERVICE, "echo", new Object[] { "hello" });
+			Object answer = producer.sendRpcMessage(rpcQueue, request, true, 30000L, null, null, null);
+			assertEquals("hello", answer,
+					"the reply must find its way back through a temp queue addressed by name");
+		} finally {
+			producer.close();
+			service.removeMessageConsumer(responder);
+			if (previousBlobProperty == null) {
+				System.clearProperty(PropertyLoader.jmsBlobMessageUseMongo);
+			} else {
+				System.setProperty(PropertyLoader.jmsBlobMessageUseMongo, previousBlobProperty);
+			}
+		}
+	}
+
+	public static class EchoService {
+		public String echo(String value) {
+			return value;
 		}
 	}
 

--- a/vcell-server/src/test/java/cbit/vcell/message/server/batch/opt/OptimizationQueuePortTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/batch/opt/OptimizationQueuePortTest.java
@@ -1,0 +1,148 @@
+package cbit.vcell.message.server.batch.opt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.jms.Connection;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import cbit.vcell.message.SimpleMessagingDelegate;
+import cbit.vcell.message.VCMessageSession;
+import cbit.vcell.message.VCMessagingService;
+import cbit.vcell.message.VCQueueConsumer;
+import cbit.vcell.message.VCellQueue;
+import cbit.vcell.message.jms.artemis.VCMessagingServiceArtemis;
+
+/**
+ * Pins the wire contract of the optimization bridge after moving it from hand-rolled JMS onto
+ * {@link VCMessagingService}.
+ *
+ * The other side of these two queues is vcell-rest, publishing and consuming over AMQP 1.0 on
+ * the same Artemis addresses. So what has to survive the port is not the Java plumbing but the
+ * observable contract: JSON text on {@code opt-request} and {@code opt-status}, readable by a
+ * client that shares no code with this one.
+ */
+@Tag("Fast")
+public class OptimizationQueuePortTest {
+
+	private static final String IMAGE = "quay.io/artemiscloud/activemq-artemis-broker:1.0.25";
+	private static final VCellQueue OPT_REQUEST = new VCellQueue("opt-request");
+	private static final VCellQueue OPT_STATUS = new VCellQueue("opt-status");
+
+	private static GenericContainer<?> artemis;
+
+	@BeforeAll
+	public static void startBroker() {
+		Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(),
+				"needs Docker for the Artemis broker container");
+		artemis = new GenericContainer<>(IMAGE)
+				.withExposedPorts(5672, 61616)
+				.withEnv("AMQ_USER", "guest")
+				.withEnv("AMQ_PASSWORD", "guest")
+				.waitingFor(Wait.forListeningPort());
+		artemis.start();
+	}
+
+	@AfterAll
+	public static void stopBroker() {
+		if (artemis != null) {
+			artemis.stop();
+		}
+	}
+
+	private static VCMessagingServiceArtemis service() {
+		VCMessagingServiceArtemis service = new VCMessagingServiceArtemis();
+		service.setConfiguration(new SimpleMessagingDelegate(),
+				artemis.getHost(), artemis.getMappedPort(61616));
+		return service;
+	}
+
+	/**
+	 * A JSON request published by a plain client — standing in for vcell-rest — must reach a
+	 * consumer registered through the framework, unchanged.
+	 */
+	@Test
+	public void aJsonRequestFromAnotherClientReachesAFrameworkConsumer() throws Exception {
+		VCMessagingServiceArtemis service = service();
+		AtomicReference<String> seen = new AtomicReference<>();
+		java.util.concurrent.CountDownLatch arrived = new java.util.concurrent.CountDownLatch(1);
+
+		VCQueueConsumer consumer = new VCQueueConsumer(OPT_REQUEST, (vcMessage, session) -> {
+			seen.set(vcMessage.getTextContent());
+			arrived.countDown();
+		}, null, "opt request listener", 1);
+		service.addMessageConsumer(consumer);
+
+		Connection plain = plainConnection();
+		try {
+			Session session = plain.createSession(false, Session.AUTO_ACKNOWLEDGE);
+			MessageProducer producer = session.createProducer(session.createQueue(OPT_REQUEST.getName()));
+			producer.send(session.createTextMessage(
+					"{\"command\":\"submit\",\"jobId\":\"job-42\"}"));
+
+			assertTrue(arrived.await(30, TimeUnit.SECONDS), "the framework consumer should receive it");
+			assertEquals("{\"command\":\"submit\",\"jobId\":\"job-42\"}", seen.get(),
+					"JSON must pass through the framework byte-for-byte -- the AMQP side parses this");
+		} finally {
+			plain.close();
+			service.removeMessageConsumer(consumer);
+			service.close();
+		}
+	}
+
+	/**
+	 * And the reply direction: a status published through the framework must be readable as a
+	 * plain TextMessage, since vcell-rest consumes it over AMQP with no VCell classes involved.
+	 */
+	@Test
+	public void aStatusSentThroughTheFrameworkIsPlainJsonOnTheWire() throws Exception {
+		VCMessagingServiceArtemis service = service();
+		Connection plain = plainConnection();
+		try {
+			Session session = plain.createSession(false, Session.AUTO_ACKNOWLEDGE);
+			MessageConsumer consumer = session.createConsumer(session.createQueue(OPT_STATUS.getName()));
+
+			VCMessageSession producer = service.createProducerSession();
+			try {
+				String json = "{\"jobId\":\"job-42\",\"status\":\"RUNNING\"}";
+				producer.sendQueueMessage(OPT_STATUS, producer.createTextMessage(json),
+						Boolean.FALSE, 3600_000L);
+
+				TextMessage got = (TextMessage) consumer.receive(30000);
+				assertNotNull(got, "a plain AMQP/OpenWire consumer must see the status");
+				assertEquals(json, got.getText());
+			} finally {
+				producer.close();
+			}
+		} finally {
+			plain.close();
+			service.close();
+		}
+	}
+
+	private static Connection plainConnection() throws Exception {
+		ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(
+				"tcp://" + artemis.getHost() + ":" + artemis.getMappedPort(61616));
+		factory.setTrustAllPackages(true);
+		Connection connection = factory.createConnection();
+		connection.start();
+		return connection;
+	}
+}


### PR DESCRIPTION
Artemis is where messaging is heading, but the IoC framework only knew how to build an ActiveMQ Classic service. Anything on Artemis therefore had to hand-roll its own JMS — which is exactly what happened, and the cost is visible in the one place that did it.

### `VCMessagingServiceArtemis`

Sits alongside `VCMessagingServiceActiveMQ`. `VCMessagingService` was already broker-agnostic, so callers change nothing: a destination moves broker by constructing a different service.

Two deliberate differences from the Classic implementation, both about staying portable:

- **Prefetch on the connection, not the destination name.** ActiveMQ's `?consumer.prefetchSize=N` suffix *does* work against Artemis, but only because the OpenWire client strips it before the broker sees the address. It is client-specific syntax; an AMQP client would take it as part of the address and leave the consumer waiting on a queue nobody publishes to.
- **No advisory watching** (`setWatchTopicAdvisories(false)`), for the same reason as #1871: the client must not decide for itself whether another connection's temporary destination exists.

**On the client choice.** AMQP would give protocol parity with the Quarkus side, and that is the eventual destination. It is not reachable yet: qpid-jms 2.x implements *Jakarta* Messaging while this framework is `javax.jms` in 47 places, so adopting it means migrating the namespace first — separate work. OpenWire against Artemis is not speculative; it is what the bridge already did in production. Switching later is a change to `createConnectionFactory()` alone.

### Porting `OptimizationBatchServer`

That bridge was the one place bypassing the framework, and it showed:

| | before | after |
|---|---|---|
| connection URL | plain `tcp://host:port` | bounded `failover:(...)` |
| wedged transport | no escalation path | `JmsFailoverWatchdog` recycles the pod |
| receive loop | own daemon thread + `while(true)` | `VCQueueConsumer` |
| errors | `JMSException` | `VCMessagingException` |

Nobody decided the optimization path should be less resilient than everything else — it just was not routed through the place that decides.

**The wire contract is unchanged**: JSON text on `opt-request` and `opt-status`, which is what vcell-rest publishes and consumes over AMQP 1.0 on the same addresses. `OptimizationQueuePortTest` pins that from both directions, with a client sharing no code with the framework.

### Testing

Against a real Artemis broker in a container — the image vcell-rest's cross-protocol test uses — because the risks here are broker semantics, not plumbing: anycast vs multicast routing (a topic routed anycast delivers to one subscriber and fails silently), selector filtering (RPC replies depend on it), and cross-client interop.

One assumption was wrong and the broker caught it: the first version asserted Artemis would *reject* the prefetch suffix. It does not. The test now records what actually happens, and the rationale above is the corrected one — the suffix is avoided for portability, not because it breaks.

Fast group 70 green over two runs with CI's parallel flags; vcell-api and vcell-rest compile.

### Not in scope

No production wiring is switched to Artemis here — this adds the capability and moves the one caller that was already on Artemis. Which of the remaining destinations migrate, and when, is a deployment decision (`docs/MESSAGING.md` has the inventory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg