### PR TITLE
Match MovingBoundary times by nearest rather than by near-equality

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/simdata/MovingBoundarySimDataReader.java
+++ b/vcell-core/src/main/java/cbit/vcell/simdata/MovingBoundarySimDataReader.java
@@ -112,6 +112,31 @@ public class MovingBoundarySimDataReader {
         return ((Number) value).doubleValue();
     }
 
+    /**
+     * How far the nearest saved time may be from the requested one before it is treated as a
+     * different time altogether.
+     *
+     * The requested time has been through the .log file, which carries six significant digits, so
+     * the error scales with the magnitude of the time rather than being a fixed quantity -- an
+     * absolute bound is either too tight for late times or needlessly loose for early ones. The
+     * relative part covers the rounding; the absolute floor keeps t=0 and very small times from
+     * demanding exactness they cannot have.
+     *
+     * 1e-4 is chosen with margin at both ends. Six significant digits is a relative error of at
+     * most 5e-6 -- worst when the leading digit is 1, which is why the error is not the 5e-7 that
+     * "six digits" suggests: 0.0104058 stands for 0.010405830662209813, a relative error of 3e-6.
+     * So this is roughly 20x the largest rounding error possible, while still well inside the
+     * spacing of saved times (1e-3 apart in the file this was diagnosed on, i.e. a relative gap of
+     * about 1e-3 at t=1, ten times this bound). Nearest-match does the real work; this only decides
+     * when to declare that no saved time corresponds to the request at all.
+     *
+     * Package-visible so the rule can be tested against real values without an HDF5 fixture.
+     */
+    static double timeMatchTolerance(double time)
+    {
+        return Math.max(1e-9, 1e-4 * Math.abs(time));
+    }
+
     public static double[] readMBSData(String fileName, Vector<DataBlock> dataBlockList, String varName, Double time) throws Exception {
         try (HdfFile solFile = new HdfFile(new File(fileName).toPath()))
         {
@@ -131,7 +156,22 @@ public class MovingBoundarySimDataReader {
                 throw new Exception("Variable " + varName + " not found");
             }
 
+            // Match the nearest saved time rather than requiring near-equality.
+            //
+            // The caller's time comes from the .log file, which the solver writes with C's "%g" --
+            // six significant digits. The time attributes in the HDF5 file are full doubles, so the
+            // two disagree by up to a part in 1e6: for this file the logged 0.122269 stands for
+            // 0.1222685102809653, a difference of 4.9e-7. An exact-ish match therefore fails for
+            // almost every time point; on a 386-point simulation only the 20 earliest times, where
+            // six digits happen to be enough, could be read at all. The rest failed with
+            // "No time group found", which reads like missing data rather than a rounding problem.
+            //
+            // Nearest-match is the right shape regardless of how the log is formatted. The bound
+            // below only rejects a time that belongs to no saved point at all: saved times are far
+            // apart compared with the rounding error (here 1.0e-3 apart versus a 4.0e-6 worst-case
+            // error), so nearest is unambiguous by three orders of magnitude.
             Group timeGroup = null;
+            double closestDelta = Double.MAX_VALUE;
             for (Node member : solutionGroup(solFile).getChildren().values())
             {
                 if (!(member instanceof Group))
@@ -139,13 +179,18 @@ public class MovingBoundarySimDataReader {
                     continue;
                 }
                 Attribute timeAttribute = member.getAttribute(CartesianMeshMovingBoundary.MSBDataAttribute.time.name());
-                if (timeAttribute != null && Math.abs(doubleValue(timeAttribute.getData()) - time) < 1e-8)
+                if (timeAttribute == null)
                 {
+                    continue;
+                }
+                double delta = Math.abs(doubleValue(timeAttribute.getData()) - time);
+                if (delta < closestDelta)
+                {
+                    closestDelta = delta;
                     timeGroup = (Group) member;
-                    break;
                 }
             }
-            if (timeGroup == null)
+            if (timeGroup == null || closestDelta > timeMatchTolerance(time))
             {
                 throw new Exception("No time group found for time=" + time);
             }

--- a/vcell-core/src/test/java/cbit/vcell/simdata/MovingBoundaryTimeMatchTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/simdata/MovingBoundaryTimeMatchTest.java
@@ -1,0 +1,98 @@
+package cbit.vcell.simdata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A MovingBoundary simulation's saved times reach the reader by two routes that do not agree.
+ *
+ * The .log file, which is where the caller's requested time comes from, is written by the solver
+ * with C's "%g" -- six significant digits. The time attributes inside the HDF5 file are full
+ * doubles. So a request for "0.122269" has to find a group whose stored time is 0.1222685102809653.
+ *
+ * The reader used to require the two to agree within 1e-8 absolute. On the 386-timepoint simulation
+ * this was diagnosed on, that matched 20 of 386 times: only the earliest, where six digits happen to
+ * be enough. Every other time failed with "No time group found", which reads like missing data
+ * rather than a rounding problem, and it took reading the .log and the .h5 side by side to see why.
+ *
+ * The values below are real: taken from SimID_109369415, whose logged times were compared against
+ * the time attributes in its own HDF5 file.
+ */
+@Tag("Fast")
+public class MovingBoundaryTimeMatchTest {
+
+	/** {logged (what the caller asks for), stored (what the file holds)} */
+	private static final double[][] LOGGED_VS_STORED = {
+			{0.0,        0.0},
+			{0.00260146, 0.002601457665552453},
+			{0.0104058,  0.010405830662209813},
+			{0.122269,   0.1222685102809653},
+			{0.127471,   0.1274714256120702},
+			{0.280957,   0.28095742787966493},
+			{0.28616,    0.28616034321076983},
+			{0.312175,   0.31217491986629436},
+			{0.702394,   0.7023935696991623},
+	};
+
+	/**
+	 * The point of the fix: every one of these is a time a user can select in the viewer.
+	 */
+	@Test
+	public void everyLoggedTimeMatchesTheTimeStoredInTheFile() {
+		for (double[] pair : LOGGED_VS_STORED) {
+			double logged = pair[0], stored = pair[1];
+			double delta = Math.abs(stored - logged);
+			assertTrue(delta <= MovingBoundarySimDataReader.timeMatchTolerance(logged),
+					"logged " + logged + " should match stored " + stored + " (differ by " + delta
+							+ ", tolerance " + MovingBoundarySimDataReader.timeMatchTolerance(logged) + ")");
+		}
+	}
+
+	/**
+	 * The regression this replaces, kept as a statement of what was wrong: under the old fixed 1e-8
+	 * bound all but the two earliest of these were unreadable.
+	 */
+	@Test
+	public void theOldFixedToleranceWouldHaveRejectedMostOfThem() {
+		int rejected = 0;
+		for (double[] pair : LOGGED_VS_STORED) {
+			if (Math.abs(pair[1] - pair[0]) >= 1e-8) {
+				rejected++;
+			}
+		}
+		assertEquals(7, rejected, "7 of these 9 real times were unreadable before the fix");
+	}
+
+	/**
+	 * The tolerance still has to be small enough that it cannot reach a neighbouring saved time.
+	 * Saved times in this simulation are ~1.04e-3 apart.
+	 */
+	@Test
+	public void theToleranceStaysWellInsideTheSpacingOfSavedTimes() {
+		double smallestGapBetweenSavedTimes = 1.04e-3;
+		for (double[] pair : LOGGED_VS_STORED) {
+			assertTrue(MovingBoundarySimDataReader.timeMatchTolerance(pair[0]) < smallestGapBetweenSavedTimes / 10,
+					"tolerance at t=" + pair[0] + " must stay an order of magnitude inside the gap"
+							+ " between saved times, or it could select the wrong one");
+		}
+	}
+
+	/** t=0 is exact in both routes, and must not be handed a tolerance of zero. */
+	@Test
+	public void zeroIsMatchedExactlyAndKeepsAPositiveTolerance() {
+		assertTrue(MovingBoundarySimDataReader.timeMatchTolerance(0.0) > 0.0);
+		assertTrue(Math.abs(0.0 - 0.0) <= MovingBoundarySimDataReader.timeMatchTolerance(0.0));
+	}
+
+	/** A time that belongs to no saved point must still be rejected. */
+	@Test
+	public void aTimeBetweenTwoSavedPointsIsStillRejected() {
+		double savedTime = 0.1222685102809653;
+		double halfwayToTheNext = savedTime + 5.2e-4;
+		assertTrue(Math.abs(savedTime - halfwayToTheNext) > MovingBoundarySimDataReader.timeMatchTolerance(halfwayToTheNext),
+				"nearest-match must not silently return a different time's data");
+	}
+}


### PR DESCRIPTION
Fixes the errors reading MovingBoundary time points on dev (SimID 109369415).

### The two routes disagree

A MovingBoundary simulation's saved times reach the reader two ways:

| route | value for one time point |
|---|---|
| `.log` — where the requested time comes from, written by the solver with C's `%g` (6 significant digits) | `0.122269` |
| `.h5` — the `time` attribute on each group, a full double | `0.1222685102809653` |

The reader required them to agree within **1e-8 absolute**. Measured against the actual simulation, a 386-timepoint run:

```
before:  readable=20   failed=366
after:   readable=386  failed=0
```

The 20 that worked are the earliest times, where six significant digits happen to land within 1e-8. Everything from `t=0.0104058` on was unreadable, failing with `No time group found for time=…` — which reads like missing data rather than a rounding problem, and is why this looked like a file or library issue.

### Not the jhdf migration

That was my first suspicion too, and it is wrong. #1906 left the tolerance and the `double` read identical, and this file stores **float64**, so the `float[]` widening path it introduced never executes. The comparison has been this tight since well before; MovingBoundary data viewing simply had not exercised it.

### The fix

Nearest saved time wins; the tolerance now only decides whether the request corresponds to *any* saved time. That is the right shape whatever precision the log carries.

The bound is relative — `1e-4` of the requested time with a small absolute floor for `t=0`. Six significant digits is a relative error of up to **5e-6**, worst when the leading digit is 1, which is why it is not the 5e-7 that "six digits" suggests (`0.0104058` stands for `0.010405830662209813`, 3e-6 relative). That leaves ~20x margin over the largest possible rounding error while staying an order of magnitude inside the ~1e-3 spacing of saved times, so it cannot reach a neighbour.

### Tests

`MovingBoundaryTimeMatchTest` (5, Fast) pins the numeric rule against **real** logged/stored pairs taken from this simulation, including a test asserting the old bound rejected 7 of the 9, one that the tolerance stays inside the spacing of saved times, and one that a time between two saved points is still rejected. The helper is package-visible so this needs no 50MB HDF5 fixture.

Verified end to end by reading every time in the simulation's `.log` from its `.h5` with the built classes, before and after — the numbers above.