### PR TITLE
Export tables to HDF5 with the pure-java writer (ASCIIExporter needs incremental writes)

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/simdata/MultiTrialNonspatialStochSimDataReader.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/MultiTrialNonspatialStochSimDataReader.java
@@ -2,7 +2,6 @@ package cbit.vcell.simdata;
 
 import cbit.vcell.solver.ode.ODESimData;
 import com.google.common.io.Files;
-import hdf.hdf5lib.exceptions.HDF5Exception;
 import io.jhdf.HdfFile;
 import io.jhdf.api.Dataset;
 import org.vcell.util.ObjectNotFoundException;
@@ -26,7 +25,7 @@ import java.util.Arrays;
 
 public class MultiTrialNonspatialStochSimDataReader {
 
-    public static double[] extractColumn(ODESimData odeSimData, String columnName, SummaryStatisticType summaryStatisticType) throws HDF5Exception, ObjectNotFoundException {
+    public static double[] extractColumn(ODESimData odeSimData, String columnName, SummaryStatisticType summaryStatisticType) throws ObjectNotFoundException {
         File localHdf5File = null;
         try {
             byte[] hdf5FileBytes = odeSimData.getHdf5FileBytes();

--- a/vcell-core/src/main/java/cbit/vcell/simdata/UiTableExporterToHDF5.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/UiTableExporterToHDF5.java
@@ -1,10 +1,11 @@
 package cbit.vcell.simdata;
 
+import cbit.vcell.export.server.JhdfUtils;
 import cbit.vcell.math.ReservedVariable;
-import hdf.hdf5lib.H5;
-import hdf.hdf5lib.HDF5Constants;
-import hdf.hdf5lib.exceptions.HDF5Exception;
-import hdf.hdf5lib.exceptions.HDF5LibraryException;
+import io.jhdf.HdfFile;
+import io.jhdf.WritableHdfFile;
+import io.jhdf.api.WritableDataset;
+import io.jhdf.api.WritableGroup;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -14,12 +15,12 @@ import java.util.ListIterator;
 
 public class UiTableExporterToHDF5 {
     public static File exportTableToHDF5(boolean bHistogram, String blankCellValue, int[] columns, int[] rows, String xVarColumnName, String hdf5DescriptionText, String[] columnNames, String[] paramScanParamNames, Double[][] paramScanParamValues, Object[][] rowColValues) throws Exception {
-		long hdf5FileID = -1;//Used if HDF5 format
 		File hdf5TempFile = null;
 		try {
 			hdf5TempFile = File.createTempFile("plot2D", ".hdf");
-			//System.out.println("/home/vcell/Downloads/hdf5/HDFView/bin/HDFView "+hdf5TempFile.getAbsolutePath());
-			hdf5FileID = H5.H5Fcreate(hdf5TempFile.getAbsolutePath(), HDF5Constants.H5F_ACC_TRUNC,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+			// jhdf assembles the file in memory and writes it on close; this export is a table the
+			// caller already holds, so there is nothing to stream
+			WritableHdfFile hdf5File = HdfFile.write(hdf5TempFile.toPath());
 			ArrayList<ArrayList<Integer>> paramScanJobs = new ArrayList<>();
 			if(!bHistogram && !columnNames[0].equals((xVarColumnName==null? ReservedVariable.TIME.getName():xVarColumnName))) {
 				throw new Exception("Expecting first column in table to have name '"+xVarColumnName+"'");
@@ -90,10 +91,8 @@ public class UiTableExporterToHDF5 {
 				if(selectedColCount == 0) {
 					continue;
 				}
-				long jobGroupID = -1;//(int) UiTableExporterToHDF5.createGroup(hdf5FileID, "Set "+k);
-						//writeHDF5Dataset(hdf5FileID, "Set "+k, null, null, false);
-				HDF5WriteHelper help0 = null;//UiTableExporterToHDF5.createDataset(jobGroupID, "data", new long[] {selectedColCount,rows.length});
-						//(HDF5WriteHelper) UiTableExporterToHDF5.writeHDF5Dataset(jobGroupID, "data", new long[] {selectedColCount,rows.length}, new Object[] {}, false);
+				WritableGroup jobGroup = null;
+				Integer setNumber = null;
 				//((DefaultTableModel)getScrollPaneTable().getModel()).getDataVector()
 				double[] fromData = new double[rows.length*selectedColCount];
 				int actualLength = -1;
@@ -141,8 +140,7 @@ public class UiTableExporterToHDF5 {
 						if(!bParamsDone) {
 							bParamsDone = true;
 							int set = Integer.parseInt(colName.substring(colName.lastIndexOf("Set ")+4));
-							jobGroupID = createGroup(hdf5FileID, "Set "+set);
-							help0 = createDataset(jobGroupID, "data", new long[] {selectedColCount,actualLength});
+							setNumber = set;
 							for(int z=0;z<paramScanParamNames.length;z++) {
 								paramNames.add(paramScanParamNames[z]);
 								paramValues.add(paramScanParamValues[set][z]+"");
@@ -154,207 +152,35 @@ public class UiTableExporterToHDF5 {
 
 				}
 
-				double[] fromData2 = new double[actualLength*selectedColCount];
+				// [column][row], the shape the dataset was created with
+				double[][] setData = new double[selectedColCount][actualLength];
 				for(int i=0;i<selectedColCount;i++) {
-					System.arraycopy(fromData, i* rows.length, fromData2, i*actualLength, actualLength);
+					System.arraycopy(fromData, i* rows.length, setData[i], 0, actualLength);
 				}
-				if(help0 == null) {
-					jobGroupID = createGroup(hdf5FileID, "Set "+k);
-					help0 = createDataset(jobGroupID, "data", new long[] {selectedColCount,actualLength});
-				}
-				copySlice(help0.hdf5DatasetValuesID,fromData2,new long[] {0,0},new long[] {selectedColCount,actualLength},new long[] {selectedColCount,actualLength},new long[] {0,0},new long[] {selectedColCount,actualLength},help0.hdf5DataSpaceID);
-					//writeHDF5Dataset(help0.hdf5DatasetValuesID, null, null, objArr, false);
-				insertAttribute(help0.hdf5DatasetValuesID, "_type", "ODE Data Export");//.writeHDF5Dataset(help0.hdf5DatasetValuesID, "_type", null, "ODE Data Export", true);
-				insertAttributes(help0.hdf5DatasetValuesID,"dataSetDataTypes", dataTypes);//.writeHDF5Dataset(help0.hdf5DatasetValuesID, "dataSetDataTypes", null, dataTypes, true);
-				insertAttributes(help0.hdf5DatasetValuesID,"dataSetIds",dataIDs);//UiTableExporterToHDF5.writeHDF5Dataset(help0.hdf5DatasetValuesID, "dataSetIds", null,dataIDs , true);
-				insertAttributes(help0.hdf5DatasetValuesID,"dataSetLabels",dataLabels);//UiTableExporterToHDF5.writeHDF5Dataset(help0.hdf5DatasetValuesID, "dataSetLabels", null,dataLabels , true);
-				insertAttributes(help0.hdf5DatasetValuesID,"dataSetNames",dataNames);//UiTableExporterToHDF5.writeHDF5Dataset(help0.hdf5DatasetValuesID, "dataSetNames", null,dataNames , true);
-				insertAttributes(help0.hdf5DatasetValuesID,"dataSetShapes",dataShapes);//UiTableExporterToHDF5.writeHDF5Dataset(help0.hdf5DatasetValuesID, "dataSetShapes", null,dataShapes , true);
-				insertAttribute(help0.hdf5DatasetValuesID,"id","report");//UiTableExporterToHDF5.writeHDF5Dataset(help0.hdf5DatasetValuesID, "id", null,"report" , true);
+				jobGroup = hdf5File.putGroup("Set " + (setNumber == null ? k : setNumber));
+				WritableDataset dataset = jobGroup.putDataset("data", setData);
+
+				JhdfUtils.putAttribute(dataset, "_type", "ODE Data Export");
+				JhdfUtils.putAttribute(dataset, "dataSetDataTypes", dataTypes);
+				JhdfUtils.putAttribute(dataset, "dataSetIds", dataIDs);
+				JhdfUtils.putAttribute(dataset, "dataSetLabels", dataLabels);
+				JhdfUtils.putAttribute(dataset, "dataSetNames", dataNames);
+				JhdfUtils.putAttribute(dataset, "dataSetShapes", dataShapes);
+				JhdfUtils.putAttribute(dataset, "id", "report");
 				if(paramNames.size() != 0) {
-					insertAttributes(help0.hdf5DatasetValuesID,"paramNames",paramNames);
-					insertAttributes(help0.hdf5DatasetValuesID,"paramValues",paramValues);
+					JhdfUtils.putAttribute(dataset, "paramNames", paramNames);
+					JhdfUtils.putAttribute(dataset, "paramValues", paramValues);
 				}
-				help0.close();
-				H5.H5Gclose(jobGroupID);
 			}
 			if(hdf5DescriptionText != null) {
-				insertAttributes(hdf5FileID,"dataSourceDescr", Arrays.asList(new String[] {hdf5DescriptionText}));
+				JhdfUtils.putAttribute(hdf5File, "dataSourceDescr", Arrays.asList(hdf5DescriptionText));
 			}
-			H5.H5Fclose(hdf5FileID);
-			hdf5FileID = -1;
-		}finally {
-			if(hdf5FileID != -1) {try{H5.H5Fclose(hdf5FileID);}catch(Exception e){e.printStackTrace();}}
-			if(hdf5TempFile != null && hdf5TempFile.exists()) {try{hdf5TempFile.delete();}catch(Exception e){e.printStackTrace();}}
+			hdf5File.close(); // writes the file
+		}catch(Exception e) {
+			if(hdf5TempFile != null && hdf5TempFile.exists()) {try{hdf5TempFile.delete();}catch(Exception ignored){}}
+			throw e;
 		}
 		return hdf5TempFile;
-	}
-
-    /**
-	 * Helper class to ensure HDF5 documents are closed properly.
-	 */
-	private static class HDF5WriteHelper {
-		/**
-		 * The id number of the hdf5 dataspace
-		 */
-		public long hdf5DataSpaceID;
-
-		/**
-		 * The id number of the hdf5 dataset
-		 */
-		public long hdf5DatasetValuesID;
-
-		/**
-		 * Construtor of te helper
-		 * 
-		 * @param hdf5DataSpaceID The id number of the hdf5 dataspace
-		 * @param hdf5DatasetValuesID The id number of the hdf5 dataset
-		 */
-		public HDF5WriteHelper(long hdf5DataSpaceID, long hdf5DatasetValuesID) {
-			super();
-			this.hdf5DataSpaceID = hdf5DataSpaceID;
-			this.hdf5DatasetValuesID = hdf5DatasetValuesID;
-		}
-		/**
-		 * Closes the dataspace and dataset referenced in this helper class
-		 * 
-		 * @throws HDF5LibraryException if the hdf5 dataset and/or dataspace was unable to be successfully closed
-		 */
-		public void close() throws HDF5LibraryException {
-			H5.H5Sclose(hdf5DataSpaceID);
-			H5.H5Dclose(hdf5DatasetValuesID);
-		}
-	}
-
-	/**
-	 * Creates a dataset at the specified hdf5 group
-	 * @param hdf5GroupID the group to place the dataset in
-	 * @param datasetName the name to give the dataset
-	 * @param dims n-dimentional sizes to give the dataset
-	 * @return a HDF5 Writer helper class to store the relevant values
-	 * @throws HDF5Exception if the hdf5 library encounters something unusual
-	 */
-	private static HDF5WriteHelper createDataset(long hdf5GroupID,String datasetName,long[] dims) throws HDF5Exception {
-		//Create dataset and return it, must be closed when finished
-		long[] datasetDimensions = dims;
-		long hdf5DataspaceIDValues = H5.H5Screate_simple(datasetDimensions.length, datasetDimensions, null);
-		long hdf5DatasetIDValues = H5.H5Dcreate(hdf5GroupID, datasetName, HDF5Constants.H5T_NATIVE_DOUBLE, hdf5DataspaceIDValues,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
-		return new HDF5WriteHelper(hdf5DataspaceIDValues,hdf5DatasetIDValues);
-	}
-
-	/**
-	 * Creates a new HDF5 group underneath an exisitng group / top of the hdf5 file
-	 * 
-	 * @param hdf5GroupID the ID of the top-level hdf5 file or one of its subgroups
-	 * @param groupName the name of the group
-	 * @return the new group's ID number
-	 * @throws HDF5Exception if the hdf5 library encounters something unusual
-	 */
-	private static long createGroup(long hdf5GroupID,String groupName) throws HDF5Exception{
-		return H5.H5Gcreate(hdf5GroupID, (String)groupName,HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
-	}
-
-	/**
-	 * Use the HDF5 hyperslab feature to copy data from one play to another (not sure how to use it though...)
-	 * 
-	 * @param copyToDataSet
-	 * @param copyFromData
-	 * @param copyToStart
-	 * @param copyToLength
-	 * @param copyFromDims
-	 * @param copyFromStart
-	 * @param copyFromLength
-	 * @param dataspaceID
-	 * @throws NullPointerException
-	 * @throws IllegalArgumentException
-	 * @throws HDF5Exception
-	 */
-	private static void copySlice(long copyToDataSet,double[] copyFromData,long[] copyToStart,long[] copyToLength,long[] copyFromDims,long[] copyFromStart,long[] copyFromLength,long dataspaceID) throws NullPointerException, IllegalArgumentException, HDF5Exception {
-		long hdf5DataspaceIDSlice = H5.H5Screate_simple(copyFromDims.length, copyFromDims, null);
-		//Select the generated sliceData to copy-from
-		H5.H5Sselect_hyperslab(hdf5DataspaceIDSlice, HDF5Constants.H5S_SELECT_SET, copyFromStart, null, copyFromLength, null);
-		//Select next section of destination to copy-to
-		H5.H5Sselect_hyperslab(dataspaceID, HDF5Constants.H5S_SELECT_SET, copyToStart, null, copyToLength,null);
-		//Copy from extracted sliceData to hdf5 file dataset
-		H5.H5Dwrite_double(copyToDataSet, HDF5Constants.H5T_NATIVE_DOUBLE, hdf5DataspaceIDSlice, dataspaceID, HDF5Constants.H5P_DEFAULT, copyFromData);
-		H5.H5Sselect_none(dataspaceID);
-		H5.H5Sclose(hdf5DataspaceIDSlice);
-	}
-
-	/**
-	 * Insert an attribute at the specified group where the data are a single value
-	 * 
-	 * @param hdf5GroupID the id of the group to apply the attribute to
-	 * @param attributeName name of the attribute
-	 * @param data the data to place
-	 * @throws NullPointerException (unsure how this occurs)
-	 * @throws HDF5Exception if the hdf5 library encounters something unusual
-	 */
-	private static void insertAttribute(long hdf5GroupID,String attributeName,String data) throws NullPointerException, HDF5Exception {
-		//insertAttributes(hdf5GroupID, dataspaceName, new ArrayList<String>(Arrays.asList(new String[] {data})));
-		//String[] attr = data.toArray(new String[0]);
-
-		String attr = data + '\u0000';
-
-		//https://support.hdfgroup.org/ftp/HDF5/examples/misc-examples/vlstra.c
-		long h5attrcs1 = H5.H5Tcopy(HDF5Constants.H5T_C_S1);
-		H5.H5Tset_size (h5attrcs1, attr.length() /*HDF5Constants.H5T_VARIABLE*/);
-		long dataspace_id = -1;
-		//dataspace_id = H5.H5Screate_simple(dims.length, dims,null);
-		dataspace_id = H5.H5Screate(HDF5Constants.H5S_SCALAR);
-		long attribute_id = H5.H5Acreate(hdf5GroupID, attributeName, h5attrcs1, dataspace_id, HDF5Constants.H5P_DEFAULT,HDF5Constants.H5P_DEFAULT);
-		H5.H5Awrite(attribute_id, h5attrcs1, attr.getBytes());
-		H5.H5Sclose(dataspace_id);
-		H5.H5Aclose(attribute_id);
-		H5.H5Tclose(h5attrcs1);
-	}
-	
-	/**
-	 * Insert an attribute at the specified group where the data are multiple values
-	 * 
-	 * @param hdf5GroupID the id of the group to apply the attribute to
-	 * @param attributeName name of the attribute
-	 * @param data the data to place
-	 * @throws NullPointerException (unsure how this occurs)
-	 * @throws HDF5Exception if the hdf5 library encounters something unusual
-	 */
-	private static void insertAttributes(long hdf5GroupID,String attributeName,List<String> data) throws NullPointerException, HDF5Exception {
-		String[] attr = data.toArray(new String[0]);
-		long[] dims = new long[] {attr.length}; // Always an array of length == 1
-		StringBuffer sb = new StringBuffer();
-		int MAXSTRSIZE=  -1;
-
-		// Get the max length of all the data strings
-		for(int i=0;i<attr.length;i++) {
-			int len = attr[i] == null ? -1 : attr[i].length(); 
-
-			if (len == 0) 
-				len = 1; // Need to pad with null char for empty str; passing a 0 causes null exception
-
-			if (attr[i] == null) 
-				attr[i] = "";
-			
-			MAXSTRSIZE = Math.max(MAXSTRSIZE, len);
-		}
-
-		// Append data to single string buffer, padding with null characters to create uniformity.
-		for(int i=0;i<attr.length;i++) {
-			sb.append(attr[i]);
-			for(int j=0;j<(MAXSTRSIZE-attr[i].length());j++) {
-				sb.append('\u0000');//null terminated string for hdf5 native code
-			}
-		}
-
-		//https://support.hdfgroup.org/ftp/HDF5/examples/misc-examples/vlstra.c
-		long h5attrcs1 = H5.H5Tcopy(HDF5Constants.H5T_C_S1);
-		H5.H5Tset_size (h5attrcs1, MAXSTRSIZE/*HDF5Constants.H5T_VARIABLE*/);
-		long dataspace_id = -1;
-		dataspace_id = H5.H5Screate_simple(dims.length, dims,null);
-		long attribute_id = H5.H5Acreate(hdf5GroupID, attributeName, h5attrcs1, dataspace_id, HDF5Constants.H5P_DEFAULT,HDF5Constants.H5P_DEFAULT);
-		H5.H5Awrite(attribute_id, h5attrcs1, sb.toString().getBytes());
-		H5.H5Sclose(dataspace_id);
-		H5.H5Aclose(attribute_id);
-		H5.H5Tclose(h5attrcs1);
 	}
 
 }

--- a/vcell-core/src/test/java/cbit/vcell/simdata/UiTableExporterToHDF5Test.java
+++ b/vcell-core/src/test/java/cbit/vcell/simdata/UiTableExporterToHDF5Test.java
@@ -1,0 +1,70 @@
+package cbit.vcell.simdata;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.jhdf.HdfFile;
+import io.jhdf.api.Dataset;
+import io.jhdf.api.Group;
+
+/**
+ * Exports a small table and reads the file back, so the structure the exporter promises — one group
+ * per parameter-scan set, a [column][row] dataset of doubles, and the labelling attributes a
+ * consumer reads — is pinned rather than assumed.
+ */
+@Tag("Fast")
+public class UiTableExporterToHDF5Test {
+
+	private static final String[] COLUMN_NAMES = { "t", "A", "B" };
+
+	/** three timepoints of two variables, as the plot table holds them */
+	private static Object[][] table() {
+		return new Object[][] {
+				{ 0.0, 1.0, 10.0 },
+				{ 0.5, 2.0, 20.0 },
+				{ 1.0, 3.0, 30.0 },
+		};
+	}
+
+	@Test
+	public void exportsATableThatReadsBack() throws Exception {
+		File exported = UiTableExporterToHDF5.exportTableToHDF5(false, "0", new int[] { 0, 1, 2 },
+				new int[] { 0, 1, 2 }, "t", "a description", COLUMN_NAMES,
+				new String[0], new Double[0][0], table());
+		exported.deleteOnExit();
+		Assertions.assertTrue(exported.length() > 0, "the export is not empty");
+
+		try (HdfFile file = new HdfFile(exported.toPath())) {
+			Group set = (Group) file.getChildren().get("Set 0");
+			Assertions.assertNotNull(set, "one group per parameter-scan set");
+
+			Dataset data = (Dataset) set.getChildren().get("data");
+			Assertions.assertArrayEquals(new int[] { 3, 3 }, data.getDimensions(),
+					"[column][row]: the x column plus two variables, three timepoints each");
+
+			double[][] values = (double[][]) data.getData();
+			Assertions.assertArrayEquals(new double[] { 0.0, 0.5, 1.0 }, values[0], 1e-12, "the x column");
+			Assertions.assertArrayEquals(new double[] { 1.0, 2.0, 3.0 }, values[1], 1e-12);
+			Assertions.assertArrayEquals(new double[] { 10.0, 20.0, 30.0 }, values[2], 1e-12);
+
+			Assertions.assertEquals("ODE Data Export", attribute(data, "_type"));
+			Assertions.assertEquals("report", attribute(data, "id"));
+			Assertions.assertEquals(List.of("t", "A", "B"), Arrays.asList((String[]) data.getAttribute("dataSetLabels").getData()));
+			Assertions.assertEquals(List.of("float64", "float64", "float64"),
+					Arrays.asList((String[]) data.getAttribute("dataSetDataTypes").getData()));
+
+			Assertions.assertEquals("a description",
+					((String[]) file.getAttribute("dataSourceDescr").getData())[0]);
+		}
+	}
+
+	private static String attribute(Dataset dataset, String name) {
+		Object value = dataset.getAttribute(name).getData();
+		return value instanceof String[] ? ((String[]) value)[0] : String.valueOf(value);
+	}
+}


### PR DESCRIPTION
Moves what can move off the native HDF5 binding (`cisd:jhdf5` / `hdf.hdf5lib`) onto pure-java `io.jhdf`. **It does not finish the job, and the reason is worth a decision** — see the last section.

Stacked on #1906, which brings jhdf 0.13.0 and retires the *other* native binding (`ncsa.hdf`).

### Converted

- **`UiTableExporterToHDF5`** — writes a table the caller already holds in memory, one full-extent write per parameter-scan set. Nothing about it needed the C-style API it was using: 174 lines of dataspace, dataset-handle and hyperslab bookkeeping become `putGroup` / `putDataset` / `putAttribute`, reusing the attribute helpers `JhdfUtils` already provides for the biosimulations writer. 360 lines → 186.
- **`MultiTrialNonspatialStochSimDataReader`** — only named `HDF5Exception` in a `throws` clause. It reads through `io.jhdf` and cannot raise one.

New `UiTableExporterToHDF5Test` exports a small table and reads the file back, pinning the structure a consumer depends on: one group per set, a `[column][row]` dataset of doubles, and the labelling attributes (`_type`, `id`, `dataSetLabels`, `dataSetDataTypes`, `dataSourceDescr`).

### Not converted, on purpose: `ASCIIExporter`

**jhdf cannot write a dataset incrementally.** `WritableDatasetImpl` takes the entire array in its constructor, `DatasetCreationOptions` only configures chunking and filters, and the file is assembled in memory and written on close. There is no hyperslab-write equivalent.

`ASCIIExporter` depends on exactly that. It creates a dataset of the export's full extent up front and then streams into it one time-slice at a time, holding only a single slice in memory:

```java
long[] dimsValues = { sizeXYZ[outer], sizeXYZ[inner], numSlices, timeCount };   // dataset
H5.H5Sselect_hyperslab(..., { 0, 0, nSlices, currentTimeIndex }, ..., { outer, inner, 1, 1 }, ...);
H5.H5Dwrite_double(..., sliceData);                                              // one slice
```

Converting it means buffering the whole export before writing. For a 3D export that full extent is `outer × inner × slices × times` doubles — a 200×200 slice, 50 slices, 200 timepoints is **3.2 GB**, and a user can ask for that from the export dialog today without anything going wrong. Trading a bounded-memory export for an unbounded one is not an improvement, so this PR leaves it alone.

That means `cisd:jhdf5` and `NativeLoader` stay for now, for this one writer. Options, if you want it finished:

1. **Leave it.** One native writer, no reader depends on it, and it is the status quo.
2. **Contribute incremental writes to jhdf.** The project is active — 0.13.0 added chunked writing with compression — and writing chunk-by-chunk is the natural next step. Then `ASCIIExporter` converts unchanged in shape.
3. **Restructure the exporter** to write each time-slice as its own dataset rather than a slab of one big dataset. That changes the file layout consumers see, so it is a data-format decision, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
