### PR TITLE
Send on a session of the call's own; stop opening a JMS connection per data event

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/MessageProducerSessionJms.java
@@ -127,10 +127,34 @@ public class MessageProducerSessionJms implements VCMessageSession {
      */
     private Session openSessionForSend() throws VCMessagingException{
         try {
-            return getSession();
+            // A session of this call's own, for the same reason sendRpcMessage uses one:
+            // javax.jms.Session is not thread-safe, and a producer session is routinely shared
+            // across threads -- VCPooledQueueConsumer hands one to every worker thread in
+            // SimDataServer, DatabaseServer and HtcSimulationWorker. createProducer/send/commit
+            // on one shared session is the race that produced "Transaction TX:<id> has not been
+            // started" (#1845). Connection is thread-safe, so this costs no new connection.
+            //
+            // It also removes the reason a caller would create a whole producer session per
+            // event to stay safe: SimDataServer.dataJobMessage did exactly that, and each one
+            // opened its own connection -- 209 connections in one minute on the dev site for a
+            // single user's data session.
+            boolean bTransacted = true;
+            return getConnection().createSession(bTransacted, Session.AUTO_ACKNOWLEDGE);
         } catch(JMSException e){
             onException(e);
             throw new VCMessagingException("unable to open JMS session: " + e.getMessage(), e);
+        }
+    }
+
+    /** Closes a per-send session; failure to close must not mask a send failure. */
+    private void closeSessionAfterSend(Session sendSession){
+        if(sendSession == null){
+            return;
+        }
+        try {
+            sendSession.close();
+        } catch(JMSException e){
+            lg.error("failed to close per-send JMS session: " + e.getMessage(), e);
         }
     }
 
@@ -254,6 +278,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
             Session jmsSession = openSessionForSend();
             MessageProducer messageProducer = null;
             try {
+                // jmsSession is this call's own session -- see openSessionForSend()
                 Destination destination = jmsSession.createQueue(queue.getName());
                 messageProducer = jmsSession.createProducer(destination);
                 if(persistent == null || persistent.booleanValue()){
@@ -279,6 +304,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                         lg.error(e.getMessage(), e);
                     }
                 }
+                closeSessionAfterSend(jmsSession);
             }
         } else {
             throw new RuntimeException("expected JMS message for JMS message service");
@@ -315,6 +341,7 @@ public class MessageProducerSessionJms implements VCMessageSession {
                         lg.error(e.getMessage(), e);
                     }
                 }
+                closeSessionAfterSend(jmsSession);
             }
         } else {
             throw new RuntimeException("must send a JMS message to a JMS messaging service");

--- a/vcell-server/src/main/java/cbit/vcell/message/server/data/SimDataServer.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/data/SimDataServer.java
@@ -117,15 +117,21 @@ public void init(SimDataServiceType serviceType) throws Exception {
 	vcMessagingService_int.addMessageConsumer(rpcConsumer);
 }
 
+/**
+ * Data and export events are published on {@link #sharedProducerSession} rather than on a
+ * producer session created per event. Each of those cost a whole JMS connection --
+ * createProducerSession() opens eagerly -- which on the dev site meant 209 connections in one
+ * minute for a single user's data session. Sends now take a session of their own from the
+ * shared connection (see MessageProducerSessionJms.openSessionForSend), so reusing this
+ * session is safe from the pooled consumer's worker threads.
+ */
 public void dataJobMessage(cbit.rmi.event.DataJobEvent event) {
 	try {
-		VCMessageSession dataSession = vcMessagingService_int.createProducerSession();
-		VCMessage dataEventMessage = dataSession.createObjectMessage(event);
+		VCMessage dataEventMessage = sharedProducerSession.createObjectMessage(event);
 		dataEventMessage.setStringProperty(VCMessagingConstants.MESSAGE_TYPE_PROPERTY, MessageConstants.MESSAGE_TYPE_DATA_EVENT_VALUE);
 		dataEventMessage.setStringProperty(VCMessagingConstants.USERNAME_PROPERTY, event.getUser().getName());
-		
-		dataSession.sendTopicMessage(VCellTopic.ClientStatusTopic, dataEventMessage);
-		dataSession.close();
+
+		sharedProducerSession.sendTopicMessage(VCellTopic.ClientStatusTopic, dataEventMessage);
 	} catch (VCMessagingException ex) {
 		lg.error(ex.getMessage(), ex);
 	}
@@ -133,13 +139,11 @@ public void dataJobMessage(cbit.rmi.event.DataJobEvent event) {
 
 public void exportMessage(cbit.rmi.event.ExportEvent event) {
 	try {
-		VCMessageSession dataSession = vcMessagingService_int.createProducerSession();
-		VCMessage exportEventMessage = dataSession.createObjectMessage(event);
+		VCMessage exportEventMessage = sharedProducerSession.createObjectMessage(event);
 		exportEventMessage.setStringProperty(VCMessagingConstants.MESSAGE_TYPE_PROPERTY, MessageConstants.MESSAGE_TYPE_EXPORT_EVENT_VALUE);
 		exportEventMessage.setStringProperty(VCMessagingConstants.USERNAME_PROPERTY, event.getUser().getName());
-		
-		dataSession.sendTopicMessage(VCellTopic.ClientStatusTopic, exportEventMessage);
-		dataSession.close();
+
+		sharedProducerSession.sendTopicMessage(VCellTopic.ClientStatusTopic, exportEventMessage);
 	} catch (VCMessagingException ex) {
 		lg.error(ex.getMessage(), ex);
 	}

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/MessageProducerSessionJmsTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -533,6 +534,104 @@ public class MessageProducerSessionJmsTest {
 				connection.close();
 			} catch (JMSException ignored) {
 			}
+		}
+	}
+
+	/**
+	 * The property SimDataServer now depends on: a producer session reused for many sends costs
+	 * ONE connection, however many messages go through it.
+	 *
+	 * It used to build a producer session per data event instead, and the contrast measured here
+	 * is why that mattered -- createProducerSession() opens eagerly, so each event cost a whole
+	 * connection. On the dev site that was 209 connections in one minute for a single user
+	 * browsing simulation data.
+	 */
+	@Test
+	public void manySendsOnOneProducerSessionCostOneConnection() throws Exception {
+		VCellTopic topic = new VCellTopic("MessageProducerSessionJmsTestReuseTopic");
+		int before = service.connectionsOpened.get();
+		MessageProducerSessionJms shared = new MessageProducerSessionJms(service);
+		try {
+			for (int i = 0; i < 25; i++) {
+				shared.sendTopicMessage(topic, shared.createTextMessage("event-" + i));
+			}
+			assertEquals(before + 1, service.connectionsOpened.get(),
+					"25 sends through one producer session must open exactly one connection");
+		} finally {
+			shared.close();
+		}
+
+		// the pattern it replaced, for contrast: a producer session per event
+		int beforePerEvent = service.connectionsOpened.get();
+		for (int i = 0; i < 5; i++) {
+			VCMessageSession perEvent = service.createProducerSession();
+			perEvent.sendTopicMessage(topic, perEvent.createTextMessage("per-event-" + i));
+			perEvent.close();
+		}
+		assertEquals(beforePerEvent + 5, service.connectionsOpened.get(),
+				"a producer session per event costs a connection per event -- this is what was fixed");
+	}
+
+	/**
+	 * A producer session is shared across threads by design -- VCPooledQueueConsumer hands one to
+	 * every worker thread in SimDataServer, DatabaseServer and HtcSimulationWorker -- so its send
+	 * path must tolerate that. javax.jms.Session does not: concurrent createProducer/send/commit
+	 * on one session is what produced "Transaction 'TX:<id>' has not been started" (#1845), and
+	 * the same shape applies to plain sends, not just RPC.
+	 *
+	 * Every message must arrive exactly once, and no send may fail.
+	 */
+	@Test
+	public void concurrentSendsOnOneSharedProducerSessionAllSucceed() throws Exception {
+		VCellQueue queue = new VCellQueue("MessageProducerSessionJmsTestConcurrentSend");
+		int threads = 8;
+		int perThread = 10;
+		MessageProducerSessionJms shared = new MessageProducerSessionJms(service);
+		ExecutorService pool = Executors.newFixedThreadPool(threads);
+		List<String> failures = Collections.synchronizedList(new ArrayList<>());
+		Set<String> delivered = Collections.synchronizedSet(new java.util.HashSet<>());
+		CountDownLatch allArrived = new CountDownLatch(threads * perThread);
+
+		VCQueueConsumer collector = new VCQueueConsumer(queue, (vcMessage, ignored) -> {
+			delivered.add(vcMessage.getTextContent());
+			allArrived.countDown();
+		}, null, "concurrent send collector", 1);
+		service.addMessageConsumer(collector);
+
+		try {
+			CountDownLatch startTogether = new CountDownLatch(1);
+			List<Future<?>> done = new ArrayList<>();
+			for (int t = 0; t < threads; t++) {
+				final int threadIndex = t;
+				done.add(pool.submit(() -> {
+					try {
+						startTogether.await();
+						for (int i = 0; i < perThread; i++) {
+							shared.sendQueueMessage(queue,
+									shared.createTextMessage("t" + threadIndex + "-m" + i),
+									Boolean.FALSE, 60000L);
+						}
+					} catch (Exception e) {
+						failures.add(e.toString());
+					}
+					return null;
+				}));
+			}
+			startTogether.countDown();
+			for (Future<?> f : done) {
+				f.get(90, TimeUnit.SECONDS);
+			}
+
+			assertTrue(failures.isEmpty(), "no concurrent send should fail, but got: " + failures);
+			assertTrue(allArrived.await(60, TimeUnit.SECONDS),
+					"every message must be delivered; missing " + allArrived.getCount()
+							+ " of " + (threads * perThread));
+			assertEquals(threads * perThread, delivered.size(),
+					"each message must arrive exactly once and unmangled");
+		} finally {
+			pool.shutdownNow();
+			service.removeMessageConsumer(collector);
+			shared.close();
 		}
 	}
 


### PR DESCRIPTION
Found in the dev-site logs rather than by reading code. A Loki sweep of `namespace=dev` showed **209 `Successfully connected to tcp://activemqint` in a single minute** on the data server, paired one-for-one with 209 topic sends, during one user's data session on 8.0.10.01.

### What was happening

`SimDataServer.dataJobMessage` and `exportMessage` each called `createProducerSession()`, sent one message, and closed. `createProducerSession()` calls `open()`, which connects eagerly — so **every data event cost a whole TCP connection and JMS handshake.**

This is the same per-message-connection shape as the August 6 incident, in a path #1842 didn't cover. The doc comment I wrote on `open()` says these sessions "are opened at server startup and are always used" — these two call sites are precisely the counterexample.

### Why the caller did it that way

Because sharing a producer session wasn't safe. `VCPooledQueueConsumer` hands one shared session to every worker thread in `SimDataServer`, `DatabaseServer` and `HtcSimulationWorker`, and `sendQueueMessage`/`sendTopicMessage` did `createProducer` → `send` → `commit` on it. `javax.jms.Session` is not thread-safe, and that is the race behind `Transaction 'TX:<id>' has not been started` (#1845).

`sendRpcMessage` was fixed then by taking a session per call from the `Connection`, which *is* thread-safe. This applies the same treatment to plain sends — so it costs no new connection, sharing becomes safe, and `SimDataServer` can just reuse the session it already holds.

| | before | after |
|---|---|---|
| 25 sends, one producer session | 1 connection | 1 connection |
| 25 data events (`SimDataServer`) | **25 connections** | 1 connection |
| concurrent sends on a shared session | racing `createProducer`/`send`/`commit` | session per call |

### Testing

Two tests, because the two properties fail independently:
- 25 sends through one producer session open exactly one connection — with the per-event pattern measured right alongside at one connection each, so the contrast is demonstrated rather than asserted.
- 8 threads × 10 sends concurrently through one shared session: no send fails, every message delivered exactly once.

Fast group 75 green over two runs with CI's parallel flags.

### Not fixed — stated explicitly

Message **creation** still happens on the shared session (`createObjectMessage`/`createTextMessage`), and `VCRpcMessageHandler` already calls it *outside* its `synchronized (session)` block. That concurrency is pre-existing on `data` and `db` today and is not introduced here, but it's the remaining hazard on this object. Fixing it means changing where messages are built, which is a larger change than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg