### PR TITLE
Declare the properties these services actually require

### DIFF
--- a/vcell-core/src/test/java/cbit/vcell/resource/RequiredPropertyDeclarationTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/resource/RequiredPropertyDeclarationTest.java
@@ -1,0 +1,138 @@
+package cbit.vcell.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+/**
+ * Pins what {@code "PROPERTY: x not marked required"} actually means, because for a long time it
+ * was simply noise nobody could act on — on the dev site it was over 90% of all ERROR volume, and
+ * it drowned the errors that mattered.
+ *
+ * It is a real signal: {@code loadProperties(required[])} marks exactly the listed properties as
+ * required, and {@code getRequiredProperty} complains when it is asked for one that is not on that
+ * list. So the message says "this service demands a property it never declared" — the fix is to
+ * declare it, not to lower the level.
+ */
+@Tag("Fast")
+// PropertyLoader keeps its property map and checkRequired flag in static state, and these tests
+// set system properties; the Fast group runs class-parallel in one JVM.
+@ResourceLock("vcellGlobalConfig")
+public class RequiredPropertyDeclarationTest {
+
+	private ListAppender captured;
+	private final List<String> setProperties = new ArrayList<>();
+
+	@AfterEach
+	public void cleanUp() {
+		if (captured != null) {
+			captured.detach();
+			captured = null;
+		}
+		for (String key : setProperties) {
+			System.clearProperty(key);
+		}
+		setProperties.clear();
+	}
+
+	private void give(String key, String value) {
+		System.setProperty(key, value);
+		setProperties.add(key);
+	}
+
+	private List<String> complaintsWhileFetching(String propertyName, String... declaredAsRequired) throws java.io.IOException {
+		captured = ListAppender.attachTo(PropertyLoader.class);
+		PropertyLoader.loadProperties(declaredAsRequired);
+		PropertyLoader.getRequiredProperty(propertyName);
+		return captured.messagesContaining("not marked required");
+	}
+
+	/** Declared: no complaint. This is what adding the missing entries achieves. */
+	@Test
+	public void aDeclaredRequiredPropertyIsFetchedSilently() throws java.io.IOException {
+		give(PropertyLoader.htcHosts, "some-cluster.example");
+
+		List<String> complaints = complaintsWhileFetching(PropertyLoader.htcHosts, PropertyLoader.htcHosts);
+
+		assertTrue(complaints.isEmpty(), "a declared property should be fetchable without complaint, got: " + complaints);
+	}
+
+	/**
+	 * Undeclared: it complains, and it is right to. This is the case the noisy log was reporting
+	 * all along — the service was demanding a property its own required list never mentioned.
+	 */
+	@Test
+	public void fetchingAnUndeclaredPropertyIsReported() throws java.io.IOException {
+		give(PropertyLoader.htcHosts, "some-cluster.example");
+
+		List<String> complaints = complaintsWhileFetching(PropertyLoader.htcHosts /* declaring nothing */);
+
+		assertEquals(1, complaints.size(), "an undeclared property should be reported exactly once per fetch");
+		assertTrue(complaints.get(0).contains(PropertyLoader.htcHosts), complaints.get(0));
+	}
+
+	/** Captures events from one logger so a test can assert on them. */
+	private static final class ListAppender extends AbstractAppender {
+		private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+		private final Logger logger;
+		private final Level previousLevel;
+
+		private ListAppender(Logger logger) {
+			super("required-property-test-capture", null, null, true, Property.EMPTY_ARRAY);
+			this.logger = logger;
+			this.previousLevel = logger.getLevel();
+		}
+
+		static ListAppender attachTo(Class<?> cls) {
+			LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+			Logger logger = ctx.getLogger(cls.getName());
+			ListAppender appender = new ListAppender(logger);
+			appender.start();
+			logger.addAppender(appender);
+			// Configurator rather than logger.setLevel(): the latter moves only this Logger
+			// instance, and the class under test holds a different instance of the same name.
+			Configurator.setLevel(cls.getName(), Level.DEBUG);
+			return appender;
+		}
+
+		void detach() {
+			logger.removeAppender(this);
+			Configurator.setLevel(logger.getName(), previousLevel);
+			stop();
+		}
+
+		List<String> messagesContaining(String fragment) {
+			List<String> out = new ArrayList<>();
+			synchronized (events) {
+				for (LogEvent event : events) {
+					String message = event.getMessage().getFormattedMessage();
+					if (message.contains(fragment)) {
+						out.add(message);
+					}
+				}
+			}
+			return out;
+		}
+
+		@Override
+		public void append(LogEvent event) {
+			events.add(event.toImmutable());
+		}
+	}
+}

--- a/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
@@ -455,6 +455,7 @@ public static void main(String[] args) throws IOException {
 }
 
 private static final String REQUIRED_SERVICE_PROPERTIES[] = {
+
 		PropertyLoader.vcellSoftwareVersion,
 		PropertyLoader.primarySimDataDirInternalProperty,
 		PropertyLoader.primarySimDataDirExternalProperty,
@@ -506,7 +507,20 @@ private static final String REQUIRED_SERVICE_PROPERTIES[] = {
 		PropertyLoader.htcPowerUserMemoryMaxMB,
 		PropertyLoader.slurm_langevin_timeoutPerTaskSeconds,
 		PropertyLoader.slurm_langevin_batchMemoryLimitPerTaskMB,
-		PropertyLoader.slurm_langevin_memoryBlockSizeMB
+		PropertyLoader.slurm_langevin_memoryBlockSizeMB,
+
+		// Fetched with getRequiredProperty() but previously absent from this list, so
+		// PropertyLoader logged "not marked required" on every fetch. Declaring them
+		// silences that honestly and makes a missing value fail at startup, where it
+		// can be read, rather than at first use.
+		PropertyLoader.htc_singularity_imagedir,
+		PropertyLoader.htc_vcellfvsolver_solver_list,
+		PropertyLoader.slurm_singularity_pullfolder,
+		PropertyLoader.slurm_singularity_cachedir,
+		PropertyLoader.jmsArtemisPortInternal,
+		PropertyLoader.jmsArtemisHostInternal,
+		PropertyLoader.htcUserKeyFile,
+		PropertyLoader.htcHosts
 	};
 
 

--- a/vcell-server/src/main/java/cbit/vcell/message/server/dispatcher/SimulationDispatcherMain.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/dispatcher/SimulationDispatcherMain.java
@@ -52,6 +52,7 @@ public class SimulationDispatcherMain {
 
 
 	private static final String REQUIRED_SERVICE_PROPERTIES[] = {
+
 			PropertyLoader.vcellServerIDProperty,
 			PropertyLoader.installationRoot,
 			PropertyLoader.dbConnectURL,
@@ -75,7 +76,15 @@ public class SimulationDispatcherMain {
 			PropertyLoader.maxPdeJobsPerUser,
 			PropertyLoader.slurm_partition,
 			PropertyLoader.htcPowerUserMemoryMaxMB,
-			PropertyLoader.htcMaxMemoryMB
+			PropertyLoader.htcMaxMemoryMB,
+
+		// Fetched with getRequiredProperty() but previously absent from this list, so
+		// PropertyLoader logged "not marked required" on every fetch. Declaring them
+		// silences that honestly and makes a missing value fail at startup, where it
+		// can be read, rather than at first use.
+		PropertyLoader.htcMinMemoryMB,
+		PropertyLoader.htcUserKeyFile,
+		PropertyLoader.htcHosts
 		};
 
 }


### PR DESCRIPTION
`PROPERTY: x not marked required` was **over 90% of all ERROR volume on the dev site** — 530 lines in twelve hours — and it drowned the errors that mattered. Every log sweep this week had to filter it out first.

**It reads like noise, but it isn't.** `loadProperties(required[])` marks exactly the listed properties as required, and `getRequiredProperty` complains when it is asked for one that isn't on that list. The message means *"this service demands a property it never declared."*

So the fix is the declarations, not the log level.

| service | added |
|---|---|
| `submit` | `htc_singularity_imagedir`, `htc_vcellfvsolver_solver_list`, `slurm_singularity_pullfolder`, `slurm_singularity_cachedir`, `jmsArtemisPortInternal`, `jmsArtemisHostInternal`, `htcUserKeyFile`, `htcHosts` |
| `sched` | `htcMinMemoryMB`, `htcUserKeyFile`, `htcHosts` |

Determined by comparing each service's declared set against what the running services actually complained about, rather than by eye.

## This is worth more than quiet logs

A property on the list is **validated at startup**. A missing or malformed value now fails immediately with a report naming it, instead of throwing at whatever moment the code first reaches for it — which for something like `slurm_singularity_cachedir` could be well into a simulation submission.

## Testing

Two tests pin the *mechanism* rather than restating the lists, so the meaning survives someone editing them: a declared property is fetched silently, an undeclared one is reported. They capture the logger's output rather than asserting on a return value, because what gets logged **is** the behaviour under test.

`vcell-server` Fast group 99 green. `vcell-core` 499 with the one pre-existing environmental error (`VCellDataTest` needs the `pythonVtk` Poetry env, per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY1XHgTZXZPqUECo2VBAWg