### PR TITLE
Field viewer: lab-frame point plots and moving-domain statistics for MovingBoundary runs

### DIFF
--- a/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/FieldViewerServer.java
@@ -571,16 +571,7 @@ public final class FieldViewerServer {
 		double[] times = source.dataManager.getDataSetTimes(source.vcdID);
 		double time = times[timeIndex];
 
-		VtuVarInfo varInfo = null;
-		for (VtuVarInfo v : vtuVarInfos(source)) {
-			if (v.name.equals(varName)) {
-				varInfo = v;
-				break;
-			}
-		}
-		if (varInfo == null) {
-			throw new IllegalArgumentException("unknown variable '" + varName + "'");
-		}
+		VtuVarInfo varInfo = vtuVarInfoFor(source, varName);
 		// the VTU seam's contract: values are ordered by the same sequential inside-cell ordinal
 		// the mesh's cells were written in, so values[i] belongs to cells[i] of the SAME timeIndex
 		double[] values = source.dataManager.getVtuMeshData(emptyOutputContext(), source.vcdID, varInfo, time);
@@ -604,6 +595,166 @@ public final class FieldViewerServer {
 		sb.append(",\"location\":\"cell\",\"values\":");
 		appendDoubles(sb, values, values.length);
 		sb.append(",\"range\":[").append(min).append(',').append(max).append("]}");
+		return sb.toString();
+	}
+
+	private static VtuVarInfo vtuVarInfoFor(DataSource source, String varName) throws Exception {
+		for (VtuVarInfo v : vtuVarInfos(source)) {
+			if (v.name.equals(varName)) {
+				return v;
+			}
+		}
+		throw new IllegalArgumentException("unknown variable '" + varName + "'");
+	}
+
+	/**
+	 * {@code /timeseries?sim=&job=&domain=&var=&x=&y=} for MovingBoundary runs — the variable's
+	 * time course at a fixed LAB-FRAME point. Cell ordinals are not stable across time on a moving
+	 * mesh, so the browser addresses a spatial point instead; each saved time locates that point in
+	 * THAT time's body-fitted mesh. Times where the point lies outside the domain (the boundary has
+	 * moved past it) serialize as {@code null} — a physically meaningful gap, not missing data.
+	 */
+	private static String handleTimeSeriesMovingBoundary(DataSource source, Map<String, String> q)
+			throws Exception {
+		String varName = q.get("var");
+		if (varName == null || varName.isEmpty()) {
+			throw new IllegalArgumentException("missing required query parameter 'var'");
+		}
+		String domain = q.getOrDefault("domain", "");
+		if (domain.isEmpty()) {
+			domain = MovingBoundaryReader.getFakeInsideDomainName();
+		}
+		if (q.get("x") == null || q.get("y") == null) {
+			throw new IllegalArgumentException(
+					"a MovingBoundary time series is addressed by lab-frame point: 'x' and 'y' are required"
+							+ " ('cell' ordinals are not stable on a moving mesh)");
+		}
+		double x = Double.parseDouble(q.get("x"));
+		double y = Double.parseDouble(q.get("y"));
+		VtuVarInfo varInfo = vtuVarInfoFor(source, varName);
+
+		double[] times = source.dataManager.getDataSetTimes(source.vcdID);
+		if (times == null || times.length == 0) {
+			throw new IllegalArgumentException("run " + source.vcdID.getID() + " has no saved times");
+		}
+		double[] values = new double[times.length];
+		int inside = 0;
+		for (int i = 0; i < times.length; i++) {
+			VtuGridParser.VtuGrid grid = mbGrid(source, domain, i);
+			int cell = VtuGridParser.locateCell(grid, x, y, 0);
+			if (cell < 0) {
+				values[i] = Double.NaN; // serializes as null: the domain has moved past the point
+				continue;
+			}
+			inside++;
+			values[i] = source.dataManager.getVtuMeshData(emptyOutputContext(), source.vcdID,
+					varInfo, times[i])[cell];
+		}
+
+		StringBuilder sb = new StringBuilder(32 * times.length + 256);
+		sb.append("{\"name\":\"").append(jsonEscape(varName)).append('"');
+		sb.append(",\"domain\":\"").append(jsonEscape(domain)).append('"');
+		sb.append(",\"x\":").append(x).append(",\"y\":").append(y);
+		sb.append(",\"insideCount\":").append(inside);
+		sb.append(",\"times\":");
+		appendDoubles(sb, times, times.length);
+		sb.append(",\"values\":");
+		appendDoubles(sb, values, values.length);
+		sb.append('}');
+		return sb.toString();
+	}
+
+	/**
+	 * {@code /stats?sim=&job=[&var=a,b,c]} for MovingBoundary runs — per saved time, min, max and
+	 * measure-weighted mean over that time's body-fitted mesh. The statistics follow the moving
+	 * domain: each frame integrates over the cells the domain actually occupies then, weighting
+	 * each cell by its area (the display-mesh statistics family — self-consistent with what is
+	 * drawn). Each series also carries the domain's total measure per time, the size of the moving
+	 * region itself.
+	 */
+	private static String handleStatsMovingBoundary(DataSource source, Map<String, String> q)
+			throws Exception {
+		String domain = MovingBoundaryReader.getFakeInsideDomainName();
+		Set<String> requested = null;
+		String varParam = q.get("var");
+		if (varParam != null && !varParam.isEmpty()) {
+			requested = new LinkedHashSet<>(Arrays.asList(varParam.split(",")));
+		}
+		List<VtuVarInfo> chosen = new ArrayList<>();
+		for (VtuVarInfo var : vtuVarInfos(source)) {
+			if (var.bMeshVariable || var.dataType != VtuVarInfo.DataType.CellData) {
+				continue;
+			}
+			if (requested == null || requested.contains(var.name)) {
+				chosen.add(var);
+			}
+		}
+		if (chosen.isEmpty()) {
+			throw new IllegalArgumentException("no cell-data variables match " + varParam);
+		}
+		double[] times = source.dataManager.getDataSetTimes(source.vcdID);
+		if (times == null || times.length == 0) {
+			throw new IllegalArgumentException("run " + source.vcdID.getID() + " has no saved times");
+		}
+
+		int nv = chosen.size();
+		double[][] mins = new double[nv][times.length];
+		double[][] maxs = new double[nv][times.length];
+		double[][] means = new double[nv][times.length];
+		double[] domainMeasure = new double[times.length];
+		for (int i = 0; i < times.length; i++) {
+			VtuGridParser.VtuGrid grid = mbGrid(source, domain, i);
+			double[] measures = VtuGridParser.cellMeasures(grid);
+			double total = 0;
+			for (double m : measures) {
+				total += m;
+			}
+			domainMeasure[i] = total;
+			for (int v = 0; v < nv; v++) {
+				double[] values = source.dataManager.getVtuMeshData(emptyOutputContext(),
+						source.vcdID, chosen.get(v), times[i]);
+				double min = Double.POSITIVE_INFINITY;
+				double max = Double.NEGATIVE_INFINITY;
+				double weighted = 0;
+				double weight = 0;
+				int n = Math.min(values.length, measures.length);
+				for (int c = 0; c < n; c++) {
+					if (Double.isNaN(values[c])) {
+						continue;
+					}
+					min = Math.min(min, values[c]);
+					max = Math.max(max, values[c]);
+					weighted += values[c] * measures[c];
+					weight += measures[c];
+				}
+				mins[v][i] = min <= max ? min : Double.NaN;
+				maxs[v][i] = min <= max ? max : Double.NaN;
+				means[v][i] = weight > 0 ? weighted / weight : Double.NaN;
+			}
+		}
+
+		StringBuilder sb = new StringBuilder(64 * times.length * nv + 512);
+		sb.append("{\"times\":");
+		appendDoubles(sb, times, times.length);
+		sb.append(",\"weighting\":\"measure\"");
+		sb.append(",\"series\":[");
+		for (int v = 0; v < nv; v++) {
+			if (v > 0) {
+				sb.append(',');
+			}
+			sb.append("{\"name\":\"").append(jsonEscape(chosen.get(v).name)).append('"');
+			sb.append(",\"domain\":\"").append(jsonEscape(domain)).append('"');
+			sb.append(",\"min\":");
+			appendDoubles(sb, mins[v], times.length);
+			sb.append(",\"max\":");
+			appendDoubles(sb, maxs[v], times.length);
+			sb.append(",\"mean\":");
+			appendDoubles(sb, means[v], times.length);
+			sb.append(",\"measure\":");
+			appendDoubles(sb, domainMeasure, times.length);
+			sb.append('}');
+		}
+		sb.append("]}");
 		return sb.toString();
 	}
 
@@ -677,10 +828,7 @@ public final class FieldViewerServer {
 		Map<String, String> q = query(ex);
 		DataSource source = sourceFor(q);
 		if (isMovingBoundary(source)) {
-			// per-cell ordinals are not stable across time on a moving mesh; needs a
-			// spatial-point formulation (#1879 follow-up)
-			throw new IllegalArgumentException(
-					"not yet supported for MovingBoundary runs");
+			return handleTimeSeriesMovingBoundary(source, q);
 		}
 		String domain = domainOf(q, source);
 		String varName = q.get("var");
@@ -737,10 +885,7 @@ public final class FieldViewerServer {
 		Map<String, String> q = query(ex);
 		DataSource source = sourceFor(q);
 		if (isMovingBoundary(source)) {
-			// per-cell ordinals are not stable across time on a moving mesh; needs a
-			// spatial-point formulation (#1879 follow-up)
-			throw new IllegalArgumentException(
-					"not yet supported for MovingBoundary runs");
+			return handleStatsMovingBoundary(source, q);
 		}
 		DataIdentifier[] ids = source.dataManager.getDataIdentifiers(emptyOutputContext(), source.vcdID);
 		Set<String> requested = null;

--- a/vcell-client/src/main/java/org/vcell/client/viz/VtuGridParser.java
+++ b/vcell-client/src/main/java/org/vcell/client/viz/VtuGridParser.java
@@ -42,6 +42,114 @@ final class VtuGridParser {
 		}
 	}
 
+	private static final int VTK_TRIANGLE = 5;
+	private static final int VTK_POLYGON = 7;
+	private static final int VTK_QUAD = 9;
+	private static final int VTK_TETRA = 10;
+	private static final int VTK_VOXEL = 11;
+
+	/**
+	 * Per-cell measure — area for in-plane 2D cells, volume for 3D cells — for volume-weighted
+	 * statistics over body-fitted meshes.
+	 */
+	static double[] cellMeasures(VtuGrid grid) {
+		double[] measures = new double[grid.cells.length];
+		for (int c = 0; c < grid.cells.length; c++) {
+			int[] cell = grid.cells[c];
+			double[] p = grid.points;
+			switch (grid.cellTypes[c]) {
+				case VTK_TRIANGLE, VTK_POLYGON, VTK_QUAD -> {
+					// shoelace over the in-plane polygon (z ignored)
+					double twiceArea = 0;
+					for (int v = 0; v < cell.length; v++) {
+						int a = cell[v];
+						int b = cell[(v + 1) % cell.length];
+						twiceArea += p[3 * a] * p[3 * b + 1] - p[3 * b] * p[3 * a + 1];
+					}
+					measures[c] = Math.abs(twiceArea) / 2;
+				}
+				case VTK_TETRA -> measures[c] = Math.abs(tripleProduct(p, cell[0], cell[1], cell[2], cell[3])) / 6;
+				case VTK_VOXEL -> {
+					// axis-aligned by definition; corners 0 and 7 span the box
+					double dx = Math.abs(p[3 * cell[7]] - p[3 * cell[0]]);
+					double dy = Math.abs(p[3 * cell[7] + 1] - p[3 * cell[0] + 1]);
+					double dz = Math.abs(p[3 * cell[7] + 2] - p[3 * cell[0] + 2]);
+					measures[c] = dx * dy * dz;
+				}
+				default -> throw new IllegalArgumentException(
+						"no measure for VTK cell type " + grid.cellTypes[c]);
+			}
+		}
+		return measures;
+	}
+
+	private static double tripleProduct(double[] p, int i0, int i1, int i2, int i3) {
+		double ax = p[3 * i1] - p[3 * i0], ay = p[3 * i1 + 1] - p[3 * i0 + 1], az = p[3 * i1 + 2] - p[3 * i0 + 2];
+		double bx = p[3 * i2] - p[3 * i0], by = p[3 * i2 + 1] - p[3 * i0 + 1], bz = p[3 * i2 + 2] - p[3 * i0 + 2];
+		double cx = p[3 * i3] - p[3 * i0], cy = p[3 * i3 + 1] - p[3 * i0 + 1], cz = p[3 * i3 + 2] - p[3 * i0 + 2];
+		return ax * (by * cz - bz * cy) - ay * (bx * cz - bz * cx) + az * (bx * cy - by * cx);
+	}
+
+	/**
+	 * The cell containing a lab-frame point, or -1 when the point lies outside the mesh — which
+	 * for a moving-boundary run is the physically meaningful "the domain has moved past this
+	 * point". In-plane cells test by point-in-polygon (z ignored); voxels by bounds; tets by
+	 * barycentric signs.
+	 */
+	static int locateCell(VtuGrid grid, double x, double y, double z) {
+		double[] p = grid.points;
+		for (int c = 0; c < grid.cells.length; c++) {
+			int[] cell = grid.cells[c];
+			boolean hit = switch (grid.cellTypes[c]) {
+				case VTK_TRIANGLE, VTK_POLYGON, VTK_QUAD -> pointInPolygon(p, cell, x, y);
+				case VTK_VOXEL -> x >= Math.min(p[3 * cell[0]], p[3 * cell[7]])
+						&& x <= Math.max(p[3 * cell[0]], p[3 * cell[7]])
+						&& y >= Math.min(p[3 * cell[0] + 1], p[3 * cell[7] + 1])
+						&& y <= Math.max(p[3 * cell[0] + 1], p[3 * cell[7] + 1])
+						&& z >= Math.min(p[3 * cell[0] + 2], p[3 * cell[7] + 2])
+						&& z <= Math.max(p[3 * cell[0] + 2], p[3 * cell[7] + 2]);
+				case VTK_TETRA -> pointInTetra(p, cell, x, y, z);
+				default -> false;
+			};
+			if (hit) {
+				return c;
+			}
+		}
+		return -1;
+	}
+
+	private static boolean pointInPolygon(double[] p, int[] cell, double x, double y) {
+		boolean inside = false;
+		for (int v = 0, w = cell.length - 1; v < cell.length; w = v++) {
+			double xv = p[3 * cell[v]], yv = p[3 * cell[v] + 1];
+			double xw = p[3 * cell[w]], yw = p[3 * cell[w] + 1];
+			if ((yv > y) != (yw > y) && x < (xw - xv) * (y - yv) / (yw - yv) + xv) {
+				inside = !inside;
+			}
+		}
+		return inside;
+	}
+
+	private static boolean pointInTetra(double[] p, int[] cell, double x, double y, double z) {
+		// same-side test against each face, tolerant of degenerate (near-flat) tets
+		double total = tripleProduct(p, cell[0], cell[1], cell[2], cell[3]);
+		if (Math.abs(total) < 1e-300) {
+			return false;
+		}
+		for (int f = 0; f < 4; f++) {
+			double[] q = p.clone();
+			int replaced = cell[f];
+			q[3 * replaced] = x;
+			q[3 * replaced + 1] = y;
+			q[3 * replaced + 2] = z;
+			double sub = tripleProduct(q, cell[0], cell[1], cell[2], cell[3]);
+			if (sub * total < -1e-12 * Math.abs(total)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	private VtuGridParser() {
 	}
 

--- a/vcell-client/src/test/java/org/vcell/client/viz/VtuGridParserTest.java
+++ b/vcell-client/src/test/java/org/vcell/client/viz/VtuGridParserTest.java
@@ -39,4 +39,53 @@ public class VtuGridParserTest {
 		Assertions.assertEquals(0.9, grid.points[7], 1e-6);
 		Assertions.assertEquals(0.0, grid.points[8], 1e-6);
 	}
+
+	// cellMeasures / locateCell power the moving-boundary lab-frame time series and the
+	// measure-weighted statistics; exercised on hand-built grids with known geometry
+
+	@Test
+	public void measuresTwoDimensionalCells() {
+		// unit right triangle, unit square (as VTK_QUAD), and an L-shaped hexagon of area 3
+		VtuGrid grid = new VtuGrid(
+				new double[] {
+						0, 0, 0,  1, 0, 0,  0, 1, 0, // triangle
+						2, 0, 0,  3, 0, 0,  3, 1, 0,  2, 1, 0, // square
+						4, 0, 0,  6, 0, 0,  6, 1, 0,  5, 1, 0,  5, 2, 0,  4, 2, 0, // L
+				},
+				new int[][] { { 0, 1, 2 }, { 3, 4, 5, 6 }, { 7, 8, 9, 10, 11, 12 } },
+				new int[] { 5, 9, 7 });
+		double[] measures = VtuGridParser.cellMeasures(grid);
+		Assertions.assertEquals(0.5, measures[0], 1e-12);
+		Assertions.assertEquals(1.0, measures[1], 1e-12);
+		Assertions.assertEquals(3.0, measures[2], 1e-12);
+
+		Assertions.assertEquals(0, VtuGridParser.locateCell(grid, 0.2, 0.2, 0));
+		Assertions.assertEquals(1, VtuGridParser.locateCell(grid, 2.5, 0.5, 0));
+		Assertions.assertEquals(2, VtuGridParser.locateCell(grid, 4.5, 1.5, 0));
+		// inside the L's bounding box but outside the L itself
+		Assertions.assertEquals(-1, VtuGridParser.locateCell(grid, 5.9, 1.5, 0));
+		Assertions.assertEquals(-1, VtuGridParser.locateCell(grid, 1.5, 0.5, 0));
+	}
+
+	@Test
+	public void measuresThreeDimensionalCells() {
+		// unit cube in VTK_VOXEL point order, and the corner tetrahedron of volume 1/6
+		VtuGrid grid = new VtuGrid(
+				new double[] {
+						0, 0, 0,  1, 0, 0,  0, 1, 0,  1, 1, 0,
+						0, 0, 1,  1, 0, 1,  0, 1, 1,  1, 1, 1, // voxel
+						2, 0, 0,  3, 0, 0,  2, 1, 0,  2, 0, 1, // tetra
+				},
+				new int[][] { { 0, 1, 2, 3, 4, 5, 6, 7 }, { 8, 9, 10, 11 } },
+				new int[] { 11, 10 });
+		double[] measures = VtuGridParser.cellMeasures(grid);
+		Assertions.assertEquals(1.0, measures[0], 1e-12);
+		Assertions.assertEquals(1.0 / 6, measures[1], 1e-12);
+
+		Assertions.assertEquals(0, VtuGridParser.locateCell(grid, 0.5, 0.5, 0.5));
+		Assertions.assertEquals(1, VtuGridParser.locateCell(grid, 2.1, 0.1, 0.1));
+		// inside the tetra's bounding box but beyond its slanted face
+		Assertions.assertEquals(-1, VtuGridParser.locateCell(grid, 2.9, 0.9, 0.9));
+		Assertions.assertEquals(-1, VtuGridParser.locateCell(grid, 0.5, 0.5, 1.5));
+	}
 }

--- a/webapp-viewer/index.html
+++ b/webapp-viewer/index.html
@@ -48,6 +48,7 @@
                                margin-right: 4px; vertical-align: -1px; }
   .plot-panel svg { display: block; width: 100%; height: 220px; }
   .plot-panel .curve { fill: none; stroke: #2a7; stroke-width: 2; vector-effect: non-scaling-stroke; }
+  .plot-panel .curve-dot { fill: #2a7; stroke: none; }
   .plot-panel .axis { stroke: currentColor; stroke-opacity: .3; vector-effect: non-scaling-stroke; }
   .plot-panel .lbl { font: 11px ui-monospace, monospace; fill: currentColor; fill-opacity: .7; }
 </style>

--- a/webapp-viewer/viewer.js
+++ b/webapp-viewer/viewer.js
@@ -809,6 +809,20 @@ async function zoom2d(factor) {
 // picking (#1859 items 6 and 8)
 // ---------------------------------------------------------------------------
 
+/**
+ * Mouse → lab-frame world coordinates under the 2D orthographic camera. The inverse of what
+ * pan2d/zoom2d maintain: the view maps world x/y linearly onto the canvas, scaled so the
+ * camera's parallel scale spans half the canvas height.
+ */
+async function labPointFromMouse(clientX, clientY) {
+  const rect = el.canvas.getBoundingClientRect();
+  const worldPerPixel = (2 * (await camera.getParallelScale())) / rect.height;
+  const F = await camera.getFocalPoint();
+  const x = F[0] + (clientX - rect.left - rect.width / 2) * worldPerPixel;
+  const y = F[1] - (clientY - rect.top - rect.height / 2) * worldPerPixel;
+  return [x, y];
+}
+
 /** Center coordinates of a picked cell, for the readouts. */
 function cellCenter(cell) {
   const pk = state.pick;
@@ -822,7 +836,22 @@ function cellCenter(cell) {
 
 let hoverBusy = false;
 async function hoverPick(clientX, clientY) {
-  if (!state.ready || !state.pick || hoverBusy || state.bodyFitted) return;
+  if (!state.ready || hoverBusy) return;
+  if (state.bodyFitted) {
+    // no occupancy index on a body-fitted mesh; the readout shows where a click would sample
+    if (state.dimension !== 2) return;
+    hoverBusy = true;
+    try {
+      const [x, y] = await labPointFromMouse(clientX, clientY);
+      el.pickReadout.textContent = `lab (${x.toFixed(2)}, ${y.toFixed(2)}) — click to plot time course`;
+    } catch (e) {
+      console.warn('hover failed', e);
+    } finally {
+      hoverBusy = false;
+    }
+    return;
+  }
+  if (!state.pick) return;
   hoverBusy = true;
   try {
     const { origin, dir } = await rayFromMouse(clientX, clientY);
@@ -849,7 +878,9 @@ async function hoverPick(clientX, clientY) {
  * explicitly ruled out in #1859.
  */
 async function plotPick(clientX, clientY) {
-  if (!state.ready || !state.pick || !state.dataset || state.bodyFitted) return;
+  if (!state.ready || !state.dataset) return;
+  if (state.bodyFitted) return void plotLabPick(clientX, clientY);
+  if (!state.pick) return;
   try {
     const { origin, dir } = await rayFromMouse(clientX, clientY);
     const cell = castRay(origin, dir);
@@ -860,6 +891,26 @@ async function plotPick(clientX, clientY) {
       url('/timeseries', { domain: state.selectedDomain, var: state.selectedVar, cell: String(cell) }),
       '/timeseries');
     renderPlot(series, c);
+    setStatus(`${describe()} ✓`);
+  } catch (e) {
+    setStatus('time-series pick failed: ' + (e?.message ?? e), true);
+  }
+}
+
+/**
+ * Click on a moving-boundary view → time course at that fixed LAB-FRAME point. The point does not
+ * follow the material: /timeseries locates it in each saved time's own mesh, and frames where the
+ * boundary has moved past it come back as nulls, drawn as gaps in the curve.
+ */
+async function plotLabPick(clientX, clientY) {
+  if (state.dimension !== 2) return;
+  try {
+    const [x, y] = await labPointFromMouse(clientX, clientY);
+    setStatus(`fetching time series for ${state.selectedVar} at lab (${x.toFixed(2)}, ${y.toFixed(2)})…`);
+    const series = await fetchJson(
+      url('/timeseries', { domain: state.selectedDomain, var: state.selectedVar, x: String(x), y: String(y) }),
+      '/timeseries');
+    renderPlot(series, [x, y, 0]);
     setStatus(`${describe()} ✓`);
   } catch (e) {
     setStatus('time-series pick failed: ' + (e?.message ?? e), true);
@@ -893,18 +944,40 @@ function plotFrame(times, lo, hi) {
   return { mk, sx, sy, lo };
 }
 
-/** Framework-free line plot: one polyline in an SVG, min/max labels, nothing else to maintain. */
+/**
+ * Framework-free line plot: polylines in an SVG, min/max labels, nothing else to maintain. Null
+ * values break the curve into segments — on a moving-boundary run a null means the domain had
+ * moved past the sampled lab point at that time, a physically meaningful gap that must not be
+ * drawn through. A segment of one frame renders as a dot so it does not vanish.
+ */
 function renderPlot(series, center) {
   const { times, values, name } = series;
   const finite = values.filter((v) => v != null && Number.isFinite(v));
   if (!times?.length || !finite.length) return;
   const f = plotFrame(times, Math.min(...finite), Math.max(...finite));
-  f.mk('polyline', {
-    class: 'curve',
-    points: times.map((t, i) => `${f.sx(t).toFixed(1)},${f.sy(values[i] ?? f.lo).toFixed(1)}`).join(' '),
+  let seg = [];
+  const flush = () => {
+    if (seg.length > 1) {
+      f.mk('polyline', { class: 'curve', points: seg.join(' ') });
+    } else if (seg.length === 1) {
+      const [cx, cy] = seg[0].split(',');
+      f.mk('circle', { class: 'curve-dot', cx, cy, r: 3 });
+    }
+    seg = [];
+  };
+  times.forEach((t, i) => {
+    const v = values[i];
+    if (v == null || !Number.isFinite(v)) {
+      flush();
+      return;
+    }
+    seg.push(`${f.sx(t).toFixed(1)},${f.sy(v).toFixed(1)}`);
   });
+  flush();
+  const gaps = values.length - finite.length;
   const at = center ? ` @ (${center.slice(0, state.dimension === 2 ? 2 : 3).map((x) => x.toFixed(1)).join(', ')})` : '';
-  el.plotTitle.textContent = `${name}${at} · ${times.length} timepoints`;
+  el.plotTitle.textContent = `${name}${at} · ${times.length} timepoints`
+    + (gaps > 0 ? ` · ${gaps} outside the moving domain` : '');
   el.plotLegend.innerHTML = '';
   el.plotPanel.hidden = false;
 }
@@ -932,7 +1005,8 @@ function renderStatsPlot(stats) {
       points: times.map((t, i) => `${f.sx(t).toFixed(1)},${f.sy(s.mean[i] ?? f.lo).toFixed(1)}`).join(' '),
     });
   });
-  el.plotTitle.textContent = `min / mean / max over space · ${times.length} timepoints`;
+  el.plotTitle.textContent = `min / mean / max over space · ${times.length} timepoints`
+    + (stats.weighting === 'measure' ? ' · area-weighted over the moving domain' : '');
   el.plotLegend.innerHTML = '';
   series.forEach((s, k) => {
     const item = document.createElement('span');
@@ -1159,7 +1233,7 @@ el.smoothingReset.addEventListener('click', () => {
     el.colorbar.disabled = false;
     el.axes.disabled = false;
     el.sliceAxis.disabled = state.bodyFitted;
-    el.statsBtn.disabled = state.bodyFitted;
+    el.statsBtn.disabled = false;
     if (state.bodyFitted) {
       el.smoothingReadout.textContent = 'body-fitted solver mesh — shown as computed';
       el.smoothingReset.disabled = true;


### PR DESCRIPTION
Follow-up to #1879 (MovingBoundary field-viewer support): time-series point plots and spatial statistics for moving-boundary runs, per the two requirements:

- **Point plots are in the lab frame of reference.** `/timeseries` for a MovingBoundary run is addressed by a fixed spatial point `(x, y)` rather than a cell ordinal (cell ordinals are not stable on a re-cut mesh). Each saved time locates that point in *that time's* body-fitted mesh; times where the boundary has moved past the point come back as `null`, and the plot breaks its curve there — a physically meaningful gap, not missing data — with the title reporting how many frames were outside.
- **Statistics follow the cell.** `/stats` computes, per saved time, min / max / measure-weighted mean over the cells the moving domain occupies *at that time*, weighting each cut cell by its actual polygon area. Each series also carries the domain's total measure per time (the size of the moving region itself). These are display-mesh statistics — self-consistent with what is drawn.

### Implementation

- `VtuGridParser` gains `cellMeasures` (shoelace areas for triangle/quad/polygon, tet & voxel volumes) and `locateCell` (point-in-polygon / point-in-tet / voxel bounds; `-1` = outside), unit-tested on hand-built grids with known geometry (areas 0.5 / 1 / 3, volumes 1 / ⅙, hits and misses including bounding-box-but-outside cases).
- `FieldViewerServer` replaces the two "not yet supported for MovingBoundary runs" rejections with real handlers reusing the existing per-time mesh cache; `null`s ride the existing NaN→`null` JSON serialization.
- Viewer: hovering a body-fitted view shows the lab coordinates a click would sample; clicking fetches and plots the point's time course; the Stats button is enabled in body-fitted mode, and the stats plot is labeled *area-weighted over the moving domain*.

### Evidence (mock MB run: drifting, shrinking disk with true cut-cell polygons)

The integrated cut-cell areas reproduce the analytic disk area exactly (t=0: 451.8 ≈ π·12², t=1: 200.5 ≈ π·8²), and a lab point at (15.6, 20) — inside the initial disk, abandoned by the final one — plots with the gap:

| lab-frame point plot with gap | moving-domain statistics |
|---|---|
| ![gap plot](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/cac9d225c2ecd1947e2f9fea9e6531a00a5344c1/mb-stats-plot-gap.png) | ![stats plot](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/cac9d225c2ecd1947e2f9fea9e6531a00a5344c1/mb-stats-domain-stats.png) |

Live verification against a real MovingBoundary run needs a desktop build carrying this plus the #1889 fix, i.e. the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
