### PR TITLE
Run each CodeQL language only when that language changed

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,9 +21,90 @@ on:
     - cron: '38 0 * * 0'
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Decides which languages this change can possibly affect.
+  #
+  # The Java analysis is the expensive one -- it compiles the whole project, and runs 8-10
+  # minutes -- and it is run on every push to master and every pull request regardless of what
+  # changed. Two cases where that buys nothing:
+  #
+  #   * A merge commit on master whose tree equals the merged branch's tree: the pull request
+  #     analysed this exact tree already.
+  #   * A change that touches no file of that language. A CHANGELOG edit or a Dockerfile tweak
+  #     cannot alter Java findings.
+  #
+  # The weekly schedule always runs everything. That is the safety net: it re-analyses the whole
+  # repository against current queries, which is what catches a newly-published rule matching old
+  # code, and no per-change filter should be able to suppress it.
+  #
+  # Fails open: anything it cannot determine runs every language.
+  should-run:
+    name: should-run
+    runs-on: ubuntu-24.04
+    outputs:
+      java: ${{ steps.decide.outputs.java }}
+      javascript: ${{ steps.decide.outputs.javascript }}
+      python: ${{ steps.decide.outputs.python }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: decide
+        shell: bash
+        run: |
+          set -uo pipefail
+          all() {
+            for l in java javascript python; do echo "$l=$1" >> "$GITHUB_OUTPUT"; done
+            echo "::notice::CodeQL languages $( [ "$1" = true ] && echo "all run" || echo skipped ): $2"
+            exit 0
+          }
+
+          # The weekly sweep is never filtered.
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+            all true "scheduled full analysis"
+          fi
+
+          # A merge commit whose tree matches the branch it merged was already analysed there.
+          if [ "${GITHUB_REF}" = "refs/heads/master" ] && git rev-parse -q --verify "HEAD^2" >/dev/null 2>&1; then
+            if [ "$(git rev-parse "HEAD^{tree}")" = "$(git rev-parse "HEAD^2^{tree}")" ]; then
+              all false "merge commit tree is identical to the branch already analysed"
+            fi
+          fi
+
+          base=""
+          if [ -n "${GITHUB_EVENT_BEFORE:-}" ] && git rev-parse -q --verify "${GITHUB_EVENT_BEFORE}^{commit}" >/dev/null 2>&1; then
+            base="${GITHUB_EVENT_BEFORE}"
+          elif git rev-parse -q --verify "HEAD^1" >/dev/null 2>&1; then
+            base="HEAD^1"
+          fi
+          if [ -z "${base}" ]; then
+            all true "could not determine what changed"
+          fi
+
+          changed="$(git diff --name-only "${base}" HEAD)"
+          if [ -z "${changed}" ]; then
+            all true "no diff available"
+          fi
+
+          decide_one() {
+            if printf '%s\n' "${changed}" | grep -qE "$2"; then
+              echo "$1=true" >> "$GITHUB_OUTPUT"; echo "::notice::CodeQL $1: runs"
+            else
+              echo "$1=false" >> "$GITHUB_OUTPUT"; echo "::notice::CodeQL $1: skipped, no $1 files changed"
+            fi
+          }
+          decide_one java       '(\.java$|(^|/)pom\.xml$)'
+          decide_one javascript '(\.(js|jsx|ts|tsx|mjs|cjs)$|(^|/)package(-lock)?\.json$)'
+          decide_one python     '(\.py$|(^|/)(pyproject\.toml|poetry\.lock|requirements[^/]*\.txt)$)'
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+
   analyze:
     name: Analyze
     runs-on: ubuntu-24.04
+    needs: should-run
+    if: ${{ needs.should-run.outputs[matrix.language] == 'true' }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,9 +42,10 @@ jobs:
     name: should-run
     runs-on: ubuntu-24.04
     outputs:
-      java: ${{ steps.decide.outputs.java }}
-      javascript: ${{ steps.decide.outputs.javascript }}
-      python: ${{ steps.decide.outputs.python }}
+      # A JSON array of the languages worth analysing, consumed as the analyze matrix.
+      # It has to be the matrix rather than a per-job `if`, because `matrix` is not one of the
+      # contexts available to a job-level `if` -- only github, needs, vars and inputs are.
+      languages: ${{ steps.decide.outputs.languages }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,8 +56,13 @@ jobs:
         run: |
           set -uo pipefail
           all() {
-            for l in java javascript python; do echo "$l=$1" >> "$GITHUB_OUTPUT"; done
-            echo "::notice::CodeQL languages $( [ "$1" = true ] && echo "all run" || echo skipped ): $2"
+            if [ "$1" = true ]; then
+              echo 'languages=["java","javascript","python"]' >> "$GITHUB_OUTPUT"
+              echo "::notice::CodeQL: all languages run -- $2"
+            else
+              echo 'languages=[]' >> "$GITHUB_OUTPUT"
+              echo "::notice::CodeQL: skipped -- $2"
+            fi
             exit 0
           }
 
@@ -87,16 +93,19 @@ jobs:
             all true "no diff available"
           fi
 
-          decide_one() {
+          selected=""
+          consider() {
             if printf '%s\n' "${changed}" | grep -qE "$2"; then
-              echo "$1=true" >> "$GITHUB_OUTPUT"; echo "::notice::CodeQL $1: runs"
+              selected="${selected:+${selected},}\"$1\""
+              echo "::notice::CodeQL $1: runs"
             else
-              echo "$1=false" >> "$GITHUB_OUTPUT"; echo "::notice::CodeQL $1: skipped, no $1 files changed"
+              echo "::notice::CodeQL $1: skipped, no $1 files changed"
             fi
           }
-          decide_one java       '(\.java$|(^|/)pom\.xml$)'
-          decide_one javascript '(\.(js|jsx|ts|tsx|mjs|cjs)$|(^|/)package(-lock)?\.json$)'
-          decide_one python     '(\.py$|(^|/)(pyproject\.toml|poetry\.lock|requirements[^/]*\.txt)$)'
+          consider java       '(\.java$|(^|/)pom\.xml$)'
+          consider javascript '(\.(js|jsx|ts|tsx|mjs|cjs)$|(^|/)package(-lock)?\.json$)'
+          consider python     '(\.py$|(^|/)(pyproject\.toml|poetry\.lock|requirements[^/]*\.txt)$)'
+          echo "languages=[${selected}]" >> "$GITHUB_OUTPUT" 
         env:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
 
@@ -104,7 +113,8 @@ jobs:
     name: Analyze
     runs-on: ubuntu-24.04
     needs: should-run
-    if: ${{ needs.should-run.outputs[matrix.language] == 'true' }}
+    # An empty matrix vector is an error, so the job is skipped outright when nothing applies.
+    if: ${{ needs.should-run.outputs.languages != '[]' }}
     permissions:
       actions: read
       contents: read
@@ -113,7 +123,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java', 'javascript', 'python' ]
+        # Chosen by should-run: only the languages this change can affect.
+        language: ${{ fromJson(needs.should-run.outputs.languages) }}
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 


### PR DESCRIPTION
The Java analysis compiles the whole project and takes **8–10 minutes**, and it ran on every push to master and every pull request regardless of what changed.

**Of the last five merges, three touched no Java at all** — release notes, Dockerfile `ENV` twins, and a workflow edit. Three Java analyses ran to confirm that files they never saw hadn't changed.

## The guard

Same shape as the fast-lane guard in `ci.yml`, plus per-language relevance:

- a merge commit on master whose tree equals the merged branch's tree — already analysed there
- a language runs only if the change touches a file of that language:

| language | triggers on |
|---|---|
| java | `*.java`, `pom.xml` |
| javascript | `*.{js,jsx,ts,tsx,mjs,cjs}`, `package.json`, `package-lock.json` |
| python | `*.py`, `pyproject.toml`, `poetry.lock`, `requirements*.txt` |

**The weekly schedule always runs everything**, and no per-change filter can suppress it. That matters more here than for tests: the sweep re-analyses the whole repository against *current* queries, which is what catches a newly published rule matching old code.

**Fails open** — anything it can't determine runs every language.

## Why this is safe

CodeQL is **not a required status check** (the ruleset requires `build`, `CI-Test-group-Fast`, `CI-Test-group-Quarkus`, `regression-gate`), so a skipped analysis cannot block a merge.

## Verified against real commits

| commit | java | js | py |
|---|---|---|---|
| release notes (CHANGELOG only) | skip | skip | skip |
| Dockerfile `ENV` twins | skip | skip | skip |
| `ci.yml` guard (workflow only) | skip | skip | skip |
| `-D` wall removal (Dockerfiles + Java) | **run** | skip | skip |
| config provider (Java) | **run** | skip | skip |

🤖 Generated with [Claude Code](https://claude.com/claude-code)