### PR TITLE
Reference the AMQP broker address by its environment variable name

### DIFF
--- a/vcell-rest/src/main/resources/application.properties
+++ b/vcell-rest/src/main/resources/application.properties
@@ -188,17 +188,23 @@ quarkus.swagger-ui.always-include=true
 %test.mp.messaging.incoming.subscriber-opt-status.capabilities=queue
 
 quarkus.amqp.devservices.enabled=false
-# The broker address, under the same names as everything else. These were jmshost_artemis_internal
-# and jmsport_artemis_internal -- historical short names that the deployment stopped supplying when
-# it finished the configuration-name migration. Nothing resolved them after that, so both silently
-# took the defaults below and rest spent its life retrying localhost:5672 while the broker sat on
-# artemismq:61616. The defaults are what made it quiet: a missing value looked like a working one.
+# The broker address. These were jmshost_artemis_internal and jmsport_artemis_internal -- historical
+# short names that the deployment stopped supplying when it finished the configuration-name
+# migration. Nothing resolved them after that, so both silently took the defaults below and rest
+# spent its life retrying localhost:5672 while the broker sat on artemismq:61616. The defaults are
+# what made it quiet: a missing value looked like a working one.
 #
-# MicroProfile maps these to VCELL_JMS_ARTEMIS_HOST_INTERNAL and VCELL_JMS_ARTEMIS_PORT_INTERNAL,
-# which every overlay defines. AMQP_HOST/AMQP_PORT still override, being environment variables, and
-# that is how the deployment currently supplies them.
-%prod.amqp-host=${vcell.jms.artemis.host.internal:localhost}
-%prod.amqp-port=${vcell.jms.artemis.port.internal:5672}
+# Written as the environment variable name rather than the property name vcell.jms.artemis.*, even
+# though MicroProfile resolves either. The names below are exactly the keys in
+# kustomize/config/*/rest.env and submit.env, so anyone changing a key there and searching the two
+# repositories for it finds this line. The dotted form does not match that search, and a consumer
+# invisible to a search for its own key is how both migration regressions happened -- this one, and
+# the SIF prepull job that reported success while pulling nothing.
+#
+# AMQP_HOST/AMQP_PORT still take precedence, being set directly as environment variables, and that
+# is how the deployment supplies them today.
+%prod.amqp-host=${VCELL_JMS_ARTEMIS_HOST_INTERNAL:localhost}
+%prod.amqp-port=${VCELL_JMS_ARTEMIS_PORT_INTERNAL:5672}
 %prod.amqp-username=${AMQP_USER:guest}
 %prod.amqp-password=${AMQP_PASSWORD:guest}
 


### PR DESCRIPTION
Follow-up to #1942. **No behavioural change** — it changes whether the dependency can be found.

### Both forms resolve

Verified against the real dependency set rather than argued from the spec:

```
with VCELL_JMS_ARTEMIS_HOST_INTERNAL=artemismq in the environment:
    vcell.jms.artemis.host.internal = artemismq     <- as merged in #1942
    VCELL_JMS_ARTEMIS_HOST_INTERNAL = artemismq     <- this PR
```

### Why the change is worth making

The names here are now **exactly the keys** in `kustomize/config/*/rest.env` and `submit.env`, so anyone changing a key there and grepping the two repositories for it lands on this line. The dotted form does not match that search.

That is not hypothetical. A consumer invisible to a search for its own key is precisely how both migration regressions happened: this property, which sent `rest` to `localhost:5672` and took parameter estimation and export status with it, and the SIF prepull job that reported success while pulling nothing until a simulation died on the cluster. It is also exactly what Check 5 in `docs/site-config-migration.md` runs.

Grepping the merged version *does* match this file today — but only because the comment spells the name out:

```
matches on NON-comment lines:
  as merged (dotted):   (none)
  this PR:              160:%prod.amqp-host=${VCELL_JMS_ARTEMIS_HOST_INTERNAL:localhost}
                        161:%prod.amqp-port=${VCELL_JMS_ARTEMIS_PORT_INTERNAL:5672}
```

So the discoverability currently rests on prose anyone may reword. This puts it in the configuration.

### It also restores the file's own convention

The only other environment-supplied values here are `${AMQP_USER:guest}` and `${AMQP_PASSWORD:guest}`, two lines below, both written as the environment variable name. #1942 broke that local consistency.

The source-agnosticism the property name bought (resolving from `-Dvcell.jms.artemis.host.internal` or from `application.properties`) is theoretical — nothing sets that for a Quarkus service configured entirely by environment.

Credit to Jim for catching it.