### PR TITLE
Field viewer: fix MovingBoundary boot-time geometry/field mismatch

### DIFF
--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -205,9 +205,15 @@ function nearestTimeIndex(t) {
 
 async function loadGeometry() {
   setStatus(`loading geometry for ${state.selectedDomain}…`);
+  // ALWAYS send the time: on the very first load the client cannot yet know the run is
+  // body-fitted (that flag arrives IN this response), and without a time the server defaults a
+  // body-fitted run's geometry to its last frame while the first /field honors the requested
+  // initial time — the exact mismatch seen live ("field is for ...@t0 but the view holds
+  // ...@tN"). Cartesian runs ignore the parameter.
+  const t = state.times[state.timeIndex];
   const geometry = await fetchJson(url('/grid', {
     domain: state.selectedDomain,
-    ...(state.bodyFitted ? { time: String(state.times[state.timeIndex]) } : {}),
+    ...(t !== undefined ? { time: String(t) } : {}),
   }), '/grid');
   state.geometryId = geometry.geometryId;
   return geometry;


### PR DESCRIPTION
First live test of #1883 (alpha client, a real MovingBoundary run) failed at open with `viewer failed: field is for geometry SimID_…@t0 but the view holds SimID_…@t20`.

**Root cause — a chicken-and-egg on first load:** the client only learns a run is body-fitted from the `/grid` response itself, so the first `/grid` request carried no `time` parameter; the server defaults a body-fitted run's geometry to its **last** frame, while the first `/field` honored the **requested initial** time from the launch URL. The geometry/field pairing guard then (correctly) refused the mismatched frames.

**Fix:** `/grid` always carries the current time — Cartesian runs ignore the parameter, body-fitted runs get the right frame from the first request. One-line change plus the explanatory comment.

Reproduced first in the headless harness (the mock reproduces the server's no-time→last-frame default; same error string), then verified fixed: body-fitted boot at t=0 renders, time scrubbing still works, and the 3D and 2D Cartesian modes are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYqrC3BiB4JRsJoz7BXJF4