### PR TITLE
Stop re-downloading the same dependencies on every CI job

### DIFF
--- a/.github/workflows/CI-full.yml
+++ b/.github/workflows/CI-full.yml
@@ -66,12 +66,25 @@ jobs:
           popd;\
         done
 
-    - name: setup java 17 with maven cache
+    - name: setup java 17
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'
-        cache: 'maven'
+
+    # Not setup-java's `cache: maven`, which saves only on a cache MISS -- so the first cache
+    # ever written, incomplete, was restored unchanged by every later run and never updated.
+    # A key that always differs means it is always saved, and restore-keys falls back to the
+    # newest previous one, so the cache converges on complete. This job saves for the run;
+    # docker-build restores only.
+    - name: maven repository cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: maven-${{ hashFiles('**/pom.xml') }}-${{ github.run_id }}
+        restore-keys: |
+          maven-${{ hashFiles('**/pom.xml') }}-
+          maven-
 
     - name: Maven build
       run: mvn --batch-mode clean install dependency:copy-dependencies -DskipTests=true
@@ -190,13 +203,23 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: setup java 17 with maven cache
+    - name: setup java 17
       if: ${{ matrix.image.pre_build }}
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'
-        cache: 'maven'
+
+    # Restore only. This is a matrix job, so saving here would write one cache entry per image.
+    - name: maven repository cache (restore only)
+      if: ${{ matrix.image.pre_build }}
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.m2/repository
+        key: maven-${{ hashFiles('**/pom.xml') }}-${{ github.run_id }}
+        restore-keys: |
+          maven-${{ hashFiles('**/pom.xml') }}-
+          maven-
 
     - name: Download Maven artifacts
       if: ${{ matrix.image.needs_maven }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,12 +162,27 @@ jobs:
           poetry install
           poetry run python -m pytest
 
-      - name: setup java 17 with maven cache
+      - name: setup java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
+
+      # Not setup-java's `cache: maven`. That saves only on a cache MISS, so the first cache
+      # ever written -- which was incomplete -- was restored unchanged by every later run and
+      # never updated, because the key only changes when a pom does. One build measured 1200
+      # artifacts (811 poms, 409 jars) re-downloaded on a cache HIT, in every job of every run.
+      #
+      # A key that always differs means the cache is always saved, and restore-keys falls back
+      # to the newest previous one, so it converges on complete instead of freezing incomplete.
+      - name: maven repository cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}-${{ github.run_id }}
+          restore-keys: |
+            maven-${{ hashFiles('**/pom.xml') }}-
+            maven-
 
       - name: Maven build (compile, no tests)
         shell: bash
@@ -244,12 +259,21 @@ jobs:
           (cd pythonData && poetry install)
           (cd docker/swarm/vcell-admin && poetry install)
 
-      - name: setup java 17 with maven cache
+      - name: setup java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
+
+      # Restore only: the build job saves the shared cache for the run. See the note there.
+      - name: maven repository cache (restore only)
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}-${{ github.run_id }}
+          restore-keys: |
+            maven-${{ hashFiles('**/pom.xml') }}-
+            maven-
 
       # Step 1: compile the whole reactor once (no tests). Step 2: run ONLY this
       # shard's modules' Fast tests, with JUnit class-level parallelism (enabled
@@ -320,12 +344,21 @@ jobs:
       - name: Set Docker API version workaround
         run: echo "api.version=1.44" >> ~/.docker-java.properties
 
-      - name: setup java 17 with maven cache
+      - name: setup java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
+
+      # Restore only: the build job saves the shared cache for the run. See the note there.
+      - name: maven repository cache (restore only)
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}-${{ github.run_id }}
+          restore-keys: |
+            maven-${{ hashFiles('**/pom.xml') }}-
+            maven-
 
       - name: Maven build, validate OpenAPI spec, run Quarkus tests
         shell: bash

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,27 @@
 
 
 	<repositories>
+		<!-- Central first, deliberately.
+
+		     Maven asks repositories in declaration order and stops at the first that has the
+		     artifact. Central is not declared here at all by default: it comes from the super-POM
+		     and is therefore consulted LAST, after every repository below. Nearly everything we
+		     depend on lives in Central, so each of those artifacts was looked up - and 404'd - in
+		     five other repositories first.
+
+		     Measured on one CI build with a warm dependency cache: 7028 "Downloading from" attempts
+		     produced 1222 artifacts. Central served 1205 of them, while alfresco, scijava, jitpack,
+		     terracotta and lib-maven-repo served zero between them and absorbed roughly 5800 failed
+		     round trips. The repositories below still matter for the handful of artifacts that are
+		     genuinely only there; they simply should not be asked first.
+
+		     Keep Central first when adding a repository. -->
+		<repository>
+			<id>central</id>
+			<url>https://repo.maven.apache.org/maven2</url>
+			<releases><enabled>true</enabled></releases>
+			<snapshots><enabled>false</enabled></snapshots>
+		</repository>
 		<!-- Vendored artifacts not available on Maven Central: jai_core, jai-codec, netcdf, udunits, thredds-parent -->
 		<repository>
 			<id>lib-maven-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -256,11 +256,24 @@
 			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 		<!-- needed for com.mxgraph.jgraphx -->
+		<!-- Commented out 2026-08-14. Two cold-cache `mvn clean install -DskipTests` runs against
+	     an empty local repository, one with this repository and one without: both BUILD SUCCESS,
+	     and every artifact resolved from the same place either way (central 2465/2471,
+	     maven-restlet 15, jitpack 13, lib-maven-repo 9, scijava 6, ej-technologies 2,
+	     terracotta 1). This repository served ZERO. It has been here since the original
+	     single-maven-project reorganisation.
+
+	     Removing it saves little on its own - 4285 lookup attempts became 4253 - because with
+	     Central ordered ahead of it, it was already rarely reached. The ordering is what removed
+	     the waste; this removes a flaky third-party server from the critical path entirely.
+		     Left commented rather than deleted so it is one line to restore if something outside
+		     the default profile set turns out to need it.
 		<repository>
 			<id>com.alfresco.repository.public</id>
 			<name>Alfresco Public Repository</name>
 			<url>https://artifacts.alfresco.com/nexus/content/repositories/public/</url>
 		</repository>
+		-->
 
 		<!-- needed for imagej dependencies -->
 		<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,8 @@
 
 
 	<repositories>
-		<!-- Central first, deliberately.
+		<!-- Order matters: Maven asks repositories in the order below and stops at the first that
+		     has the artifact.
 
 		     Maven asks repositories in declaration order and stops at the first that has the
 		     artifact. Central is not declared here at all by default: it comes from the super-POM
@@ -213,13 +214,19 @@
 		     round trips. The repositories below still matter for the handful of artifacts that are
 		     genuinely only there; they simply should not be asked first.
 
-		     Keep Central first when adding a repository. -->
-		<repository>
-			<id>central</id>
-			<url>https://repo.maven.apache.org/maven2</url>
-			<releases><enabled>true</enabled></releases>
-			<snapshots><enabled>false</enabled></snapshots>
-		</repository>
+		     The vendored file:// repository stays FIRST, ahead of Central. A miss there is a
+		     filesystem stat rather than a network round trip, so it costs the ~1200 Central
+		     artifacts almost nothing, while the artifacts that are only vendored resolve with no
+		     network at all. It also keeps vendoring meaning what it says: whatever is in
+		     lib/maven-repo wins. That is not hypothetical - edu.ucar:netcdf:4.3.22 is vendored
+		     AND present on Central. The two are byte-identical today (sha1
+		     a9b0be3ddf020c3aebf6498fcfc3ef007805cec0), so nothing turns on it right now, but with
+		     Central first the vendored copy would quietly stop being the one that is used, and
+		     that should not depend on a coincidence. jai_core, jai-codec and udunits are not on
+		     Central at all.
+
+		     So: vendored first, then Central, then the rest. Add new repositories after Central
+		     unless they are vendored artifacts. -->
 		<!-- Vendored artifacts not available on Maven Central: jai_core, jai-codec, netcdf, udunits, thredds-parent -->
 		<repository>
 			<id>lib-maven-repo</id>
@@ -230,6 +237,12 @@
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
+		</repository>
+		<repository>
+			<id>central</id>
+			<url>https://repo.maven.apache.org/maven2</url>
+			<releases><enabled>true</enabled></releases>
+			<snapshots><enabled>false</enabled></snapshots>
 		</repository>
 		<!-- needed for com.mxgraph.jgraphx -->
 		<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,18 @@
 
 		     So: vendored first, then Central, then the rest. Add new repositories after Central
 		     unless they are vendored artifacts. -->
-		<!-- Vendored artifacts not available on Maven Central: jai_core, jai-codec, netcdf, udunits, thredds-parent -->
+		<!-- Vendored artifacts: jai_core, jai-codec, netcdf, udunits, thredds-parent.
+
+		     Vendored for RELIABILITY, not availability. The upstream servers that carried these
+		     were flaky enough that builds failed on them, so a copy lives in the tree and the
+		     build never depends on a third party being up to compile.
+
+		     The distinction matters when deciding whether one can be dropped. This comment used to
+		     say "not available on Maven Central", which is not true of all of them:
+		     edu.ucar:netcdf:4.3.22 is on Central and byte-identical to the vendored copy. It stays
+		     vendored anyway, because availability today was never the reason. jai_core, jai-codec
+		     and udunits do 404 from Central. -->
+		<!-- Keep this repository FIRST; see the ordering note above. -->
 		<repository>
 			<id>lib-maven-repo</id>
 			<url>file://${maven.multiModuleProjectDirectory}/lib/maven-repo</url>


### PR DESCRIPTION
Your hypothesis was right, and it is worse than "not threaded" — the downloads are **entirely repeated work**. Two independent causes, both measured on PR #1943's build job (maven `Total time 08:17`) whose dependency cache had been *restored successfully*.

### 1. The cache never updated

`setup-java`'s `cache: maven` saves only on a cache **MISS**:

```
Post setup java 17 with maven cache: Cache hit occurred on the primary key …, not saving cache
```

The first cache ever written was incomplete. Because the key changes only when a pom does, every run since restored that same incomplete snapshot and never saved an updated one. **1222 artifacts (811 poms, 409 jars) were downloaded on a cache hit** — and would be on every job of every run indefinitely.

Replaced with an explicit cache whose key always differs (so it always saves) plus `restore-keys` falling back to the newest previous one, so it converges on complete instead of freezing incomplete. **Only one job per workflow saves** — `build` in ci.yml, `maven-build` in CI-full.yml — so a run adds one entry, not four (or sixteen across the `docker-build` matrix).

### 2. Central was consulted last

Central is not declared in our pom at all, so it comes from the super-POM **after** every repository we declare. Nearly everything we depend on is in Central, so each artifact was looked up in five other repositories first:

| repo | attempts | served |
|---|---|---|
| central | 1207 | **1205** |
| terracotta | 1157 | 0 |
| scijava.public | 1157 | 0 |
| jitpack.io | 1157 | 0 |
| com.alfresco.repository.public | 1157 | 0 |
| lib-maven-repo | 1156 | 0 |

**7028 attempts produced 1222 artifacts** — roughly 5800 failed round trips per job. Declaring Central first makes the common case stop at the first repository; the others still serve the handful of artifacts genuinely only there, they are just not asked first. Verified in the effective POM: `central` is now first of six.

### Why they compound

Fixing the cache removes most downloads; fixing the order makes whatever remains cost one lookup instead of six.

### What I did not change

`ci.yml:11-13` documents that each job compiles independently on purpose ("reusing compiled output across jobs proved unreliable for inter-module test-runtime classpaths"). I left that alone. If you want to go further afterwards, `-T 1C` for parallel module builds is the contained next step — it speeds each job without sharing artifacts between them — but it deserves its own timed experiment since not every plugin is thread-safe.

### Measuring it

The first run on this branch still pays a cold-ish cache (the pom hash changes, so it falls back through `restore-keys`) and **writes a complete cache**. The run *after* it is the one to compare — expect the `Downloading from` count to collapse. Worth watching `maven Total time` on the build job over the next few merges rather than judging from one run, given the 3:24–8:17 spread I measured across today's runs on identical work.