### PR TITLE
Monitor asks slurm through HtcProxy instead of running its own sacct

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
@@ -21,7 +21,9 @@ import cbit.vcell.message.server.ManageUtils;
 import cbit.vcell.message.server.ServerMessagingDelegate;
 import cbit.vcell.message.server.batch.opt.OptimizationBatchServer;
 import cbit.vcell.message.server.cmd.CommandService.CommandOutput;
+import cbit.vcell.message.server.htc.HtcJobStatus;
 import cbit.vcell.message.server.htc.HtcProxy;
+import cbit.vcell.message.server.htc.HtcProxy.HtcJobInfo;
 import cbit.vcell.message.server.htc.slurm.SlurmProxy;
 import cbit.vcell.messaging.server.SimulationTask;
 import cbit.vcell.resource.OperatingSystemInfo;
@@ -350,82 +352,61 @@ public void startJobMonitor() {
 				try {
 					int sleeptime=60000;
 					Thread.sleep(sleeptime);
-					StringBuffer slurmJobidSB = new StringBuffer();
-					for(String jobid:monitorTheseJobs.keySet()) {
-						slurmJobidSB.append((slurmJobidSB.length()>0?",":"")+jobid);
-					}
-					if(slurmJobidSB.length() == 0) {
+					if(monitorTheseJobs.isEmpty()) {
 						continue;
 					}
-					StringBuffer slurmJobInfoSB = new StringBuffer();
-					try {
-						HtcSimulationWorker.this.htcProxy.getCommandService();
-						String[] tryStr = new String[] {"sacct","--format=jobid%25,jobname%40,state%30 -n -j "+slurmJobidSB.toString()+" | grep -v \".batch\""+" | grep -v \".extern\""};
-						CommandOutput commandOutput = htcProxy.getCommandService().command(tryStr);
-						slurmJobInfoSB.append(commandOutput.getStandardOutput());
-						lg.debug("sacct stdoutput:\n"+commandOutput.getStandardOutput());
-						lg.debug("sacct stderror:\n"+commandOutput.getStandardError());
-					}catch(Exception e) {
-						lg.error(e.getMessage(), e);
-					}
-//					Process p = null;
-//					try{
-//						String[] cmd = new String[] {"ssh","-i","/run/secrets/batchuserkeyfile","vcell@172.16.246.118","sacct --format=jobid,jobname%40,state -n -j "+slurmJobidSB.toString()+"| grep -v \".batch\""};
-//						ProcessBuilder pb = new ProcessBuilder(Arrays.asList(cmd));
-//						pb.redirectErrorStream(true);
-//						p = pb.start();
-//						int ioByte = -1;
-//						while((ioByte = p.getInputStream().read()) != -1) {
-//							sb.append((char)ioByte);
-//						}
-//						p.waitFor();
-//					}catch(Exception e) {
-//						lg.error(e);
-//						continue;
-//					}
 					
-//					lg.debug("-----"+sb.toString());
-
-					StringTokenizer st = new StringTokenizer(slurmJobInfoSB.toString(),"\n\r");
-					while(st.hasMoreTokens()) {
-						String line = st.nextToken();
-						StringTokenizer lineTokenizer = new StringTokenizer(line," \t");
-						String slurmJobID = lineTokenizer.nextToken();
-						String jobName = lineTokenizer.nextToken();
-						String jobState = lineTokenizer.nextToken();
-						if(jobState.equalsIgnoreCase("FAILED") ||
-							jobState.equalsIgnoreCase("BOOT_FAIL") ||
-							jobState.equalsIgnoreCase("DEADLINE") ||
-							jobState.equalsIgnoreCase("NODE_FAIL") ||
-							jobState.equalsIgnoreCase("OUT_OF_MEMORY") ||
-							jobState.equalsIgnoreCase("PREEMPTED") ||
-							jobState.equalsIgnoreCase("TIMEOUT")) {
-							MonitorJobInfo failedMonitorJobInfo = monitorTheseJobs.get(slurmJobID);
+					// Ask through HtcProxy rather than running sacct here. The private copy this replaced
+					// hardcoded the command name, parsed fixed-width columns with a whitespace tokenizer,
+					// counted `.batch`/`.extern`/`.0`..`.N` step rows as jobs, and had no guard against
+					// slurm reusing a job id. getJobStatus() does none of those things, and its parsing is
+					// pinned by fixtures of real output in src/test/resources/slurm-outputs.
+					List<HtcJobInfo> requested = new ArrayList<HtcJobInfo>();
+					Map<String,MonitorJobInfo> byJobName = new HashMap<String,MonitorJobInfo>();
+					for(MonitorJobInfo monitorJobInfo : monitorTheseJobs.values()) {
+						HtcProxy.SimTaskInfo simTaskInfo = new HtcProxy.SimTaskInfo(
+							monitorJobInfo.vcsimID.getSimulationKey(), monitorJobInfo.jobIndex, monitorJobInfo.taskID);
+						// the name matters: getJobStatus() discards anything whose id AND name were not asked
+						// for, which is what protects against a recycled slurm job id
+						String jobName = HtcProxy.createHtcSimJobName(simTaskInfo);
+						requested.add(new HtcJobInfo(new HtcJobID(Long.toString(monitorJobInfo.slurmJobID), HtcJobID.BatchSystemType.SLURM), jobName));
+						byJobName.put(jobName, monitorJobInfo);
+					}
+					
+					Map<HtcJobInfo,HtcJobStatus> statusMap;
+					try {
+						statusMap = htcProxy.getJobStatus(requested);
+					} catch(Exception e) {
+						// an accounting outage must be loud: with no status at all this loop reports nothing,
+						// and silence is indistinguishable from every job being healthy
+						lg.error("could not read slurm job status for " + requested.size()
+							+ " monitored jobs; no failures will be detected this cycle: " + e.getMessage(), e);
+						continue;
+					}
+					
+					for(Map.Entry<HtcJobInfo,HtcJobStatus> entry : statusMap.entrySet()) {
+						HtcJobInfo htcJobInfo = entry.getKey();
+						HtcJobStatus htcJobStatus = entry.getValue();
+						MonitorJobInfo monitorJobInfo = byJobName.get(htcJobInfo.getJobName());
+						if(monitorJobInfo == null) {
+							continue;
+						}
+						String slurmJobID = Long.toString(monitorJobInfo.slurmJobID);
+						if(htcJobStatus.isFailed()) {
 							WorkerEventMessage.sendWorkerExitError(messageProducer_sim, HtcSimulationWorker.class.getName(), ManageUtils.getHostName(),
-								failedMonitorJobInfo.vcsimID, failedMonitorJobInfo.jobIndex, failedMonitorJobInfo.taskID,
-								SimulationMessage.jobFailed("Fail found by monitor, slrmJobID="+slurmJobID+" jobName="+jobName+" jobState="+jobState));
-							removeMonitorJob(Long.parseLong(slurmJobID));
-						}else if(jobState.startsWith("CANCELLED")) {
-							// Cancelled is not a solver failure -- somebody stopped this job on purpose.
-							//
-							// When the user stops a simulation, VCell records STOPPED and then issues the
-							// scancel itself, and SimulationStateMachine.onWorkerEvent discards anything that
-							// arrives once the status isDone() -- so this message is ignored in that case and
-							// the stop is preserved. What reaches a user is the other case: cancelled outside
-							// VCell, where the job really has stopped without finishing and saying so beats
-							// leaving the simulation apparently running. Report it as what it is.
-							MonitorJobInfo cancelledMonitorJobInfo = monitorTheseJobs.get(slurmJobID);
-							if(cancelledMonitorJobInfo != null) {
-								WorkerEventMessage.sendWorkerExitError(messageProducer_sim, HtcSimulationWorker.class.getName(), ManageUtils.getHostName(),
-									cancelledMonitorJobInfo.vcsimID, cancelledMonitorJobInfo.jobIndex, cancelledMonitorJobInfo.taskID,
-									SimulationMessage.solverStopped("simulation was cancelled on the cluster (slurm job "+slurmJobID+", "+jobState+")"));
-							}
-							removeMonitorJob(Long.parseLong(slurmJobID));
-						}else if(jobState.equalsIgnoreCase("COMPLETED")) {
-							MonitorJobInfo completedMonitorJobInfo = monitorTheseJobs.get(slurmJobID);
-							WorkerEventMessage.sendAlternateCompleted(messageProducer_sim, HtcSimulationWorker.class.getName(), completedMonitorJobInfo.vcsimID,
-								ManageUtils.getHostName(), completedMonitorJobInfo.jobIndex, completedMonitorJobInfo.taskID);
-							removeMonitorJob(Long.parseLong(slurmJobID));
+								monitorJobInfo.vcsimID, monitorJobInfo.jobIndex, monitorJobInfo.taskID,
+								SimulationMessage.jobFailed("Fail found by monitor, slurmJobID="+slurmJobID+" jobName="+htcJobInfo.getJobName()+" jobState="+htcJobStatus));
+							removeMonitorJob(monitorJobInfo.slurmJobID);
+						} else if(htcJobStatus.isStopped()) {
+							// cancelled is deliberate -- see the state machine, which records STOPPED for this
+							WorkerEventMessage.sendWorkerExitError(messageProducer_sim, HtcSimulationWorker.class.getName(), ManageUtils.getHostName(),
+								monitorJobInfo.vcsimID, monitorJobInfo.jobIndex, monitorJobInfo.taskID,
+								SimulationMessage.solverStopped("simulation was cancelled on the cluster (slurm job "+slurmJobID+")"));
+							removeMonitorJob(monitorJobInfo.slurmJobID);
+						} else if(htcJobStatus.isComplete()) {
+							WorkerEventMessage.sendAlternateCompleted(messageProducer_sim, HtcSimulationWorker.class.getName(), monitorJobInfo.vcsimID,
+								ManageUtils.getHostName(), monitorJobInfo.jobIndex, monitorJobInfo.taskID);
+							removeMonitorJob(monitorJobInfo.slurmJobID);
 						}
 					}
 //					BF BOOT_FAIL

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/HtcJobStatus.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/HtcJobStatus.java
@@ -48,7 +48,12 @@ public class HtcJobStatus implements Serializable {
 	}
 	
 	public boolean isDone() {
-		return isComplete() || isFailed();
+		return isComplete() || isFailed() || isStopped();
+	}
+
+	/** Terminated on purpose rather than by going wrong. Only slurm distinguishes this. */
+	public boolean isStopped() {
+		return slurmJobStatus != null && slurmJobStatus.isStopped();
 	}
 
 	public boolean isFailed() {

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmJobStatus.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmJobStatus.java
@@ -52,8 +52,30 @@ public enum SlurmJobStatus {
 		return this == COMPLETING;
 	}
 
+	/**
+	 * Every way slurm ends a job badly, not just the state literally named FAILED.
+	 *
+	 * A job the scheduler kills -- out of time, out of memory, node lost, preempted -- did not
+	 * finish, and callers that ask "did this fail" have to be told so. Previously only FAILED
+	 * answered true, which left TIMEOUT and friends reading as neither failed nor complete, so a
+	 * job ended by the scheduler looked like it was still going.
+	 */
 	public boolean isFailed() {
-		return this == FAILED;
+		return this == FAILED
+				|| this == BOOTFAIL
+				|| this == DEADLINE
+				|| this == NODE_FAIL
+				|| this == OUT_OF_MEMORY
+				|| this == PREEMPTED
+				|| this == TIMEOUT;
+	}
+
+	/**
+	 * Cancelled is deliberate, so it is terminal without being a failure -- somebody stopped this
+	 * job on purpose. Reporting it as a failure tells the owner their model broke.
+	 */
+	public boolean isStopped() {
+		return this == CANCELLED;
 	}
 
 	public boolean isCompleted() {

--- a/vcell-server/src/test/java/cbit/vcell/message/server/htc/slurm/SlurmOutputParsingTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/htc/slurm/SlurmOutputParsingTest.java
@@ -145,12 +145,10 @@ public class SlurmOutputParsingTest {
 		// stop into a spurious error for the user who asked for it.
 		assertFalse(status.isFailed(), "a user-cancelled job is stopped, not failed");
 
-		// What is wrong is that it is not considered finished either: isDone() is
-		// isComplete() || isFailed(), so a cancelled job reads as still in progress. Terminal is
-		// terminal; only the reason differs. Changing that is a behaviour change, not a parsing
-		// fix -- see issue #1912.
-		assertFalse(status.isDone(),
-				"current behaviour: a cancelled job reads as not finished, which is the real gap");
+		// It is finished, though. Terminal is terminal; only the reason differs, and a caller
+		// asking "is this still going" must be told no.
+		assertTrue(status.isStopped(), "cancelled is a deliberate stop");
+		assertTrue(status.isDone(), "and a stop is an ending");
 	}
 
 	/** The scheduler-side endings the job monitor exists to report. */
@@ -158,6 +156,16 @@ public class SlurmOutputParsingTest {
 	public void everyTerminalStateParses() throws IOException {
 		Map<HtcJobInfo, HtcJobStatus> statusMap =
 				SlurmProxy.extractJobIds(fixture("sacct-terminal-states.txt"));
+
+		// Every one of these is a way the scheduler ended a job that did not finish, so each must
+		// read as failed -- not merely as "parsed". Before this, isFailed() was true only for the
+		// state literally named FAILED, so a job killed by TIMEOUT or OUT_OF_MEMORY was neither
+		// failed nor complete and read as though it were still running.
+		for (Map.Entry<HtcJobInfo, HtcJobStatus> entry : statusMap.entrySet()) {
+			assertTrue(entry.getValue().isFailed(),
+					entry.getKey().getJobName() + " should be failed: " + entry.getValue());
+			assertTrue(entry.getValue().isDone(), entry.getKey().getJobName() + " should be done");
+		}
 
 		// The point of this case is that every one of these states PARSES. OUT_OF_MEMORY was
 		// missing from SlurmJobStatus entirely, so parseStatus() threw IllegalArgumentException


### PR DESCRIPTION
Closes #1911. **Stacked on #1914** — both touch the monitor's terminal-state handling, so this branch is cut from that one; the diff below reads cleanly once #1914 lands.

The job monitor built and parsed its own `sacct` command. `SlurmProxy.getJobStatus` already did that query, and did it better on four counts:

| | `getJobStatus` | the private copy |
|---|---|---|
| command name | `PropertyLoader.slurm_cmd_sacct` | hardcoded `"sacct"` |
| output | `-P`, split on `\|` | fixed-width columns, whitespace tokenizer |
| user scoping | `-u <htcUser>` | none |
| **slurm job-id reuse** | discards results whose id **and** name were not requested | none |

That last guard also drops step rows, which removes the `NullPointerException` the private parser hit on any multi-step job: `sacct` reports 23 rows for a 20-task SpringSaLaD multirun, the private filter dropped one of the three step kinds, and the leftovers looked up null in a map keyed by allocation id.

## Two supporting changes, required rather than incidental

**`SlurmJobStatus.isFailed()` was true only for `FAILED`.** A job killed by `TIMEOUT`, `OUT_OF_MEMORY`, `NODE_FAIL`, `PREEMPTED`, `BOOT_FAIL` or `DEADLINE` was neither failed nor complete — it read as though it were **still running**. That is precisely why the monitor kept its own list of terminal states instead of asking, and why simply calling `getJobStatus()` would have silently dropped failure detection. It now covers them, and `isStopped()` distinguishes `CANCELLED`, which is terminal without being a failure. `isDone()` covers a stop.

**An `sacct` failure is now loud.** The old code caught the exception and then parsed an empty buffer, so an accounting outage disabled failure detection with no alarm — no failures reported, indistinguishable from every job being healthy.

`HtcJobStatus` has no production consumers beyond `SlurmProxy` constructing it (`ZombieKiller` uses only the map keys), so widening the classification is contained.

## Behaviour preserved

Failed still reports `jobFailed`; cancelled still reports `solverStopped` (#1914); completed still sends alternate-completed.

## Testing

The fixture tests now assert the **classification** against captured output rather than against the enum: every state in `sacct-terminal-states` reads as failed *and* done, and the cancelled capture reads as stopped and done but not failed.

`vcell-server` Fast group **95 green over two runs**.

## Related

- #1914 — cancelled is stopped, not failed (this is stacked on it)
- #1913 — the fixtures and parser hardening this builds on
- #1912 — remaining: `scontrol` fallback for accounting outages, and the `--json` question
- #1910 — move the reconciliation to `sched` with `squeue` + `sacct` as combined evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg