### PR TITLE
Field viewer: MovingBoundary (mbsolver) visualization — body-fitted, time-varying meshes (#1879)

### DIFF
--- a/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
@@ -24,6 +24,8 @@ import org.vcell.util.document.TSJobResultsNoStats;
 import org.vcell.util.document.TSJobResultsSpaceStats;
 import org.vcell.util.document.TimeSeriesJobSpec;
 import org.vcell.util.document.VCDataJobID;
+import org.vcell.vis.io.VtuFileContainer;
+import org.vcell.vis.io.VtuVarInfo;
 import org.vcell.vis.mapping.vcell.CartesianMeshMapping;
 import org.vcell.vis.vcell.CartesianMeshBuilder;
 import org.vcell.vis.vcell.SubdomainInfo;
@@ -42,6 +44,8 @@ import cbit.vcell.simdata.DataIdentifier;
 import cbit.vcell.simdata.OutputContext;
 import cbit.vcell.simdata.SimDataBlock;
 import cbit.vcell.simdata.VCDataManager;
+import cbit.vcell.solvers.CartesianMeshMovingBoundary;
+import cbit.vcell.solvers.mb.MovingBoundaryReader;
 import cbit.vcell.solver.AnnotatedFunction;
 import cbit.vcell.solver.VCSimulationDataIdentifier;
 
@@ -108,6 +112,9 @@ public final class FieldViewerServer {
 		final SubdomainInfo subdomainInfo;
 		/** Human-readable name of the run, e.g. "model::app::sim"; may be null — the ID always exists, a name may not. */
 		final String simName;
+		/** Lazily detected: MovingBoundary runs serve per-timestep body-fitted meshes via the VTU seam. */
+		volatile Boolean movingBoundary;
+		volatile VtuVarInfo[] vtuVarInfos;
 
 		DataSource(VCSimulationDataIdentifier vcdID, VCDataManager dataManager, SubdomainInfo subdomainInfo,
 				String simName) {
@@ -116,6 +123,30 @@ public final class FieldViewerServer {
 			this.subdomainInfo = subdomainInfo;
 			this.simName = simName;
 		}
+	}
+
+	/**
+	 * Whether this run is a MovingBoundary (mbsolver) run. Detected from the mesh type the data
+	 * manager returns rather than from the simulation, so it works identically for a re-opened
+	 * remote run where only the data still exists. MovingBoundary is a server-only solver, so this
+	 * path always reaches the data over the same remote {@link VCDataManager} seam.
+	 */
+	private static boolean isMovingBoundary(DataSource source) throws Exception {
+		Boolean mb = source.movingBoundary;
+		if (mb == null) {
+			mb = source.dataManager.getMesh(source.vcdID) instanceof CartesianMeshMovingBoundary;
+			source.movingBoundary = mb;
+		}
+		return mb;
+	}
+
+	private static VtuVarInfo[] vtuVarInfos(DataSource source) throws Exception {
+		VtuVarInfo[] infos = source.vtuVarInfos;
+		if (infos == null) {
+			infos = source.dataManager.getVtuVarInfos(emptyOutputContext(), source.vcdID);
+			source.vtuVarInfos = infos;
+		}
+		return infos;
 	}
 
 	/** Raised when a request names a dataset no window has registered; reported as 404. */
@@ -293,6 +324,9 @@ public final class FieldViewerServer {
 	private static String handleInfo(HttpExchange ex) throws Exception {
 		DataSource source = sourceFor(query(ex));
 		VCSimulationDataIdentifier vcdID = source.vcdID;
+		if (isMovingBoundary(source)) {
+			return handleInfoMovingBoundary(source);
+		}
 
 		double[] times = source.dataManager.getDataSetTimes(vcdID);
 		DataIdentifier[] ids = source.dataManager.getDataIdentifiers(emptyOutputContext(), vcdID);
@@ -343,6 +377,9 @@ public final class FieldViewerServer {
 	private static String handleGrid(HttpExchange ex) throws Exception {
 		Map<String, String> q = query(ex);
 		DataSource source = sourceFor(q);
+		if (isMovingBoundary(source)) {
+			return handleGridMovingBoundary(source, q);
+		}
 		String domain = domainOf(q, source);
 		VisMesh visMesh = grid(source, domain);
 
@@ -392,6 +429,184 @@ public final class FieldViewerServer {
 		return sb.toString();
 	}
 
+	// ---------------------------------------------------------------------
+	// MovingBoundary (mbsolver) — per-timestep body-fitted meshes via the VTU seam (#1879)
+	// ---------------------------------------------------------------------
+
+	/**
+	 * MovingBoundary runs serve a DIFFERENT geometry per saved time: the solver's body-fitted 2D
+	 * mesh, whose boundary cells are true cut polygons. These handlers reach it through the
+	 * VTU-era {@link VCDataManager} methods, which are already time-indexed for MovingBoundary
+	 * and already pair each mesh with a per-cell value array by shared ordinal — and which work
+	 * against today's deployed servers with no interface changes (MovingBoundary is server-only,
+	 * so the data always arrives over this remote seam; the server side runs the Python VTK
+	 * service that writes the .vtu). {@link VtuGridParser} converts those bytes to the viewer's
+	 * JSON contract; the geometryId carries the time index, which is what tells the viewer to
+	 * re-fetch geometry as time moves.
+	 */
+	private static String handleInfoMovingBoundary(DataSource source) throws Exception {
+		VCSimulationDataIdentifier vcdID = source.vcdID;
+		double[] times = source.dataManager.getDataSetTimes(vcdID);
+		StringBuilder sb = new StringBuilder(1024);
+		sb.append("{\"simId\":\"").append(jsonEscape(vcdID.getID())).append('"');
+		if (source.simName != null && !source.simName.isEmpty()) {
+			sb.append(",\"simName\":\"").append(jsonEscape(source.simName)).append('"');
+		}
+		sb.append(",\"jobIndex\":").append(vcdID.getJobIndex());
+		sb.append(",\"times\":");
+		appendDoubles(sb, times, times.length);
+		String domain = MovingBoundaryReader.getFakeInsideDomainName();
+		sb.append(",\"domains\":[\"").append(jsonEscape(domain)).append("\"]");
+		sb.append(",\"variables\":[");
+		boolean first = true;
+		for (VtuVarInfo var : vtuVarInfos(source)) {
+			if (var.bMeshVariable || var.dataType != VtuVarInfo.DataType.CellData) {
+				continue;
+			}
+			if (!first) {
+				sb.append(',');
+			}
+			first = false;
+			sb.append("{\"name\":\"").append(jsonEscape(var.name)).append('"');
+			sb.append(",\"domain\":\"").append(jsonEscape(domain)).append('"');
+			sb.append(",\"isFunction\":").append(var.functionExpression != null).append('}');
+		}
+		sb.append("]}");
+		return sb.toString();
+	}
+
+	/** Snaps the requested time to the nearest saved index; defaults to the last one. */
+	private static int timeIndexFor(DataSource source, Map<String, String> q) throws Exception {
+		double[] times = source.dataManager.getDataSetTimes(source.vcdID);
+		if (times == null || times.length == 0) {
+			throw new IllegalArgumentException("run " + source.vcdID.getID() + " has no saved times");
+		}
+		String requested = q.get("time");
+		if (requested == null || requested.isEmpty()) {
+			return times.length - 1;
+		}
+		double target = Double.parseDouble(requested);
+		int best = 0;
+		for (int i = 1; i < times.length; i++) {
+			if (Math.abs(times[i] - target) < Math.abs(times[best] - target)) {
+				best = i;
+			}
+		}
+		return best;
+	}
+
+	private static String mbGeometryId(DataSource source, String domain, int timeIndex) {
+		return source.vcdID.getID() + "/" + domain + "@t" + timeIndex;
+	}
+
+	/** Parsed per-time meshes; a run's meshes are dropped with it in {@link #unregister}. */
+	private static final Map<String, VtuGridParser.VtuGrid> mbGridCache = new HashMap<>();
+
+	private static synchronized VtuGridParser.VtuGrid mbGrid(DataSource source, String domain,
+			int timeIndex) throws Exception {
+		String key = mbGeometryId(source, domain, timeIndex);
+		VtuGridParser.VtuGrid cached = mbGridCache.get(key);
+		if (cached != null) {
+			return cached;
+		}
+		VtuFileContainer container = source.dataManager.getEmptyVtuMeshFiles(source.vcdID, timeIndex);
+		for (VtuFileContainer.VtuMesh mesh : container.vtuMeshes) {
+			if (mesh.domainName.equals(domain)) {
+				VtuGridParser.VtuGrid grid = VtuGridParser.parse(mesh.vtuMeshContents);
+				mbGridCache.put(key, grid);
+				return grid;
+			}
+		}
+		throw new IllegalArgumentException("no VTU mesh for domain '" + domain + "' at time index "
+				+ timeIndex + "; this run has "
+				+ container.vtuMeshes.stream().map(m -> m.domainName).toList());
+	}
+
+	private static String handleGridMovingBoundary(DataSource source, Map<String, String> q) throws Exception {
+		String domain = q.getOrDefault("domain", "");
+		if (domain.isEmpty()) {
+			domain = MovingBoundaryReader.getFakeInsideDomainName();
+		}
+		int timeIndex = timeIndexFor(source, q);
+		VtuGridParser.VtuGrid grid = mbGrid(source, domain, timeIndex);
+
+		StringBuilder sb = new StringBuilder(32 * grid.numPoints() + 32 * grid.cells.length + 512);
+		sb.append("{\"geometryId\":\"").append(jsonEscape(mbGeometryId(source, domain, timeIndex))).append('"');
+		sb.append(",\"dimension\":2,\"bodyFitted\":true");
+		sb.append(",\"timeIndex\":").append(timeIndex);
+		sb.append(",\"numPoints\":").append(grid.numPoints());
+		sb.append(",\"points\":");
+		appendDoubles(sb, grid.points, grid.points.length);
+		sb.append(",\"cellType\":").append(grid.cellTypes.length > 0 ? grid.cellTypes[0] : 7);
+		sb.append(",\"cells\":[");
+		for (int c = 0; c < grid.cells.length; c++) {
+			if (c > 0) {
+				sb.append(',');
+			}
+			sb.append('[');
+			for (int v = 0; v < grid.cells[c].length; v++) {
+				if (v > 0) {
+					sb.append(',');
+				}
+				sb.append(grid.cells[c][v]);
+			}
+			sb.append(']');
+		}
+		sb.append(']');
+		sb.append(",\"domain\":\"").append(jsonEscape(domain)).append('"');
+		sb.append('}');
+		return sb.toString();
+	}
+
+	private static String handleFieldMovingBoundary(DataSource source, Map<String, String> q) throws Exception {
+		String varName = q.get("var");
+		if (varName == null || varName.isEmpty()) {
+			throw new IllegalArgumentException("missing required query parameter 'var'");
+		}
+		String domain = q.getOrDefault("domain", "");
+		if (domain.isEmpty()) {
+			domain = MovingBoundaryReader.getFakeInsideDomainName();
+		}
+		int timeIndex = timeIndexFor(source, q);
+		double[] times = source.dataManager.getDataSetTimes(source.vcdID);
+		double time = times[timeIndex];
+
+		VtuVarInfo varInfo = null;
+		for (VtuVarInfo v : vtuVarInfos(source)) {
+			if (v.name.equals(varName)) {
+				varInfo = v;
+				break;
+			}
+		}
+		if (varInfo == null) {
+			throw new IllegalArgumentException("unknown variable '" + varName + "'");
+		}
+		// the VTU seam's contract: values are ordered by the same sequential inside-cell ordinal
+		// the mesh's cells were written in, so values[i] belongs to cells[i] of the SAME timeIndex
+		double[] values = source.dataManager.getVtuMeshData(emptyOutputContext(), source.vcdID, varInfo, time);
+		double min = Double.POSITIVE_INFINITY;
+		double max = Double.NEGATIVE_INFINITY;
+		for (double v : values) {
+			if (!Double.isNaN(v)) {
+				min = Math.min(min, v);
+				max = Math.max(max, v);
+			}
+		}
+		if (min > max) {
+			min = 0;
+			max = 0;
+		}
+		StringBuilder sb = new StringBuilder(16 * values.length + 256);
+		sb.append("{\"geometryId\":\"").append(jsonEscape(mbGeometryId(source, domain, timeIndex))).append('"');
+		sb.append(",\"name\":\"").append(jsonEscape(varName)).append('"');
+		sb.append(",\"domain\":\"").append(jsonEscape(domain)).append('"');
+		sb.append(",\"time\":").append(time);
+		sb.append(",\"location\":\"cell\",\"values\":");
+		appendDoubles(sb, values, values.length);
+		sb.append(",\"range\":[").append(min).append(',').append(max).append("]}");
+		return sb.toString();
+	}
+
 	/**
 	 * {@code /field?sim=<simKey>&job=<n>&domain=<name>&var=<name>&time=<t>} — one variable at one
 	 * time, as one value per grid cell.
@@ -406,6 +621,9 @@ public final class FieldViewerServer {
 	private static String handleField(HttpExchange ex) throws Exception {
 		Map<String, String> q = query(ex);
 		DataSource source = sourceFor(q);
+		if (isMovingBoundary(source)) {
+			return handleFieldMovingBoundary(source, q);
+		}
 		String domain = domainOf(q, source);
 		String varName = q.get("var");
 		if (varName == null || varName.isEmpty()) {
@@ -458,6 +676,12 @@ public final class FieldViewerServer {
 	private static String handleTimeSeries(HttpExchange ex) throws Exception {
 		Map<String, String> q = query(ex);
 		DataSource source = sourceFor(q);
+		if (isMovingBoundary(source)) {
+			// per-cell ordinals are not stable across time on a moving mesh; needs a
+			// spatial-point formulation (#1879 follow-up)
+			throw new IllegalArgumentException(
+					"not yet supported for MovingBoundary runs");
+		}
 		String domain = domainOf(q, source);
 		String varName = q.get("var");
 		if (varName == null || varName.isEmpty()) {
@@ -512,6 +736,12 @@ public final class FieldViewerServer {
 	private static String handleStats(HttpExchange ex) throws Exception {
 		Map<String, String> q = query(ex);
 		DataSource source = sourceFor(q);
+		if (isMovingBoundary(source)) {
+			// per-cell ordinals are not stable across time on a moving mesh; needs a
+			// spatial-point formulation (#1879 follow-up)
+			throw new IllegalArgumentException(
+					"not yet supported for MovingBoundary runs");
+		}
 		DataIdentifier[] ids = source.dataManager.getDataIdentifiers(emptyOutputContext(), source.vcdID);
 		Set<String> requested = null;
 		String varParam = q.get("var");
@@ -682,6 +912,7 @@ public final class FieldViewerServer {
 	public static synchronized void unregister(VCSimulationDataIdentifier vcdID) {
 		if (dataSources.remove(key(vcdID)) != null) {
 			meshCache.keySet().removeIf(cached -> cached.startsWith(vcdID.getID() + "/"));
+			mbGridCache.keySet().removeIf(cached -> cached.startsWith(vcdID.getID() + "/"));
 		}
 	}
 

--- a/vcell-client/src/main/java/org/vcell/client/viz/VtuGridParser.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/VtuGridParser.java
@@ -1,0 +1,182 @@
+package org.vcell.client.viz;
+
+import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Base64;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Parses a VTK XML unstructured-grid file ({@code .vtu}) into flat arrays, for re-serving as the
+ * field viewer's JSON grid contract.
+ * <p>
+ * This is deliberately NOT a general VTU reader. It exists for exactly one producer: the server's
+ * Python VTK service ({@code pythonVtk/.../vtkService.py, writevtk()}), which writes
+ * single-piece, LittleEndian, <b>binary-uncompressed</b> ({@code SetCompressorTypeToNone()} +
+ * {@code SetDataModeToBinary()}) files — inline base64 blocks, each prefixed by a byte-count
+ * header whose width is the {@code VTKFile header_type} (UInt32 here, UInt64 tolerated). ASCII
+ * data arrays are also accepted for robustness. Anything else (appended data, compression,
+ * multiple pieces) is rejected loudly rather than half-read.
+ */
+final class VtuGridParser {
+
+	/** One parsed unstructured grid: points as x,y,z triples, cells as point-index lists. */
+	static final class VtuGrid {
+		final double[] points; // 3 per point
+		final int[][] cells;
+		final int[] cellTypes; // VTK cell type per cell
+
+		VtuGrid(double[] points, int[][] cells, int[] cellTypes) {
+			this.points = points;
+			this.cells = cells;
+			this.cellTypes = cellTypes;
+		}
+
+		int numPoints() {
+			return points.length / 3;
+		}
+	}
+
+	private VtuGridParser() {
+	}
+
+	static VtuGrid parse(byte[] vtuFileBytes) throws Exception {
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		dbf.setNamespaceAware(false);
+		dbf.setExpandEntityReferences(false);
+		dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+		Document doc = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(vtuFileBytes));
+
+		Element vtkFile = doc.getDocumentElement();
+		if (!"VTKFile".equals(vtkFile.getTagName())
+				|| !"UnstructuredGrid".equals(vtkFile.getAttribute("type"))) {
+			throw new IllegalArgumentException("not a VTKFile/UnstructuredGrid document");
+		}
+		String byteOrder = attrOr(vtkFile, "byte_order", "LittleEndian");
+		if (!"LittleEndian".equals(byteOrder)) {
+			throw new IllegalArgumentException("unsupported byte order " + byteOrder);
+		}
+		int headerBytes = "UInt64".equals(attrOr(vtkFile, "header_type", "UInt32")) ? 8 : 4;
+
+		NodeList pieces = doc.getElementsByTagName("Piece");
+		if (pieces.getLength() != 1) {
+			throw new IllegalArgumentException("expected exactly one Piece, found " + pieces.getLength());
+		}
+		Element piece = (Element) pieces.item(0);
+
+		Element pointsEl = onlyChild(piece, "Points");
+		double[] points = readDataArray(firstDataArray(pointsEl), headerBytes);
+
+		Element cellsEl = onlyChild(piece, "Cells");
+		double[] connectivity = null;
+		double[] offsets = null;
+		double[] types = null;
+		NodeList arrays = cellsEl.getElementsByTagName("DataArray");
+		for (int i = 0; i < arrays.getLength(); i++) {
+			Element da = (Element) arrays.item(i);
+			double[] values = readDataArray(da, headerBytes);
+			switch (da.getAttribute("Name")) {
+				case "connectivity": connectivity = values; break;
+				case "offsets": offsets = values; break;
+				case "types": types = values; break;
+				default: // ignore
+			}
+		}
+		if (connectivity == null || offsets == null || types == null) {
+			throw new IllegalArgumentException("Cells is missing connectivity, offsets or types");
+		}
+
+		int[][] cells = new int[offsets.length][];
+		int[] cellTypes = new int[offsets.length];
+		int start = 0;
+		for (int c = 0; c < offsets.length; c++) {
+			int end = (int) offsets[c];
+			int[] cell = new int[end - start];
+			for (int v = 0; v < cell.length; v++) {
+				cell[v] = (int) connectivity[start + v];
+			}
+			cells[c] = cell;
+			cellTypes[c] = (int) types[c];
+			start = end;
+		}
+		return new VtuGrid(points, cells, cellTypes);
+	}
+
+	private static String attrOr(Element el, String name, String fallback) {
+		String v = el.getAttribute(name);
+		return v == null || v.isEmpty() ? fallback : v;
+	}
+
+	private static Element onlyChild(Element parent, String tag) {
+		NodeList list = parent.getElementsByTagName(tag);
+		if (list.getLength() != 1) {
+			throw new IllegalArgumentException("expected exactly one <" + tag + ">, found " + list.getLength());
+		}
+		return (Element) list.item(0);
+	}
+
+	private static Element firstDataArray(Element parent) {
+		NodeList list = parent.getElementsByTagName("DataArray");
+		if (list.getLength() < 1) {
+			throw new IllegalArgumentException("no DataArray under <" + parent.getTagName() + ">");
+		}
+		return (Element) list.item(0);
+	}
+
+	/** Reads one DataArray's values as doubles, whatever its declared numeric type. */
+	private static double[] readDataArray(Element dataArray, int headerBytes) {
+		String format = attrOr(dataArray, "format", "ascii");
+		String type = dataArray.getAttribute("type");
+		String text = dataArray.getTextContent();
+		if ("ascii".equals(format)) {
+			String[] tokens = text.trim().split("\\s+");
+			double[] values = new double[tokens.length];
+			for (int i = 0; i < tokens.length; i++) {
+				values[i] = Double.parseDouble(tokens[i]);
+			}
+			return values;
+		}
+		if (!"binary".equals(format)) {
+			throw new IllegalArgumentException("unsupported DataArray format '" + format
+					+ "' (appended/compressed VTU is not produced by the VCell Python VTK service)");
+		}
+		// InformationKey children contribute text too; the base64 block is the first token
+		String base64 = text.trim().split("\\s+")[0];
+		byte[] raw = Base64.getDecoder().decode(base64);
+		ByteBuffer buf = ByteBuffer.wrap(raw).order(ByteOrder.LITTLE_ENDIAN);
+		long byteCount = headerBytes == 8 ? buf.getLong() : Integer.toUnsignedLong(buf.getInt());
+		int width = widthOf(type);
+		int n = (int) (byteCount / width);
+		double[] values = new double[n];
+		for (int i = 0; i < n; i++) {
+			values[i] = switch (type) {
+				case "Float32" -> buf.getFloat();
+				case "Float64" -> buf.getDouble();
+				case "Int8" -> buf.get();
+				case "UInt8" -> buf.get() & 0xFF;
+				case "Int16" -> buf.getShort();
+				case "UInt16" -> buf.getShort() & 0xFFFF;
+				case "Int32" -> buf.getInt();
+				case "UInt32" -> Integer.toUnsignedLong(buf.getInt());
+				case "Int64", "UInt64" -> buf.getLong();
+				default -> throw new IllegalArgumentException("unsupported DataArray type " + type);
+			};
+		}
+		return values;
+	}
+
+	private static int widthOf(String type) {
+		return switch (type) {
+			case "Int8", "UInt8" -> 1;
+			case "Int16", "UInt16" -> 2;
+			case "Float32", "Int32", "UInt32" -> 4;
+			case "Float64", "Int64", "UInt64" -> 8;
+			default -> throw new IllegalArgumentException("unsupported DataArray type " + type);
+		};
+	}
+}

--- a/vcell-client/src/test/java/org/vcell/client/viz/VtuGridParserTest.java
+++ b/vcell-client/src/test/java/org/vcell/client/viz/VtuGridParserTest.java
@@ -1,0 +1,42 @@
+package org.vcell.client.viz;
+
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import org.vcell.client.viz.VtuGridParser.VtuGrid;
+
+/**
+ * Parses a reference {@code .vtu} generated with the exact settings of the server's Python VTK
+ * service ({@code writevtk()}: LittleEndian, binary data mode, compressor NONE, UInt32 headers):
+ * two VTK_POLYGON cells (a 5-vertex cut cell and a quad) over 7 points, mimicking a
+ * MovingBoundary mesh fragment. See {@code pythonVtk/python_vtk/vtkService/vtkService.py}.
+ */
+@Tag("Fast")
+public class VtuGridParserTest {
+
+	@Test
+	public void parsesBinaryUncompressedPolygons() throws Exception {
+		byte[] bytes;
+		try (InputStream in = VtuGridParserTest.class.getResourceAsStream("binary-uncompressed.vtu")) {
+			Assertions.assertNotNull(in, "test resource binary-uncompressed.vtu missing");
+			bytes = in.readAllBytes();
+		}
+		VtuGrid grid = VtuGridParser.parse(bytes);
+
+		Assertions.assertEquals(7, grid.numPoints());
+		Assertions.assertEquals(2, grid.cells.length);
+
+		// the 5-vertex cut cell, then the quad — both written as VTK_POLYGON (7)
+		Assertions.assertArrayEquals(new int[] { 0, 1, 2, 3, 4 }, grid.cells[0]);
+		Assertions.assertArrayEquals(new int[] { 1, 5, 6, 2 }, grid.cells[1]);
+		Assertions.assertArrayEquals(new int[] { 7, 7 }, grid.cellTypes);
+
+		// spot-check the one non-integral coordinate (point 2 = 1.6, 0.9, 0), Float32 precision
+		Assertions.assertEquals(1.6, grid.points[6], 1e-6);
+		Assertions.assertEquals(0.9, grid.points[7], 1e-6);
+		Assertions.assertEquals(0.0, grid.points[8], 1e-6);
+	}
+}

--- a/vcell-client/src/test/resources/org/vcell/client/viz/binary-uncompressed.vtu
+++ b/vcell-client/src/test/resources/org/vcell/client/viz/binary-uncompressed.vtu
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian" header_type="UInt32">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="7" NumberOfCells="2">
+      <PointData>
+      </PointData>
+      <CellData>
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Points" NumberOfComponents="3" format="binary" RangeMin="0" RangeMax="2.23606797749979">
+          VAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAM3MzD9mZmY/AAAAAAAAgD8AAIA/AAAAAAAAAAAAAIA/AAAAAAAAAEAAAAAAAAAAAAAAAEAAAIA/AAAAAA==
+          <InformationKey name="L2_NORM_RANGE" location="vtkDataArray" length="2">
+            <Value index="0">
+              0
+            </Value>
+            <Value index="1">
+              2.2360679775
+            </Value>
+          </InformationKey>
+        </DataArray>
+      </Points>
+      <Cells>
+        <DataArray type="Int64" Name="connectivity" format="binary" RangeMin="0" RangeMax="6">
+          SAAAAAAAAAAAAAAAAQAAAAAAAAACAAAAAAAAAAMAAAAAAAAABAAAAAAAAAABAAAAAAAAAAUAAAAAAAAABgAAAAAAAAACAAAAAAAAAA==
+        </DataArray>
+        <DataArray type="Int64" Name="offsets" format="binary" RangeMin="5" RangeMax="9">
+          EAAAAAUAAAAAAAAACQAAAAAAAAA=
+        </DataArray>
+        <DataArray type="UInt8" Name="types" format="binary" RangeMin="7" RangeMax="7">
+          AgAAAAcH
+        </DataArray>
+      </Cells>
+    </Piece>
+  </UnstructuredGrid>
+</VTKFile>

--- a/webapp-viewer/README.md
+++ b/webapp-viewer/README.md
@@ -106,6 +106,15 @@ scrub time — a time step costs about 5.7× less than shipping both.
   parallel projection (drag pans, wheel scales — `dolly` does nothing under an ortho camera), the
   slice row is hidden, and picking switches to a parallel-projection ray. 1D runs get a clear
   dialog in the desktop client instead of a broken page.
+- **MovingBoundary (mbsolver) runs are a third mode: body-fitted, time-varying geometry.** The
+  server detects the run from its mesh type and switches to the VTU seam (`getVtuTimes` /
+  `getEmptyVtuMeshFiles(timeIndex)` / `getVtuMeshData`), parsing the Python VTK service's
+  binary-uncompressed `.vtu` into the same JSON contract (`bodyFitted: true`, `cellType` 7 cut
+  polygons, `geometryId` carrying the time index). The viewer bypasses the whole smooth/deform
+  chain — the mesh IS the solver's geometry — and re-fetches `/grid` on every time step, keeping
+  the camera where the user put it. Smoothing, crop, picking and statistics are gated off
+  (per-cell ordinals are not stable across time on a moving mesh; spatial-point formulations are
+  the #1879 follow-up).
 - `probe.html` is a scratch page for exactly these capability probes: point it at a suspect class,
   read the on-page result, and keep the console open for `is not permitted`.
 - **The scalar bar labels the lookup table's range, not the mapper's.** `mapper.setScalarRange`

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -71,6 +71,7 @@ const state = {
   selectedDomain: '',
   geometryId: '',
   dimension: 3,
+  bodyFitted: false, // MovingBoundary runs: solver's body-fitted mesh, geometry varies per time
   bounds: null,
   sliceAxis: -1,
   slicePos: 50,
@@ -204,7 +205,10 @@ function nearestTimeIndex(t) {
 
 async function loadGeometry() {
   setStatus(`loading geometry for ${state.selectedDomain}…`);
-  const geometry = await fetchJson(url('/grid', { domain: state.selectedDomain }), '/grid');
+  const geometry = await fetchJson(url('/grid', {
+    domain: state.selectedDomain,
+    ...(state.bodyFitted ? { time: String(state.times[state.timeIndex]) } : {}),
+  }), '/grid');
   state.geometryId = geometry.geometryId;
   return geometry;
 }
@@ -412,10 +416,16 @@ async function buildGrid(geometry, field) {
     await (await ug.getCellData()).setScalars(arr);
     fieldArray = arr;
   }
-  // the raw grid feeds the smoothing chain and the deform filter; everything the user sees
-  // (shell, crop, cut face) derives from the ONE deformed grid downstream of them
-  await surfSource.setInputData(ug);
-  await deform.setInputData(ug);
+  if (state.bodyFitted) {
+    // MovingBoundary: the mesh IS the solver's body-fitted geometry — no smoothing, no deform,
+    // no crop; the display shows it exactly as computed
+    await geomFilter.setInputData(ug);
+  } else {
+    // the raw grid feeds the smoothing chain and the deform filter; everything the user sees
+    // (shell, crop, cut face) derives from the ONE deformed grid downstream of them
+    await surfSource.setInputData(ug);
+    await deform.setInputData(ug);
+  }
 
   if (field) {
     await mapper.setScalarModeToUseCellData();
@@ -443,6 +453,7 @@ async function buildGrid(geometry, field) {
  */
 async function applyCrop() {
   if (!tableClip) return;
+  if (state.bodyFitted) return; // geomFilter is fed the solver mesh directly in buildGrid
   const axis = state.sliceAxis;
   if (axis < 0) {
     await geomFilter.setInputConnection(await deform.getOutputPort());
@@ -540,6 +551,7 @@ async function buildScene(geometry, field) {
   sinc = vtk.vtkWindowedSincPolyDataFilter();
   await sinc.setInputConnection(await surfSource.getOutputPort());
   state.dimension = geometry.dimension ?? 3;
+  state.bodyFitted = !!geometry.bodyFitted;
   if (state.dimension === 2) {
     // 2D: the quads ARE the display and the mesh's boundary edge is the domain outline — exactly
     // what the convention smooths. A flat regular interior is already a Laplacian fixed point,
@@ -551,9 +563,11 @@ async function buildScene(geometry, field) {
   await sinc.featureEdgeSmoothingOff();
   await sinc.nonManifoldSmoothingOff();
   await sinc.normalizeCoordinatesOn();
-  await sinc.setNumberOfIterations(geometry.sinc.iterations);
-  await sinc.setFeatureAngle(geometry.sinc.feature_angle);
-  await sinc.setPassBand(geometry.sinc.pass_band);
+  if (geometry.sinc) {
+    await sinc.setNumberOfIterations(geometry.sinc.iterations);
+    await sinc.setFeatureAngle(geometry.sinc.feature_angle);
+    await sinc.setPassBand(geometry.sinc.pass_band);
+  }
 
   deform = vtk.vtkVCellDeformGridToSurface(); // our custom filter; bundle >= v1.2.0
   await deform.setSourceConnection(await sinc.getOutputPort());
@@ -802,7 +816,7 @@ function cellCenter(cell) {
 
 let hoverBusy = false;
 async function hoverPick(clientX, clientY) {
-  if (!state.ready || !state.pick || hoverBusy) return;
+  if (!state.ready || !state.pick || hoverBusy || state.bodyFitted) return;
   hoverBusy = true;
   try {
     const { origin, dir } = await rayFromMouse(clientX, clientY);
@@ -829,7 +843,7 @@ async function hoverPick(clientX, clientY) {
  * explicitly ruled out in #1859.
  */
 async function plotPick(clientX, clientY) {
-  if (!state.ready || !state.pick || !state.dataset) return;
+  if (!state.ready || !state.pick || !state.dataset || state.bodyFitted) return;
   try {
     const { origin, dir } = await rayFromMouse(clientX, clientY);
     const cell = castRay(origin, dir);
@@ -974,6 +988,7 @@ const formatPassBand = (v) => (v >= 0.01 ? v.toFixed(3) : v.toExponential(1));
 
 /** Update the readout while dragging, without re-running the filter. */
 function previewSmoothing(strength) {
+  if (state.bodyFitted) return; // the readout explains the mode; there is nothing to preview
   state.smoothing = strength;
   const p = smoothingFor(strength);
   let note = '';
@@ -1026,14 +1041,14 @@ async function refreshField() {
   }
 }
 
-async function rebuildGeometry() {
+async function rebuildGeometry(resetCam = true) {
   if (!state.ready || state.busy || !state.dataset) return;
   state.busy = true;
   const t0 = performance.now();
   try {
     const geometry = await loadGeometry();
     await buildGrid(geometry, await loadField());
-    await renderer.resetCamera();
+    if (resetCam) await renderer.resetCamera();
     await renderWindow.render();
     setStatus(`${describe()} ✓ (${Math.round(performance.now() - t0)} ms)`);
   } catch (e) {
@@ -1049,7 +1064,8 @@ el.time.addEventListener('input', () => {
 });
 el.time.addEventListener('change', () => {
   state.timeIndex = Number(el.time.value);
-  void refreshField();
+  // a body-fitted mesh is a different geometry at each time; keep the camera where the user put it
+  void (state.bodyFitted ? rebuildGeometry(false) : refreshField());
 });
 el.variable.addEventListener('change', () => {
   const chosen = state.variables.find((v) => v.name === el.variable.value);
@@ -1133,11 +1149,15 @@ el.smoothingReset.addEventListener('click', () => {
     state.ready = true;
     el.variable.disabled = false;
     el.time.disabled = state.times.length < 2;
-    el.smoothing.disabled = false;
+    el.smoothing.disabled = state.bodyFitted;
     el.colorbar.disabled = false;
     el.axes.disabled = false;
-    el.sliceAxis.disabled = false;
-    el.statsBtn.disabled = false;
+    el.sliceAxis.disabled = state.bodyFitted;
+    el.statsBtn.disabled = state.bodyFitted;
+    if (state.bodyFitted) {
+      el.smoothingReadout.textContent = 'body-fitted solver mesh — shown as computed';
+      el.smoothingReset.disabled = true;
+    }
     previewSmoothing(state.smoothing);
     setStatus(`rendered ${describe()} ✓ (${Math.round(performance.now() - t0)} ms) — drag to rotate, wheel to zoom`);
   } catch (e) {


### PR DESCRIPTION
Implements the core of #1879: MovingBoundary runs render in the browser field viewer as a third mode — **body-fitted, time-varying 2D geometry**.

## Design (from the #1879 investigation)

- **The VTU seam, through the same `VCDataManager` the server already holds.** MovingBoundary is server-only (`Feature_ServerOnly`), so its data always arrives over the remote seam — where `getVtuTimes` / `getEmptyVtuMeshFiles(timeIndex)` / `getVtuVarInfos` / `getVtuMeshData` are **already time-indexed for MB** and already pair each per-time mesh with a per-cell value array by shared ordinal. This works against today's deployed servers: no `DataSetController` interface changes, no client/server version skew.
- **`VtuGridParser`** converts the Python VTK service's `.vtu` (single-piece, LittleEndian, binary-uncompressed — the one format that producer writes) into the viewer's JSON contract; unit-tested against a reference file generated with exactly those writer settings, including a 5-vertex cut cell.
- **`/grid` gains a `time` parameter**; the `geometryId` carries the time index (`…@tN`) — the protocol hook reserved for exactly this since the first crop work. `/field` values are ordinal-matched to the same frame. `/timeseries` and `/stats` reject with a clear message: per-cell ordinals are not stable across time on a moving mesh, so those need spatial-point formulations (follow-up in #1879).
- **Viewer `bodyFitted` mode**: the smooth/deform chain is bypassed entirely — the mesh IS the solver's geometry, shown as computed (the smoothing readout says so). Every time step re-fetches `/grid` and rebuilds, **keeping the camera where the user put it**. Smoothing, crop, picking and statistics are gated off. Run detection is by mesh type (`getMesh() instanceof CartesianMeshMovingBoundary`), so it works for re-opened runs where only data exists.

## Verification

Headless harness against a mock serving a drifting, shrinking disk with true cut-cell polygons per frame: geometry genuinely changes across scrub (screenshots), body-fitted rims are smooth by construction, ranges re-label per frame, gated controls verified off, no invoker refusals. The Java path compiles and the parser is unit-tested (`VtuGridParserTest`, Fast); end-to-end exercise against a real mbsolver run needs a server-connected client, the same route as the rest of the feature train.

| t = 1 (shrunken, drifted) | t = 0 (same camera — geometry changed under it) |
|---|---|
| ![t4](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/eeb32af27bfd0f299bc411f8982bc397f5e07e0e/mb-t4.png) | ![t0](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/eeb32af27bfd0f299bc411f8982bc397f5e07e0e/mb-t0.png) |

Leaves open in #1879: spatial-point picking/timeseries/stats on moving meshes, membrane/outside domains (the VTU writer currently emits only the inside domain), and the FEniCSx-era ALE-segment amortization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYqrC3BiB4JRsJoz7BXJF4