### PR TITLE
Install only runtime python dependencies, and drop the artifact cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,10 +82,18 @@ COPY ./vcell-cli/target/vcell-cli-0.0.1-SNAPSHOT.jar \
 
 # Install required python-packages
 COPY ./vcell-cli-utils/ /usr/local/app/vcell/installDir/python/vcell_cli_utils/
+# --only main: pytest and mypy are dev dependencies and have no business in a runtime image.
+# They were being installed, and at different versions in each virtualenv (mypy 0.991
+# alongside 1.13.0), which is a fair sign nothing was reading them.
+#
+# The artifact cache is pruned in the SAME layer as the install: doing it in a later RUN
+# would leave the 256MB sitting in this layer and shrink nothing. virtualenvs/ is a sibling
+# directory and is untouched.
 RUN cd /usr/local/app/vcell/installDir/python/vcell_cli_utils/ && \
     poetry config cache-dir "/poetry/.cache" --local && \
     chmod 755 poetry.toml && \
-    poetry install
+    poetry install --only main && \
+    rm -rf /poetry/.cache/artifacts /poetry/.cache/cache
 
 # Add linux local solvers only
 ADD ./localsolvers /usr/local/app/vcell/installDir/localsolvers

--- a/docker/build/Dockerfile-api-dev
+++ b/docker/build/Dockerfile-api-dev
@@ -38,10 +38,18 @@ COPY ./vcell-api/target/vcell-api-0.0.1-SNAPSHOT.jar \
 
 # Copy and install vcell-cli-utils
 COPY ./vcell-cli-utils/ /usr/local/app/python/vcell_cli_utils/
+# --only main: pytest and mypy are dev dependencies and have no business in a runtime image.
+# They were being installed, and at different versions in each virtualenv (mypy 0.991
+# alongside 1.13.0), which is a fair sign nothing was reading them.
+#
+# The artifact cache is pruned in the SAME layer as the install: doing it in a later RUN
+# would leave the 256MB sitting in this layer and shrink nothing. virtualenvs/ is a sibling
+# directory and is untouched.
 RUN cd /usr/local/app/python/vcell_cli_utils/ && \
     poetry config cache-dir "/poetry/.cache" --local && \
     chmod 755 poetry.toml && \
-    poetry install
+    poetry install --only main && \
+    rm -rf /poetry/.cache/artifacts /poetry/.cache/cache
 
 # copy API resources
 COPY ./vcell-api/docroot ./docroot

--- a/docker/build/Dockerfile-data-dev
+++ b/docker/build/Dockerfile-data-dev
@@ -36,9 +36,17 @@ COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \
 
 # Copy and install pythonVtk
 COPY ./pythonVtk/ /usr/local/app/pythonVtk/
+# --only main: pytest and mypy are dev dependencies and have no business in a runtime image.
+# They were being installed, and at different versions in each virtualenv (mypy 0.991
+# alongside 1.13.0), which is a fair sign nothing was reading them.
+#
+# The artifact cache is pruned in the SAME layer as the install: doing it in a later RUN
+# would leave the 256MB sitting in this layer and shrink nothing. virtualenvs/ is a sibling
+# directory and is untouched.
 RUN  cd /usr/local/app/pythonVtk && \
      poetry config cache-dir "/poetry/.cache" --local && \
-     poetry install
+     poetry install --only main && \
+    rm -rf /poetry/.cache/artifacts /poetry/.cache/cache
 
 COPY ./nativelibs/linux64 ./nativelibs/linux64
 COPY ./docker/build/vcell-data.log4j.xml .

--- a/docker/build/Dockerfile-service-dev
+++ b/docker/build/Dockerfile-service-dev
@@ -67,10 +67,18 @@ COPY ./vcell-server/target/vcell-server-0.0.1-SNAPSHOT.jar \
 
 # api
 COPY ./vcell-cli-utils/ /usr/local/app/python/vcell_cli_utils/
+# --only main: pytest and mypy are dev dependencies and have no business in a runtime image.
+# They were being installed, and at different versions in each virtualenv (mypy 0.991
+# alongside 1.13.0), which is a fair sign nothing was reading them.
+#
+# The artifact cache is pruned in the SAME layer as the install: doing it in a later RUN
+# would leave the 256MB sitting in this layer and shrink nothing. virtualenvs/ is a sibling
+# directory and is untouched.
 RUN cd /usr/local/app/python/vcell_cli_utils/ && \
     poetry config cache-dir "/poetry/.cache" --local && \
     chmod 755 poetry.toml && \
-    poetry install
+    poetry install --only main && \
+    rm -rf /poetry/.cache/artifacts /poetry/.cache/cache
 COPY ./vcell-api/docroot ./docroot
 COPY ./vcell-api/webapp ./webapp
 COPY ./vcell-api/keystore_macbook.jks .
@@ -79,7 +87,8 @@ COPY ./vcell-api/keystore_macbook.jks .
 COPY ./pythonVtk/ /usr/local/app/pythonVtk/
 RUN cd /usr/local/app/pythonVtk && \
     poetry config cache-dir "/poetry/.cache" --local && \
-    poetry install
+    poetry install --only main && \
+    rm -rf /poetry/.cache/artifacts /poetry/.cache/cache
 COPY ./nativelibs/linux64 ./nativelibs/linux64
 
 # One log4j configuration per service; the entrypoint selects by name.


### PR DESCRIPTION
Measured in the running dev sim-data container, whose image carries **1.3 GB of Python**:

```
/poetry/.cache/virtualenvs   976M    python-vtk 602M + vcell-cli-utils 375M
/poetry/.cache/artifacts     256M    downloaded wheels, never read again
/poetry/.cache/cache         616K
```

Two things were being shipped that need not be.

### 1. Dev dependencies in runtime images

`poetry install` with no arguments installs them, so **pytest and mypy are in the production images** — and at different versions in each virtualenv (mypy 0.991 in one, 1.13.0 in the other), which is a fair sign nothing reads them. mypy is heavier than it looks: 10 MB of package plus a 47 MB `__mypyc…so` compiled extension, in *each* venv.

Confirmed by dry run against both projects, re-checked after #1947 and #1949 changed the dependency set:

```
pythonVtk         dev tools:  with --only main = 0   without = 3
vcell-cli-utils   dev tools:  with --only main = 0   without = 3
```

Poetry still handles their legacy `[tool.poetry.dev-dependencies]` sections, so this needed no restructuring.

### 2. The artifact cache

256 MB of downloaded wheels the running service never touches. **Pruned in the same `RUN` as the install** — that is the part that matters, since a later `RUN` would leave the weight in this layer and shrink nothing. `virtualenvs/` is a sibling directory and is untouched.

Applied to all five runtime installs: the root `Dockerfile`, `api`, `data`, and both in the consolidated service image.

### What this deliberately does not do

Merge the two python projects. They do duplicate **151 MB** (39 shared packages — numpy, matplotlib, fontTools, pillow), and their shared distributions differ only by drift from independently resolved locks rather than any real conflict, so a merge would resolve cleanly.

But `vcell-cli-utils` is installed **on its own** in the root image, and merging would pull VTK's 600 MB in with it: 151 MB saved in one image, ~450 MB added to another. Worth revisiting only after measuring what is left once the easy weight is gone.
