### PR TITLE
Evaluate the SaLaD site radius before formatting it (results viewer crash)

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SpringSaladSpeciesLegend.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SpringSaladSpeciesLegend.java
@@ -14,7 +14,12 @@ import cbit.vcell.math.LangevinParticleMolecularType;
 import cbit.vcell.math.MathDescription;
 import cbit.vcell.math.ParticleMolecularComponent;
 import cbit.vcell.math.ParticleMolecularType;
+import cbit.vcell.parser.Expression;
+import cbit.vcell.parser.ExpressionException;
 import cbit.vcell.simdata.SpringSaladTrajectory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.awt.Color;
 import java.util.ArrayList;
@@ -48,6 +53,8 @@ import java.util.Set;
  * cannot be told apart and collapse into a single entry.
  */
 public class SpringSaladSpeciesLegend {
+
+	private static final Logger lg = LogManager.getLogger(SpringSaladSpeciesLegend.class);
 
 	/** Molecule name used for site types the model could not name. */
 	public static final String UNNAMED_SPECIES = "Unidentified";
@@ -181,12 +188,42 @@ public class SpringSaladSpeciesLegend {
 				}
 				String color = lpmc.getColor().getName() == null
 						? "" : lpmc.getColor().getName().trim().toUpperCase(Locale.ROOT);
-				SiteType st = byKey.get(String.format(Locale.ROOT, "color:%s@%.5f", color, lpmc.getRadius()));
+				// The radius is an Expression here and a double on the trajectory side, so it has
+				// to be evaluated before it can be formatted -- passing the Expression to "%.5f"
+				// threw IllegalFormatConversionException and took the whole results viewer down.
+				Double radius = constantRadius(lpmc);
+				if (radius == null) {
+					continue;   // a non-constant radius cannot match a key built from a number
+				}
+				SiteType st = byKey.get(String.format(Locale.ROOT, "color:%s@%.5f", color, radius));
 				if (st != null) {
 					st.moleculeNames.add(pmt.getName());
 					st.siteNames.add(lpmc.getName());
 				}
 			}
+		}
+	}
+
+	/**
+	 * The site radius as a number, or null if it is missing or not a constant.
+	 *
+	 * Naming is a convenience: a radius that cannot be evaluated means this site simply goes
+	 * unnamed in the legend, which is what happens today for any run without {@code SiteIDs.csv}.
+	 * It must never abort building the legend, because the legend failing takes the results
+	 * viewer with it.
+	 */
+	private static Double constantRadius(LangevinParticleMolecularComponent lpmc) {
+		Expression radius = lpmc.getRadius();
+		if (radius == null) {
+			return null;
+		}
+		try {
+			return radius.evaluateConstant();
+		} catch (ExpressionException e) {
+			// infix(), not toString(), is the readable form of an Expression
+			lg.warn("site '" + lpmc.getName() + "' has a non-constant radius '" + radius.infix()
+					+ "'; it will not be named in the SpringSaLaD legend", e);
+			return null;
 		}
 	}
 

--- a/vcell-client/src/test/java/cbit/vcell/solver/ode/gui/SpringSaladSpeciesLegendTest.java
+++ b/vcell-client/src/test/java/cbit/vcell/solver/ode/gui/SpringSaladSpeciesLegendTest.java
@@ -1,6 +1,11 @@
 package cbit.vcell.solver.ode.gui;
 
+import cbit.vcell.math.LangevinParticleMolecularComponent;
+import cbit.vcell.math.LangevinParticleMolecularType;
+import cbit.vcell.math.MathDescription;
+import cbit.vcell.parser.Expression;
 import cbit.vcell.simdata.SpringSaladTrajectory;
+import org.vcell.util.springsalad.NamedColor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -124,6 +129,75 @@ public class SpringSaladSpeciesLegendTest {
 
 		canvas.showAllSiteTypes();
 		assertEquals(visiblePixels, countGlyphPixels(canvas.renderToImage(300, 300)));
+	}
+
+
+	/**
+	 * The fallback naming path -- a run with no SiteIDs.csv, named by joining against the math.
+	 *
+	 * Every other test in this class passed null for the math description, so this path had no
+	 * coverage at all, and it threw IllegalFormatConversionException the moment it ran: the site
+	 * radius is an Expression in the math and a double on the trajectory side, and the Expression
+	 * was being handed straight to "%.5f". That took down the whole simulation results viewer,
+	 * reported as "DataAccessException-f != cbit.vcell.parser.Expression".
+	 */
+	@Test
+	public void namesSitesFromTheMathWhenTheRunHasNoSiteIds() throws Exception {
+		SpringSaladTrajectory traj = singleTypeTrajectory();   // radius 3.0, colour LIME
+		MathDescription math = mathWithSite("MolA", "SiteA", 3.0, Colors.LIME);
+
+		SpringSaladSpeciesLegend legend = SpringSaladSpeciesLegend.build(traj, math);
+
+		assertTrue(legend.isNamed(), "the model should have supplied a name");
+		assertEquals(List.of("MolA"), new ArrayList<>(legend.bySpecies().keySet()));
+		assertEquals("SiteA", legend.getSiteTypes().get(0).getSiteLabel());
+	}
+
+	/** A radius that does not match any trajectory entry simply names nothing -- and never throws. */
+	@Test
+	public void aRadiusThatMatchesNothingLeavesTheLegendUnnamed() throws Exception {
+		SpringSaladTrajectory traj = singleTypeTrajectory();   // radius 3.0
+		MathDescription math = mathWithSite("MolA", "SiteA", 99.0, Colors.LIME);
+
+		SpringSaladSpeciesLegend legend = SpringSaladSpeciesLegend.build(traj, math);
+
+		assertFalse(legend.isNamed());
+		assertEquals(List.of(SpringSaladSpeciesLegend.UNNAMED_SPECIES),
+				new ArrayList<>(legend.bySpecies().keySet()));
+	}
+
+	/**
+	 * A non-constant radius cannot be matched against a numeric key, but naming is a convenience:
+	 * it must leave the site unnamed rather than abort the legend and take the viewer with it.
+	 */
+	@Test
+	public void aNonConstantRadiusIsSkippedRatherThanFatal() throws Exception {
+		SpringSaladTrajectory traj = singleTypeTrajectory();
+		MathDescription math = mathWithSiteRadius("MolA", "SiteA", new Expression("someParameter * 2"), Colors.LIME);
+
+		SpringSaladSpeciesLegend legend = SpringSaladSpeciesLegend.build(traj, math);
+
+		assertFalse(legend.isNamed(), "an unevaluable radius names nothing");
+		assertFalse(legend.isEmpty(), "but the legend itself must still be built");
+	}
+
+	private static MathDescription mathWithSite(String molecule, String site, double radius, NamedColor color)
+			throws Exception {
+		return mathWithSiteRadius(molecule, site, new Expression(radius), color);
+	}
+
+	private static MathDescription mathWithSiteRadius(String molecule, String site, Expression radius,
+			NamedColor color) throws Exception {
+		LangevinParticleMolecularComponent component =
+				new LangevinParticleMolecularComponent(molecule + "_" + site, site);
+		component.setRadius(radius);
+		component.setColor(color);
+		LangevinParticleMolecularType type = new LangevinParticleMolecularType(molecule);
+		type.addMolecularComponent(component);
+
+		MathDescription math = new MathDescription("test");
+		math.addParticleMolecularType(type);
+		return math;
 	}
 
 	private static SpringSaladTrajectory singleTypeTrajectory() {


### PR DESCRIPTION
Viewing the results of a completed SpringSaLaD run on alpha fails with

```
DataAccessException-f != cbit.vcell.parser.Expression
IllegalFormatConversionException-f != cbit.vcell.parser.Expression
```

and it takes down the **whole simulation results viewer**, not just the legend — the exception propagates out of `SimResultsViewer.<init>`.

### Cause

The site radius has two types on the two sides of the same lookup key:

| | radius | |
|---|---|---|
| `SpringSaladTrajectory.siteTypeKey:183` | `double`, from the trajectory file | fine |
| `SpringSaladSpeciesLegend.joinNamesFromModel:184` | **`Expression`**, from the math | `String.format("%.5f", expr)` throws |

Fixed by evaluating the expression before formatting.

### Why it shipped in 8.0.10.01 unnoticed

Two things had to line up. The path only runs for a run **without `SiteIDs.csv`** — when the solver wrote that file it has already named every site and the join never executes. And **every existing test in `SpringSaladSpeciesLegendTest` passed `null` for the math description**, so `joinNamesFromModel` had no coverage whatsoever. It threw the first time it ever ran.

Introduced in `00d0ccc98b` (2026-08-01), present in tags 8.0.6.01 through 8.0.10.01.

### Behaviour on a radius that can't be evaluated

Naming is a convenience, so a non-constant radius now leaves that site unnamed and logs it, rather than aborting the legend. Reported with `infix()` — `toString()` is not the readable form of an `Expression`.

### Testing

Three tests, each **confirmed to reproduce the reported exception against the unfixed source** and pass with the fix: the join names a site, a radius matching nothing leaves the legend unnamed, and a non-constant radius is skipped rather than fatal.

`vcell-client` Fast group 22 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg