### PR TITLE
Resolve rest's AMQP broker address under the modern configuration names

### DIFF
--- a/vcell-rest/src/main/resources/application.properties
+++ b/vcell-rest/src/main/resources/application.properties
@@ -188,8 +188,17 @@ quarkus.swagger-ui.always-include=true
 %test.mp.messaging.incoming.subscriber-opt-status.capabilities=queue
 
 quarkus.amqp.devservices.enabled=false
-%prod.amqp-host=${jmshost_artemis_internal:localhost}
-%prod.amqp-port=${jmsport_artemis_internal:5672}
+# The broker address, under the same names as everything else. These were jmshost_artemis_internal
+# and jmsport_artemis_internal -- historical short names that the deployment stopped supplying when
+# it finished the configuration-name migration. Nothing resolved them after that, so both silently
+# took the defaults below and rest spent its life retrying localhost:5672 while the broker sat on
+# artemismq:61616. The defaults are what made it quiet: a missing value looked like a working one.
+#
+# MicroProfile maps these to VCELL_JMS_ARTEMIS_HOST_INTERNAL and VCELL_JMS_ARTEMIS_PORT_INTERNAL,
+# which every overlay defines. AMQP_HOST/AMQP_PORT still override, being environment variables, and
+# that is how the deployment currently supplies them.
+%prod.amqp-host=${vcell.jms.artemis.host.internal:localhost}
+%prod.amqp-port=${vcell.jms.artemis.port.internal:5672}
 %prod.amqp-username=${AMQP_USER:guest}
 %prod.amqp-password=${AMQP_PASSWORD:guest}
 


### PR DESCRIPTION
Code half of vcell-fluxcd#44 (already merged and verified on dev and stage).

`application.properties` derived the broker address from **legacy** names:

```properties
%prod.amqp-host=${jmshost_artemis_internal:localhost}
%prod.amqp-port=${jmsport_artemis_internal:5672}
```

The deployment stopped supplying those when dev and stage finished the configuration-name migration. Nothing resolved them after that, so both fell through to the defaults and rest retried `localhost:5672` forever while the broker sat on `artemismq:61616` — 216 `Connection refused` in half an hour on dev. **The defaults are what kept it quiet:** a missing value looked like a working one instead of a startup failure. Affected channels are `publisher-opt-request`/`subscriber-opt-status` (parameter estimation) and export request/status, so it was not only noise.

MicroProfile maps the names used here to `VCELL_JMS_ARTEMIS_HOST_INTERNAL` and `VCELL_JMS_ARTEMIS_PORT_INTERNAL`, which **every** overlay defines — including the three that have not migrated — so this is safe everywhere. `AMQP_HOST`/`AMQP_PORT` still override as environment variables, which is how vcell-fluxcd#44 fixed the running sites without waiting for a release.

I swept the rest resources: these two were the only legacy-style references left. The others are `java.io.tmpdir`, `AMQP_USER`, `AMQP_PASSWORD` and `quarkus.oidc.auth-server-url`.

Verified on the running sites after the config half landed: `Connection refused` 0 on both, two broker connections established, and the AMQP receiver listening on `opt-status`.