### PR TITLE
Size the JVM heap to fit the container, so an OOM is diagnosable

### DIFF
--- a/docker/build/Dockerfile-api-dev
+++ b/docker/build/Dockerfile-api-dev
@@ -83,7 +83,24 @@ EXPOSE 8000
 
 ENTRYPOINT java \
     -Xdebug -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n \
-    -XX:MaxRAMPercentage=80 \
+# Heap must leave room for the rest of the JVM. Measured on the api container (2000Mi
+# limit): metaspace 83Mi + code cache 65Mi + ~56Mi of thread stacks + ~500Mi of other
+# native allocation, so roughly 700Mi is not heap. At MaxRAMPercentage=80 the heap alone
+# may reach 1600Mi, and 1600 + 700 does not fit in 2000 -- the container gets OOM-killed
+# (exit 137) by the kernel while the Java heap is still ~95% free. Because the JVM never
+# throws OutOfMemoryError in that situation, the two flags below can never fire, which is
+# why this looked like an undiagnosed leak for 183 days rather than a sizing mistake.
+#
+# It is not a leak: forcing one full GC on a live api JVM sitting at 1934Mi dropped the
+# heap live set to 36Mi and RSS to 1032Mi. G1 had simply accumulated garbage, because it
+# collects under heap pressure and the binding limit is the container's, which it cannot
+# see. db has run 83 days at 566Mi on the same flags, so the JVM itself is fine.
+#
+# Revisit if the container memory limit changes -- a percentage cannot express "leave
+# 700Mi of headroom" on its own.
+    -XX:MaxRAMPercentage=50 \
+    -XX:G1PeriodicGCInterval=300000 \
+    -XX:NativeMemoryTracking=summary \
     -XX:+ExitOnOutOfMemoryError \
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:HeapDumpPath=/dump \

--- a/docker/build/Dockerfile-db-dev
+++ b/docker/build/Dockerfile-db-dev
@@ -55,7 +55,18 @@ EXPOSE 8000
 
 ENTRYPOINT java \
     -Xdebug -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n \
-	-XX:MaxRAMPercentage=80 \
+# Heap must leave room for the rest of the JVM. Measured on the api container (2000Mi
+# limit): metaspace 83Mi + code cache 65Mi + ~56Mi of thread stacks + ~500Mi of other
+# native allocation, so roughly 700Mi is not heap. At MaxRAMPercentage=80 the heap alone
+# may reach 1600Mi, and 1600 + 700 does not fit in 2000 -- the container gets OOM-killed
+# (exit 137) by the kernel while the Java heap is still ~95% free. Because the JVM never
+# throws OutOfMemoryError in that situation, the two flags below can never fire.
+#
+# Revisit if the container memory limit changes -- a percentage cannot express "leave
+# 700Mi of headroom" on its own.
+	-XX:MaxRAMPercentage=50 \
+	-XX:G1PeriodicGCInterval=300000 \
+	-XX:NativeMemoryTracking=summary \
 	-XX:+ExitOnOutOfMemoryError \
 	-XX:+HeapDumpOnOutOfMemoryError \
 	-XX:HeapDumpPath=/dump \

--- a/docker/build/Dockerfile-sched-dev
+++ b/docker/build/Dockerfile-sched-dev
@@ -86,7 +86,18 @@ VOLUME /htclogs
 
 ENTRYPOINT java \
     -Xdebug -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n \
-	-XX:MaxRAMPercentage=80 \
+# Heap must leave room for the rest of the JVM. Measured on the api container (2000Mi
+# limit): metaspace 83Mi + code cache 65Mi + ~56Mi of thread stacks + ~500Mi of other
+# native allocation, so roughly 700Mi is not heap. At MaxRAMPercentage=80 the heap alone
+# may reach 1600Mi, and 1600 + 700 does not fit in 2000 -- the container gets OOM-killed
+# (exit 137) by the kernel while the Java heap is still ~95% free. Because the JVM never
+# throws OutOfMemoryError in that situation, the two flags below can never fire.
+#
+# Revisit if the container memory limit changes -- a percentage cannot express "leave
+# 700Mi of headroom" on its own.
+	-XX:MaxRAMPercentage=50 \
+	-XX:G1PeriodicGCInterval=300000 \
+	-XX:NativeMemoryTracking=summary \
 	-XX:+ExitOnOutOfMemoryError \
 	-XX:+HeapDumpOnOutOfMemoryError \
 	-XX:HeapDumpPath=/dump \

--- a/docker/build/Dockerfile-submit-dev
+++ b/docker/build/Dockerfile-submit-dev
@@ -116,7 +116,18 @@ EXPOSE 8000
 
 ENTRYPOINT java \
     -Xdebug -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n \
-	-XX:MaxRAMPercentage=80 \
+# Heap must leave room for the rest of the JVM. Measured on the api container (2000Mi
+# limit): metaspace 83Mi + code cache 65Mi + ~56Mi of thread stacks + ~500Mi of other
+# native allocation, so roughly 700Mi is not heap. At MaxRAMPercentage=80 the heap alone
+# may reach 1600Mi, and 1600 + 700 does not fit in 2000 -- the container gets OOM-killed
+# (exit 137) by the kernel while the Java heap is still ~95% free. Because the JVM never
+# throws OutOfMemoryError in that situation, the two flags below can never fire.
+#
+# Revisit if the container memory limit changes -- a percentage cannot express "leave
+# 700Mi of headroom" on its own.
+	-XX:MaxRAMPercentage=50 \
+	-XX:G1PeriodicGCInterval=300000 \
+	-XX:NativeMemoryTracking=summary \
 	-XX:+ExitOnOutOfMemoryError \
 	-XX:+HeapDumpOnOutOfMemoryError \
 	-XX:HeapDumpPath=/dump \


### PR DESCRIPTION
prod has restarted the `api` pod **every hour for 183 days** (`restart-api-cron`) to work around what was believed to be an undiagnosed memory leak.

**It is not a leak.** Forcing a single full GC on a live api JVM sitting at 1934Mi of its 2000Mi limit:

| | before | after |
|---|---|---|
| heap committed | 1205Mi | 124Mi |
| **heap live set** | 739Mi | **36Mi** |
| process RSS | 1934Mi | **1032Mi** |

A 36Mi live set after a day of uptime. All of that heap was garbage, and G1 returned ~900Mi to the OS the moment it was asked. `db` has run **83 days at 566Mi on the same flags**, so nothing here leaks generally — api simply produces garbage fast, because its health check creates and deletes a BioModel in a loop.

### What actually kills it

`MaxRAMPercentage=80` of a 2000Mi limit lets the heap reach **1600Mi**. Measured non-heap is **~700Mi** (metaspace 83, code cache 65, thread stacks ~56, ~500 native). **1600 + 700 does not fit in 2000.**

G1 has no reason to collect: it collects under *heap* pressure, and the binding limit is the *container's*, which it cannot see. So the heap grows until the kernel intervenes.

### Why 183 days of restarts never produced a diagnosis

The kernel kills the container (exit 137) while the Java heap is **~95% free**. The JVM therefore never throws `OutOfMemoryError`, so `-XX:+HeapDumpOnOutOfMemoryError` and `-XX:+ExitOnOutOfMemoryError` — both already configured — **can never fire**. Every diagnostic in place was inert by construction, and each restart left no evidence behind. That's the trap, and it's worth remembering beyond this service.

### Change

Applied to the four services on a 2000Mi limit (`api`, `db`, `sched`, `submit`):

| flag | why |
|---|---|
| `MaxRAMPercentage` 80 → **50** | heap ≤ 1000Mi, leaving ~1000Mi for ~700Mi of non-heap |
| `G1PeriodicGCInterval=300000` | an idle JVM returns memory instead of hoarding garbage |
| `NativeMemoryTracking=summary` | the missing diagnostic for the ~500Mi I could not attribute |

`data` stays at 80%: its limit is 8000Mi, so 6400 + 700 fits, and shrinking its heap would hurt simdata caching.

### Deliberately not changed

**`MALLOC_ARENA_MAX`.** It's a plausible contributor to the unattributed native memory (unset, 4 cores, so glibc may spread frees across up to 32 arenas it never returns), but changing it in the same commit would make the result unattributable. NMT first, then decide.

### Rollout

**Keep the hourly prod cron until dev proves this out.** dev has no cron and is where the OOM-kills were observed, so it's the honest test bed — if RSS plateaus there over a few days, the cron can be retired.

Dockerfile lint is unchanged from master (same 3 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg