### PR TITLE
Let the download plugin unpack the linux solvers, as it already does for mac and windows

### DIFF
--- a/vcell-core/pom.xml
+++ b/vcell-core/pom.xml
@@ -760,6 +760,15 @@
 									</goals>
 									<configuration>
 										<url>https://github.com/virtualcell/vcell-solvers/releases/download/${solvers-vcell-linux.version}/linux64.tgz</url>
+										<!-- Unpacked by the plugin, as mac64 and win64 already are. It used to be extracted
+										     afterwards by shelling out to `tar xzfh`, which BSD tar (that is, every macOS
+										     machine) rejects: "tar: Option -L is not permitted in mode -x". The build printed
+										     an [ERROR] and carried on green, leaving the linux solvers unextracted locally.
+										     Ant's <untar> is not the alternative: it does not restore unix permissions, and
+										     nothing chmods these binaries - they rely on the archive's own modes, which this
+										     plugin preserves. mac64 is the proof: unpacked the same way, no chmod task, and
+										     localsolvers/mac64/FiniteVolume_x64 comes out executable. -->
+										<unpack>true</unpack>
 										<outputDirectory>${project.build.directory}/../../localsolvers/linux64</outputDirectory>
 									</configuration>
 								</execution>
@@ -851,13 +860,6 @@
 									<configuration>
 										<target>
 											<chmod file="${project.build.directory}/../../localsolvers/linux64/langevin_x64" perm="755"/>
-											<exec executable="tar">
-												<arg value="xzfh"/>
-												<arg value="${project.build.directory}/../../localsolvers/linux64/linux64.tgz"/>
-												<arg value="-C"/>
-												<arg value="${project.build.directory}/../../localsolvers/linux64"/>
-											</exec>
-											<delete file="${project.build.directory}/../../localsolvers/linux64/linux64.tgz"/>
 										</target>
 									</configuration>
 								</execution>
@@ -889,6 +891,15 @@
 									</goals>
 									<configuration>
 										<url>https://github.com/virtualcell/vcell-solvers/releases/download/${solvers-vcell-linux.version}/linux64.tgz</url>
+										<!-- Unpacked by the plugin, as mac64 and win64 already are. It used to be extracted
+										     afterwards by shelling out to `tar xzfh`, which BSD tar (that is, every macOS
+										     machine) rejects: "tar: Option -L is not permitted in mode -x". The build printed
+										     an [ERROR] and carried on green, leaving the linux solvers unextracted locally.
+										     Ant's <untar> is not the alternative: it does not restore unix permissions, and
+										     nothing chmods these binaries - they rely on the archive's own modes, which this
+										     plugin preserves. mac64 is the proof: unpacked the same way, no chmod task, and
+										     localsolvers/mac64/FiniteVolume_x64 comes out executable. -->
+										<unpack>true</unpack>
 										<outputDirectory>${project.build.directory}/../../localsolvers/linux64</outputDirectory>
 									</configuration>
 								</execution>
@@ -980,13 +991,6 @@
 									<configuration>
 										<target>
 											<chmod file="${project.build.directory}/../../localsolvers/linux64/langevin_x64" perm="755"/>
-											<exec executable="tar">
-												<arg value="xzfh"/>
-												<arg value="${project.build.directory}/../../localsolvers/linux64/linux64.tgz"/>
-												<arg value="-C"/>
-												<arg value="${project.build.directory}/../../localsolvers/linux64"/>
-											</exec>
-											<delete file="${project.build.directory}/../../localsolvers/linux64/linux64.tgz"/>
 										</target>
 									</configuration>
 								</execution>


### PR DESCRIPTION
You asked for ant's `<untar>`; the evidence pointed somewhere better, so this does that instead — happy to switch if you disagree.

### What the error actually was

```
[INFO] --- antrun:3.1.0:run (process-solvers-linux64) @ vcell-core ---
[INFO]      [exec] tar: Option -L is not permitted in mode -x
[ERROR]     [exec] Result: 1
[INFO]    [delete] Deleting: .../localsolvers/linux64/linux64.tgz
```

`linux64.tgz` was extracted by shelling out to `tar xzfh`. The `h` maps to `-L` in BSD tar — every macOS machine — which refuses it while extracting. The ant `<exec>` has no `failonerror`, so the build stayed **green while printing an ERROR**, then deleted the tarball anyway. Every Mac developer has had `localsolvers/linux64` holding one file instead of forty-seven.

I had been calling this "the known-broken solver-download plugin" — wrong twice over. The *download* succeeds (`File already exist, skipping`); it is the extraction afterwards. And it is not broken generally, only on BSD tar; CI on Linux is fine.

### Why not `<untar>`

**Ant's `<untar>` does not restore unix permissions**, and nothing chmods these binaries — they depend on the modes inside the archive. Using it would have shipped non-executable solvers to Linux/CI, where the regression suites actually run them. The one `<chmod>` in that antrun target is for `langevin_x64`, which comes from a different download.

### What it does instead

`mac64.tgz` and `win64.zip` were **already** unpacked by the download plugin itself (`<unpack>true</unpack>`); linux64 was the only one doing it by hand. Now it matches.

That the plugin preserves modes is not an assumption — mac64 proves it: same mechanism, no chmod task, and `localsolvers/mac64/FiniteVolume_x64` is executable.

### Verified on macOS

```
exec-tar errors:        1 -> 0
localsolvers/linux64:   1 file -> 47 files
executable:             47 of 48 files   (the 48th is .gitignore)
```
