### PR TITLE
Add modern names alongside the legacy ENV defaults in the five images

### DIFF
--- a/docker/build/Dockerfile-api-dev
+++ b/docker/build/Dockerfile-api-dev
@@ -50,25 +50,43 @@ COPY ./vcell-api/keystore_macbook.jks .
 COPY ./docker/build/vcell-api.log4j.xml .
 
 ENV softwareVersion=SOFTWARE-VERSION-NOT-SET \
+    VCELL_SOFTWAREVERSION=SOFTWARE-VERSION-NOT-SET \
 	serverid=SITE \
+	VCELL_SERVER_ID=SITE \
     jmshost_int_internal=activemqint \
+    VCELL_JMS_INT_HOST_INTERNAL=activemqint \
     jmsport_int_internal=61616 \
+    VCELL_JMS_INT_PORT_INTERNAL=61616 \
     jmsuser=clientUser \
+    VCELL_JMS_USER=clientUser \
     mongodb_host_internal=mongodb \
+    VCELL_MONGODB_HOST_INTERNAL=mongodb \
     mongodb_port_internal=27017 \
+    VCELL_MONGODB_PORT_INTERNAL=27017 \
     mongodb_database=test \
+    VCELL_MONGODB_DATABASE=test \
     jmsblob_minsize=100000 \
+    VCELL_JMS_BLOBMESSAGEMINSIZE=100000 \
 	ssl_ignoreHostMismatch=true \
+	VCELL_SSL_IGNOREHOSTMISMATCH=true \
 	ssl_ignoreCertProblems=false \
+	VCELL_SSL_IGNORECERTPROBLEMS=false \
 	protocol="https" \
-	workingDir="/usr/local/app"
+	workingDir="/usr/local/app" \
+	CLI_WORKINGDIR="/usr/local/app"
 
 ENV dbpswdfile=/run/secrets/dbpswd \
+    VCELL_DB_PSWDFILE=/run/secrets/dbpswd \
     jmspswdfile=/run/secrets/jmspswd \
+    VCELL_JMS_PSWDFILE=/run/secrets/jmspswd \
     keystore=/run/secrets/keystorefile \
+    VCELLAPI_KEYSTORE_FILE=/run/secrets/keystorefile \
     keystorepswdfile=/run/secrets/keystorepswd \
+    VCELLAPI_KEYSTORE_PSWDFILE=/run/secrets/keystorepswd \
     vcellapi_privatekeyfile=/run/secrets/apiprivkey \
-    vcellapi_publickeyfile=/run/secrets/apipubkey
+    VCELLAPI_PRIVATEKEY_FILE=/run/secrets/apiprivkey \
+    vcellapi_publickeyfile=/run/secrets/apipubkey \
+    VCELLAPI_PUBLICKEY_FILE=/run/secrets/apipubkey
 
 EXPOSE 8080
 ENV VCELL_DEBUG_OPTS=""

--- a/docker/build/Dockerfile-data-dev
+++ b/docker/build/Dockerfile-data-dev
@@ -44,24 +44,41 @@ COPY ./nativelibs/linux64 ./nativelibs/linux64
 COPY ./docker/build/vcell-data.log4j.xml .
 
 ENV softwareVersion=SOFTWARE-VERSION-NOT-SET \
+    VCELL_SOFTWAREVERSION=SOFTWARE-VERSION-NOT-SET \
 	serverid=SITE \
+	VCELL_SERVER_ID=SITE \
 	dburl="db-url-not-set" \
+	VCELL_SERVER_DBCONNECTURL="db-url-not-set" \
     dbdriver="db-driver-not-set" \
+    VCELL_SERVER_DBDRIVERNAME="db-driver-not-set" \
     dbuser="db-user-not-set" \
+    VCELL_SERVER_DBUSERID="db-user-not-set" \
     jmshost_int_internal=activemqint \
+    VCELL_JMS_INT_HOST_INTERNAL=activemqint \
     jmsport_int_internal=61616 \
+    VCELL_JMS_INT_PORT_INTERNAL=61616 \
     jmsuser=clientUser \
+    VCELL_JMS_USER=clientUser \
     jmsblob_minsize=100000 \
+    VCELL_JMS_BLOBMESSAGEMINSIZE=100000 \
 	mongodb_host_internal=mongodb \
+	VCELL_MONGODB_HOST_INTERNAL=mongodb \
 	mongodb_port_internal=27017 \
+	VCELL_MONGODB_PORT_INTERNAL=27017 \
     mongodb_database=test \
+    VCELL_MONGODB_DATABASE=test \
     simdatadir_external=/path/to/external/simdata/ \
+    VCELL_PRIMARYSIMDATADIR_EXTERNAL=/path/to/external/simdata/ \
     servertype="servertype-not-set"
 
 ENV dbpswdfile=/run/secrets/dbpswd \
+    VCELL_DB_PSWDFILE=/run/secrets/dbpswd \
     jmspswdfile=/run/secrets/jmspswd \
+    VCELL_JMS_PSWDFILE=/run/secrets/jmspswd \
     keystore=/run/secrets/keystorefile \
-    keystorepswdfile=/run/secrets/keystorepswd
+    VCELLAPI_KEYSTORE_FILE=/run/secrets/keystorefile \
+    keystorepswdfile=/run/secrets/keystorepswd \
+    VCELLAPI_KEYSTORE_PSWDFILE=/run/secrets/keystorepswd
     
 
 VOLUME /simdata

--- a/docker/build/Dockerfile-db-dev
+++ b/docker/build/Dockerfile-db-dev
@@ -33,20 +33,34 @@ COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \
 COPY ./docker/build/vcell-db.log4j.xml .
 
 ENV softwareVersion=SOFTWARE-VERSION-NOT-SET \
+    VCELL_SOFTWAREVERSION=SOFTWARE-VERSION-NOT-SET \
 	serverid=SITE \
+	VCELL_SERVER_ID=SITE \
     jmshost_int_internal=activemqint \
+    VCELL_JMS_INT_HOST_INTERNAL=activemqint \
     jmsport_int_internal=61616 \
+    VCELL_JMS_INT_PORT_INTERNAL=61616 \
     jmsuser=clientUser \
+    VCELL_JMS_USER=clientUser \
 	mongodb_host_internal=mongodb \
+	VCELL_MONGODB_HOST_INTERNAL=mongodb \
 	mongodb_port_internal=27017 \
+	VCELL_MONGODB_PORT_INTERNAL=27017 \
     mongodb_database=test \
+    VCELL_MONGODB_DATABASE=test \
     mongodb_host_external="mongodb-host-external-not-set" \
+    VCELL_MONGODB_HOST_EXTERNAL="mongodb-host-external-not-set" \
     mongodb_port_external="mongodb-port-external-not-set" \
+    VCELL_MONGODB_PORT_EXTERNAL="mongodb-port-external-not-set" \
     export_baseurl="export-baseurl-not-set" \
-    jmsblob_minsize=100000
+    VCELL_EXPORT_BASEURL="export-baseurl-not-set" \
+    jmsblob_minsize=100000 \
+    VCELL_JMS_BLOBMESSAGEMINSIZE=100000
 
 ENV dbpswdfile=/run/secrets/dbpswd \
-    jmspswdfile=/run/secrets/jmspswd
+    VCELL_DB_PSWDFILE=/run/secrets/dbpswd \
+    jmspswdfile=/run/secrets/jmspswd \
+    VCELL_JMS_PSWDFILE=/run/secrets/jmspswd
 
 ENV VCELL_DEBUG_OPTS=""
 

--- a/docker/build/Dockerfile-sched-dev
+++ b/docker/build/Dockerfile-sched-dev
@@ -43,29 +43,48 @@ COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \
 COPY ./docker/build/vcell-sched.log4j.xml .
 
 ENV softwareVersion=SOFTWARE-VERSION-NOT-SET \
+    VCELL_SOFTWAREVERSION=SOFTWARE-VERSION-NOT-SET \
 	serverid=SITE \
+	VCELL_SERVER_ID=SITE \
     jmshost_int_internal=activemqint \
+    VCELL_JMS_INT_HOST_INTERNAL=activemqint \
     jmsport_int_internal=61616 \
+    VCELL_JMS_INT_PORT_INTERNAL=61616 \
     jmshost_sim_internal=activemqsim \
+    VCELL_JMS_SIM_HOST_INTERNAL=activemqsim \
     jmsport_sim_internal=61616 \
+    VCELL_JMS_SIM_PORT_INTERNAL=61616 \
     jmsuser=clientUser \
+    VCELL_JMS_USER=clientUser \
     jmsblob_minsize=100000 \
+    VCELL_JMS_BLOBMESSAGEMINSIZE=100000 \
 	mongodb_host_internal=mongodb \
+	VCELL_MONGODB_HOST_INTERNAL=mongodb \
 	mongodb_port_internal=27017 \
+	VCELL_MONGODB_PORT_INTERNAL=27017 \
     mongodb_database=test \
+    VCELL_MONGODB_DATABASE=test \
 #    htclogdir_internal=/path/to/internal/htclogs/
     htcnodelist="batch-host-not-set" \
+    VCELL_HTC_NODELIST="batch-host-not-set" \
     slurm_reservation="slurm_reservation-not-set" \
+    VCELL_SLURM_RESERVATION="slurm_reservation-not-set" \
     slurm_partition_pu="slurm_partition_pu-not-set" \
+    VCELL_SLURM_PARTITIONPU="slurm_partition_pu-not-set" \
     slurm_reservation_pu="slurm_reservation_pu-not-set" \
+    VCELL_SLURM_RESERVATIONPU="slurm_reservation_pu-not-set" \
 	vcell_ssh_cmd_cmdtimeout="cmdSrvcSshCmdTimeoutMS-not-set" \
     vcell_ssh_cmd_restoretimeout="cmdSrvcSshCmdRestoreTimeoutFactor-not-set" \
     vcell_ssh_cmd_options_csv="cmdSrvcSshCmdRestoreOptionsCsv-not-set" \
-	htcPowerUserMemoryFloorMB="htc-power-user-memory-floor-not-set"
+	htcPowerUserMemoryFloorMB="htc-power-user-memory-floor-not-set" \
+	VCELL_HTC_MEMORY_PU_FLOOR_MB="htc-power-user-memory-floor-not-set"
 
 ENV dbpswdfile=/run/secrets/dbpswd \
+    VCELL_DB_PSWDFILE=/run/secrets/dbpswd \
     jmspswdfile=/run/secrets/jmspswd \
-    batchuserkeyfile=/run/secrets/batchuserkeyfile
+    VCELL_JMS_PSWDFILE=/run/secrets/jmspswd \
+    batchuserkeyfile=/run/secrets/batchuserkeyfile \
+    VCELL_HTC_USERKEYFILE=/run/secrets/batchuserkeyfile
 
 ENV VCELL_DEBUG_OPTS=""
 

--- a/docker/build/Dockerfile-submit-dev
+++ b/docker/build/Dockerfile-submit-dev
@@ -42,38 +42,65 @@ COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \
 COPY ./docker/build/vcell-submit.log4j.xml .
 
 ENV softwareVersion=SOFTWARE-VERSION-NOT-SET \
+    VCELL_SOFTWAREVERSION=SOFTWARE-VERSION-NOT-SET \
 	serverid=SITE \
+	VCELL_SERVER_ID=SITE \
     jmshost_int_internal=activemqint \
+    VCELL_JMS_INT_HOST_INTERNAL=activemqint \
     jmsport_int_internal=61616 \
+    VCELL_JMS_INT_PORT_INTERNAL=61616 \
     jmshost_sim_internal=activemqsim \
+    VCELL_JMS_SIM_HOST_INTERNAL=activemqsim \
     jmsport_sim_internal=61616 \
+    VCELL_JMS_SIM_PORT_INTERNAL=61616 \
     jmsuser=clientUser \
+    VCELL_JMS_USER=clientUser \
 	mongodb_host_internal=mongodb \
+	VCELL_MONGODB_HOST_INTERNAL=mongodb \
 	mongodb_port_internal=27017 \
+	VCELL_MONGODB_PORT_INTERNAL=27017 \
     mongodb_database=test \
+    VCELL_MONGODB_DATABASE=test \
 #    export_baseurl="export-baseurl-not-set" \
     simdatadir_external=/path/to/external/simdata/ \
+    VCELL_PRIMARYSIMDATADIR_EXTERNAL=/path/to/external/simdata/ \
     simdatadir_secondary_external=/path/to/external/secondary/simdata/ \
+    VCELL_SECONDARYSIMDATADIR_EXTERNAL=/path/to/external/secondary/simdata/ \
     simdatadir_parallel_external=/path/to/external/parallel/simdata/ \
+    VCELL_PARALLELDATADIR_EXTERNAL=/path/to/external/parallel/simdata/ \
 #    htclogdir_internal=/path/to/internal/htclogs/ \
     htclogdir_external=/path/to/external/htclogs/ \
+    VCELL_HTC_LOGDIR_EXTERNAL=/path/to/external/htclogs/ \
     nativesolverdir_external=/path/to/external/nativesolvers/ \
+    VCELL_NATIVESOLVERDIR_EXTERNAL=/path/to/external/nativesolvers/ \
     htcnodelist="batch-host-not-set" \
+    VCELL_HTC_NODELIST="batch-host-not-set" \
     htc_vcellfvsolver_apptainer_image="htc-vcellfvsolver-apptainer-image-not-set" \
+    VCELL_HTC_VCELLFVSOLVER_APPTAINER_IMAGE="htc-vcellfvsolver-apptainer-image-not-set" \
     slurm_cmd_sbatch=sbatch \
+    VCELL_SLURM_CMD_SBATCH=sbatch \
     slurm_cmd_sacct=sacct \
+    VCELL_SLURM_CMD_SACCT=sacct \
     slurm_cmd_scancel=scancel \
+    VCELL_SLURM_CMD_SCANCEL=scancel \
     slurm_cmd_squeue=squeue \
+    VCELL_SLURM_CMD_SQUEUE=squeue \
     jmshost_artemis_internal=artemismq \
+    VCELL_JMS_ARTEMIS_HOST_INTERNAL=artemismq \
     jmsport_artemis_internal=61616 \
+    VCELL_JMS_ARTEMIS_PORT_INTERNAL=61616 \
     jmsblob_minsize=100000 \
+    VCELL_JMS_BLOBMESSAGEMINSIZE=100000 \
     vcell_ssh_cmd_cmdtimeout="cmdSrvcSshCmdTimeoutMS-not-set" \
     vcell_ssh_cmd_restoretimeout="cmdSrvcSshCmdRestoreTimeoutFactor-not-set" \
     vcell_ssh_cmd_options_csv="cmdSrvcSshCmdRestoreOptionsCsv-not-set"
 
 ENV jmspswdfile=/run/secrets/jmspswd \
+    VCELL_JMS_PSWDFILE=/run/secrets/jmspswd \
 	jmsrestpswdfile=/run/secrets/jmsrestpswd \
-    batchuserkeyfile=/run/secrets/batchuserkeyfile
+	VCELL_JMS_REST_PSWDFILE=/run/secrets/jmsrestpswd \
+    batchuserkeyfile=/run/secrets/batchuserkeyfile \
+    VCELL_HTC_USERKEYFILE=/run/secrets/batchuserkeyfile
 
 VOLUME /simdata
 VOLUME /simdata_secondary


### PR DESCRIPTION
Step 3 of 3 — the last source of legacy-named configuration. Pairs with virtualcell/vcell-fluxcd#36.

| layer | modern names | status |
|---|---|---|
| ConfigMap keys | 830 twins | ✅ vcell-fluxcd#35 merged |
| `env:` entries in `kustomize/base` | 14 twins | vcell-fluxcd#36 |
| **`ENV` defaults in the five images** | **95 twins** | **this PR** |

These are the defaults the image itself is the source of — `jmsport_int_internal=61616`, `mongodb_database=test`, `jmsblob_minsize`, `workingDir` and 91 others — which no ConfigMap supplies.

## What this made visible

Twinning the images alone would have been actively unsafe, and the check that caught it compared **values**, not names. The deployment overrides an image default under the *legacy* name only:

```
dbpswdfile        = /run/secrets/api-secrets/dbpswd    (deployment)
VCELL_DB_PSWDFILE = /run/secrets/dbpswd                (image default, unoverridden)
```

**13 such divergences**, every one a secret path — database password, JMS password, HPC ssh key, JWT signing keys. Removing the fallback in that state would not fail loudly: the property resolves fine, to a file that isn't there. vcell-fluxcd#36 closes them by twinning **every** legacy `env:` entry rather than a hand-picked list — its first version covered three and missed the two JWT keys.

## Verified

- every `ENV` block still well formed (a comment inside a continuation broke an earlier attempt at this kind of edit)
- **95 matched pairs**, no mismatches
- `docker buildx build --call=check`: same 3 pre-existing warnings
- cross-layer divergence check: **0** (was 13)
- **no property in any of the five services is reachable only by a legacy name**

## Explicitly not included

Removing the fallback table. That is the one irreversible step, and it should follow a deploy that proves the modern names resolve **while the fallback is still there** to catch anything missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)