### PR TITLE
Make JDWP opt-in instead of always-on

### DIFF
--- a/docker/build/Dockerfile-api-dev
+++ b/docker/build/Dockerfile-api-dev
@@ -79,10 +79,30 @@ ENV dbpswdfile=/run/secrets/dbpswd \
     vcellapi_publickeyfile=/run/secrets/apipubkey
 
 EXPOSE 8080
+ENV VCELL_DEBUG_OPTS=""
+
 EXPOSE 8000
 
 ENTRYPOINT java \
-    -Xdebug -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n \
+# Debugging is opt-in, not always-on. A JDWP listener accepts any connection with no
+# authentication whatsoever: whoever reaches the port can invoke arbitrary methods, read
+# and write any field, and load classes -- code execution as the JVM user. It used to be
+# baked in here, and Services published it inside the cluster, so every workload in the
+# cluster had that reach into production.
+#
+# It cannot be attached later: libjdwp implements only Agent_OnLoad, so
+# `jcmd <pid> JVMTI.agent_load .../libjdwp.so` fails with "Agent_OnAttach is not
+# available" (verified on a dev pod). Enabling it therefore costs a restart:
+#
+#   kubectl -n <ns> set env deployment/<svc> \
+#     VCELL_DEBUG_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000'
+#   kubectl -n <ns> set env deployment/<svc> VCELL_DEBUG_OPTS-      # to turn it back off
+#
+# That restart clears whatever state you wanted to look at, which is the real cost of this
+# change. What does NOT need a restart, and captures the misbehaving process as it is:
+# `jcmd <pid> GC.heap_dump`, `jcmd <pid> JFR.start settings=profile`, `Thread.print`, and
+# `VM.native_memory` -- all confirmed working on demand against a running JVM.
+    ${VCELL_DEBUG_OPTS} \
 # Heap must leave room for the rest of the JVM. Measured on the api container (2000Mi
 # limit): metaspace 83Mi + code cache 65Mi + ~56Mi of thread stacks + ~500Mi of other
 # native allocation, so roughly 700Mi is not heap. At MaxRAMPercentage=80 the heap alone

--- a/docker/build/Dockerfile-data-dev
+++ b/docker/build/Dockerfile-data-dev
@@ -71,10 +71,30 @@ VOLUME /simdata
 VOLUME /simdata_secondary
 VOLUME /exportdir
 
+ENV VCELL_DEBUG_OPTS=""
+
 EXPOSE 8000
 
 ENTRYPOINT java \
-    -Xdebug -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n \
+# Debugging is opt-in, not always-on. A JDWP listener accepts any connection with no
+# authentication whatsoever: whoever reaches the port can invoke arbitrary methods, read
+# and write any field, and load classes -- code execution as the JVM user. It used to be
+# baked in here, and Services published it inside the cluster, so every workload in the
+# cluster had that reach into production.
+#
+# It cannot be attached later: libjdwp implements only Agent_OnLoad, so
+# `jcmd <pid> JVMTI.agent_load .../libjdwp.so` fails with "Agent_OnAttach is not
+# available" (verified on a dev pod). Enabling it therefore costs a restart:
+#
+#   kubectl -n <ns> set env deployment/<svc> \
+#     VCELL_DEBUG_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000'
+#   kubectl -n <ns> set env deployment/<svc> VCELL_DEBUG_OPTS-      # to turn it back off
+#
+# That restart clears whatever state you wanted to look at, which is the real cost of this
+# change. What does NOT need a restart, and captures the misbehaving process as it is:
+# `jcmd <pid> GC.heap_dump`, `jcmd <pid> JFR.start settings=profile`, `Thread.print`, and
+# `VM.native_memory` -- all confirmed working on demand against a running JVM.
+    ${VCELL_DEBUG_OPTS} \
 	-XX:MaxRAMPercentage=80 \
 	-XX:+ExitOnOutOfMemoryError \
 	-XX:+HeapDumpOnOutOfMemoryError \

--- a/docker/build/Dockerfile-db-dev
+++ b/docker/build/Dockerfile-db-dev
@@ -51,10 +51,30 @@ ENV softwareVersion=SOFTWARE-VERSION-NOT-SET \
 ENV dbpswdfile=/run/secrets/dbpswd \
     jmspswdfile=/run/secrets/jmspswd
 
+ENV VCELL_DEBUG_OPTS=""
+
 EXPOSE 8000
 
 ENTRYPOINT java \
-    -Xdebug -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n \
+# Debugging is opt-in, not always-on. A JDWP listener accepts any connection with no
+# authentication whatsoever: whoever reaches the port can invoke arbitrary methods, read
+# and write any field, and load classes -- code execution as the JVM user. It used to be
+# baked in here, and Services published it inside the cluster, so every workload in the
+# cluster had that reach into production.
+#
+# It cannot be attached later: libjdwp implements only Agent_OnLoad, so
+# `jcmd <pid> JVMTI.agent_load .../libjdwp.so` fails with "Agent_OnAttach is not
+# available" (verified on a dev pod). Enabling it therefore costs a restart:
+#
+#   kubectl -n <ns> set env deployment/<svc> \
+#     VCELL_DEBUG_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000'
+#   kubectl -n <ns> set env deployment/<svc> VCELL_DEBUG_OPTS-      # to turn it back off
+#
+# That restart clears whatever state you wanted to look at, which is the real cost of this
+# change. What does NOT need a restart, and captures the misbehaving process as it is:
+# `jcmd <pid> GC.heap_dump`, `jcmd <pid> JFR.start settings=profile`, `Thread.print`, and
+# `VM.native_memory` -- all confirmed working on demand against a running JVM.
+    ${VCELL_DEBUG_OPTS} \
 # Heap must leave room for the rest of the JVM. Measured on the api container (2000Mi
 # limit): metaspace 83Mi + code cache 65Mi + ~56Mi of thread stacks + ~500Mi of other
 # native allocation, so roughly 700Mi is not heap. At MaxRAMPercentage=80 the heap alone

--- a/docker/build/Dockerfile-sched-dev
+++ b/docker/build/Dockerfile-sched-dev
@@ -79,13 +79,33 @@ ENV dbpswdfile=/run/secrets/dbpswd \
     jmspswdfile=/run/secrets/jmspswd \
     batchuserkeyfile=/run/secrets/batchuserkeyfile
 
+ENV VCELL_DEBUG_OPTS=""
+
 EXPOSE 8000
 
 VOLUME /simdata
 VOLUME /htclogs
 
 ENTRYPOINT java \
-    -Xdebug -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n \
+# Debugging is opt-in, not always-on. A JDWP listener accepts any connection with no
+# authentication whatsoever: whoever reaches the port can invoke arbitrary methods, read
+# and write any field, and load classes -- code execution as the JVM user. It used to be
+# baked in here, and Services published it inside the cluster, so every workload in the
+# cluster had that reach into production.
+#
+# It cannot be attached later: libjdwp implements only Agent_OnLoad, so
+# `jcmd <pid> JVMTI.agent_load .../libjdwp.so` fails with "Agent_OnAttach is not
+# available" (verified on a dev pod). Enabling it therefore costs a restart:
+#
+#   kubectl -n <ns> set env deployment/<svc> \
+#     VCELL_DEBUG_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000'
+#   kubectl -n <ns> set env deployment/<svc> VCELL_DEBUG_OPTS-      # to turn it back off
+#
+# That restart clears whatever state you wanted to look at, which is the real cost of this
+# change. What does NOT need a restart, and captures the misbehaving process as it is:
+# `jcmd <pid> GC.heap_dump`, `jcmd <pid> JFR.start settings=profile`, `Thread.print`, and
+# `VM.native_memory` -- all confirmed working on demand against a running JVM.
+    ${VCELL_DEBUG_OPTS} \
 # Heap must leave room for the rest of the JVM. Measured on the api container (2000Mi
 # limit): metaspace 83Mi + code cache 65Mi + ~56Mi of thread stacks + ~500Mi of other
 # native allocation, so roughly 700Mi is not heap. At MaxRAMPercentage=80 the heap alone

--- a/docker/build/Dockerfile-submit-dev
+++ b/docker/build/Dockerfile-submit-dev
@@ -112,10 +112,30 @@ VOLUME /simdata
 VOLUME /simdata_secondary
 VOLUME /htclogs
 
+ENV VCELL_DEBUG_OPTS=""
+
 EXPOSE 8000
 
 ENTRYPOINT java \
-    -Xdebug -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n \
+# Debugging is opt-in, not always-on. A JDWP listener accepts any connection with no
+# authentication whatsoever: whoever reaches the port can invoke arbitrary methods, read
+# and write any field, and load classes -- code execution as the JVM user. It used to be
+# baked in here, and Services published it inside the cluster, so every workload in the
+# cluster had that reach into production.
+#
+# It cannot be attached later: libjdwp implements only Agent_OnLoad, so
+# `jcmd <pid> JVMTI.agent_load .../libjdwp.so` fails with "Agent_OnAttach is not
+# available" (verified on a dev pod). Enabling it therefore costs a restart:
+#
+#   kubectl -n <ns> set env deployment/<svc> \
+#     VCELL_DEBUG_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000'
+#   kubectl -n <ns> set env deployment/<svc> VCELL_DEBUG_OPTS-      # to turn it back off
+#
+# That restart clears whatever state you wanted to look at, which is the real cost of this
+# change. What does NOT need a restart, and captures the misbehaving process as it is:
+# `jcmd <pid> GC.heap_dump`, `jcmd <pid> JFR.start settings=profile`, `Thread.print`, and
+# `VM.native_memory` -- all confirmed working on demand against a running JVM.
+    ${VCELL_DEBUG_OPTS} \
 # Heap must leave room for the rest of the JVM. Measured on the api container (2000Mi
 # limit): metaspace 83Mi + code cache 65Mi + ~56Mi of thread stacks + ~500Mi of other
 # native allocation, so roughly 700Mi is not heap. At MaxRAMPercentage=80 the heap alone


### PR DESCRIPTION
A JDWP listener **authenticates nobody**. Whoever reaches the port can invoke arbitrary methods, read and write any field, and load classes — code execution as the JVM user. It was baked into five entrypoints on port 8000, and Services publish 8000 inside the cluster for four of them, so any workload in the cluster had that reach into production.

### Change

Driven by `VCELL_DEBUG_OPTS`, empty by default:

```bash
kubectl -n <ns> set env deployment/<svc> \
  VCELL_DEBUG_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000'
kubectl -n <ns> set env deployment/<svc> VCELL_DEBUG_OPTS-     # off again
```

### The cost, stated plainly

Enabling it now requires a restart, and **that restart clears the state you wanted to debug**. That is a genuine capability loss, accepted deliberately — the alternative is a standing unauthenticated entry point into production.

There is no way around the restart: `libjdwp` implements only `Agent_OnLoad`, so `jcmd <pid> JVMTI.agent_load .../libjdwp.so` fails with `Agent_OnAttach is not available`. **Rehearsed on a dev pod against a purpose-started agent-free JVM** — an earlier version of this proposal claimed on-demand attach would work, and the rehearsal disproved it.

### What still works with no restart

Verified in the same rehearsal, capturing the misbehaving process as it is:

| | |
|---|---|
| `GC.heap_dump` | 5.9M hprof in 0.021s |
| `JFR.start settings=profile` | recording confirmed running |
| `Thread.print`, `VM.native_memory` | working |

What is lost is specifically *interactive* debugging — breakpoints and stepping — which in production freeze a thread serving a real user anyway.

### Proven, not reasoned about

Built a container with this exact pattern: with the variable empty the JVM starts normally and no listener appears; with it set the JVM prints `Listening for transport dt_socket at address: 8000`. An empty shell-form variable expands to nothing rather than an empty argument.

Dockerfile lint unchanged from master (same 3 pre-existing warnings).

### Companion change needed in vcell-fluxcd

This repo cannot finish the job: **`rest` and `export` get JDWP on port 5005 from `JAVA_OPTS`** in the deployment, and the Services publishing 8000 also live there. Seven services, two mechanisms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg