### PR TITLE
Run Python through vcell.python.executable instead of hard-coding poetry

### DIFF
--- a/vcell-cli/src/main/java/org/vcell/cli/CLIPythonManager.java
+++ b/vcell-cli/src/main/java/org/vcell/cli/CLIPythonManager.java
@@ -2,6 +2,7 @@ package org.vcell.cli;
 
 import cbit.vcell.resource.OperatingSystemInfo;
 import cbit.vcell.resource.PropertyLoader;
+import org.vcell.util.PythonUtils;
 import com.google.common.io.Files;
 
 import java.io.*;
@@ -95,7 +96,9 @@ public class CLIPythonManager {
             throws InterruptedException, IOException, PythonStreamException {
         Path cliWorkingDir = Paths.get(PropertyLoader.getRequiredProperty(PropertyLoader.cliWorkingDir));
         String commandString = "from vcell_cli_utils import wrapper; " + cliCommand;
-        ProcessBuilder pb = new ProcessBuilder("poetry", "run", "python", "-c", commandString);
+        List<String> command = PythonUtils.pythonCommandPrefix();
+        command.addAll(List.of("-c", commandString));
+        ProcessBuilder pb = new ProcessBuilder(command);
         pb.directory(cliWorkingDir.toFile());
         return CLIPythonManager.runAndPrintProcessStreams(pb, "","");
     }
@@ -148,7 +151,9 @@ public class CLIPythonManager {
         // e.g. source ~/Library/Caches/pypoetry/virtualenvs/vcell-cli-utils-g4hrdDfL-py3.9/bin/activate
 
         // Start poetry based Python
-        ProcessBuilder pb = new ProcessBuilder("poetry", "run", "python", "-i", "-W ignore");
+        List<String> command = PythonUtils.pythonCommandPrefix();
+        command.addAll(List.of("-i", "-W ignore"));
+        ProcessBuilder pb = new ProcessBuilder(command);
         pb.redirectErrorStream(true);
         File cliWorkingDir = PropertyLoader.getRequiredDirectory(PropertyLoader.cliWorkingDir).getCanonicalFile();
         pb.directory(cliWorkingDir);

--- a/vcell-core/src/main/java/org/vcell/optimization/CopasiUtils.java
+++ b/vcell-core/src/main/java/org/vcell/optimization/CopasiUtils.java
@@ -339,11 +339,13 @@ public class CopasiUtils {
         File installDir = PropertyLoader.getRequiredDirectory(PropertyLoader.installationRoot);
         File optDir = Paths.get(installDir.getAbsolutePath(),"pythonCopasiOpt", "vcell-opt").toAbsolutePath().toFile();
 //        final String pythonExe = "/Users/schaff/Library/Caches/pypoetry/virtualenvs/vcell-opt-XIpjcTyI-py3.9/bin/python";
-        ProcessBuilder pb = new ProcessBuilder(new String[]{
-                "poetry","run","python", "-m", "vcell_opt.optService",
+        List<String> optCommand = PythonUtils.pythonCommandPrefix();
+        optCommand.addAll(List.of(
+                "-m", "vcell_opt.optService",
                 String.valueOf(optProblemFile.toAbsolutePath()),
                 String.valueOf(resultsFile.toAbsolutePath()),
-                String.valueOf(reportFile.toAbsolutePath())});
+                String.valueOf(reportFile.toAbsolutePath())));
+        ProcessBuilder pb = new ProcessBuilder(optCommand);
         pb.directory(optDir);
         System.out.println(pb.command());
         PythonUtils.runAndPrintProcessStreams(pb);

--- a/vcell-core/src/main/java/org/vcell/sbml/OmexPythonUtils.java
+++ b/vcell-core/src/main/java/org/vcell/sbml/OmexPythonUtils.java
@@ -88,7 +88,7 @@ public class OmexPythonUtils {
                 String.valueOf(omexFile.toAbsolutePath()),
                 String.valueOf(tempDir.toAbsolutePath()),
                 String.valueOf(reportJsonFile.toAbsolutePath()) };
-        PythonUtils.callPoetryModule(cliPythonDir, "vcell_cli_utils.wrapper", commands);
+        PythonUtils.callPythonModule(cliPythonDir, "vcell_cli_utils.wrapper", commands);
     }
 
 }

--- a/vcell-core/src/main/java/org/vcell/util/PythonUtils.java
+++ b/vcell-core/src/main/java/org/vcell/util/PythonUtils.java
@@ -1,5 +1,6 @@
 package org.vcell.util;
 
+import cbit.vcell.resource.PropertyLoader;
 import com.google.common.io.Files;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,8 +15,34 @@ import java.util.List;
 public class PythonUtils {
     private final static Logger lg = LogManager.getLogger(PythonUtils.class);
 
-    public static void callPoetryModule(File workingDir, String pythonModule, String[] commands) throws InterruptedException, IOException {
-        List<String> commandList = new ArrayList<>(Arrays.asList("poetry", "run", "python", "-m", pythonModule));
+    /**
+     * How to run Python: a command prefix that callers append their own arguments to.
+     *
+     * Every call site used to hard-code {@code poetry run python}, which decided in Java how a
+     * deployment must install its Python packages. {@code vcell.python.executable} already existed
+     * for exactly this and was already being passed to the sim-data service, but nothing read it.
+     *
+     * It is not only a tidiness question. In the deployed container {@code poetry run} fails
+     * outright: the image runs as uid 10001 while {@code poetry.toml} is {@code -rw------- root},
+     * so Poetry cannot read its own configuration and exits with
+     * "[Errno 13] Permission denied: .../poetry.toml". The interpreter the property points at
+     * imports the same packages perfectly well, because the image installs them into it.
+     *
+     * When the property is absent -- a developer's machine, the CLI run from a checkout -- the
+     * behaviour is exactly what it was, so nothing changes outside a deployment that opts in by
+     * setting it.
+     */
+    public static List<String> pythonCommandPrefix() {
+        String configured = PropertyLoader.getProperty(PropertyLoader.pythonExe, null);
+        if (configured != null && !configured.trim().isEmpty()) {
+            return new ArrayList<>(List.of(configured.trim()));
+        }
+        return new ArrayList<>(Arrays.asList("poetry", "run", "python"));
+    }
+
+    public static void callPythonModule(File workingDir, String pythonModule, String[] commands) throws InterruptedException, IOException {
+        List<String> commandList = pythonCommandPrefix();
+        commandList.addAll(Arrays.asList("-m", pythonModule));
         commandList.addAll(Arrays.asList(commands));
         ProcessBuilder pb = new ProcessBuilder(commandList);
         pb.directory(workingDir);

--- a/vcell-core/src/main/java/org/vcell/vis/vtk/VtkServicePython.java
+++ b/vcell-core/src/main/java/org/vcell/vis/vtk/VtkServicePython.java
@@ -62,7 +62,7 @@ public class VtkServicePython extends VtkService {
 				String.valueOf(visMeshFile.toAbsolutePath()),
 				String.valueOf(vtkFile.toAbsolutePath()),
 				String.valueOf(indexFile.toAbsolutePath()) };
-		PythonUtils.callPoetryModule(vtkPythonDir, "python_vtk.vtkService.vtkService", commands);
+		PythonUtils.callPythonModule(vtkPythonDir, "python_vtk.vtkService.vtkService", commands);
 	}
 
 }

--- a/vcell-core/src/test/java/org/vcell/util/PythonCommandPrefixTest.java
+++ b/vcell-core/src/test/java/org/vcell/util/PythonCommandPrefixTest.java
@@ -1,0 +1,67 @@
+package org.vcell.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import cbit.vcell.resource.PropertyLoader;
+
+/**
+ * Which interpreter runs our Python is a deployment decision, and it now travels through
+ * {@code vcell.python.executable} rather than being fixed in Java as {@code poetry run python}.
+ *
+ * The property already existed and was already being passed to the sim-data service; nothing read
+ * it. That was not merely untidy: in the deployed container {@code poetry run} fails, because the
+ * image runs as uid 10001 while {@code poetry.toml} is {@code -rw------- root}, so Poetry cannot
+ * read its own configuration. The interpreter the property names imports the same packages.
+ *
+ * Both branches matter, so both are pinned here: a deployment that sets the property gets it, and
+ * a developer's machine that does not keeps the behaviour it has always had.
+ */
+@Tag("Fast")
+public class PythonCommandPrefixTest {
+
+	@AfterEach
+	public void clearProperty() {
+		System.clearProperty(PropertyLoader.pythonExe);
+	}
+
+	/** Unset is the developer's machine and the CLI run from a checkout. Unchanged behaviour. */
+	@Test
+	public void withoutTheProperty_theCommandIsStillPoetry() {
+		System.clearProperty(PropertyLoader.pythonExe);
+		assertEquals(List.of("poetry", "run", "python"), PythonUtils.pythonCommandPrefix());
+	}
+
+	/** Set is a deployment opting in -- the sim-data service already passes this. */
+	@Test
+	public void withTheProperty_theConfiguredInterpreterIsUsed() {
+		System.setProperty(PropertyLoader.pythonExe, "/usr/local/bin/python");
+		assertEquals(List.of("/usr/local/bin/python"), PythonUtils.pythonCommandPrefix());
+	}
+
+	/**
+	 * An empty value is what an unset environment variable looks like once it has been through a
+	 * shell -- {@code -Dvcell.python.executable=} is not null and would otherwise be run as the
+	 * command, failing with something unhelpful.
+	 */
+	@Test
+	public void anEmptyValueFallsBackRatherThanRunningNothing() {
+		System.setProperty(PropertyLoader.pythonExe, "   ");
+		assertEquals(List.of("poetry", "run", "python"), PythonUtils.pythonCommandPrefix());
+	}
+
+	/** The caller appends to the prefix, so it must be mutable and must not be shared. */
+	@Test
+	public void theReturnedListIsMutableAndFresh() {
+		System.clearProperty(PropertyLoader.pythonExe);
+		List<String> first = PythonUtils.pythonCommandPrefix();
+		first.add("-m");
+		assertEquals(List.of("poetry", "run", "python"), PythonUtils.pythonCommandPrefix(),
+				"a caller appending its own arguments must not affect the next caller");
+	}
+}


### PR DESCRIPTION
Step 1 of the uv discussion: decouple *which tool runs Python* from Java, so switching Poetry→uv later is a deployment change rather than a code change.

It turned out to be a bug fix as well.

### The property already existed and nothing read it

`PropertyLoader` declares `vcell.python.executable` (`ValueType.EXE`), and the sim-data service has been passing `-Dvcell.python.executable=/usr/local/bin/python` all along. No Java code read it — the second declared-but-unread property found this week, after `vcell.primarySimdatadir.external`.

### `poetry run` is currently broken in the deployed container

```
$ kubectl -n dev exec deploy/data -- sh -c 'cd /usr/local/app/pythonVtk && poetry run python -c "import python_vtk"'
[Errno 13] Permission denied: '/usr/local/app/pythonVtk/poetry.toml'

$ kubectl -n dev exec deploy/data -- /usr/local/bin/python -c "import python_vtk; print(python_vtk.__file__)"
/usr/local/app/pythonVtk/python_vtk/__init__.py
```

The image runs as uid 10001 while `poetry.toml` is `-rw------- root`, so Poetry cannot read its own config — while the interpreter the property names imports the packages fine, because the image installs them into it. (Relevant to #1893, which found `VtkServicePython` broken along a different axis.)

### The change

`PythonUtils.pythonCommandPrefix()` is now the one place that decides; the four sites append their own arguments:

| was | now |
|---|---|
| `PythonUtils.callPoetryModule` | `callPythonModule`, prefix + `-m module` |
| `CLIPythonManager` ×2 | prefix + `-c` / `-i` |
| `CopasiUtils` | prefix + `-m vcell_opt.optService` |

Property set → that interpreter. Unset → `poetry run python`, exactly as before, so developer machines and the CLI from a checkout are untouched. Empty falls back too, since `-Dvcell.python.executable=` is not null and would otherwise be executed as the command.

### Blast radius

Only where the property is set:
- **sim-data**, per-service and consolidated images — where Poetry is currently failing, so this is a fix;
- **admin image**, which sets it but installs neither Python nor Poetry, so those paths are broken either way and stay that way.

### Tests

`PythonCommandPrefixTest` (4, Fast) pins both branches, the empty-value fallback, and that the returned list is mutable and not shared between callers.