### PR TITLE
Field viewer: Chombo solutions via the VTU seam (static embedded-boundary meshes, mixed cells)

### DIFF
--- a/docs/chombo-solver-notes.md
+++ b/docs/chombo-solver-notes.md
@@ -1,0 +1,141 @@
+# Chombo solver — status, run specification, and file formats
+
+Working notes gathered while adding Chombo support to the VTK-based field viewer
+(PR #1890). Chombo is a retired solver: stored results exist, but as of August 2026
+no deployed image or solver bundle can *run* it (details below). This document
+records what is needed to read its output today and to resurrect the solver later.
+
+## 1. Current availability (as of 2026-08)
+
+- **Source still exists**: `virtualcell/vcell-solvers` repo, directories
+  `VCellChombo/` (the VCell driver) and `Chombo/` (the LBNL library). The CMake
+  options `OPTION_TARGET_CHOMBO2D_SOLVER` and `OPTION_TARGET_CHOMBO3D_SOLVER`
+  default to **off**, and current CI does not enable them.
+- **No binaries anywhere current**:
+  - `localsolvers/` bundles (release `v0.0.44-dev4`: linux64/mac64/win64) contain
+    FiniteVolume, MovingBoundary, Sundials, VCellStoch, NFsim, smoldyn, langevin —
+    no `VCellChombo2D`/`VCellChombo3D`.
+  - `ghcr.io/virtualcell/vcell-batch:8.0.11.01` (the image the HPC Singularity/Apptainer
+    image is built from): `find / -iname '*hombo*'` is empty.
+  - `ghcr.io/virtualcell/vcell-solvers:latest` and `:v0.0.42-dev3`: none.
+- **Consequence**: a Chombo simulation submitted today would fail at executable
+  resolution (`SolverUtilities.getExes` → `ResourceUtil.findSolverExecutable`)
+  both client-side and on HPC. Resurrection means either building from source with
+  the two CMake options enabled (linux/amd64; Fortran + HDF5 toolchain) or
+  recovering binaries from a VCell 7.x-era image.
+
+## 2. How a Chombo run is specified
+
+- `SolverDescription.Chombo` — display name **"Chombo Standalone"** ("EBChombo,
+  Semi-Implicit (Fixed Time Step), Experimental"), KISAO:0000285. Features:
+  spatial, deterministic, region-size functions, Dirichlet-at-membrane-boundary,
+  parallel, fast systems.
+- `SolverExecutable.VCellChombo` maps to **two** executables: `VCellChombo2D` and
+  `VCellChombo3D`; `FVSolverStandalone` (the same Java driver used for the
+  FiniteVolume solver, via its `isChombo` flag) picks `getExes()[0]` for 2D and
+  `[1]` for 3D. `FiniteVolumeFileWriter` writes the input file with
+  `bChomboSolver` branching.
+- VCML: `<SolverTaskDescription Solver="Chombo Standalone">` containing a
+  `<ChomboSolverSpec>`:
+
+  ```xml
+  <ChomboSolverSpec>
+    <MaxBoxSize>32</MaxBoxSize>
+    <FillRatio>0.9</FillRatio>
+    <SaveVCellOutput>true</SaveVCellOutput>
+    <SaveChomboOutput>true</SaveChomboOutput>
+    <ActivateFeatureUnderDevelopment>false</ActivateFeatureUnderDevelopment>
+    <SmallVolfracThreshold>0.0</SmallVolfracThreshold>
+    <BlockFactor>4</BlockFactor>
+    <TagsGrow>2</TagsGrow>
+    <TimeBound>
+      <TimeInterval StartTime="0.0" EndTime="1.0" TimeStep="0.1" OutputTimeStep="0.1"/>
+    </TimeBound>
+    <MeshRefinement/>
+  </ChomboSolverSpec>
+  ```
+
+- `<SaveChomboOutput>true</SaveChomboOutput>` is what makes the run VTK-visualizable
+  later: `SimulationData.getChomboFiles()` refuses to build the VTK view of a run
+  whose stored `..._0_.simtask.xml` lacks it ("Export of Chombo simulations to VTK
+  requires chombo data"). Old simtask files predate the element entirely.
+- Reference model with runnably-small Chombo sims: **BioModel 276459600 (user
+  `schaff`, "Solver_Suite_7_5")**, saved at `exampleModels/Solver_Suite_7_5.vcml`
+  (git-ignored). It has a "2D chombo" application (sims on 8×8 meshes) and a
+  "3D chombo" application (8×8×8 and 16×16×16) — ideal fixture size once the
+  solver can run again.
+
+## 3. Output file formats (per `SimID_<key>_<job>_` prefix)
+
+All HDF5 files are written by the solver itself (native code), so format follows
+the *solver build* era, not the reading-code era.
+
+| File | Content |
+|---|---|
+| `.mesh.hdf5` | Chombo mesh: group `mesh` with attrs `dimension`, `Nx`, extents, and datasets including the compound table `membrane elements` |
+| `_%06d.feature_<subdomain>.vol<ivol>.hdf5` (alt: `_%06d_<subdomain>_vol<ivol>.hdf5`) | per-output-time, per-feature, per-volume solution data — the files `SimulationData.findChomboFeatureVolFile` looks for |
+| `.sim.hdf5` (often zipped into the sim `.zip`) | raw Chombo solver output; **not** readable by the vis pipeline — only the loose feature/vol extracts are |
+| `_.hdf5` | post-processing output (statistics etc.) |
+| `.simtask.xml`, `.log`, `.functions` | as for other FV-family solvers |
+
+### Format eras (observed in real archives on the dev cluster)
+
+- **~2011**: `membrane elements` uses an older layout whose columns are typed
+  differently — current `CartesianMeshChombo.collectMembraneElements` fails with
+  `ClassCastException` (`[D` vs `[I`). Not readable without a legacy branch.
+- **~2014**: modern-looking mesh, but only zipped `.sim.hdf5` solver output — no
+  loose feature/vol files, so the VTK path has nothing to read.
+- **≥ ~2015**: modern `membrane elements` schema. 2D columns:
+  `index, level, i, j, x, y, normalX, normalY, volumeFraction, areaFraction,
+  membraneId, cornerPhaseMask`; 3D adds `k`, `z`, `normalZ`. Note: even a
+  2015-era set (boris/SimID_96785812, which has mesh + loose vol files at
+  t=0/50/100) still failed inside `org.vcell.vis`'s Chombo dataset reader with an
+  NPE ("Cannot read the array length because <local9> is null") — there is at
+  least one more schema gap in that era that was not diagnosed.
+- **Legacy post-processing files** use a statistic named `mean`, which the current
+  `Hdf5PostProcessor.StatisticType.fromName` rejects (`No Statistic with name mean`)
+  and which aborts *unrelated* data access for the run. Workaround when reading
+  legacy runs: move `SimID_<key>_<job>_.hdf5` aside (or extend the enum).
+
+### Reading requires linux/amd64
+
+The Chombo readers go through the legacy native HDF5 library (`NativeLib.HDF5`),
+which cannot load on macOS arm64 (documented in `VtkMeshGenerator`). Practical
+recipe: run the reading code inside `ghcr.io/virtualcell/vcell-data:<tag>`
+(`--platform linux/amd64`), jars on classpath from `/usr/local/app/lib/*`, with
+`-Dvcell.installDir=/usr/local/app -Dvcell.primarySimdatadir.internal=<mount>
+-Dvcell.python.executable=/usr/local/bin/python -Dvcell.vtk.pythonDir=/usr/local/app/pythonVtk`.
+
+## 4. VTK / field-viewer pipeline for Chombo results
+
+- Transport is the same VTU seam used for MovingBoundary (`VCDataManager`:
+  `getVtuTimes`, `getEmptyVtuMeshFiles(vcdID, timeIndex)`, `getVtuVarInfos`,
+  `getVtuMeshData`) — no interface changes. The distinction is
+  `FieldViewerServer.VtuMode`: Chombo is **STATIC** (one mesh for all times;
+  `getEmptyVtuMeshFiles` must be called with `timeIndex = 0`), MovingBoundary is
+  **TIME_VARYING** (mesh per time index). Detection: `getMesh() instanceof
+  CartesianMeshChombo` vs `CartesianMeshMovingBoundary`.
+- The Python VTK service (`pythonVtk/python_vtk/vtkService/vtkService.py`,
+  `writeChomboVolumeVtkGridAndIndexData`) converts Chombo cut cells (irregular
+  polyhedra) to tetrahedra and emits ordinal `chomboVolumeIndices` pairing data
+  values to cells — 2D: polygons; 3D: **voxels first, then tets**. So a 3D Chombo
+  VTU is a mixed-cell grid: `VTK_VOXEL` (11) interior + `VTK_TETRA` (10) at the
+  embedded boundary; 2D mixes triangle/quad/polygon.
+- VTU files are written single-piece, LittleEndian, binary **uncompressed**
+  (`SetCompressorTypeToNone` + `SetDataModeToBinary`), UInt32 headers, inline
+  base64 — exactly what `org.vcell.client.viz.VtuGridParser` parses (unit-tested
+  against a reference file).
+- The viewer renders mixed-cell VTUs via per-cell `insertNextCell(type, npts, ids)`
+  (verified marshalled in vtk.wasm ≥ v1.2.0) in "bodyFitted" mode: no deform/smooth,
+  the solver mesh is shown as computed.
+
+## 5. Known real datasets (dev cluster `/simdata`, for future resurrection work)
+
+| Dataset | Era | Notes |
+|---|---|---|
+| `boris/SimID_96785812_0_` | ~2015, 3D | modern mesh schema + loose feature/vol files at t-index 0/50/100; still trips the undiagnosed `org.vcell.vis` reader NPE |
+| `boris/SimID_85735024_0_`, `SimID_78363520_0_` | 2011–2014 | old membrane-element schema and/or zipped-only solver output — not readable |
+| `schaff/SimID_1058*/1059*/106104475` (105x series) | 2017, **2D** | modern schema, plenty of loose vol files — best 2D candidates |
+
+The cleanest path to a *test fixture*, once the solver is buildable again, is not
+these archives but a fresh local run of the small sims in BioModel 276459600.

--- a/docs/chombo-solver-notes.md
+++ b/docs/chombo-solver-notes.md
@@ -5,6 +5,27 @@ Working notes gathered while adding Chombo support to the VTK-based field viewer
 no deployed image or solver bundle can *run* it (details below). This document
 records what is needed to read its output today and to resurrect the solver later.
 
+> **2026-08-11 update — it builds and runs from source.** `VCellChombo3D_x64` built from
+> vcell-solvers master (macOS arm64, homebrew gcc + HDF5 2.1.0) ran the "chombo 3d" sim of
+> BioModel 276459600 to completion locally, producing modern-format output end-to-end through
+> the VTK seam. Recipe: symlink the binary into `localsolvers/mac64/`, generate
+> `.fvinput`/`.functions`/`..._0__0.simtask.xml` via `FVSolverStandalone` from the VCML, then run
+> `VCellChombo3D_x64 <fvinput>` (serial mode writes everything; no `-ccd` pass needed). A
+> self-contained input+expected-output package for a Java-free vcell-solvers unit test lives at
+> `/tmp/chombo-local/` (see its README). Four defects found on the way:
+>
+> 1. **`ChomboScheduler::writeData` buffer overflow** (vcell-solvers): the per-time output path is
+>    sprintf'd into `char hdf5FileName[128]`; a long base directory silently creates the file at a
+>    truncated path and the follow-up `H5Fopen` aborts. Run in a short directory until fixed.
+> 2. **`VtkServicePython` passed the output directory where the .vtu path belongs** (since July
+>    2023) — server-side Chombo/FV/comsol VTU generation was silently broken. Fixed in PR #1893.
+> 3. **`Hdf5PostProcessor` rejects statistic name `mean`** — written by *today's* solver, not just
+>    legacy archives — and aborts all data access for the run (issue #1894).
+> 4. **Chombo .vtu files are in doubled-index coordinates**, not microns: `ChomboMeshMapping`
+>    maps vertices to `(p-origin)*N/extent*2 - 1` (exact integers, a VisIt-era convention).
+>    Consumers must invert this (`p = origin + (v+1)*extent/(2N)`); the field viewer does so in
+>    `FieldViewerServer.chomboToPhysical`.
+
 ## 1. Current availability (as of 2026-08)
 
 - **Source still exists**: `virtualcell/vcell-solvers` repo, directories

--- a/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
@@ -44,8 +44,8 @@ import cbit.vcell.simdata.DataIdentifier;
 import cbit.vcell.simdata.OutputContext;
 import cbit.vcell.simdata.SimDataBlock;
 import cbit.vcell.simdata.VCDataManager;
+import cbit.vcell.solvers.CartesianMeshChombo;
 import cbit.vcell.solvers.CartesianMeshMovingBoundary;
-import cbit.vcell.solvers.mb.MovingBoundaryReader;
 import cbit.vcell.solver.AnnotatedFunction;
 import cbit.vcell.solver.VCSimulationDataIdentifier;
 
@@ -112,8 +112,9 @@ public final class FieldViewerServer {
 		final SubdomainInfo subdomainInfo;
 		/** Human-readable name of the run, e.g. "model::app::sim"; may be null — the ID always exists, a name may not. */
 		final String simName;
-		/** Lazily detected: MovingBoundary runs serve per-timestep body-fitted meshes via the VTU seam. */
-		volatile Boolean movingBoundary;
+		/** Lazily detected; non-null for runs served through the VTU seam (see {@link VtuMode}). */
+		volatile VtuMode vtuMode;
+		volatile boolean vtuModeResolved;
 		volatile VtuVarInfo[] vtuVarInfos;
 
 		DataSource(VCSimulationDataIdentifier vcdID, VCDataManager dataManager, SubdomainInfo subdomainInfo,
@@ -126,18 +127,30 @@ public final class FieldViewerServer {
 	}
 
 	/**
-	 * Whether this run is a MovingBoundary (mbsolver) run. Detected from the mesh type the data
-	 * manager returns rather than from the simulation, so it works identically for a re-opened
-	 * remote run where only the data still exists. MovingBoundary is a server-only solver, so this
-	 * path always reaches the data over the same remote {@link VCDataManager} seam.
+	 * Runs served through the VTU-era {@link VCDataManager} seam rather than the raw Cartesian
+	 * path: body-fitted meshes the solver itself produced. MovingBoundary meshes change per saved
+	 * time; Chombo (retired solver, but its stored solutions remain viewable) has one static mesh
+	 * with per-time values.
 	 */
-	private static boolean isMovingBoundary(DataSource source) throws Exception {
-		Boolean mb = source.movingBoundary;
-		if (mb == null) {
-			mb = source.dataManager.getMesh(source.vcdID) instanceof CartesianMeshMovingBoundary;
-			source.movingBoundary = mb;
+	private enum VtuMode {
+		TIME_VARYING, // MovingBoundary: a different geometry at every saved time
+		STATIC // Chombo: one embedded-boundary mesh, values vary over time
+	}
+
+	/**
+	 * Detected from the mesh type the data manager returns rather than from the simulation, so it
+	 * works identically for a re-opened remote run where only the data still exists. Both solvers
+	 * are server-only, so these paths always reach the data over the remote seam, where the
+	 * server-side Python VTK service that writes the .vtu is available.
+	 */
+	private static VtuMode vtuMode(DataSource source) throws Exception {
+		if (!source.vtuModeResolved) {
+			Object mesh = source.dataManager.getMesh(source.vcdID);
+			source.vtuMode = mesh instanceof CartesianMeshMovingBoundary ? VtuMode.TIME_VARYING
+					: mesh instanceof CartesianMeshChombo ? VtuMode.STATIC : null;
+			source.vtuModeResolved = true;
 		}
-		return mb;
+		return source.vtuMode;
 	}
 
 	private static VtuVarInfo[] vtuVarInfos(DataSource source) throws Exception {
@@ -324,8 +337,9 @@ public final class FieldViewerServer {
 	private static String handleInfo(HttpExchange ex) throws Exception {
 		DataSource source = sourceFor(query(ex));
 		VCSimulationDataIdentifier vcdID = source.vcdID;
-		if (isMovingBoundary(source)) {
-			return handleInfoMovingBoundary(source);
+		VtuMode vtuMode = vtuMode(source);
+		if (vtuMode != null) {
+			return handleInfoVtu(source, vtuMode);
 		}
 
 		double[] times = source.dataManager.getDataSetTimes(vcdID);
@@ -377,8 +391,9 @@ public final class FieldViewerServer {
 	private static String handleGrid(HttpExchange ex) throws Exception {
 		Map<String, String> q = query(ex);
 		DataSource source = sourceFor(q);
-		if (isMovingBoundary(source)) {
-			return handleGridMovingBoundary(source, q);
+		VtuMode gridVtuMode = vtuMode(source);
+		if (gridVtuMode != null) {
+			return handleGridVtu(source, q, gridVtuMode);
 		}
 		String domain = domainOf(q, source);
 		VisMesh visMesh = grid(source, domain);
@@ -444,7 +459,7 @@ public final class FieldViewerServer {
 	 * JSON contract; the geometryId carries the time index, which is what tells the viewer to
 	 * re-fetch geometry as time moves.
 	 */
-	private static String handleInfoMovingBoundary(DataSource source) throws Exception {
+	private static String handleInfoVtu(DataSource source, VtuMode mode) throws Exception {
 		VCSimulationDataIdentifier vcdID = source.vcdID;
 		double[] times = source.dataManager.getDataSetTimes(vcdID);
 		StringBuilder sb = new StringBuilder(1024);
@@ -455,8 +470,15 @@ public final class FieldViewerServer {
 		sb.append(",\"jobIndex\":").append(vcdID.getJobIndex());
 		sb.append(",\"times\":");
 		appendDoubles(sb, times, times.length);
-		String domain = MovingBoundaryReader.getFakeInsideDomainName();
-		sb.append(",\"domains\":[\"").append(jsonEscape(domain)).append("\"]");
+		List<String> domains = vtuDomains(source);
+		sb.append(",\"domains\":[");
+		for (int i = 0; i < domains.size(); i++) {
+			if (i > 0) {
+				sb.append(',');
+			}
+			sb.append('"').append(jsonEscape(domains.get(i))).append('"');
+		}
+		sb.append("]");
 		sb.append(",\"variables\":[");
 		boolean first = true;
 		for (VtuVarInfo var : vtuVarInfos(source)) {
@@ -468,11 +490,29 @@ public final class FieldViewerServer {
 			}
 			first = false;
 			sb.append("{\"name\":\"").append(jsonEscape(var.name)).append('"');
-			sb.append(",\"domain\":\"").append(jsonEscape(domain)).append('"');
+			sb.append(",\"domain\":\"").append(jsonEscape(var.domainName == null ? "" : var.domainName)).append('"');
 			sb.append(",\"isFunction\":").append(var.functionExpression != null).append('}');
 		}
 		sb.append("]}");
 		return sb.toString();
+	}
+
+	/** Distinct domains of the run's cell-data variables, in first-seen order. */
+	private static List<String> vtuDomains(DataSource source) throws Exception {
+		List<String> domains = new ArrayList<>();
+		for (VtuVarInfo var : vtuVarInfos(source)) {
+			if (var.bMeshVariable || var.dataType != VtuVarInfo.DataType.CellData) {
+				continue;
+			}
+			if (var.domainName != null && !domains.contains(var.domainName)) {
+				domains.add(var.domainName);
+			}
+		}
+		if (domains.isEmpty()) {
+			throw new IllegalArgumentException("run " + source.vcdID.getID()
+					+ " exposes no cell-data variables over the VTU seam");
+		}
+		return domains;
 	}
 
 	/** Snaps the requested time to the nearest saved index; defaults to the last one. */
@@ -495,8 +535,9 @@ public final class FieldViewerServer {
 		return best;
 	}
 
-	private static String mbGeometryId(DataSource source, String domain, int timeIndex) {
-		return source.vcdID.getID() + "/" + domain + "@t" + timeIndex;
+	private static String vtuGeometryId(DataSource source, String domain, VtuMode mode, int timeIndex) {
+		String base = source.vcdID.getID() + "/" + domain;
+		return mode == VtuMode.TIME_VARYING ? base + "@t" + timeIndex : base;
 	}
 
 	/** Parsed per-time meshes; a run's meshes are dropped with it in {@link #unregister}. */
@@ -504,7 +545,8 @@ public final class FieldViewerServer {
 
 	private static synchronized VtuGridParser.VtuGrid mbGrid(DataSource source, String domain,
 			int timeIndex) throws Exception {
-		String key = mbGeometryId(source, domain, timeIndex);
+		// internal cache key is always time-qualified; the public geometryId may not be
+		String key = source.vcdID.getID() + "/" + domain + "@t" + timeIndex;
 		VtuGridParser.VtuGrid cached = mbGridCache.get(key);
 		if (cached != null) {
 			return cached;
@@ -522,22 +564,43 @@ public final class FieldViewerServer {
 				+ container.vtuMeshes.stream().map(m -> m.domainName).toList());
 	}
 
-	private static String handleGridMovingBoundary(DataSource source, Map<String, String> q) throws Exception {
+	private static String handleGridVtu(DataSource source, Map<String, String> q, VtuMode mode) throws Exception {
 		String domain = q.getOrDefault("domain", "");
 		if (domain.isEmpty()) {
-			domain = MovingBoundaryReader.getFakeInsideDomainName();
+			domain = vtuDomains(source).get(0);
 		}
-		int timeIndex = timeIndexFor(source, q);
+		// a Chombo mesh is static — the server refuses any other index — while a MovingBoundary
+		// mesh is a different geometry at every saved time
+		int timeIndex = mode == VtuMode.TIME_VARYING ? timeIndexFor(source, q) : 0;
 		VtuGridParser.VtuGrid grid = mbGrid(source, domain, timeIndex);
 
+		boolean threeD = false;
+		boolean uniform = true;
+		for (int c = 0; c < grid.cellTypes.length; c++) {
+			// tets (10), voxels (11), hexes (12), wedges (13), pyramids (14) are volume cells
+			threeD |= grid.cellTypes[c] >= 10 && grid.cellTypes[c] <= 14;
+			uniform &= grid.cellTypes[c] == grid.cellTypes[0];
+		}
 		StringBuilder sb = new StringBuilder(32 * grid.numPoints() + 32 * grid.cells.length + 512);
-		sb.append("{\"geometryId\":\"").append(jsonEscape(mbGeometryId(source, domain, timeIndex))).append('"');
-		sb.append(",\"dimension\":2,\"bodyFitted\":true");
+		sb.append("{\"geometryId\":\"").append(jsonEscape(vtuGeometryId(source, domain, mode, timeIndex))).append('"');
+		sb.append(",\"dimension\":").append(threeD ? 3 : 2).append(",\"bodyFitted\":true");
 		sb.append(",\"timeIndex\":").append(timeIndex);
 		sb.append(",\"numPoints\":").append(grid.numPoints());
 		sb.append(",\"points\":");
 		appendDoubles(sb, grid.points, grid.points.length);
 		sb.append(",\"cellType\":").append(grid.cellTypes.length > 0 ? grid.cellTypes[0] : 7);
+		if (!uniform) {
+			// Chombo 3D mixes voxels with tetrahedra (converted cut polyhedra); the viewer inserts
+			// per-cell types when this array is present
+			sb.append(",\"cellTypes\":[");
+			for (int c = 0; c < grid.cellTypes.length; c++) {
+				if (c > 0) {
+					sb.append(',');
+				}
+				sb.append(grid.cellTypes[c]);
+			}
+			sb.append(']');
+		}
 		sb.append(",\"cells\":[");
 		for (int c = 0; c < grid.cells.length; c++) {
 			if (c > 0) {
@@ -558,14 +621,14 @@ public final class FieldViewerServer {
 		return sb.toString();
 	}
 
-	private static String handleFieldMovingBoundary(DataSource source, Map<String, String> q) throws Exception {
+	private static String handleFieldVtu(DataSource source, Map<String, String> q, VtuMode mode) throws Exception {
 		String varName = q.get("var");
 		if (varName == null || varName.isEmpty()) {
 			throw new IllegalArgumentException("missing required query parameter 'var'");
 		}
 		String domain = q.getOrDefault("domain", "");
 		if (domain.isEmpty()) {
-			domain = MovingBoundaryReader.getFakeInsideDomainName();
+			domain = vtuDomains(source).get(0);
 		}
 		int timeIndex = timeIndexFor(source, q);
 		double[] times = source.dataManager.getDataSetTimes(source.vcdID);
@@ -597,7 +660,7 @@ public final class FieldViewerServer {
 			max = 0;
 		}
 		StringBuilder sb = new StringBuilder(16 * values.length + 256);
-		sb.append("{\"geometryId\":\"").append(jsonEscape(mbGeometryId(source, domain, timeIndex))).append('"');
+		sb.append("{\"geometryId\":\"").append(jsonEscape(vtuGeometryId(source, domain, mode, timeIndex))).append('"');
 		sb.append(",\"name\":\"").append(jsonEscape(varName)).append('"');
 		sb.append(",\"domain\":\"").append(jsonEscape(domain)).append('"');
 		sb.append(",\"time\":").append(time);
@@ -621,8 +684,9 @@ public final class FieldViewerServer {
 	private static String handleField(HttpExchange ex) throws Exception {
 		Map<String, String> q = query(ex);
 		DataSource source = sourceFor(q);
-		if (isMovingBoundary(source)) {
-			return handleFieldMovingBoundary(source, q);
+		VtuMode fieldVtuMode = vtuMode(source);
+		if (fieldVtuMode != null) {
+			return handleFieldVtu(source, q, fieldVtuMode);
 		}
 		String domain = domainOf(q, source);
 		String varName = q.get("var");
@@ -676,11 +740,11 @@ public final class FieldViewerServer {
 	private static String handleTimeSeries(HttpExchange ex) throws Exception {
 		Map<String, String> q = query(ex);
 		DataSource source = sourceFor(q);
-		if (isMovingBoundary(source)) {
-			// per-cell ordinals are not stable across time on a moving mesh; needs a
+		if (vtuMode(source) != null) {
+			// per-cell ordinals are per-mesh, not solver raster indices; needs a
 			// spatial-point formulation (#1879 follow-up)
 			throw new IllegalArgumentException(
-					"not yet supported for MovingBoundary runs");
+					"not yet supported for MovingBoundary/Chombo runs");
 		}
 		String domain = domainOf(q, source);
 		String varName = q.get("var");
@@ -736,11 +800,11 @@ public final class FieldViewerServer {
 	private static String handleStats(HttpExchange ex) throws Exception {
 		Map<String, String> q = query(ex);
 		DataSource source = sourceFor(q);
-		if (isMovingBoundary(source)) {
-			// per-cell ordinals are not stable across time on a moving mesh; needs a
+		if (vtuMode(source) != null) {
+			// per-cell ordinals are per-mesh, not solver raster indices; needs a
 			// spatial-point formulation (#1879 follow-up)
 			throw new IllegalArgumentException(
-					"not yet supported for MovingBoundary runs");
+					"not yet supported for MovingBoundary/Chombo runs");
 		}
 		DataIdentifier[] ids = source.dataManager.getDataIdentifiers(emptyOutputContext(), source.vcdID);
 		Set<String> requested = null;

--- a/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
@@ -555,6 +555,9 @@ public final class FieldViewerServer {
 		for (VtuFileContainer.VtuMesh mesh : container.vtuMeshes) {
 			if (mesh.domainName.equals(domain)) {
 				VtuGridParser.VtuGrid grid = VtuGridParser.parse(mesh.vtuMeshContents);
+				if (vtuMode(source) == VtuMode.STATIC) {
+					grid = chomboToPhysical(grid, source);
+				}
 				mbGridCache.put(key, grid);
 				return grid;
 			}
@@ -562,6 +565,30 @@ public final class FieldViewerServer {
 		throw new IllegalArgumentException("no VTU mesh for domain '" + domain + "' at time index "
 				+ timeIndex + "; this run has "
 				+ container.vtuMeshes.stream().map(m -> m.domainName).toList());
+	}
+
+	/**
+	 * A Chombo .vtu carries {@code ChomboMeshMapping}'s doubled-index coordinates — vertex
+	 * {@code v = (p-origin)*N/extent*2 - 1}, chosen there so mesh vertices land on exact integers —
+	 * not physical coordinates (a legacy of the VisIt-era consumers). Everything the viewer does
+	 * with the mesh (axes, lab-frame points, cell measures) needs microns, so invert that map as
+	 * the mesh comes over the seam: {@code p = origin + (v+1)*extent/(2N)}.
+	 */
+	private static VtuGridParser.VtuGrid chomboToPhysical(VtuGridParser.VtuGrid grid,
+			DataSource source) throws Exception {
+		cbit.vcell.solvers.CartesianMesh mesh =
+				(cbit.vcell.solvers.CartesianMesh) source.dataManager.getMesh(source.vcdID);
+		double[] origin = { mesh.getOrigin().getX(), mesh.getOrigin().getY(), mesh.getOrigin().getZ() };
+		double[] extent = { mesh.getExtent().getX(), mesh.getExtent().getY(), mesh.getExtent().getZ() };
+		int[] n = { mesh.getSizeX(), mesh.getSizeY(), mesh.getSizeZ() };
+		double[] physical = new double[grid.points.length];
+		for (int i = 0; i < grid.points.length; i++) {
+			int axis = i % 3;
+			physical[i] = n[axis] > 1
+					? origin[axis] + (grid.points[i] + 1) * extent[axis] / (2.0 * n[axis])
+					: grid.points[i];
+		}
+		return new VtuGridParser.VtuGrid(physical, grid.cells, grid.cellTypes);
 	}
 
 	private static String handleGridVtu(DataSource source, Map<String, String> q, VtuMode mode) throws Exception {

--- a/webapp-viewer/probe.html
+++ b/webapp-viewer/probe.html
@@ -32,6 +32,19 @@ try {
   for (const name of ['vtkContourTriangulator', 'vtkDelaunay2D']) {
     try { vtk[name](); log(`${name}: constructible`); } catch (e) { log(`${name}: FAILED — ${e?.message ?? e}`); }
   }
+  // mixed-cell insertion (Chombo: voxels + tets in one grid)
+  try {
+    const ug = vtk.vtkUnstructuredGrid();
+    const pts = vtk.vtkPoints();
+    await pts.setNumberOfPoints(9);
+    const coords = [[0,0,0],[1,0,0],[0,1,0],[1,1,0],[0,0,1],[1,0,1],[0,1,1],[1,1,1],[2,0,0]];
+    for (let i = 0; i < 9; i++) await pts.setPoint(i, ...coords[i]);
+    await ug.setPoints(pts);
+    await ug.insertNextCell(11, 8, [0,1,2,3,4,5,6,7]); // VTK_VOXEL
+    await ug.insertNextCell(10, 4, [1,8,3,5]);          // VTK_TETRA
+    const n = await ug.getNumberOfCells();
+    log(`mixed insertNextCell: ${n === 2 ? 'OK (2 cells)' : 'WRONG count ' + n}`);
+  } catch (e) { log('mixed insertNextCell: FAILED — ' + (e?.message ?? e)); }
   // --- deformed-grid feasibility probes ---
   try {
     log('session keys: ' + Object.keys(session).join(','));

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -219,13 +219,14 @@ async function loadGeometry() {
   return geometry;
 }
 
-async function loadField() {
+async function loadField(allowMismatch = false) {
   const time = state.times[state.timeIndex];
   const field = await fetchJson(
     url('/field', { domain: state.selectedDomain, var: state.selectedVar, time: String(time) }), '/field');
   // values are only meaningful against the geometry they were computed for; pairing them with a
-  // different one would draw something silently wrong rather than obviously broken
-  if (state.geometryId && field.geometryId !== state.geometryId) {
+  // different one would draw something silently wrong rather than obviously broken. The
+  // body-fitted scrub path passes allowMismatch and treats a mismatch as "rebuild the geometry".
+  if (!allowMismatch && state.geometryId && field.geometryId !== state.geometryId) {
     throw new Error(`field is for geometry ${field.geometryId} but the view holds ${state.geometryId}`);
   }
   el.dataReadout.textContent =
@@ -404,11 +405,18 @@ async function buildGrid(geometry, field) {
   await points.setNumberOfPoints(geometry.numPoints);
   const P = geometry.points;
   for (let i = 0; i < geometry.numPoints; i++) await points.setPoint(i, P[3 * i], P[3 * i + 1], P[3 * i + 2]);
-  const cellArray = vtk.vtkCellArray();
-  for (const cell of geometry.cells) await cellArray.insertNextCell(cell.length, cell);
   const ug = vtk.vtkUnstructuredGrid();
   await ug.setPoints(points);
-  await ug.setCells(geometry.cellType, cellArray); // single cell type (VTK_VOXEL)
+  if (geometry.cellTypes) {
+    // mixed cell types (Chombo: regular voxels + tetrahedra from cut polyhedra)
+    for (let c = 0; c < geometry.cells.length; c++) {
+      await ug.insertNextCell(geometry.cellTypes[c], geometry.cells[c].length, geometry.cells[c]);
+    }
+  } else {
+    const cellArray = vtk.vtkCellArray();
+    for (const cell of geometry.cells) await cellArray.insertNextCell(cell.length, cell);
+    await ug.setCells(geometry.cellType, cellArray); // single cell type
+  }
 
   fieldArray = null;
   if (field) {
@@ -1070,9 +1078,34 @@ el.time.addEventListener('input', () => {
 });
 el.time.addEventListener('change', () => {
   state.timeIndex = Number(el.time.value);
-  // a body-fitted mesh is a different geometry at each time; keep the camera where the user put it
-  void (state.bodyFitted ? rebuildGeometry(false) : refreshField());
+  void (state.bodyFitted ? refreshTimeStep() : refreshField());
 });
+
+/**
+ * Body-fitted time step: fetch the field first and let its geometryId decide. A static mesh
+ * (Chombo) matches and only the colors change; a per-time mesh (MovingBoundary) differs and the
+ * geometry is rebuilt — with the camera kept where the user put it.
+ */
+async function refreshTimeStep() {
+  if (!state.ready || state.busy || !state.dataset) return;
+  state.busy = true;
+  const t0 = performance.now();
+  try {
+    const field = await loadField(true);
+    if (field.geometryId !== state.geometryId) {
+      const geometry = await loadGeometry();
+      await buildGrid(geometry, field);
+    } else {
+      await applyField(field);
+    }
+    await renderWindow.render();
+    setStatus(`${describe()} ✓ (${Math.round(performance.now() - t0)} ms)`);
+  } catch (e) {
+    setStatus('time step failed: ' + (e?.message ?? e), true);
+  } finally {
+    state.busy = false;
+  }
+}
 el.variable.addEventListener('change', () => {
   const chosen = state.variables.find((v) => v.name === el.variable.value);
   if (!chosen || state.busy) return;

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -89,7 +89,8 @@ let vtk = null;
 let surfSource = null; // raw-boundary extractor feeding the smoother (passThroughPointIds on)
 let sinc = null;
 let deform = null; // vtkVCellDeformGridToSurface: writes the sinc'd points back into the grid
-let tableClip = null; // the cut plane, when active: clips the DEFORMED grid
+let tableClip = null; // the cut plane, when active: clips the DEFORMED grid (or the raw body-fitted mesh)
+let currentUg = null; // the body-fitted solver mesh, for rewiring geomFilter when the crop toggles
 let geomFilter = null; // display boundary extractor (deformed or clipped-deformed grid)
 let integ = null; // vtkIntegrateAttributes for display-mesh statistics (null if unavailable)
 let mapper = null;
@@ -431,8 +432,10 @@ async function buildGrid(geometry, field) {
     fieldArray = arr;
   }
   if (state.bodyFitted) {
-    // MovingBoundary: the mesh IS the solver's body-fitted geometry — no smoothing, no deform,
-    // no crop; the display shows it exactly as computed
+    // body-fitted: the mesh IS the solver's geometry — no smoothing, no deform; the crop clips
+    // this mesh directly, so a cut exposes the solver's own interior cells (voxels and cut tets)
+    currentUg = ug;
+    await tableClip.setInputData(ug);
     await geomFilter.setInputData(ug);
   } else {
     // the raw grid feeds the smoothing chain and the deform filter; everything the user sees
@@ -467,10 +470,13 @@ async function buildGrid(geometry, field) {
  */
 async function applyCrop() {
   if (!tableClip) return;
-  if (state.bodyFitted) return; // geomFilter is fed the solver mesh directly in buildGrid
   const axis = state.sliceAxis;
   if (axis < 0) {
-    await geomFilter.setInputConnection(await deform.getOutputPort());
+    if (state.bodyFitted) {
+      if (currentUg) await geomFilter.setInputData(currentUg);
+    } else {
+      await geomFilter.setInputConnection(await deform.getOutputPort());
+    }
     el.sliceReadout.textContent = '';
     el.cropStats.textContent = '';
     return;
@@ -536,7 +542,8 @@ async function updateCropStats() {
       + (mean != null && Number.isFinite(mean) ? `mean ${mean.toExponential(3)} · ` : '')
       + `max ${range[1].toExponential(3)}`
       + (volume != null && Number.isFinite(volume) ? ` · volume ${volume.toExponential(3)}` : '')
-      + ` (smoothing ${p.iterations} iters · pass-band ${formatPassBand(p.passBand)})`;
+      + (state.bodyFitted ? ' (body-fitted solver mesh)'
+        : ` (smoothing ${p.iterations} iters · pass-band ${formatPassBand(p.passBand)})`);
   } catch (e) {
     console.warn('display-mesh stats failed', e);
     el.cropStats.textContent = '';
@@ -1265,7 +1272,7 @@ el.smoothingReset.addEventListener('click', () => {
     el.smoothing.disabled = state.bodyFitted;
     el.colorbar.disabled = false;
     el.axes.disabled = false;
-    el.sliceAxis.disabled = state.bodyFitted;
+    el.sliceAxis.disabled = false; // body-fitted 3D included: the crop clips the solver mesh
     el.statsBtn.disabled = false;
     if (state.bodyFitted) {
       el.smoothingReadout.textContent = 'body-fitted solver mesh — shown as computed';


### PR DESCRIPTION
Adds Chombo solutions (both 2D and 3D chombo solvers — retired, but their stored results remain viewable) to the field viewer through the same VTU seam as MovingBoundary (#1879 / PR #1883), with one new distinction: `VtuMode.STATIC` (one embedded-boundary mesh, values vary per time) vs `TIME_VARYING` (a mesh per saved time). The scrub is geometryId-driven: the viewer refetches geometry only when the field's geometryId differs from the one on screen, so a static mesh ships once.

**The evidence below is REAL Chombo geometry** — not a mock. It comes from a fresh local run of BioModel 276459600 ("Solver_Suite_7_5", app "3D chombo", sim "chombo 3d": an 8×8×8 embedded-boundary sphere), executed with a from-source `VCellChombo3D_x64` build, read back through the actual `getEmptyVtuMeshFiles`/`getVtuMeshData` seam (Python VTK service included), and replayed byte-for-byte through this PR's viewer.

| real EB surface (RanC_nuc) | hemisphere after z-cut | face-on cross-section (fraction-0) |
|---|---|---|
| ![surface](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/29b112b3c8c0d15c8c83903cb6810716e1f00104/chombo-real-surface.png) | ![hemisphere](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/29b112b3c8c0d15c8c83903cb6810716e1f00104/chombo-real-cut-hemisphere.png) | ![cut face](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/29b112b3c8c0d15c8c83903cb6810716e1f00104/chombo-real-cut-face.png) |

The cross-section is the embedded-boundary structure itself: whole voxels (fraction-0 = 1) inside, cut tetrahedra at the rim with their true partial volumes, a flat sharp cut, and no incorrect tet slices — the cut face tessellates the disk with no holes or overlaps. Consistency check: the mesh's integrated volume is 255.5 vs the analytic sphere's ≈248 (8³ resolution), and the mid-plane clip halves it exactly (127.7).

**Read the stray triangles in the first screenshot as a real mesh defect, not a rendering artifact — see #1895.** The cut face above tessellates cleanly, but the *volume mesh's boundary surface* does not: `ChomboMeshMapping.cropVoxels` clips each voxel independently against its own membrane facet plane, so neighbouring facets are never required to meet. The EB surface has 168 open edges (144 hairline seams 0.025 wide, plus a ~0.9 × 0.9 hole at each of the six poles), and 464 of the 1422 extracted surface faces are interior grid-plane walls exposed by tessellation mismatch — a full voxel's quad against a cut neighbour's two triangles. Through a pole hole you see one of those walls, coloured by its own cell's value; that is the bright green/cyan triangle. Verified as *not* the cause: coordinates and scale (raw doubled-index −1…15 → 0…10 exactly), volume consistency (Σ cell volume 255.45 vs Σ fraction·dx³ 256.41), and the mixed-cell reconstruction itself (zero inverted, degenerate or sliver tets, zero T-junctions, zero VTK_VOXEL corner-order violations). Volume-integrated statistics are unaffected. The defect predates this PR — it is the Chombo → VisMesh path, which the viewer renders faithfully.

### What landed since the hold

- **Physical coordinates**: a Chombo .vtu carries `ChomboMeshMapping`'s doubled-index coordinates (a VisIt-era convention). `chomboToPhysical` inverts that map as the mesh crosses the seam, so axes, lab-frame points and cell measures are microns.
- **Cut plane on body-fitted meshes**: the crop clips the solver mesh directly (no deform involved), exposing the solver's own interior cells; crop stats are labeled "body-fitted solver mesh".
- **Merged master**, generalizing #1891's lab-frame `/timeseries` and moving-domain `/stats` to VTU mode: STATIC locates the lab point once and reuses cell measures across times; the lab point gains an optional `z` for 3D.
- Mixed-cell VTUs (VTK_VOXEL + VTK_TETRA) render via per-cell `insertNextCell` (probed as marshalled in vtk.wasm ≥ v1.2.0).

### Dependencies / found along the way

- **Requires #1893** for the live server path: `VtkServicePython` has passed the output *directory* where the Python VTK service expects the .vtu *path* since July 2023, so server-side Chombo VTU generation was silently broken. (MovingBoundary was unaffected — its VTU writer is pure Java.)
- The chombo solver itself is not currently shipped anywhere (binaries absent from solver bundles and vcell-batch; see `docs/chombo-solver-notes.md` on this branch). This PR only needs the stored-data reading path.
- Legacy post-processing files (statistic name "mean") still abort unrelated data access in `Hdf5PostProcessor` — including for output written by today's solver; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

