### PR TITLE
A job cancelled on the cluster is stopped, not failed

### DIFF
--- a/vcell-rest/src/main/java/org/vcell/restq/Simulations/SimulationStateMachine.java
+++ b/vcell-rest/src/main/java/org/vcell/restq/Simulations/SimulationStateMachine.java
@@ -304,17 +304,30 @@ public class SimulationStateMachine {
 
                 SimulationExecutionStatus newExeStatus = new SimulationExecutionStatus(startDate, computeHost, lastUpdateDate, endDate, hasData, htcJobID);
 
-                // "stopped unexpectedly" is right for a crash and wrong for a configured limit:
-                // a timed-out solver stopped exactly as instructed, and prefixing it here would
-                // contradict the message the worker already wrote.
                 String failureDetail = workerEventSimulationMessage.getDisplayMessage();
-                SimulationMessage simulationMessage = SimulationMessage.workerFailure(
-                        SimulationMessage.describesTimeLimit(failureDetail)
-                                ? failureDetail
-                                : "solver stopped unexpectedly, " + failureDetail);
 
-                newJobStatus = new SimulationJobStatus(vcServerID, vcSimDataID.getVcSimID(), jobIndex, submitDate, SimulationJobStatus.SchedulerStatus.FAILED,
-                        taskID, simulationMessage, newQueueStatus, newExeStatus);
+                // A deliberate stop is not a failure. The worker reports SOLVER_STOPPED when the
+                // job was terminated on purpose rather than going wrong -- an operator running
+                // scancel on the cluster, say. Recording that as FAILED tells the owner their
+                // model or solver broke and sends them looking for a problem that is not there.
+                //
+                // A user's own stop never reaches here: onStopRequest sets STOPPED first, and
+                // STOPPED.isDone(), so onWorkerEvent discards anything arriving afterwards. What
+                // this covers is a stop VCell did not initiate, which it would otherwise never
+                // learn about at all.
+                if (workerEventSimulationMessage.getDetailedState() == SimulationMessage.DetailedState.SOLVER_STOPPED) {
+                    newJobStatus = new SimulationJobStatus(vcServerID, vcSimDataID.getVcSimID(), jobIndex, submitDate, SimulationJobStatus.SchedulerStatus.STOPPED,
+                            taskID, workerEventSimulationMessage, newQueueStatus, newExeStatus);
+                } else {
+                    // "stopped unexpectedly" is right for a crash and wrong for a configured
+                    // limit: a timed-out solver stopped exactly as instructed.
+                    SimulationMessage simulationMessage = SimulationMessage.workerFailure(
+                            SimulationMessage.describesTimeLimit(failureDetail)
+                                    ? failureDetail
+                                    : "solver stopped unexpectedly, " + failureDetail);
+                    newJobStatus = new SimulationJobStatus(vcServerID, vcSimDataID.getVcSimID(), jobIndex, submitDate, SimulationJobStatus.SchedulerStatus.FAILED,
+                            taskID, simulationMessage, newQueueStatus, newExeStatus);
+                }
 
             }
         }

--- a/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
@@ -394,7 +394,6 @@ public void startJobMonitor() {
 						String jobName = lineTokenizer.nextToken();
 						String jobState = lineTokenizer.nextToken();
 						if(jobState.equalsIgnoreCase("FAILED") ||
-							jobState.startsWith("CANCELLED") ||
 							jobState.equalsIgnoreCase("BOOT_FAIL") ||
 							jobState.equalsIgnoreCase("DEADLINE") ||
 							jobState.equalsIgnoreCase("NODE_FAIL") ||
@@ -405,6 +404,22 @@ public void startJobMonitor() {
 							WorkerEventMessage.sendWorkerExitError(messageProducer_sim, HtcSimulationWorker.class.getName(), ManageUtils.getHostName(),
 								failedMonitorJobInfo.vcsimID, failedMonitorJobInfo.jobIndex, failedMonitorJobInfo.taskID,
 								SimulationMessage.jobFailed("Fail found by monitor, slrmJobID="+slurmJobID+" jobName="+jobName+" jobState="+jobState));
+							removeMonitorJob(Long.parseLong(slurmJobID));
+						}else if(jobState.startsWith("CANCELLED")) {
+							// Cancelled is not a solver failure -- somebody stopped this job on purpose.
+							//
+							// When the user stops a simulation, VCell records STOPPED and then issues the
+							// scancel itself, and SimulationStateMachine.onWorkerEvent discards anything that
+							// arrives once the status isDone() -- so this message is ignored in that case and
+							// the stop is preserved. What reaches a user is the other case: cancelled outside
+							// VCell, where the job really has stopped without finishing and saying so beats
+							// leaving the simulation apparently running. Report it as what it is.
+							MonitorJobInfo cancelledMonitorJobInfo = monitorTheseJobs.get(slurmJobID);
+							if(cancelledMonitorJobInfo != null) {
+								WorkerEventMessage.sendWorkerExitError(messageProducer_sim, HtcSimulationWorker.class.getName(), ManageUtils.getHostName(),
+									cancelledMonitorJobInfo.vcsimID, cancelledMonitorJobInfo.jobIndex, cancelledMonitorJobInfo.taskID,
+									SimulationMessage.solverStopped("simulation was cancelled on the cluster (slurm job "+slurmJobID+", "+jobState+")"));
+							}
 							removeMonitorJob(Long.parseLong(slurmJobID));
 						}else if(jobState.equalsIgnoreCase("COMPLETED")) {
 							MonitorJobInfo completedMonitorJobInfo = monitorTheseJobs.get(slurmJobID);

--- a/vcell-server/src/main/java/cbit/vcell/message/server/dispatcher/SimulationStateMachine.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/dispatcher/SimulationStateMachine.java
@@ -307,12 +307,29 @@ public class SimulationStateMachine {
                 // a timed-out solver stopped exactly as instructed, and prefixing it here would
                 // contradict the message the worker already wrote.
                 String failureDetail = workerEventSimulationMessage.getDisplayMessage();
-                SimulationMessage simulationMessage = SimulationMessage.workerFailure(
-                        SimulationMessage.describesTimeLimit(failureDetail)
-                                ? failureDetail
-                                : "solver stopped unexpectedly, " + failureDetail);
-                newJobStatus = new SimulationJobStatus(vcServerID, vcSimDataID.getVcSimID(), jobIndex, submitDate, SchedulerStatus.FAILED,
-                        taskID, simulationMessage, newQueueStatus, newExeStatus);
+
+                // A deliberate stop is not a failure. The worker reports SOLVER_STOPPED when the
+                // job was terminated on purpose rather than going wrong -- an operator running
+                // scancel on the cluster, say. Recording that as FAILED tells the owner their
+                // model or solver broke and sends them looking for a problem that is not there.
+                //
+                // A user's own stop never reaches here: onStopRequest sets STOPPED first, and
+                // STOPPED.isDone(), so onWorkerEvent discards anything arriving afterwards. What
+                // this covers is a stop VCell did not initiate, which it would otherwise never
+                // learn about at all.
+                if (workerEventSimulationMessage.getDetailedState() == SimulationMessage.DetailedState.SOLVER_STOPPED) {
+                    newJobStatus = new SimulationJobStatus(vcServerID, vcSimDataID.getVcSimID(), jobIndex, submitDate, SchedulerStatus.STOPPED,
+                            taskID, workerEventSimulationMessage, newQueueStatus, newExeStatus);
+                } else {
+                    // "stopped unexpectedly" is right for a crash and wrong for a configured
+                    // limit: a timed-out solver stopped exactly as instructed.
+                    SimulationMessage simulationMessage = SimulationMessage.workerFailure(
+                            SimulationMessage.describesTimeLimit(failureDetail)
+                                    ? failureDetail
+                                    : "solver stopped unexpectedly, " + failureDetail);
+                    newJobStatus = new SimulationJobStatus(vcServerID, vcSimDataID.getVcSimID(), jobIndex, submitDate, SchedulerStatus.FAILED,
+                            taskID, simulationMessage, newQueueStatus, newExeStatus);
+                }
 
             }
         }

--- a/vcell-server/src/test/java/cbit/vcell/message/server/dispatcher/SimulationStateMachineTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/dispatcher/SimulationStateMachineTest.java
@@ -25,7 +25,11 @@ import java.util.NoSuchElementException;
 @ResourceLock("vcellGlobalConfig")
 public class SimulationStateMachineTest {
     private static final User testUser = DispatcherTestUtils.alice;
-    private static final MockVCMessageSession testMessageSession = new MockVCMessageSession();
+    // Not static: it accumulates every message the state machine emits, and getClientTopicMessage()
+    // reads from it, so sharing one across methods makes each test's assertion depend on what the
+    // previous test happened to send. setUp() already renews simulationDB and stateMachine; this
+    // was simply left behind.
+    private MockVCMessageSession testMessageSession;
     private static final int jobIndex = DispatcherTestUtils.jobIndex;
     private static final int taskID = DispatcherTestUtils.taskID;
     private static final KeyValue simKey = DispatcherTestUtils.simKey;
@@ -48,6 +52,7 @@ public class SimulationStateMachineTest {
     public void setUp(){
         simulationDB = new MockSimulationDB();
         stateMachine = new SimulationStateMachine(simKey, jobIndex);
+        testMessageSession = new MockVCMessageSession();
     }
 
     private record ChangedStateValues(
@@ -72,6 +77,57 @@ public class SimulationStateMachineTest {
 
     private SimulationJobStatus getClientTopicMessage(){
         return (SimulationJobStatus) testMessageSession.getTopicMessage(VCellTopic.ClientStatusTopic).getObjectContent();
+    }
+
+    private WorkerEvent createWorkerEvent(int workerEventType, SimulationMessage message){
+        return new WorkerEvent(workerEventType, simKey,
+                simID, jobIndex, "",
+                taskID, null, null,
+                message);
+    }
+
+    /**
+     * An operator running scancel on the cluster is not a solver failure. VCell learns about it
+     * the same way it learns about a crash -- a worker exit-error event -- so the only thing that
+     * distinguishes them is the message the worker attached, and recording it as FAILED tells the
+     * owner their model broke and sends them looking for a problem that is not there.
+     *
+     * A user's own stop does not come through here at all: onStopRequest sets STOPPED first, and
+     * STOPPED.isDone(), so onWorkerEvent discards whatever arrives afterwards.
+     */
+    @Test
+    public void aDeliberateStopIsRecordedAsStoppedRatherThanFailed() throws Exception {
+        DispatcherTestUtils.insertOrUpdateStatus(simulationDB);
+
+        stateMachine.onWorkerEvent(createWorkerEvent(WorkerEvent.JOB_WORKER_EXIT_ERROR,
+                SimulationMessage.solverStopped("simulation was cancelled on the cluster (slurm job 2710593, CANCELLED)")),
+                simulationDB, testMessageSession);
+
+        SimulationJobStatus result = getLatestJobSubmission();
+        Assertions.assertTrue(result.getSchedulerStatus().isStopped(),
+                "a job stopped on purpose is stopped, not failed");
+        Assertions.assertFalse(result.getSchedulerStatus().isFailed());
+        Assertions.assertTrue(result.getSimulationMessage().getDisplayMessage().contains("cancelled on the cluster"),
+                "and the reason must survive: " + result.getSimulationMessage().getDisplayMessage());
+        Assertions.assertFalse(result.getSimulationMessage().getDisplayMessage().contains("stopped unexpectedly"),
+                "nothing unexpected happened: " + result.getSimulationMessage().getDisplayMessage());
+
+        Assertions.assertTrue(getClientTopicMessage().getSchedulerStatus().isStopped(),
+                "the client is told the same thing");
+    }
+
+    /** A genuine crash still fails, and still says so. */
+    @Test
+    public void anOrdinaryWorkerExitErrorStillFails() throws Exception {
+        DispatcherTestUtils.insertOrUpdateStatus(simulationDB);
+
+        stateMachine.onWorkerEvent(createWorkerEvent(WorkerEvent.JOB_WORKER_EXIT_ERROR,
+                SimulationMessage.WorkerExited(1)), simulationDB, testMessageSession);
+
+        SimulationJobStatus result = getLatestJobSubmission();
+        Assertions.assertTrue(result.getSchedulerStatus().isFailed());
+        Assertions.assertTrue(result.getSimulationMessage().getDisplayMessage().contains("stopped unexpectedly"),
+                "an unexplained exit keeps the prefix: " + result.getSimulationMessage().getDisplayMessage());
     }
 
     @Test


### PR DESCRIPTION
If an operator runs `scancel` on a running job, VCell recorded it as:

```
SchedulerStatus.FAILED
"solver stopped unexpectedly, Fail found by monitor, slrmJobID=..., jobState=CANCELLED"
```

Both halves are wrong. Nothing about the solver went wrong, and the owner is told their model or solver broke — which sends them looking for a problem that is not there.

### Change

- the monitor separates `CANCELLED` from the genuine failure states and reports `SimulationMessage.solverStopped(...)`, naming the slurm job and state
- both state machines (`vcell-server`'s dispatcher and `vcell-rest`'s) record **`SchedulerStatus.STOPPED`** when a worker-exit event carries a `SOLVER_STOPPED` message, instead of forcing `FAILED`

Reporting *something* matters: an externally cancelled job is one VCell would otherwise never learn about, leaving the simulation apparently running until the dispatcher's 10-minute timeout sweep called it `failed: timed out`.

### A user's own stop is unaffected

It never reached this path and still doesn't: `onStopRequest` sets `STOPPED` first, `STOPPED.isDone()`, and `onWorkerEvent` discards anything arriving afterwards. So the monitor's message for a user-initiated abort was already being ignored — this change is about the stop VCell did *not* initiate.

### Testing

Two tests, one of which fails against the unfixed state machine. A genuine exit error still fails and still carries "stopped unexpectedly"; only a deliberate stop is exempt.

**The control run found a second problem worth fixing.** With the fix reverted, *three* tests failed where only mine should have. `testMessageSession` was `private static final` and accumulated every message the state machine emitted, while `setUp()` renewed everything else — so `getClientTopicMessage()` returned whatever the previous test happened to send. Renewing it per-test makes the control isolate correctly: with the fix reverted, only my test fails now. Same not-sharing lesson as #1853 and #1856.

`vcell-server` Fast group 87 green over two runs; `vcell-rest` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg