### PR TITLE
Chombo: tetrahedralize cut cells from their own faces so the mesh stays watertight

### DIFF
--- a/pythonVtk/python_vtk/vtkService/vtkService.py
+++ b/pythonVtk/python_vtk/vtkService/vtkService.py
@@ -16,6 +16,7 @@ from python_vtk.vcellvismesh.ttypes import PolyhedronFace
 from python_vtk.vcellvismesh.ttypes import VisIrregularPolyhedron
 from python_vtk.vcellvismesh.ttypes import VisLine
 from python_vtk.vcellvismesh.ttypes import VisMesh
+from python_vtk.vcellvismesh.ttypes import VisPoint
 from python_vtk.vcellvismesh.ttypes import VisPolygon
 from python_vtk.vcellvismesh.ttypes import VisTetrahedron
 
@@ -537,74 +538,63 @@ def getPointIndices(irregularPolyhedron: VisIrregularPolyhedron) -> list[int]:
 
 
 def createTetrahedra(clippedPolyhedron: VisIrregularPolyhedron, visMesh: VisMesh):
+    """
+    Decompose a clipped (cut) cell into tetrahedra by fanning every face against a new apex point
+    at the cell's centroid.
 
-    vtkpolydata = vtk.vtkPolyData()
-    vtkpoints = vtk.vtkPoints()
-    polygonType = vtk.vtkPolygon().GetCellType()
+    This has to agree with the neighbouring cell across every shared face, or the two cells stop
+    sharing that face and it gets extracted as if it were surface (issue #1895). Two properties
+    give that agreement:
+
+      - a face is always fanned from its LOWEST GLOBAL POINT INDEX, so a face listed by two cells
+        (in either winding) is cut into exactly the same triangles by both, and
+      - the faces themselves are used as given, so no geometry is invented.
+
+    The previous implementation ran vtkDelaunay3D over the cell's points, which tessellates their
+    convex hull and ignores the faces: it chose face diagonals arbitrarily (so shared faces did
+    not match), and on the near-degenerate cells at a tangent boundary it returned too few tets or
+    none at all, leaving holes in the surface and losing volume.
+    """
+    faces = [face.vertices for face in clippedPolyhedron.polyhedronFaces]
     uniquePointIndices = getPointIndices(clippedPolyhedron)
-    for point in uniquePointIndices:
-        visPoint = visMesh.points[point]
-        vtkpoints.InsertNextPoint(visPoint.x, visPoint.y, visPoint.z)
-    vtkpolydata.Allocate(100, 100)
-    vtkpolydata.SetPoints(vtkpoints)
+    if len(uniquePointIndices) < 4 or len(faces) < 4:
+        print("skipping degenerate polyhedron with " + str(len(uniquePointIndices))
+              + " points and " + str(len(faces)) + " faces")
+        return []
 
-    for face in clippedPolyhedron.polyhedronFaces:
-        faceIdList = vtk.vtkIdList()
-        for visPointIndex in face.vertices:
-            vtkpointid = -1
-            for i in range(0, len(uniquePointIndices)):
-                if uniquePointIndices[i] == visPointIndex:
-                    vtkpointid = i
-            faceIdList.InsertNextId(vtkpointid)
-        vtkpolydata.InsertNextCell(polygonType, faceIdList)
-
-    delaunayFilter = vtk.vtkDelaunay3D()
-    try:
-        delaunayFilter.SetInputData(vtkpolydata)
-    except AttributeError:
-        delaunayFilter.SetInput(vtkpolydata)
-    delaunayFilter.Update()
-    delaunayFilter.SetAlpha(0.1)
-    vtkgrid2: vtk.vtkUnstructuredGrid = delaunayFilter.GetOutput()
-    assert isinstance(vtkgrid2, vtk.vtkUnstructuredGrid) # runtime check, remove later
+    apexIndex = len(visMesh.points)
+    visMesh.points.append(VisPoint(
+        sum(visMesh.points[p].x for p in uniquePointIndices) / len(uniquePointIndices),
+        sum(visMesh.points[p].y for p in uniquePointIndices) / len(uniquePointIndices),
+        sum(visMesh.points[p].z for p in uniquePointIndices) / len(uniquePointIndices)))
 
     visTets = []
-    numTets = vtkgrid2.GetNumberOfCells()
-    if numTets < 1:
-        if len(uniquePointIndices)==4:
-            visTet = VisTetrahedron(uniquePointIndices)
-            visTet.chomboVolumeIndex = clippedPolyhedron.chomboVolumeIndex
-            visTet.finiteVolumeIndex = clippedPolyhedron.finiteVolumeIndex
-            visTets.append(visTet)
-            print("made trivial tet ... maybe inside out")
-        else:
-            print("found no tets, there are "+str(len(uniquePointIndices))+" unique point indices")
-
-
-    #	print("numFaces = "+str(vtkpolydata.GetNumberOfCells())+", numTets = "+str(numTets));
-    for cellIndex in range(0, numTets):
-        cell = vtkgrid2.GetCell(cellIndex)
-        if isinstance(cell, vtk.vtkTetra):
-            vtkTet: vtk.vtkTetra = cell
-            tetPointIds: vtk.vtkIdList = vtkTet.GetPointIds()
-            assert isinstance(tetPointIds, vtk.vtkIdList)
-            #
-            # translate from vtkgrid pointids to visMesh point ids
-            #
-            numPoints = tetPointIds.GetNumberOfIds()
-            visPointIds = []
-            for p in range(0, numPoints):
-                visPointIds.append(uniquePointIndices[tetPointIds.GetId(p)])
-            visTet = VisTetrahedron(visPointIds)
-            if clippedPolyhedron.chomboVolumeIndex != None:
+    for face in faces:
+        start = face.index(min(face))
+        numVertices = len(face)
+        for i in range(1, numVertices - 1):
+            corners = [apexIndex, face[start], face[(start + i) % numVertices],
+                       face[(start + i + 1) % numVertices]]
+            if signedVolume(visMesh, corners) < 0:
+                corners[2], corners[3] = corners[3], corners[2]
+            visTet = VisTetrahedron(corners)
+            if clippedPolyhedron.chomboVolumeIndex is not None:
                 visTet.chomboVolumeIndex = clippedPolyhedron.chomboVolumeIndex
-            if clippedPolyhedron.finiteVolumeIndex != None:
+            if clippedPolyhedron.finiteVolumeIndex is not None:
                 visTet.finiteVolumeIndex = clippedPolyhedron.finiteVolumeIndex
             visTets.append(visTet)
-        else:
-            print("ChomboMeshMapping.createTetrahedra(): expecting a tet, found a " + cell.__type__)
 
     return visTets
+
+
+def signedVolume(visMesh: VisMesh, corners: list[int]) -> float:
+    o, a, b, c = [visMesh.points[i] for i in corners]
+    u = (a.x - o.x, a.y - o.y, a.z - o.z)
+    v = (b.x - o.x, b.y - o.y, b.z - o.z)
+    w = (c.x - o.x, c.y - o.y, c.z - o.z)
+    return (u[0] * (v[1] * w[2] - v[2] * w[1])
+            - u[1] * (v[0] * w[2] - v[2] * w[0])
+            + u[2] * (v[0] * w[1] - v[1] * w[0])) / 6.0
 
 
 def main():

--- a/pythonVtk/tests/test_create_tetrahedra.py
+++ b/pythonVtk/tests/test_create_tetrahedra.py
@@ -1,0 +1,88 @@
+"""
+createTetrahedra() has to produce a decomposition that is exact and that AGREES with the
+neighbouring cell across a shared face — otherwise the shared face is no longer shared and gets
+extracted as if it were part of the domain surface (virtualcell/vcell#1895).
+"""
+import math
+
+from python_vtk.vcellvismesh.ttypes import PolyhedronFace
+from python_vtk.vcellvismesh.ttypes import VisIrregularPolyhedron
+from python_vtk.vcellvismesh.ttypes import VisMesh
+from python_vtk.vcellvismesh.ttypes import VisPoint
+from python_vtk.vtkService.vtkService import createTetrahedra, signedVolume
+
+# unit cube corners, in the VisVoxel ordering used by ChomboMeshMapping
+CUBE_POINTS = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0),
+               (0, 0, 1), (1, 0, 1), (0, 1, 1), (1, 1, 1)]
+CUBE_FACES = [[0, 4, 6, 2], [1, 3, 7, 5], [0, 1, 5, 4], [2, 6, 7, 3], [0, 2, 3, 1], [4, 5, 7, 6]]
+
+
+def _mesh(points: list[tuple[float, float, float]]) -> VisMesh:
+    mesh = VisMesh()
+    mesh.points = [VisPoint(float(x), float(y), float(z)) for (x, y, z) in points]
+    return mesh
+
+
+def _polyhedron(faces: list[list[int]]) -> VisIrregularPolyhedron:
+    poly = VisIrregularPolyhedron()
+    poly.polyhedronFaces = [PolyhedronFace(list(face)) for face in faces]
+    return poly
+
+
+def _volume(mesh: VisMesh, tets) -> float:
+    return sum(abs(signedVolume(mesh, tet.pointIndices)) for tet in tets)
+
+
+def test_decomposition_is_exact_and_positively_oriented() -> None:
+    mesh = _mesh(CUBE_POINTS)
+    tets = createTetrahedra(_polyhedron(CUBE_FACES), mesh)
+
+    assert math.isclose(_volume(mesh, tets), 1.0, rel_tol=1e-12)
+    for tet in tets:
+        assert signedVolume(mesh, tet.pointIndices) > 0
+
+
+def test_clipped_cell_volume_matches_the_polyhedron() -> None:
+    # cube with the corner at (1,1,1) cut off by the plane through its three neighbours
+    points = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 0),
+              (0, 0, 1), (1, 0, 1), (0, 1, 1)]
+    mesh = _mesh(points)
+    faces = [
+        [0, 4, 6, 2],        # x-
+        [0, 1, 5, 4],        # y-
+        [0, 2, 3, 1],        # z-
+        [1, 3, 5],           # x+ (clipped)
+        [2, 6, 3],           # y+ (clipped)
+        [4, 5, 6],           # z+ (clipped)
+        [3, 5, 6],           # the cut face
+    ]
+    tets = createTetrahedra(_polyhedron(faces), mesh)
+    assert math.isclose(_volume(mesh, tets), 1.0 - 1.0 / 6.0, rel_tol=1e-12)
+
+
+def test_neighbours_cut_a_shared_face_identically() -> None:
+    """
+    Two cells stacked in z share the face 4,5,7,6. Each lists it in its own winding and starting
+    corner, as ChomboMeshMapping does; the triangles produced on that face must be identical or
+    the face stops being shared.
+    """
+    points = CUBE_POINTS + [(0, 0, 2), (1, 0, 2), (0, 1, 2), (1, 1, 2)]
+    mesh = _mesh(points)
+
+    lower = _polyhedron(CUBE_FACES)                                  # ...z+ face is [4, 5, 7, 6]
+    upper = _polyhedron([[4, 8, 10, 6], [5, 7, 11, 9], [4, 5, 9, 8],
+                         [6, 10, 11, 7], [7, 5, 4, 6], [8, 9, 11, 10]])  # shared face reversed
+    lower_tets = createTetrahedra(lower, mesh)
+    upper_tets = createTetrahedra(upper, mesh)
+
+    shared = {4, 5, 6, 7}
+    lower_on_face = {frozenset(t.pointIndices) & shared for t in lower_tets}
+    upper_on_face = {frozenset(t.pointIndices) & shared for t in upper_tets}
+    triangles = lambda faces: {f for f in faces if len(f) == 3}
+    assert triangles(lower_on_face) == triangles(upper_on_face)
+    assert len(triangles(lower_on_face)) == 2  # the quad is split, and split the same way
+
+
+def test_degenerate_polyhedron_is_skipped() -> None:
+    mesh = _mesh(CUBE_POINTS)
+    assert createTetrahedra(_polyhedron([[0, 1, 2]]), mesh) == []


### PR DESCRIPTION
Fixes #1895 — the Chombo mesh the field viewer renders is now watertight, and its volume matches Chombo's own volume fractions exactly.

### What was wrong

Not `ChomboMeshMapping`, as #1895 first supposed. The `VisMesh` it builds is conforming: every clipped cell is closed and every shared face pairs. I verified that directly on the polyhedra of a real run (below) — 0 non-closed polyhedra, 0 exposed interior faces.

The damage was done one step later, in `createTetrahedra`, which turned each clipped cell into tets with **`vtkDelaunay3D` over the cell's points**. Delaunay tessellates the *convex hull of a point set* and never looks at the faces the cell was actually built from, so:

- **shared faces stopped being shared.** Each side chose its own diagonal across the quad, so the two triangulations didn't match, nothing paired, and surface extraction reported both copies as domain surface. On an 8×8×8 embedded sphere, 341 of 560 area units of the extracted "surface" were interior walls — against 201 for the sphere itself.
- **near-degenerate cells came back short, or empty.** Where the boundary runs almost tangent to the grid, Delaunay returned too few tets (there is even a `found no tets` branch that just prints), leaving holes at each pole of the sphere — you could see the interior cells straight through the surface — and losing volume.

`SetAlpha(0.1)` was also called *after* `Update()`, so it never took effect. Had it, it would have discarded almost every tet: alpha is a radius, and the cells are ~2 units across in these coordinates.

### The fix

Fan each face against a new apex point at the cell's centroid. Two properties make the result conform:

- every face is used **as given**, so no geometry is invented and the cell's own volume is reproduced exactly;
- each face is fanned from its **lowest global point index**, so a face listed by two cells — in either winding, from any starting corner — is cut into the identical triangles by both.

No VTK involved any more, and no failure branch: the decomposition is defined for every closed cell.

### The corrected visualization

The three views from #1890, re-rendered from the conforming mesh. All coloured by `fraction-0`, the embedded-boundary volume fraction (blue ≈ 0, red = 1), which shows the cut-cell structure itself rather than a solution field.

| embedded-boundary surface | hemisphere after a z cut | face-on cross-section |
|---|---|---|
| ![surface](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/f6d67effa2137c8eb40d9d78f2dbfaf31415e31b/chombo-1896-surface.png) | ![hemisphere](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/f6d67effa2137c8eb40d9d78f2dbfaf31415e31b/chombo-1896-hemisphere.png) | ![cut face](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/f6d67effa2137c8eb40d9d78f2dbfaf31415e31b/chombo-1896-cutface.png) |

The surface is now closed at all six poles — every blue patch is a genuine low-fraction cut cell, not a hole. The hemisphere shows the solver's own cut cells on the clipped surface, and the mid-plane clip halves the volume exactly (128.2 of 256.407). The cross-section is unchanged, as expected: that view was always correct, because the cut plane slices the cells rather than relying on their faces.

### Evidence

A fresh local run of BioModel 276459600 ("Solver_Suite_7_5", app "3D chombo"), read through the real server path (`getEmptyVtuMeshFiles` → `ChomboVtkFileWriter` → this Python service) and analysed as a cell complex — faces owned by one cell are what gets rendered:

| | before | after |
|---|---|---|
| cells | 1778 | 2840 |
| mesh volume | 255.4538 | **256.4068** |
| Chombo's volume-fraction total | 256.4068 | 256.4068 |
| open edges in the embedded-boundary surface | **168** | **0** (watertight) |
| embedded-boundary area (analytic sphere: 201.06) | 217.91 | **196.90** |
| exposed interior wall area | 341.69 | 300.00 |
| faces with >2 owners | 0 | 0 |
| tets with negative orientation | 0 | 0 |

The +z pole of the sphere, coloured by `fraction-0` (blue ≈ 0, red = 1) — before, the cap is broken open and you are looking at whole interior cells through it; after, it is a closed cap:

| before | after |
|---|---|
| ![before](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/2797e28c4b08f673bff82ebf835319029eef894e/chombo-1895-pole-before.png) | ![after](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/2797e28c4b08f673bff82ebf835319029eef894e/chombo-1895-pole-after.png) |

Whole surface, same variable and camera:

| before | after |
|---|---|
| ![surface before](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/2797e28c4b08f673bff82ebf835319029eef894e/chombo-1895-surface-before.png) | ![surface after](https://gist.githubusercontent.com/jcschaff/cc9a0c03a2cc0d67dab8d35bd27ffb23/raw/2797e28c4b08f673bff82ebf835319029eef894e/chombo-1895-surface-after.png) |

The mid-plane clip now halves the volume exactly: 128.2 of 256.407.

### What this deliberately does not fix

The interface between a **full voxel** (which contributes one quad face) and a **cut neighbour** (which contributes two triangles) still doesn't pair. That is all 300 remaining area units: 150 of actual interface, counted once from each side, all of it interior and hidden by the now-closed surface. Closing it would mean tetrahedralizing every voxel in the mesh, which multiplies interior cell count by ~12 for a defect you cannot see. The alternative worth considering later is emitting cut cells as `VTK_POLYHEDRON` (the `getVtkFaceStream` branch already in this file), which would match voxel quads exactly.

Separately: the stray coloured darts in the earlier #1890 screenshots are **not** geometry. `C_cyt` there is uniform to 2.4e-10 relative — 277 distinct values that are pure floating-point noise — and the viewer stretches the full colour bar across that. That's #1867 (colour-scale modes), not this.

### Testing

- `pythonVtk` unit tests (new, `tests/test_create_tetrahedra.py`): exact volume for a cube and for a corner-clipped cube, all tets positively oriented, degenerate input skipped, and — the property that matters — two neighbouring cells cut a shared face into the identical triangles when they list it in opposite windings.
- Regenerated the real run end-to-end through the Python service and re-measured the `.vtu` as above; re-rendered it in the field viewer.

Affects the Chombo path only: `ChomboMeshMapping` is the sole producer of `irregularPolyhedra`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
