### PR TITLE
Fix Python VTK service call writing the .vtu to a directory path (broken since 2023)

### DIFF
--- a/vcell-core/src/main/java/org/vcell/vis/vtk/VtkServicePython.java
+++ b/vcell-core/src/main/java/org/vcell/vis/vtk/VtkServicePython.java
@@ -51,7 +51,7 @@ public class VtkServicePython extends VtkService {
 		String baseFilename = vtkFile.getName().replace(".vtu",".visMesh");
 		File visMeshFile = new File(vtkFile.getParentFile(), baseFilename);
 		VisMeshUtils.writeVisMesh(visMeshFile, visMesh);
-		callVtkPython(meshType, domainName, visMeshFile.toPath(), vtkFile.getParentFile().toPath(), indexFile.toPath());
+		callVtkPython(meshType, domainName, visMeshFile.toPath(), vtkFile.toPath(), indexFile.toPath());
 	}
 
 	private void callVtkPython(MeshType meshtype, String domainName, Path visMeshFile, Path vtkFile, Path indexFile) throws IOException, InterruptedException {


### PR DESCRIPTION
Server-side VTU generation through the Python VTK service has been silently broken since the thrift→CLI refactor (`1f143237e9`, July 2023): `VtkServicePython.writeVtkGridAndIndexData` passed `vtkFile.getParentFile()` as the service's `vtkfile` argument, so `vtkXMLUnstructuredGridWriter` "wrote" every mesh to the *directory path* (a silent no-op — the service even logs `wrote to file <dir>`), and the caller then failed with `failed to retrieve VTK files: … .vtu (No such file or directory)`.

Affected: every mesh type routed through the Python service — Chombo volume + membrane, smoothed finite-volume, comsol. **MovingBoundary was unaffected** (its VTU writer is pure Java), which is why the #1879 work never tripped over this.

Found while exercising the VTU seam against a *fresh local Chombo 3D run* (`Solver_Suite_7_5.vcml` "chombo 3d", 8×8×8, run with a from-source `VCellChombo3D_x64`): with this one-line fix, the service writes the mesh and the whole seam works — `getEmptyVtuMeshFiles` returns the 115 KB mixed voxel+tet VTU and `getVtuMeshData` pairs values for all 4 variables at all 11 saved times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
