### PR TITLE
Stop losing track of running slurm jobs across a restart

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
@@ -214,7 +214,7 @@ private PostProcessingChores choresFor(SimulationTask simTask) {
 
 
 //------------------------------Job Monitor Section BEGIN
-private static class MonitorJobInfo {
+static class MonitorJobInfo {
 	private long slurmJobID;
 	private boolean bDelete;
 	private VCSimulationIdentifier vcsimID;
@@ -231,16 +231,29 @@ private static class MonitorJobInfo {
 		this.slurmJobID = slurmJobID;
 		this.bDelete = true;;
 	}
+	private static String next(StringTokenizer st, String line, String what) {
+		if (!st.hasMoreTokens()) {
+			throw new IllegalArgumentException("monitorJobs entry is missing " + what + ": '" + line + "'");
+		}
+		return st.nextToken();
+	}
+
+	/** toString() writes the username quoted; strip it, or each rewrite adds another pair. */
+	private static String unquote(String s) {
+		return (s.length() >= 2 && s.startsWith("'") && s.endsWith("'")) ? s.substring(1, s.length()-1) : s;
+	}
+
+	/** Inverse of {@link #toString()}; throws IllegalArgumentException naming the bad line. */
 	public static MonitorJobInfo fromString(String str) {
 		StringTokenizer st = new StringTokenizer(str," \n\r");
-		boolean bDelete = (st.nextToken().equals("+")?false:true);// + or -
-		long slurmJobID = Long.parseLong(st.nextToken());// slurmJobID
+		boolean bDelete = (next(st, str, "+/- marker").equals("+")?false:true);// + or -
+		long slurmJobID = Long.parseLong(next(st, str, "slurmJobID"));// slurmJobID
 		if(!bDelete) {
-			KeyValue simKey = new KeyValue(st.nextToken());// simkey
-			String username = st.nextToken();// username
-			KeyValue userkey = new KeyValue(st.nextToken());// userkey
-			int simJobIndex = Integer.parseInt(st.nextToken());// simjobidindex
-			int simTaskID = Integer.parseInt(st.nextToken());// simtaskid
+			KeyValue simKey = new KeyValue(next(st, str, "simKey"));// simkey
+			String username = unquote(next(st, str, "username"));// username
+			KeyValue userkey = new KeyValue(next(st, str, "userKey"));// userkey
+			int simJobIndex = Integer.parseInt(next(st, str, "simJobIndex"));// simjobidindex
+			int simTaskID = Integer.parseInt(next(st, str, "simTaskID"));// simtaskid
 			return new MonitorJobInfo(slurmJobID,new VCSimulationIdentifier(simKey, new User(username, userkey)), simJobIndex, simTaskID);
 		}else {
 			return new MonitorJobInfo(slurmJobID);
@@ -270,11 +283,17 @@ private static Hashtable<String,MonitorJobInfo> getMonitorJobs(){
 			for (Iterator<String> iterator = monitorJobsList.iterator(); iterator.hasNext();) {
 				String slurmJobInfoStr = (String) iterator.next();
 				if(slurmJobInfoStr != null && slurmJobInfoStr.trim().length() > 0) {
-					MonitorJobInfo monitorJobInfo = MonitorJobInfo.fromString(slurmJobInfoStr);
-					if(monitorJobInfo.bDelete) {
-						theseJobsAreDone.add(monitorJobInfo.slurmJobID+"");
-					}else {
-						result.put(monitorJobInfo.slurmJobID+"", monitorJobInfo);
+					// per line, so one unparseable entry costs that entry and not the rest of the file.
+					// Losing the tail means losing track of running slurm jobs.
+					try {
+						MonitorJobInfo monitorJobInfo = MonitorJobInfo.fromString(slurmJobInfoStr);
+						if(monitorJobInfo.bDelete) {
+							theseJobsAreDone.add(monitorJobInfo.slurmJobID+"");
+						}else {
+							result.put(monitorJobInfo.slurmJobID+"", monitorJobInfo);
+						}
+					} catch (Exception e) {
+						lg.error("skipping unparseable monitorJobs entry '" + slurmJobInfoStr + "': " + e, e);
 					}
 				}
 			}
@@ -314,8 +333,11 @@ public void startJobMonitor() {
 		lg.info("Resetting slurm monitorJobsFile");
 		//clean jobs file
 		StringBuffer sb = new StringBuffer();
-		for (Iterator<String> iterator = monitorTheseJobs.keySet().iterator(); iterator.hasNext();) {
-			sb.append((iterator.next())+"\n");	
+		// values(), not keySet(): the keys are bare slurm job ids, and writing those produced a
+		// file whose lines cannot be parsed back -- "12345" has no second token, so the next
+		// startup threw NoSuchElementException and dropped every remaining monitored job.
+		for (MonitorJobInfo monitorJobInfo : monitorTheseJobs.values()) {
+			sb.append(monitorJobInfo.toString()+"\n");
 		}
 		Files.write(monitorJobsFile.toPath(),sb.toString().getBytes(),StandardOpenOption.CREATE,StandardOpenOption.WRITE,StandardOpenOption.TRUNCATE_EXISTING);
 	} catch (IOException e1) {

--- a/vcell-server/src/test/java/cbit/vcell/message/server/batch/sim/MonitorJobInfoTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/batch/sim/MonitorJobInfoTest.java
@@ -1,0 +1,83 @@
+package cbit.vcell.message.server.batch.sim;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.vcell.util.document.KeyValue;
+import org.vcell.util.document.User;
+import cbit.vcell.solver.VCSimulationIdentifier;
+
+import cbit.vcell.message.server.batch.sim.HtcSimulationWorker.MonitorJobInfo;
+
+/**
+ * The record of which slurm jobs are being monitored is persisted as text and read back on
+ * startup, so `toString` and `fromString` have to be exact inverses — and they were not.
+ *
+ * The file was rewritten from the map's {@code keySet()}, which holds bare slurm job ids, so a
+ * restart with live jobs wrote lines like {@code "12345"}. Reading one of those threw
+ * {@code NoSuchElementException} at the second token, and because the read loop caught around
+ * the whole file rather than per line, every job after it was dropped — VCell lost track of
+ * running simulations.
+ */
+@Tag("Fast")
+public class MonitorJobInfoTest {
+
+	private static MonitorJobInfo aJob() {
+		VCSimulationIdentifier simId = new VCSimulationIdentifier(
+				new KeyValue("321868189"), new User("vcellNagios", new KeyValue("90825526")));
+		return new MonitorJobInfo(2711367L, simId, 0, 0);
+	}
+
+	/** The property that was broken: what is written must read back as what was written. */
+	@Test
+	public void aJobRoundTripsThroughItsTextForm() {
+		MonitorJobInfo original = aJob();
+		MonitorJobInfo parsed = MonitorJobInfo.fromString(original.toString());
+
+		assertEquals(original.toString(), parsed.toString(),
+				"a round trip must be stable, or every rewrite of the file mutates the entry");
+	}
+
+	/** The username is written quoted; parsing must strip it, or the quotes compound. */
+	@Test
+	public void theUsernameDoesNotAccumulateQuotes() {
+		String once = aJob().toString();
+		String twice = MonitorJobInfo.fromString(once).toString();
+		String thrice = MonitorJobInfo.fromString(twice).toString();
+
+		assertTrue(once.contains("'vcellNagios'"), once);
+		assertEquals(once, thrice, "repeated read/write cycles must not change the entry");
+	}
+
+	/** A delete marker carries only the job id, and must still parse. */
+	@Test
+	public void aDeleteMarkerParses() {
+		MonitorJobInfo parsed = MonitorJobInfo.fromString("- 2711367 ");
+		assertNotNull(parsed);
+		assertEquals("- 2711367 ", parsed.toString());
+	}
+
+	/**
+	 * The exact line the old rewrite produced. It must fail with something that names the line,
+	 * not a bare NoSuchElementException whose getMessage() is null — that is what logged as "null".
+	 */
+	@Test
+	public void aBareJobIdIsRejectedWithAUsefulMessage() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> MonitorJobInfo.fromString("2711367"));
+		assertTrue(e.getMessage().contains("2711367"), "the message must quote the bad line: " + e.getMessage());
+		assertTrue(e.getMessage().contains("slurmJobID"), "and say which field is missing: " + e.getMessage());
+	}
+
+	/** A truncated record — the shape an interrupted append leaves behind. */
+	@Test
+	public void aTruncatedRecordIsRejectedRatherThanHalfParsed() {
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+				() -> MonitorJobInfo.fromString("+ 2711367 321868189 'vcellNagios'"));
+		assertTrue(e.getMessage().contains("userKey"), e.getMessage());
+	}
+}


### PR DESCRIPTION
Found in the dev logs, not in review: `HtcSimulationWorker` logs a bare **`null`** ERROR at every startup — **77 times in the last seven days**. The message is empty because it's `NoSuchElementException`, whose `getMessage()` is null.

### The cause is one word

`startJobMonitor()` rewrites the monitor-jobs file from

```java
monitorTheseJobs.keySet()
```

but that map is `Hashtable<String,MonitorJobInfo>` keyed by the **slurm job id**. So a restart with live jobs writes lines like `12345` instead of `+ 12345 <simkey> 'user' <userkey> 0 0`.

On the next startup `12345` has no second token, `fromString` throws, and because the read loop wrapped **the whole file** rather than each line, every remaining entry was dropped. **VCell stopped monitoring simulations that were still running on the cluster.**

The live file on dev is currently clean, which fits: every `+` has a matching `-` (107 each), so the map is empty at restart and the truncate writes nothing. The corruption only lands when live jobs exist at restart — and the startup error then clears it.

### Three changes

| | |
|---|---|
| `values()` instead of `keySet()` | what is written can be read back |
| `try`/`catch` **per line** | one damaged entry costs that entry, not the tail of the file — an interrupted append can still leave a partial line |
| `fromString` validates each token | names the missing field and the offending line, so the next occurrence does not log as `null` |

Also **unquotes the username**. `toString` writes `'name'`; nothing read it back before, because values were never re-serialised — fixing `keySet()` makes that round trip real, and without stripping, every restart would add another pair of quotes.

### Testing

Five tests, **four of which fail against the unfixed parser** — including the exact production line (`"2711367"` → `NoSuchElementException`) and a stability check that a record survives repeated read/write cycles unchanged.

The nested class becomes package-private so the test can reach it. `vcell-server` Fast group 85 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg