### PR TITLE
Make the desktop client's log actually contain its errors

### DIFF
--- a/vcell-admin/src/main/java/org/vcell/standalone/VCellClientDevMain.java
+++ b/vcell-admin/src/main/java/org/vcell/standalone/VCellClientDevMain.java
@@ -11,6 +11,7 @@
 package org.vcell.standalone;
 
 import cbit.vcell.client.VCellClient;
+import cbit.vcell.client.VCellClientLogging;
 import cbit.vcell.client.VCellLookAndFeel;
 import cbit.vcell.client.server.ClientServerInfo;
 import cbit.vcell.resource.ErrorUtils;
@@ -51,6 +52,12 @@ public class VCellClientDevMain {
 
 	public static void main(String[] args) {
 		try {
+			// Before anything logs, as in VCellClientMain. This entry point does not redirect the
+			// console - a developer run should log to the terminal - but it still needs its own
+			// configuration rather than the one jsbml happens to ship, which would otherwise decide
+			// the levels here and drop a jsbml.log into the working directory.
+			VCellClientLogging.configure();
+
 			ErrorUtils.setDebug(true);
 			PropertyLoader.loadProperties(ArrayUtils.addAll(REQUIRED_CLIENT_PROPERTIES, REQUIRED_LOCAL_PROPERTIES));
 			Injector injector = Guice.createInjector(new VCellStandaloneModule());

--- a/vcell-client/src/main/java/cbit/vcell/client/VCellClientLogging.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/VCellClientLogging.java
@@ -1,0 +1,66 @@
+package cbit.vcell.client;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.apache.logging.log4j.core.config.Configurator;
+
+/**
+ * Points log4j at the desktop client's own configuration, explicitly.
+ * <p>
+ * Two problems made every client-side stack trace invisible, and this addresses the one that
+ * cannot be fixed from a configuration file (issue #1954).
+ * <p>
+ * <b>Classpath order.</b> {@code jsbml-core} and {@code biojava-ontology} each ship a
+ * {@code log4j2.xml}, and log4j uses the first one the classloader returns. {@code vcell.sh} places
+ * {@code maven-jars/*} ahead of {@code target/*}, so a file named {@code log4j2.xml} in this module
+ * would lose to jsbml's - which configures a console appender that does not follow, and a file
+ * appender writing {@code jsbml.log} into the launch directory. Loading our configuration by URL
+ * removes the ambiguity: whatever the classpath order, this is the configuration in force.
+ * <p>
+ * <b>Ordering against the stream redirect.</b> The client redirects {@code System.out}/{@code
+ * System.err} into {@code <vcellHome>/logs/vcellrun_<site>.log} after log4j is already initialized,
+ * so an appender that resolved {@code System.out} at configuration time keeps writing to the
+ * pre-redirect console - nowhere reachable from an installed macOS {@code .app}.
+ * {@code log4j2-vcell-client.xml} sets {@code follow="true"} so the appender resolves the stream per
+ * write instead, which makes this call order-independent: it is correct before or after the
+ * redirect.
+ * <p>
+ * {@link Configurator#reconfigure(java.net.URI)} rather than the {@code log4j2.configurationFile}
+ * system property, because setting a property only works if log4j has not configured itself yet.
+ * Reconfiguring is correct either way, which is what lets a test call this and get the real thing.
+ */
+public final class VCellClientLogging {
+
+	/** Deliberately not "log4j2.xml" - see the class comment. */
+	static final String CONFIG_RESOURCE = "log4j2-vcell-client.xml";
+
+	private VCellClientLogging() {
+	}
+
+	/**
+	 * Applies the client's logging configuration. Safe to call more than once.
+	 * <p>
+	 * Complains to {@code System.err} and carries on if the configuration cannot be applied, rather
+	 * than throwing. Only a packaging fault can get here - the file lives in this module's own jar -
+	 * and refusing to start a client because its logging is misconfigured would be a worse outcome
+	 * for the person trying to use it than logging to the wrong place. The regression test is what
+	 * keeps that fault from reaching a build: it asserts this configuration is the one in force, so
+	 * losing the resource fails CI rather than quietly restoring the old behaviour.
+	 */
+	public static void configure() {
+		URL url = VCellClientLogging.class.getClassLoader().getResource(CONFIG_RESOURCE);
+		if (url == null) {
+			// cannot log this: the logging is what is broken
+			System.err.println("WARNING: " + CONFIG_RESOURCE + " is not on the classpath, so this "
+					+ "client will log through whichever configuration a dependency happens to ship, "
+					+ "and its errors may not reach the log file. This is a packaging fault.");
+			return;
+		}
+		try {
+			Configurator.reconfigure(url.toURI());
+		} catch (URISyntaxException e) {
+			System.err.println("WARNING: cannot read logging configuration from " + url + ": " + e);
+		}
+	}
+}

--- a/vcell-client/src/main/java/cbit/vcell/client/VCellClientMain.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/VCellClientMain.java
@@ -80,6 +80,10 @@ public class VCellClientMain implements Callable<Integer> {
      * @param args an array of command-line arguments
      */
     public static void main(java.lang.String[] args) {
+        // Before anything logs. Without this the client inherits whichever log4j2.xml a dependency
+        // happens to ship, and its errors go to a console that an installed .app does not have.
+        VCellClientLogging.configure();
+
         // Recover gracefully when DNS lookups fail transiently (e.g. laptop wake from sleep).
         // Java's default 10s negative-result cache combined with our continuous polling loop
         // wedges the client at "connecting…" until restart, because the polling interval is

--- a/vcell-client/src/main/resources/log4j2-vcell-client.xml
+++ b/vcell-client/src/main/resources/log4j2-vcell-client.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Logging configuration for the DESKTOP CLIENT. Loaded explicitly by VCellClientLogging, NOT by
+  log4j's classpath scan - which is why the file is not called log4j2.xml.
+
+  Two dependencies on this classpath ship a log4j2.xml of their own (jsbml-core and
+  biojava-ontology), and log4j takes the first one the classloader hands it. vcell.sh puts
+  maven-jars/* ahead of target/*, so a file named log4j2.xml here would lose to jsbml's - which
+  configures a non-following console appender and a File appender writing jsbml.log into whatever
+  directory the client happened to be launched from. That is the configuration the client has
+  actually been running under. Giving this file a name nothing scans for, and loading it by URL,
+  makes the outcome independent of classpath order.
+
+  follow="true" is the other half. The client redirects System.out and System.err
+  into <vcellHome>/logs/vcellrun_<site>.log (ConsoleCapture, from VCellClientMain), and it does
+  so AFTER log4j has already configured itself - ConsoleCapture holds a static logger, so simply
+  calling ConsoleCapture.getInstance() forces log4j to initialize on the line before the streams
+  are swapped. A console appender resolves System.out once at configuration time unless it is
+  told to follow, so every logged message went to the pre-redirect console - which, for an
+  installed macOS .app, is nowhere a user can reach - while bare println calls, which resolve the
+  field per call, landed in the file. See issue #1954.
+
+  Level: WARN rather than log4j's ERROR default, so a warning that explains a subsequent failure
+  is present too. Raise the Root level to info if a diagnosis needs more; it is deliberately not
+  info by default because the third-party libraries on this classpath are chatty and this file is
+  read by users, not only by us.
+
+  There is no file appender on purpose. Everything the client emits - logged or printed - belongs
+  in one file in timestamp order, because reading a client log means correlating the two; splitting
+  them would make that harder, not easier. ConsoleCapture opens that file fresh on each launch, so
+  its size is bounded by one session.
+-->
+
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT" follow="true">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5p %c{1.} [%t] %m%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Root level="warn">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+
+</Configuration>

--- a/vcell-client/src/test/java/org/vcell/util/logging/ClientLoggingReachesRedirectedStreamTest.java
+++ b/vcell-client/src/test/java/org/vcell/util/logging/ClientLoggingReachesRedirectedStreamTest.java
@@ -1,0 +1,113 @@
+package org.vcell.util.logging;
+
+import cbit.vcell.client.VCellClientLogging;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A logged error must reach whatever {@code System.out} points at when it is logged, not the stream
+ * that was current when log4j configured itself.
+ * <p>
+ * The desktop client redirects {@code System.out}/{@code System.err} into
+ * {@code <vcellHome>/logs/vcellrun_<site>.log} (ConsoleCapture, called from VCellClientMain), and it
+ * does so <em>after</em> log4j has already initialized. With log4j's DefaultConfiguration - which is
+ * what the client had, since it shipped no {@code log4j2.xml} - the console appender resolves
+ * {@code System.out} once at configuration time and keeps that reference, so every logged message
+ * went to the pre-redirect console while only bare {@code println} calls reached the file. On an
+ * installed macOS {@code .app} that console goes nowhere, so client-side stack traces were invisible:
+ * a browser console was the only way to see that the field viewer had returned a 500. Issue #1954.
+ * <p>
+ * This test fails against the DefaultConfiguration in both directions: {@code follow} would be false,
+ * and the root level would be ERROR rather than WARN.
+ */
+@Tag("Fast")
+public class ClientLoggingReachesRedirectedStreamTest {
+
+	private static final Logger lg = LogManager.getLogger(ClientLoggingReachesRedirectedStreamTest.class);
+
+	/**
+	 * The same call VCellClientMain makes, rather than a copy of it: the ordering hazard is the
+	 * subject of the test, so the test must not arrange logging in a way the client does not.
+	 * <p>
+	 * Note this runs AFTER the static logger above has already initialized log4j - deliberately, and
+	 * exactly as it does in the client, where ConsoleCapture's own logger forces initialization
+	 * before the streams are swapped.
+	 */
+	@BeforeAll
+	public static void configureLoggingTheWayTheClientDoes() {
+		VCellClientLogging.configure();
+	}
+
+	@Test
+	public void logged_error_follows_a_later_System_out_redirect() {
+		PrintStream original = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		// the marker must be unique, since this stream also receives whatever else the JVM prints
+		String marker = "vcell-1954-marker-" + System.identityHashCode(captured);
+		try {
+			// exactly what ConsoleCapture does, and - as in the client - after log4j is already
+			// configured, which the static logger above guarantees
+			System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+			lg.error(marker);
+			System.out.flush();
+		} finally {
+			System.setOut(original);
+		}
+
+		String written = captured.toString(StandardCharsets.UTF_8);
+		assertTrue(written.contains(marker),
+				"a logged ERROR did not reach the redirected System.out, so it would not reach the "
+						+ "client's log file either. Check that vcell-client's log4j2.xml is on the "
+						+ "classpath and that its console appender still has follow=\"true\". Captured: '"
+						+ written + "'");
+	}
+
+	@Test
+	public void warnings_are_logged_too_not_only_errors() {
+		PrintStream original = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		String marker = "vcell-1954-warn-" + System.identityHashCode(captured);
+		try {
+			System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+			lg.warn(marker);
+			System.out.flush();
+		} finally {
+			System.setOut(original);
+		}
+
+		assertTrue(captured.toString(StandardCharsets.UTF_8).contains(marker),
+				"a logged WARN did not reach the log. log4j's default root level is ERROR; "
+						+ "vcell-client's log4j2.xml sets WARN so that a warning explaining a later "
+						+ "failure is present too.");
+	}
+
+	/**
+	 * The behavioural tests above would also pass if some other log4j2.xml on the classpath happened
+	 * to follow. Pin the configuration the client actually ships.
+	 */
+	@Test
+	public void the_client_configuration_is_the_one_in_use() {
+		LoggerContext context = (LoggerContext) LogManager.getContext(false);
+		Configuration configuration = context.getConfiguration();
+		assertNotNull(configuration.getAppender("console"),
+				"vcell-client's log4j2.xml defines an appender named 'console'; the active "
+						+ "configuration has none, so something else is configuring log4j: "
+						+ configuration.getAppenders().keySet());
+		assertEquals(org.apache.logging.log4j.Level.WARN,
+				configuration.getRootLogger().getLevel(),
+				"root level should be WARN - log4j's ERROR default is what hid the warnings");
+	}
+}

--- a/vcell-core/src/main/java/org/vcell/util/logging/ConsoleCapture.java
+++ b/vcell-core/src/main/java/org/vcell/util/logging/ConsoleCapture.java
@@ -78,13 +78,20 @@ public class ConsoleCapture {
 	
 	/**
 	 * redirect standard err and out to filename; if autoflush property not set add shutdown hook
-	 * @param logFile 
+	 * <p>
+	 * Autoflush defaults to ON. A log that only becomes correct after a clean exit is not a
+	 * diagnostic log: while the process is running the tail sits in the buffer, so a user asked to
+	 * send their log mid-session sends a truncated one, and a force-quit or a crash - the cases the
+	 * log exists for - loses the end outright, which is the part that says what happened. Set
+	 * {@value PropertyLoader#autoflushStandardOutAndErr} to false to get the buffered behaviour back.
+	 *
+	 * @param logFile
 	 * @throws IllegalArgumentException if logFile null
 	 */
 	public void captureStandardOutAndError(File logFile) throws IllegalArgumentException {
 		if (logFile != null) {
 			redirectedStandardOutErr = logFile;
-			boolean autoflush =  Boolean.parseBoolean(PropertyLoader.getProperty(PropertyLoader.autoflushStandardOutAndErr, Boolean.FALSE.toString()));
+			boolean autoflush =  Boolean.parseBoolean(PropertyLoader.getProperty(PropertyLoader.autoflushStandardOutAndErr, Boolean.TRUE.toString()));
 			try {
 				FileOutputStream fos = new FileOutputStream(logFile);
 				BufferedOutputStream bos = new BufferedOutputStream(fos);


### PR DESCRIPTION
Closes #1954

Every stack trace the desktop client logged was invisible. The client redirects `System.out`/`System.err` into `<vcellHome>/logs/vcellrun_<site>.log`, and users are asked to send that file — but no log4j message ever reached it. Only bare `println` calls did. A user reporting "it failed" sent a log that showed nothing.

Found while diagnosing #1879: the browser reported `/grid failed: 500 Internal Server Error`, `FieldViewerServer.wrap()` does log it (`LG.error("field viewer handler error for " + ex.getRequestURI(), e)`), and the session log contained no trace of it. A browser console was the only way to see it.

## Two independent causes

**1. The configuration in force was not ours — and not log4j's default either.**

`jsbml-core` and `biojava-ontology` each ship a `log4j2.xml`; log4j uses the first one the classloader returns; and `vcell.sh` puts `maven-jars/*` ahead of `target/*`. So the client has been running under **jsbml's** configuration — a console appender, plus a `File` appender writing `jsbml.log` into whatever directory the client happened to be launched from.

This is the part worth a second look, because it means the obvious fix does not work: adding a `log4j2.xml` to `vcell-client` would lose the same race and change nothing. Hence `log4j2-vcell-client.xml`, a name nothing scans for, loaded by URL through `Configurator.reconfigure`. Classpath order stops mattering.

**2. The appender resolved `System.out` once, at configuration time.**

`ConsoleCapture` swaps the streams afterwards, and cannot do otherwise — the log directory is only known at runtime, and merely calling `ConsoleCapture.getInstance()` initializes log4j on the line before the swap. A `println` resolves the field per call and follows the redirect; an appender does not unless told to. `follow="true"` tells it to, which also makes the `configure()` call order-independent.

## Also here

- **Autoflush defaults on.** The redirected stream was buffered and flushed only by a shutdown hook, so the tail was not on disk while the client ran, and a force-quit or crash lost the end — the part that says what happened. `vcell.autoflushlog=false` restores the old behaviour; the client is the only caller.
- **Root level `warn`** rather than log4j's `error`, so a warning explaining a later failure is in the file too. Not `info`: the third-party libraries here are chatty and this file is read by users.
- **Both entry points.** `VCellClientMain` and `VCellClientDevMain`. The dev one does not redirect the console and should not — a developer run belongs in the terminal — but it still needs our configuration rather than jsbml's.

## Testing

`ClientLoggingReachesRedirectedStreamTest` calls `VCellClientLogging.configure()` the way the client does, after its own static logger has already initialized log4j, then swaps `System.out` as `ConsoleCapture` does and asserts a logged ERROR arrives in the new stream.

Verified not decorative:

| mutation | result |
|---|---|
| configuration absent (old arrangement) | all 3 fail, captured output empty |
| `follow="true"` → `follow="false"` | both behavioural cases fail |

`vcell-client` Fast green (29 run). `vcell-core` Fast green apart from the pre-existing `VCellDataTest.test_3D` Poetry-environment failure, which fails the same way on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
