### PR TITLE
Archive to Zenodo when a release reaches production, not when it is tagged

### DIFF
--- a/.github/workflows/site_deploy.yml
+++ b/.github/workflows/site_deploy.yml
@@ -373,3 +373,16 @@ jobs:
           -H 'Content-Type: application/json' \
           --data "@body"
 
+  # A release becomes citable when it is the one users are running, not when it is tagged.
+  # Archiving on every published release produced a DOI for ~15 consecutive patch builds
+  # between 2026-07-01 and 2026-08-13, none of which reached production. This runs only for
+  # the release site, and only if the deploy actually succeeded.
+  archive-to-zenodo:
+    name: Archive to Zenodo
+    needs: deploy
+    if: ${{ needs.deploy.result == 'success' && github.event.inputs.vcell_site == 'rel' }}
+    uses: ./.github/workflows/zenodo-archive.yml
+    with:
+      tag: ${{ github.event.inputs.vcell_version }}.${{ github.event.inputs.vcell_build }}
+    secrets:
+      ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}

--- a/.github/workflows/zenodo-archive.yml
+++ b/.github/workflows/zenodo-archive.yml
@@ -1,21 +1,48 @@
 name: Archive release to Zenodo
 
-# On each published GitHub Release, archive it as a new version of the VCell
-# Zenodo concept (10.5281/zenodo.7796386) via the zenodo-maint reusable workflow.
-# Replaces the old native Zenodo<->GitHub integration (now disabled). Concept and
-# deposit metadata come from CITATION.cff (doi:) and .zenodo.json at the repo root.
+# Archives a release as a new version of the VCell Zenodo concept
+# (10.5281/zenodo.7796386) via the zenodo-maint reusable workflow. Replaces the old
+# native Zenodo<->GitHub integration (now disabled). Concept and deposit metadata come
+# from CITATION.cff (doi:) and .zenodo.json at the repo root.
 #
 # Requires an org/repo secret ZENODO_TOKEN belonging to the account that OWNS the
 # concept record (creating new versions requires ownership).
+#
+# WHEN THIS RUNS -- deliberately not on every published release.
+#
+# It used to trigger on `release: published`, which meant a DOI for every tag. Between
+# 2026-07-01 and 2026-08-13 that was ~15 releases, every one of them a patch-level build
+# and none of them deployed to production: 8.0.2.x through 8.0.15.01, two on the last day
+# alone. A citable archive of a build nobody ran is noise in the record, and the version
+# history is what people cite.
+#
+# It now runs when a release is actually deployed to the production site, which is the
+# point at which a version becomes the one users have. site_deploy.yml calls this after a
+# successful deploy with vcell_site=rel.
+#
+# workflow_dispatch remains for backfilling or re-archiving a specific tag by hand.
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to archive (e.g. 8.1.0.01)"
+        required: true
+        type: string
+    secrets:
+      ZENODO_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to archive (e.g. 8.1.0.01)"
+        required: true
+        type: string
 
 jobs:
   archive:
     uses: virtualcell/zenodo-maint/.github/workflows/archive.reusable.yml@v1
     with:
-      tag: ${{ github.event.release.tag_name }}
+      tag: ${{ inputs.tag }}
     secrets:
       ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}

--- a/.github/workflows/zenodo-drift.yml
+++ b/.github/workflows/zenodo-drift.yml
@@ -9,9 +9,22 @@ name: Zenodo drift check
 # next release is archived), this may report drift; it self-resolves once the next
 # release is archived and becomes the newest version.
 
+# The weekly schedule is OFF, deliberately.
+#
+# This check asks "is the latest GitHub release also the latest Zenodo version?", which was a
+# fair proxy for "has archiving silently stopped" while every release was archived. Archiving
+# is now tied to a production deploy (site_deploy.yml, vcell_site=rel), so the newest release
+# will usually NOT be the newest Zenodo version -- that is the intended state, not drift, and
+# the check would open a tracking issue every Monday saying so.
+#
+# The comparison lives in virtualcell/zenodo-maint and takes no inputs, so it cannot be pointed
+# at the deployed version from here. Re-enable the schedule once that workflow can compare
+# against what production is running rather than against the newest tag.
+#
+# It remains available on demand, which is when it is actually useful: after a prod deploy, to
+# confirm the archive landed.
+
 on:
-  schedule:
-    - cron: '0 12 * * 1'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
Archiving fired on **every published release**. Between 2026-07-01 and 2026-08-13 that was **~15 releases, every one patch-level, none deployed to production** — 8.0.2.x through 8.0.15.01, two on the last day alone. Each minted a version on the VCell concept (10.5281/zenodo.7796386).

A citable archive of a build nobody ran is noise, and the version history is what people cite.

## The change

`zenodo-archive.yml` becomes a `workflow_call`, invoked from `site_deploy.yml` after a **successful deploy with `vcell_site=rel`**:

```yaml
archive-to-zenodo:
  needs: deploy
  if: ${{ needs.deploy.result == 'success' && github.event.inputs.vcell_site == 'rel' }}
  uses: ./.github/workflows/zenodo-archive.yml
  with:
    tag: ${{ github.event.inputs.vcell_version }}.${{ github.event.inputs.vcell_build }}
```

`workflow_dispatch` stays, for backfilling or re-archiving a tag by hand.

## Consequence: the drift check's weekly schedule is off

`zenodo-drift.yml` asks whether the latest GitHub release is also the latest Zenodo version — a fair proxy for "archiving has silently stopped" **only while every release was archived**. Now the newest release will usually not be the newest Zenodo version *by design*, so it would open a tracking issue every Monday reporting the intended state as a fault.

Its comparison lives in `virtualcell/zenodo-maint` and takes no inputs, so it can't be pointed at the deployed version from here. **The schedule should come back once it can.** It remains available on demand — which is when it's actually useful, right after a prod deploy.

## Not addressed

Whether re-deploying the same tag to prod archives it twice depends on `zenodo-maint`'s idempotency, which isn't visible from this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)