### PR TITLE
Query slurm with --json for sacct and scontrol, and fall back when accounting is down

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
@@ -21,7 +21,9 @@ import cbit.vcell.message.server.ManageUtils;
 import cbit.vcell.message.server.ServerMessagingDelegate;
 import cbit.vcell.message.server.batch.opt.OptimizationBatchServer;
 import cbit.vcell.message.server.cmd.CommandService.CommandOutput;
+import cbit.vcell.message.server.htc.HtcJobStatus;
 import cbit.vcell.message.server.htc.HtcProxy;
+import cbit.vcell.message.server.htc.HtcProxy.HtcJobInfo;
 import cbit.vcell.message.server.htc.slurm.SlurmProxy;
 import cbit.vcell.messaging.server.SimulationTask;
 import cbit.vcell.resource.OperatingSystemInfo;
@@ -350,82 +352,61 @@ public void startJobMonitor() {
 				try {
 					int sleeptime=60000;
 					Thread.sleep(sleeptime);
-					StringBuffer slurmJobidSB = new StringBuffer();
-					for(String jobid:monitorTheseJobs.keySet()) {
-						slurmJobidSB.append((slurmJobidSB.length()>0?",":"")+jobid);
-					}
-					if(slurmJobidSB.length() == 0) {
+					if(monitorTheseJobs.isEmpty()) {
 						continue;
 					}
-					StringBuffer slurmJobInfoSB = new StringBuffer();
-					try {
-						HtcSimulationWorker.this.htcProxy.getCommandService();
-						String[] tryStr = new String[] {"sacct","--format=jobid%25,jobname%40,state%30 -n -j "+slurmJobidSB.toString()+" | grep -v \".batch\""+" | grep -v \".extern\""};
-						CommandOutput commandOutput = htcProxy.getCommandService().command(tryStr);
-						slurmJobInfoSB.append(commandOutput.getStandardOutput());
-						lg.debug("sacct stdoutput:\n"+commandOutput.getStandardOutput());
-						lg.debug("sacct stderror:\n"+commandOutput.getStandardError());
-					}catch(Exception e) {
-						lg.error(e.getMessage(), e);
-					}
-//					Process p = null;
-//					try{
-//						String[] cmd = new String[] {"ssh","-i","/run/secrets/batchuserkeyfile","vcell@172.16.246.118","sacct --format=jobid,jobname%40,state -n -j "+slurmJobidSB.toString()+"| grep -v \".batch\""};
-//						ProcessBuilder pb = new ProcessBuilder(Arrays.asList(cmd));
-//						pb.redirectErrorStream(true);
-//						p = pb.start();
-//						int ioByte = -1;
-//						while((ioByte = p.getInputStream().read()) != -1) {
-//							sb.append((char)ioByte);
-//						}
-//						p.waitFor();
-//					}catch(Exception e) {
-//						lg.error(e);
-//						continue;
-//					}
 					
-//					lg.debug("-----"+sb.toString());
-
-					StringTokenizer st = new StringTokenizer(slurmJobInfoSB.toString(),"\n\r");
-					while(st.hasMoreTokens()) {
-						String line = st.nextToken();
-						StringTokenizer lineTokenizer = new StringTokenizer(line," \t");
-						String slurmJobID = lineTokenizer.nextToken();
-						String jobName = lineTokenizer.nextToken();
-						String jobState = lineTokenizer.nextToken();
-						if(jobState.equalsIgnoreCase("FAILED") ||
-							jobState.equalsIgnoreCase("BOOT_FAIL") ||
-							jobState.equalsIgnoreCase("DEADLINE") ||
-							jobState.equalsIgnoreCase("NODE_FAIL") ||
-							jobState.equalsIgnoreCase("OUT_OF_MEMORY") ||
-							jobState.equalsIgnoreCase("PREEMPTED") ||
-							jobState.equalsIgnoreCase("TIMEOUT")) {
-							MonitorJobInfo failedMonitorJobInfo = monitorTheseJobs.get(slurmJobID);
+					// Ask through HtcProxy rather than running sacct here. The private copy this replaced
+					// hardcoded the command name, parsed fixed-width columns with a whitespace tokenizer,
+					// counted `.batch`/`.extern`/`.0`..`.N` step rows as jobs, and had no guard against
+					// slurm reusing a job id. getJobStatus() does none of those things, and its parsing is
+					// pinned by fixtures of real output in src/test/resources/slurm-outputs.
+					List<HtcJobInfo> requested = new ArrayList<HtcJobInfo>();
+					Map<String,MonitorJobInfo> byJobName = new HashMap<String,MonitorJobInfo>();
+					for(MonitorJobInfo monitorJobInfo : monitorTheseJobs.values()) {
+						HtcProxy.SimTaskInfo simTaskInfo = new HtcProxy.SimTaskInfo(
+							monitorJobInfo.vcsimID.getSimulationKey(), monitorJobInfo.jobIndex, monitorJobInfo.taskID);
+						// the name matters: getJobStatus() discards anything whose id AND name were not asked
+						// for, which is what protects against a recycled slurm job id
+						String jobName = HtcProxy.createHtcSimJobName(simTaskInfo);
+						requested.add(new HtcJobInfo(new HtcJobID(Long.toString(monitorJobInfo.slurmJobID), HtcJobID.BatchSystemType.SLURM), jobName));
+						byJobName.put(jobName, monitorJobInfo);
+					}
+					
+					Map<HtcJobInfo,HtcJobStatus> statusMap;
+					try {
+						statusMap = htcProxy.getJobStatus(requested);
+					} catch(Exception e) {
+						// an accounting outage must be loud: with no status at all this loop reports nothing,
+						// and silence is indistinguishable from every job being healthy
+						lg.error("could not read slurm job status for " + requested.size()
+							+ " monitored jobs; no failures will be detected this cycle: " + e.getMessage(), e);
+						continue;
+					}
+					
+					for(Map.Entry<HtcJobInfo,HtcJobStatus> entry : statusMap.entrySet()) {
+						HtcJobInfo htcJobInfo = entry.getKey();
+						HtcJobStatus htcJobStatus = entry.getValue();
+						MonitorJobInfo monitorJobInfo = byJobName.get(htcJobInfo.getJobName());
+						if(monitorJobInfo == null) {
+							continue;
+						}
+						String slurmJobID = Long.toString(monitorJobInfo.slurmJobID);
+						if(htcJobStatus.isFailed()) {
 							WorkerEventMessage.sendWorkerExitError(messageProducer_sim, HtcSimulationWorker.class.getName(), ManageUtils.getHostName(),
-								failedMonitorJobInfo.vcsimID, failedMonitorJobInfo.jobIndex, failedMonitorJobInfo.taskID,
-								SimulationMessage.jobFailed("Fail found by monitor, slrmJobID="+slurmJobID+" jobName="+jobName+" jobState="+jobState));
-							removeMonitorJob(Long.parseLong(slurmJobID));
-						}else if(jobState.startsWith("CANCELLED")) {
-							// Cancelled is not a solver failure -- somebody stopped this job on purpose.
-							//
-							// When the user stops a simulation, VCell records STOPPED and then issues the
-							// scancel itself, and SimulationStateMachine.onWorkerEvent discards anything that
-							// arrives once the status isDone() -- so this message is ignored in that case and
-							// the stop is preserved. What reaches a user is the other case: cancelled outside
-							// VCell, where the job really has stopped without finishing and saying so beats
-							// leaving the simulation apparently running. Report it as what it is.
-							MonitorJobInfo cancelledMonitorJobInfo = monitorTheseJobs.get(slurmJobID);
-							if(cancelledMonitorJobInfo != null) {
-								WorkerEventMessage.sendWorkerExitError(messageProducer_sim, HtcSimulationWorker.class.getName(), ManageUtils.getHostName(),
-									cancelledMonitorJobInfo.vcsimID, cancelledMonitorJobInfo.jobIndex, cancelledMonitorJobInfo.taskID,
-									SimulationMessage.solverStopped("simulation was cancelled on the cluster (slurm job "+slurmJobID+", "+jobState+")"));
-							}
-							removeMonitorJob(Long.parseLong(slurmJobID));
-						}else if(jobState.equalsIgnoreCase("COMPLETED")) {
-							MonitorJobInfo completedMonitorJobInfo = monitorTheseJobs.get(slurmJobID);
-							WorkerEventMessage.sendAlternateCompleted(messageProducer_sim, HtcSimulationWorker.class.getName(), completedMonitorJobInfo.vcsimID,
-								ManageUtils.getHostName(), completedMonitorJobInfo.jobIndex, completedMonitorJobInfo.taskID);
-							removeMonitorJob(Long.parseLong(slurmJobID));
+								monitorJobInfo.vcsimID, monitorJobInfo.jobIndex, monitorJobInfo.taskID,
+								SimulationMessage.jobFailed("Fail found by monitor, slurmJobID="+slurmJobID+" jobName="+htcJobInfo.getJobName()+" jobState="+htcJobStatus));
+							removeMonitorJob(monitorJobInfo.slurmJobID);
+						} else if(htcJobStatus.isStopped()) {
+							// cancelled is deliberate -- see the state machine, which records STOPPED for this
+							WorkerEventMessage.sendWorkerExitError(messageProducer_sim, HtcSimulationWorker.class.getName(), ManageUtils.getHostName(),
+								monitorJobInfo.vcsimID, monitorJobInfo.jobIndex, monitorJobInfo.taskID,
+								SimulationMessage.solverStopped("simulation was cancelled on the cluster (slurm job "+slurmJobID+")"));
+							removeMonitorJob(monitorJobInfo.slurmJobID);
+						} else if(htcJobStatus.isComplete()) {
+							WorkerEventMessage.sendAlternateCompleted(messageProducer_sim, HtcSimulationWorker.class.getName(), monitorJobInfo.vcsimID,
+								ManageUtils.getHostName(), monitorJobInfo.jobIndex, monitorJobInfo.taskID);
+							removeMonitorJob(monitorJobInfo.slurmJobID);
 						}
 					}
 //					BF BOOT_FAIL

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/HtcJobStatus.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/HtcJobStatus.java
@@ -48,7 +48,12 @@ public class HtcJobStatus implements Serializable {
 	}
 	
 	public boolean isDone() {
-		return isComplete() || isFailed();
+		return isComplete() || isFailed() || isStopped();
+	}
+
+	/** Terminated on purpose rather than by going wrong. Only slurm distinguishes this. */
+	public boolean isStopped() {
+		return slurmJobStatus != null && slurmJobStatus.isStopped();
 	}
 
 	public boolean isFailed() {

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmJobStatus.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmJobStatus.java
@@ -52,8 +52,30 @@ public enum SlurmJobStatus {
 		return this == COMPLETING;
 	}
 
+	/**
+	 * Every way slurm ends a job badly, not just the state literally named FAILED.
+	 *
+	 * A job the scheduler kills -- out of time, out of memory, node lost, preempted -- did not
+	 * finish, and callers that ask "did this fail" have to be told so. Previously only FAILED
+	 * answered true, which left TIMEOUT and friends reading as neither failed nor complete, so a
+	 * job ended by the scheduler looked like it was still going.
+	 */
 	public boolean isFailed() {
-		return this == FAILED;
+		return this == FAILED
+				|| this == BOOTFAIL
+				|| this == DEADLINE
+				|| this == NODE_FAIL
+				|| this == OUT_OF_MEMORY
+				|| this == PREEMPTED
+				|| this == TIMEOUT;
+	}
+
+	/**
+	 * Cancelled is deliberate, so it is terminal without being a failure -- somebody stopped this
+	 * job on purpose. Reporting it as a failure tells the owner their model broke.
+	 */
+	public boolean isStopped() {
+		return this == CANCELLED;
 	}
 
 	public boolean isCompleted() {

--- a/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/htc/slurm/SlurmProxy.java
@@ -31,6 +31,9 @@ import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class SlurmProxy extends HtcProxy {
 	
 	private final static int SCANCEL_JOB_NOT_FOUND_RETURN_CODE = 1;
@@ -328,11 +331,24 @@ public class SlurmProxy extends HtcProxy {
 			jobNumbers.add(Long.toString(jobInfo.getHtcJobID().getJobNumber()));
 		}
 		String jobList = String.join(",", jobNumbers);
-		String[] cmds = {JOB_CMD_SACCT,"-P","-u",getHtcUser(),"-j",jobList,"-o","jobid%25,jobname%25,state%13"};
-		CommandOutput commandOutput = commandService.command(cmds);
-		
-		String output = commandOutput.getStandardOutput();
-		Map<HtcJobInfo, HtcJobStatus> statusMap = extractJobIds(output);
+		// --json rather than -P: steps arrive nested inside their job instead of as sibling rows,
+		// so the .batch/.extern/.N rows the text form must filter are simply not present, and the
+		// payload carries a parser version so a schema change is detectable rather than silent.
+		String[] cmds = {JOB_CMD_SACCT,"--json","-u",getHtcUser(),"-j",jobList};
+
+		Map<HtcJobInfo, HtcJobStatus> statusMap;
+		try {
+			CommandOutput commandOutput = commandService.command(cmds);
+			statusMap = extractJobIdsFromSacctJson(commandOutput.getStandardOutput());
+		} catch (Exception e) {
+			// sacct reads the accounting database, so if slurmdbd is unavailable it answers
+			// nothing -- and a caller that reads that as "no failures" is blind without knowing
+			// it. slurmctld still holds completed jobs for MinJobAge, so ask it instead. Say so
+			// loudly: degraded knowledge is not the same as good news.
+			LG.error("sacct failed for " + requestedHtcJobInfos.size() + " jobs, falling back to scontrol"
+					+ " (only jobs still within MinJobAge will be known): " + e.getMessage(), e);
+			return getJobStatusFromScontrol(requestedHtcJobInfos);
+		}
 		//
 		// HtcJobIDs can be reused by Slurm, so make sure it has the correct JobName also.
 		//
@@ -346,6 +362,115 @@ public class SlurmProxy extends HtcProxy {
 		return statusMap;
 	}
 	
+
+	/**
+	 * Asks slurmctld directly, one job at a time, for when accounting cannot answer.
+	 *
+	 * `sacct` reads the accounting database, so if slurmdbd is unavailable it answers nothing at
+	 * all -- and a caller that reads that as "no failures" is blind without knowing it. slurmctld
+	 * keeps finished jobs in memory for MinJobAge (10800s on mantis), so scontrol still knows
+	 * what happened inside that window.
+	 *
+	 * One command per id on purpose: scontrol does not accept a comma-separated list (verified --
+	 * passing one returns no jobs at all). That cost is why this is a fallback, not the primary.
+	 *
+	 * A job scontrol has never heard of, or has already forgotten, is skipped: not knowing is not
+	 * the same as knowing it failed.
+	 */
+	public Map<HtcJobInfo,HtcJobStatus> getJobStatusFromScontrol(List<HtcJobInfo> requestedHtcJobInfos) {
+		final String JOB_CMD_SCONTROL = PropertyLoader.getProperty(PropertyLoader.slurm_cmd_scontrol,"scontrol");
+		Map<HtcJobInfo,HtcJobStatus> statusMap = new HashMap<HtcJobInfo, HtcJobStatus>();
+		for (HtcJobInfo requested : requestedHtcJobInfos) {
+			String[] cmds = {JOB_CMD_SCONTROL, "show", "job",
+					Long.toString(requested.getHtcJobID().getJobNumber()), "--json"};
+			try {
+				CommandOutput commandOutput = commandService.command(cmds);
+				for (Map.Entry<HtcJobInfo, HtcJobStatus> entry : extractJobIdsFromScontrolJson(commandOutput.getStandardOutput()).entrySet()) {
+					// same guard as getJobStatus: slurm reuses job ids, so only accept a result
+					// whose id AND name are what we asked about
+					if (requestedHtcJobInfos.contains(entry.getKey())) {
+						statusMap.put(entry.getKey(), entry.getValue());
+					}
+				}
+			} catch (Exception e) {
+				LG.debug("scontrol could not report job " + requested + " (it may have aged out of slurmctld): " + e.getMessage());
+			}
+		}
+		return statusMap;
+	}
+
+	/** `scontrol show job --json`: state lives at job_state, an array. */
+	static Map<HtcJobInfo, HtcJobStatus> extractJobIdsFromScontrolJson(String output) throws IOException {
+		return extractJobsFromJson(output, "job_state", null);
+	}
+
+	/** `sacct --json`: state lives at state.current, an array, and steps are nested per job. */
+	static Map<HtcJobInfo, HtcJobStatus> extractJobIdsFromSacctJson(String output) throws IOException {
+		return extractJobsFromJson(output, "state", "current");
+	}
+
+	/**
+	 * Reads the `jobs` array slurm emits for --json.
+	 *
+	 * Steps do not appear as siblings here -- they are nested inside their job -- so the step rows
+	 * that have to be filtered out of `sacct -P` text simply are not a problem in this shape.
+	 *
+	 * The state field differs between the two commands, hence the path arguments: `sacct` reports
+	 * state.current, `scontrol` reports job_state. Both are arrays.
+	 */
+	private static Map<HtcJobInfo, HtcJobStatus> extractJobsFromJson(String output, String stateField, String stateSubField) throws IOException {
+		Map<HtcJobInfo, HtcJobStatus> statusMap = new HashMap<HtcJobInfo, HtcJobStatus>();
+		if (output == null || output.trim().isEmpty()) {
+			return statusMap;
+		}
+		JsonNode root = new ObjectMapper().readTree(output);
+		assertKnownDataParser(root);
+		JsonNode jobs = root.path("jobs");
+		for (JsonNode job : jobs) {
+			JsonNode idNode = job.path("job_id");
+			JsonNode nameNode = job.path("name");
+			if (idNode.isMissingNode() || nameNode.isMissingNode()) {
+				continue;
+			}
+			JsonNode stateNode = job.path(stateField);
+			if (stateSubField != null) {
+				stateNode = stateNode.path(stateSubField);
+			}
+			// an array of state strings; the first is the state proper, any others qualify it
+			String state = stateNode.isArray() && stateNode.size() > 0 ? stateNode.get(0).asText() : stateNode.asText();
+			if (state == null || state.isEmpty()) {
+				continue;
+			}
+			HtcJobInfo htcJobInfo = new HtcJobInfo(new HtcJobID(idNode.asText(), BatchSystemType.SLURM), nameNode.asText());
+			statusMap.put(htcJobInfo, new HtcJobStatus(SlurmJobStatus.parseStatus(state)));
+		}
+		return statusMap;
+	}
+
+	/**
+	 * Slurm versions its JSON, so a shape change is detectable rather than something that quietly
+	 * misparses. Logged rather than thrown: an unexpected parser version is a reason to look, not
+	 * a reason to stop monitoring jobs.
+	 */
+	static final String EXPECTED_DATA_PARSER = "data_parser/v0.0.40";
+
+	private static void assertKnownDataParser(JsonNode root) {
+		String dataParser = root.path("meta").path("plugin").path("data_parser").asText("");
+		if (!dataParser.isEmpty() && !EXPECTED_DATA_PARSER.equals(dataParser)) {
+			LG.warn("slurm JSON reports " + dataParser + ", expected " + EXPECTED_DATA_PARSER
+					+ "; field names may have moved and job status may be misread");
+		}
+	}
+
+	/**
+	 * Parses `sacct -P` text into one entry per job allocation.
+	 *
+	 * NO LONGER ON THE PRODUCTION PATH: getJobStatus() asks for --json instead, where steps are
+	 * nested inside their job rather than arriving as sibling rows. Retained because --json needs
+	 * a slurm carrying the data_parser plugin (mantis runs 23.11); a deployment on an older slurm
+	 * would still need this. If every deployment is known to be new enough this and its fixtures
+	 * can go -- until someone confirms that, deleting it removes the only way back.
+	 */
 	static Map<HtcJobInfo, HtcJobStatus> extractJobIds(String output) throws IOException {
 		BufferedReader reader = new BufferedReader(new StringReader(output));
 		String line = reader.readLine();

--- a/vcell-server/src/test/java/cbit/vcell/message/server/htc/slurm/SlurmOutputParsingTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/htc/slurm/SlurmOutputParsingTest.java
@@ -145,12 +145,10 @@ public class SlurmOutputParsingTest {
 		// stop into a spurious error for the user who asked for it.
 		assertFalse(status.isFailed(), "a user-cancelled job is stopped, not failed");
 
-		// What is wrong is that it is not considered finished either: isDone() is
-		// isComplete() || isFailed(), so a cancelled job reads as still in progress. Terminal is
-		// terminal; only the reason differs. Changing that is a behaviour change, not a parsing
-		// fix -- see issue #1912.
-		assertFalse(status.isDone(),
-				"current behaviour: a cancelled job reads as not finished, which is the real gap");
+		// It is finished, though. Terminal is terminal; only the reason differs, and a caller
+		// asking "is this still going" must be told no.
+		assertTrue(status.isStopped(), "cancelled is a deliberate stop");
+		assertTrue(status.isDone(), "and a stop is an ending");
 	}
 
 	/** The scheduler-side endings the job monitor exists to report. */
@@ -158,6 +156,16 @@ public class SlurmOutputParsingTest {
 	public void everyTerminalStateParses() throws IOException {
 		Map<HtcJobInfo, HtcJobStatus> statusMap =
 				SlurmProxy.extractJobIds(fixture("sacct-terminal-states.txt"));
+
+		// Every one of these is a way the scheduler ended a job that did not finish, so each must
+		// read as failed -- not merely as "parsed". Before this, isFailed() was true only for the
+		// state literally named FAILED, so a job killed by TIMEOUT or OUT_OF_MEMORY was neither
+		// failed nor complete and read as though it were still running.
+		for (Map.Entry<HtcJobInfo, HtcJobStatus> entry : statusMap.entrySet()) {
+			assertTrue(entry.getValue().isFailed(),
+					entry.getKey().getJobName() + " should be failed: " + entry.getValue());
+			assertTrue(entry.getValue().isDone(), entry.getKey().getJobName() + " should be done");
+		}
 
 		// The point of this case is that every one of these states PARSES. OUT_OF_MEMORY was
 		// missing from SlurmJobStatus entirely, so parseStatus() threw IllegalArgumentException

--- a/vcell-server/src/test/java/cbit/vcell/message/server/htc/slurm/SlurmOutputParsingTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/server/htc/slurm/SlurmOutputParsingTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import cbit.vcell.resource.PropertyLoader;
 
 import cbit.vcell.message.server.htc.HtcJobStatus;
@@ -190,5 +192,64 @@ public class SlurmOutputParsingTest {
 	@Test
 	public void anEmptyQueueYieldsAnEmptyMap() throws IOException {
 		assertTrue(SlurmProxy.extractJobIdsFromSqueue(fixture("squeue-empty.txt")).isEmpty());
+	}
+
+	// ----------------------------------------------------------------- json
+
+	/**
+	 * The reason for using --json on this path: a 20-task SpringSaLaD multirun is ONE job with its
+	 * steps nested inside it, not 23 sibling rows. The step filtering the text form needs is not a
+	 * problem that exists in this shape.
+	 */
+	@Test
+	public void sacctJsonReportsOneJobForAMultistepAllocation() throws IOException {
+		Map<HtcJobInfo, HtcJobStatus> statusMap =
+				SlurmProxy.extractJobIdsFromSacctJson(fixture("sacct-json-multistep.json"));
+
+		assertEquals(Set.of("2710593"), jobIds(statusMap), "steps are nested, not siblings");
+		HtcJobInfo only = statusMap.keySet().iterator().next();
+		assertEquals("V_ALPHA_321860411_0_0", only.getJobName());
+		assertTrue(statusMap.get(only).isRunning());
+	}
+
+    /** No matching job is an answer, not an error. */
+	@Test
+	public void sacctJsonWithNoMatchingJobsYieldsAnEmptyMap() throws IOException {
+		assertTrue(SlurmProxy.extractJobIdsFromSacctJson(fixture("sacct-json-no-matching-jobs.json")).isEmpty());
+		assertTrue(SlurmProxy.extractJobIdsFromSacctJson("").isEmpty());
+		assertTrue(SlurmProxy.extractJobIdsFromSacctJson(null).isEmpty());
+	}
+
+	/**
+	 * scontrol puts the state somewhere else than sacct does -- job_state rather than
+	 * state.current -- which is exactly the kind of difference that makes hand-written parsing
+	 * per command a liability.
+	 */
+	@Test
+	public void scontrolJsonReportsTheJobAndItsState() throws IOException {
+		Map<HtcJobInfo, HtcJobStatus> statusMap =
+				SlurmProxy.extractJobIdsFromScontrolJson(fixture("scontrol-json-running.json"));
+
+		assertEquals(Set.of("2710594"), jobIds(statusMap));
+		HtcJobInfo only = statusMap.keySet().iterator().next();
+		assertEquals("V_ALPHA_321860413_0_0", only.getJobName(),
+				"the name matters -- it is what guards against a reused slurm job id");
+		assertTrue(statusMap.get(only).isRunning());
+	}
+
+	/**
+	 * The captures come from one slurm, and the field paths depend on its schema. Compare the
+	 * PARSED value, not the raw text: slurm escapes the slash, so the bytes read
+	 * "data_parser\\/v0.0.40" while the value is "data_parser/v0.0.40".
+	 */
+	@Test
+	public void theFixturesMatchTheDataParserVersionTheCodeExpects() throws IOException {
+		for (String name : new String[] {"sacct-json-multistep.json", "scontrol-json-running.json"}) {
+			String reported = new ObjectMapper().readTree(fixture(name))
+					.path("meta").path("plugin").path("data_parser").asText();
+			assertEquals(SlurmProxy.EXPECTED_DATA_PARSER, reported,
+					name + " reports a different schema version; re-capture the fixtures and check"
+							+ " that job_id / name / state paths still hold");
+		}
 	}
 }

--- a/vcell-server/src/test/resources/slurm-outputs/sacct-json-multistep.json
+++ b/vcell-server/src/test/resources/slurm-outputs/sacct-json-multistep.json
@@ -1,0 +1,3284 @@
+{
+  "jobs": [
+    {
+      "account": "pi-loew",
+      "comment": {
+        "administrator": "",
+        "job": "",
+        "system": ""
+      },
+      "allocation_nodes": 1,
+      "array": {
+        "job_id": 0,
+        "limits": {
+          "max": {
+            "running": {
+              "tasks": 0
+            }
+          }
+        },
+        "task_id": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        },
+        "task": ""
+      },
+      "association": {
+        "account": "pi-loew",
+        "cluster": "mantis",
+        "partition": "",
+        "user": "vcell",
+        "id": 176
+      },
+      "block": "",
+      "cluster": "mantis",
+      "constraints": "",
+      "container": "",
+      "derived_exit_code": {
+        "status": [
+          "SUCCESS"
+        ],
+        "return_code": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "signal": {
+          "id": {
+            "set": false,
+            "infinite": false,
+            "number": 0
+          },
+          "name": ""
+        }
+      },
+      "time": {
+        "elapsed": 46770,
+        "eligible": 1786540675,
+        "end": 0,
+        "start": 1786540675,
+        "submission": 1786540675,
+        "suspended": 0,
+        "system": {
+          "seconds": 0,
+          "microseconds": 0
+        },
+        "limit": {
+          "set": true,
+          "infinite": false,
+          "number": 6912
+        },
+        "total": {
+          "seconds": 0,
+          "microseconds": 0
+        },
+        "user": {
+          "seconds": 0,
+          "microseconds": 0
+        }
+      },
+      "exit_code": {
+        "status": [
+          "SUCCESS"
+        ],
+        "return_code": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "signal": {
+          "id": {
+            "set": false,
+            "infinite": false,
+            "number": 0
+          },
+          "name": ""
+        }
+      },
+      "extra": "",
+      "failed_node": "",
+      "flags": [
+        "STARTED_ON_SCHEDULE",
+        "START_RECEIVED"
+      ],
+      "group": "domain users",
+      "het": {
+        "job_id": 0,
+        "job_offset": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        }
+      },
+      "job_id": 2710593,
+      "name": "V_ALPHA_321860411_0_0",
+      "licenses": "",
+      "mcs": {
+        "label": ""
+      },
+      "nodes": "mantis-041",
+      "partition": "vcell",
+      "hold": false,
+      "priority": {
+        "set": true,
+        "infinite": false,
+        "number": 1405
+      },
+      "qos": "vcell",
+      "required": {
+        "CPUs": 20,
+        "memory_per_cpu": {
+          "set": true,
+          "infinite": false,
+          "number": 8192
+        },
+        "memory_per_node": {
+          "set": false,
+          "infinite": false,
+          "number": 0
+        }
+      },
+      "kill_request_user": "",
+      "reservation": {
+        "id": 0,
+        "name": ""
+      },
+      "script": "",
+      "state": {
+        "current": [
+          "RUNNING"
+        ],
+        "reason": "None"
+      },
+      "steps": [
+        {
+          "time": {
+            "elapsed": 46770,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540675
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "0"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.batch",
+            "name": "batch"
+          },
+          "task": {
+            "distribution": "Unknown"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 20
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 163840
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46770,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540675
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "0"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.extern",
+            "name": "extern"
+          },
+          "task": {
+            "distribution": "Unknown"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 20
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 163840
+              },
+              {
+                "type": "energy",
+                "name": "",
+                "id": 3,
+                "count": -2
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              },
+              {
+                "type": "billing",
+                "name": "",
+                "id": 5,
+                "count": 20
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.0",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.1",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.2",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.3",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.4",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.5",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.6",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.7",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.8",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.9",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.10",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.11",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.12",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.13",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.14",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.15",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.16",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.17",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.18",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        },
+        {
+          "time": {
+            "elapsed": 46763,
+            "end": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "start": {
+              "set": true,
+              "infinite": false,
+              "number": 1786540682
+            },
+            "suspended": 0,
+            "system": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "total": {
+              "seconds": 0,
+              "microseconds": 0
+            },
+            "user": {
+              "seconds": 0,
+              "microseconds": 0
+            }
+          },
+          "exit_code": {
+            "status": [
+              "SUCCESS"
+            ],
+            "return_code": {
+              "set": true,
+              "infinite": false,
+              "number": 0
+            },
+            "signal": {
+              "id": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "name": ""
+            }
+          },
+          "nodes": {
+            "count": 1,
+            "range": "mantis-041",
+            "list": [
+              "mantis-041"
+            ]
+          },
+          "tasks": {
+            "count": 1
+          },
+          "pid": "",
+          "CPU": {
+            "requested_frequency": {
+              "min": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              },
+              "max": {
+                "set": false,
+                "infinite": false,
+                "number": 0
+              }
+            },
+            "governor": "Unknown"
+          },
+          "kill_request_user": "",
+          "state": [
+            "RUNNING"
+          ],
+          "statistics": {
+            "CPU": {
+              "actual_frequency": 0
+            },
+            "energy": {
+              "consumed": {
+                "set": true,
+                "infinite": false,
+                "number": 0
+              }
+            }
+          },
+          "step": {
+            "id": "2710593.19",
+            "name": "singularity"
+          },
+          "task": {
+            "distribution": "Cyclic"
+          },
+          "tres": {
+            "requested": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "consumed": {
+              "max": [
+              ],
+              "min": [
+              ],
+              "average": [
+              ],
+              "total": [
+              ]
+            },
+            "allocated": [
+              {
+                "type": "cpu",
+                "name": "",
+                "id": 1,
+                "count": 1
+              },
+              {
+                "type": "mem",
+                "name": "",
+                "id": 2,
+                "count": 8192
+              },
+              {
+                "type": "node",
+                "name": "",
+                "id": 4,
+                "count": 1
+              }
+            ]
+          }
+        }
+      ],
+      "submit_line": "sbatch \/share\/apps\/vcell3\/htclogs\/V_ALPHA_321860411_0_0.slurm.sub",
+      "tres": {
+        "allocated": [
+          {
+            "type": "cpu",
+            "name": "",
+            "id": 1,
+            "count": 20
+          },
+          {
+            "type": "mem",
+            "name": "",
+            "id": 2,
+            "count": 163840
+          },
+          {
+            "type": "energy",
+            "name": "",
+            "id": 3,
+            "count": -2
+          },
+          {
+            "type": "node",
+            "name": "",
+            "id": 4,
+            "count": 1
+          },
+          {
+            "type": "billing",
+            "name": "",
+            "id": 5,
+            "count": 20
+          }
+        ],
+        "requested": [
+          {
+            "type": "cpu",
+            "name": "",
+            "id": 1,
+            "count": 20
+          },
+          {
+            "type": "mem",
+            "name": "",
+            "id": 2,
+            "count": 163840
+          },
+          {
+            "type": "node",
+            "name": "",
+            "id": 4,
+            "count": 1
+          },
+          {
+            "type": "billing",
+            "name": "",
+            "id": 5,
+            "count": 20
+          }
+        ]
+      },
+      "used_gres": "",
+      "user": "vcell",
+      "wckey": {
+        "wckey": "",
+        "flags": [
+        ]
+      },
+      "working_directory": "\/home\/FCAM\/vcell"
+    }
+  ],
+  "meta": {
+    "plugin": {
+      "type": "",
+      "name": "",
+      "data_parser": "data_parser\/v0.0.40",
+      "accounting_storage": "accounting_storage\/slurmdbd"
+    },
+    "client": {
+      "source": "",
+      "user": "vcell",
+      "group": "domain users"
+    },
+    "command": [
+      "sacct",
+      "--json",
+      "-j"
+    ],
+    "slurm": {
+      "version": {
+        "major": "23",
+        "micro": "10",
+        "minor": "11"
+      },
+      "release": "23.11.10",
+      "cluster": "mantis"
+    }
+  },
+  "errors": [
+  ],
+  "warnings": [
+  ]
+}

--- a/vcell-server/src/test/resources/slurm-outputs/sacct-json-no-matching-jobs.json
+++ b/vcell-server/src/test/resources/slurm-outputs/sacct-json-no-matching-jobs.json
@@ -1,0 +1,35 @@
+{
+  "jobs": [
+  ],
+  "meta": {
+    "plugin": {
+      "type": "",
+      "name": "",
+      "data_parser": "data_parser\/v0.0.40",
+      "accounting_storage": "accounting_storage\/slurmdbd"
+    },
+    "client": {
+      "source": "",
+      "user": "vcell",
+      "group": "domain users"
+    },
+    "command": [
+      "sacct",
+      "--json",
+      "-j"
+    ],
+    "slurm": {
+      "version": {
+        "major": "23",
+        "micro": "10",
+        "minor": "11"
+      },
+      "release": "23.11.10",
+      "cluster": "mantis"
+    }
+  },
+  "errors": [
+  ],
+  "warnings": [
+  ]
+}

--- a/vcell-server/src/test/resources/slurm-outputs/scontrol-json-running.json
+++ b/vcell-server/src/test/resources/slurm-outputs/scontrol-json-running.json
@@ -1,0 +1,423 @@
+{
+  "jobs": [
+    {
+      "account": "pi-loew",
+      "accrue_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1786540677
+      },
+      "admin_comment": "",
+      "allocating_node": "mantis-svcsub.cam.uchc.edu",
+      "array_job_id": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "array_task_id": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "array_max_tasks": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "array_task_string": "",
+      "association_id": 176,
+      "batch_features": "",
+      "batch_flag": true,
+      "batch_host": "mantis-041",
+      "flags": [
+        "ACCRUE_COUNT_CLEARED",
+        "JOB_WAS_RUNNING",
+        "EXACT_MEMORY_REQUESTED",
+        "USING_DEFAULT_ACCOUNT",
+        "USING_DEFAULT_WCKEY"
+      ],
+      "burst_buffer": "",
+      "burst_buffer_state": "",
+      "cluster": "mantis",
+      "cluster_features": "",
+      "command": "\/share\/apps\/vcell3\/htclogs\/V_ALPHA_321860413_0_0.slurm.sub",
+      "comment": "",
+      "container": "",
+      "container_id": "",
+      "contiguous": false,
+      "core_spec": 0,
+      "thread_spec": 32766,
+      "cores_per_socket": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "billable_tres": {
+        "set": true,
+        "infinite": false,
+        "number": 1.0
+      },
+      "cpus_per_task": {
+        "set": true,
+        "infinite": false,
+        "number": 1
+      },
+      "cpu_frequency_minimum": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "cpu_frequency_maximum": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "cpu_frequency_governor": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "cpus_per_tres": "",
+      "cron": "",
+      "deadline": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "delay_boot": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "dependency": "",
+      "derived_exit_code": {
+        "status": [
+          "SUCCESS"
+        ],
+        "return_code": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "signal": {
+          "id": {
+            "set": false,
+            "infinite": false,
+            "number": 0
+          },
+          "name": ""
+        }
+      },
+      "eligible_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1786540677
+      },
+      "end_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1788355079
+      },
+      "excluded_nodes": "",
+      "exit_code": {
+        "status": [
+          "SUCCESS"
+        ],
+        "return_code": {
+          "set": true,
+          "infinite": false,
+          "number": 0
+        },
+        "signal": {
+          "id": {
+            "set": false,
+            "infinite": false,
+            "number": 0
+          },
+          "name": ""
+        }
+      },
+      "extra": "",
+      "failed_node": "",
+      "features": "",
+      "federation_origin": "",
+      "federation_siblings_active": "",
+      "federation_siblings_viable": "",
+      "gres_detail": [
+      ],
+      "group_id": 10000,
+      "group_name": "domain users",
+      "het_job_id": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "het_job_id_set": "",
+      "het_job_offset": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "job_id": 2710594,
+      "job_resources": {
+        "nodes": "mantis-041",
+        "allocated_cores": 1,
+        "allocated_cpus": 0,
+        "allocated_hosts": 1,
+        "allocated_nodes": [
+          {
+            "sockets": {
+              "0": {
+                "cores": {
+                  "20": "allocated"
+                }
+              }
+            },
+            "nodename": "mantis-041",
+            "cpus_used": 0,
+            "memory_used": 0,
+            "memory_allocated": 8192
+          }
+        ]
+      },
+      "job_size_str": [
+      ],
+      "job_state": [
+        "RUNNING"
+      ],
+      "last_sched_evaluation": {
+        "set": true,
+        "infinite": false,
+        "number": 1786540679
+      },
+      "licenses": "",
+      "mail_type": [
+      ],
+      "mail_user": "vcell",
+      "max_cpus": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "max_nodes": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "mcs_label": "",
+      "memory_per_tres": "",
+      "name": "V_ALPHA_321860413_0_0",
+      "network": "",
+      "nodes": "mantis-041",
+      "nice": 0,
+      "tasks_per_core": {
+        "set": true,
+        "infinite": false,
+        "number": 1
+      },
+      "tasks_per_tres": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "tasks_per_node": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "tasks_per_socket": {
+        "set": false,
+        "infinite": true,
+        "number": 0
+      },
+      "tasks_per_board": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "cpus": {
+        "set": true,
+        "infinite": false,
+        "number": 1
+      },
+      "node_count": {
+        "set": true,
+        "infinite": false,
+        "number": 1
+      },
+      "tasks": {
+        "set": true,
+        "infinite": false,
+        "number": 1
+      },
+      "partition": "vcell",
+      "prefer": "",
+      "memory_per_cpu": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "memory_per_node": {
+        "set": true,
+        "infinite": false,
+        "number": 8192
+      },
+      "minimum_cpus_per_node": {
+        "set": true,
+        "infinite": false,
+        "number": 1
+      },
+      "minimum_tmp_disk_per_node": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "power": {
+        "flags": [
+        ]
+      },
+      "preempt_time": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "preemptable_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1786540679
+      },
+      "pre_sus_time": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "hold": false,
+      "priority": {
+        "set": true,
+        "infinite": false,
+        "number": 1405
+      },
+      "profile": [
+        "NOT_SET"
+      ],
+      "qos": "vcell",
+      "reboot": false,
+      "required_nodes": "",
+      "minimum_switches": 0,
+      "requeue": false,
+      "resize_time": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "restart_cnt": 0,
+      "resv_name": "",
+      "scheduled_nodes": "",
+      "selinux_context": "",
+      "shared": [
+      ],
+      "exclusive": [
+      ],
+      "oversubscribe": true,
+      "show_flags": [
+        "DETAIL",
+        "LOCAL"
+      ],
+      "sockets_per_board": 0,
+      "sockets_per_node": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "start_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1786540679
+      },
+      "state_description": "",
+      "state_reason": "None",
+      "standard_error": "\/share\/apps\/vcell3\/htclogs\/V_ALPHA_321860413_0_0.slurm.log",
+      "standard_input": "\/dev\/null",
+      "standard_output": "\/share\/apps\/vcell3\/htclogs\/V_ALPHA_321860413_0_0.slurm.log",
+      "submit_time": {
+        "set": true,
+        "infinite": false,
+        "number": 1786540677
+      },
+      "suspend_time": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "system_comment": "",
+      "time_limit": {
+        "set": true,
+        "infinite": false,
+        "number": 30240
+      },
+      "time_minimum": {
+        "set": true,
+        "infinite": false,
+        "number": 0
+      },
+      "threads_per_core": {
+        "set": false,
+        "infinite": false,
+        "number": 0
+      },
+      "tres_bind": "",
+      "tres_freq": "",
+      "tres_per_job": "",
+      "tres_per_node": "",
+      "tres_per_socket": "",
+      "tres_per_task": "",
+      "tres_req_str": "cpu=1,mem=8G,node=1,billing=1",
+      "tres_alloc_str": "cpu=1,mem=8G,node=1,billing=1",
+      "user_id": 10001,
+      "user_name": "vcell",
+      "maximum_switch_wait_time": 0,
+      "wckey": "",
+      "current_working_directory": "\/home\/FCAM\/vcell"
+    }
+  ],
+  "last_backfill": {
+    "set": true,
+    "infinite": false,
+    "number": 1786587429
+  },
+  "last_update": {
+    "set": true,
+    "infinite": false,
+    "number": 0
+  },
+  "meta": {
+    "plugin": {
+      "type": "",
+      "name": "",
+      "data_parser": "data_parser\/v0.0.40",
+      "accounting_storage": "accounting_storage\/slurmdbd"
+    },
+    "client": {
+      "source": "",
+      "user": "vcell",
+      "group": "domain users"
+    },
+    "command": [
+      "show",
+      "job"
+    ],
+    "slurm": {
+      "version": {
+        "major": "23",
+        "micro": "10",
+        "minor": "11"
+      },
+      "release": "23.11.10",
+      "cluster": "mantis"
+    }
+  },
+  "errors": [
+  ],
+  "warnings": [
+  ]
+}


### PR DESCRIPTION
Completes #1912. **Stacked on #1915** — it builds on the shared-query consolidation there.

Two changes that go together: what VCell asks slurm for, and what it does when slurm's accounting cannot answer.

## `--json` for `sacct` and `scontrol`, text for `squeue`

Measured on mantis (slurm 23.11.10) rather than assumed:

| path | text | `--json` | decision |
|---|---|---|---|
| `sacct -j <ids>` (monitor) | steps as sibling rows | **steps nested in the job** | **json** |
| `scontrol show job <id>` (fallback) | key=value lines | structured | **json** |
| `squeue` (ZombieKiller, every cycle) | ~200 B, 3 jobs | **1.26 MB, 146 jobs** | **stays text** |

A SpringSaLaD multirun is **one job with its steps nested inside**, rather than 23 sibling rows that must be filtered by spotting a dot in the job id — the whole class of step-row confusion is *absent from this shape* rather than handled.

`squeue --json` was the surprise: it ignores the default state filter, so it returns every job still in slurmctld memory — **146 where the text form returns 3**, at ~6.3 KB/job. That call answers one question, which jobs are alive, and text does it in ~60 B/job. Paying 6000× the bytes over ssh every cycle for three fields isn't a trade worth making.

## Schema drift becomes detectable

The JSON carries `meta.plugin.data_parser` (`data_parser/v0.0.40` here). `EXPECTED_DATA_PARSER` is checked on every parse and **warns rather than throws** — an unfamiliar schema is a reason to look, not a reason to stop monitoring jobs. Text output offers no equivalent.

The two schemas genuinely differ, which is itself an argument for parsing over scraping: **`sacct` reports `state.current`, `scontrol` reports `job_state`**, and both are *arrays*, not strings.

## The fallback

`sacct` reads the accounting database, so when `slurmdbd` is unavailable it answers nothing — and a caller reading that as "no failures" is blind without knowing it. `slurmctld` keeps finished jobs for `MinJobAge` (**10800 s** on mantis), so `scontrol` still knows what happened inside that window.

Queried **one job at a time**, because slurm rejects a comma-separated list for `scontrol` — verified: passing one returns no jobs at all. That cost is why it's a fallback, and the failure that triggers it is logged loudly.

## Left in place, flagged

The text `sacct` parser now has no production caller. It's retained and marked as such: `--json` needs a slurm carrying the `data_parser` plugin, so a deployment on an older slurm would still need the text form. **If every deployment is known to be new enough, it and its fixtures can go** — that's a question for someone who knows the estate, and deleting it now would remove the only way back.

## Testing

Fixtures are verbatim captures from mantis, including the 20-step multirun and an empty result. One test compares the *parsed* `data_parser` value rather than raw text — slurm escapes the slash, so the bytes read `data_parser\/v0.0.40` while the value is `data_parser/v0.0.40`.

`vcell-server` Fast group **99 green over two runs**; `vcell-rest` compiles.

## Related

- #1915 — the shared-query consolidation this is stacked on
- #1910 — move the reconciliation to `sched`, using `squeue` + `sacct` as combined evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg