### PR TITLE
Configurable UI font size: scale look-and-feel fonts, and the constants that clip

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/VCellLookAndFeel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/VCellLookAndFeel.java
@@ -43,11 +43,35 @@ public class VCellLookAndFeel {
 	private static final float MIN_FONT_SCALE = 0.5f;
 	private static final float MAX_FONT_SCALE = 4.0f;
 
+	/** Resolved once: the property cannot change while the client is running. */
+	private static volatile Float cachedFontScale = null;
+
 	/**
 	 * @return the requested font scale, or 1.0 if unset, unparseable or out of range - a bad value
 	 *         here must never stop the client from starting.
 	 */
-	static float getFontScale() {
+	public static float getFontScale() {
+		Float scale = cachedFontScale;
+		if (scale == null) {
+			scale = computeFontScale();
+			cachedFontScale = scale;
+		}
+		return scale;
+	}
+
+	/**
+	 * Scales a hard-coded pixel dimension that exists to fit text - a split-pane divider, a
+	 * minimum size, a column width. Such a constant was chosen against the default font, so it
+	 * has to move with the font or the text it was sized for no longer fits.
+	 * <p>
+	 * This is for dimensions that <em>bound text</em>. Do not use it for icon sizes, insets or
+	 * borders, which should stay where they are.
+	 */
+	public static int scaleTextPixels(int pixels) {
+		return Math.round(pixels * getFontScale());
+	}
+
+	private static float computeFontScale() {
 		final String raw = System.getProperty(PROPERTY_FONT_SCALE);
 		if (raw == null || raw.trim().isEmpty()) {
 			return 1.0f;

--- a/vcell-client/src/main/java/cbit/vcell/client/VCellLookAndFeel.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/VCellLookAndFeel.java
@@ -12,9 +12,13 @@ package cbit.vcell.client;
 
 import java.awt.Font;
 import java.awt.Toolkit;
+import java.util.ArrayList;
+import java.util.List;
 
+import javax.swing.UIDefaults;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.plaf.FontUIResource;
 
 import cbit.vcell.resource.ResourceUtil;
 import org.apache.logging.log4j.LogManager;
@@ -24,7 +28,77 @@ import cbit.vcell.resource.OperatingSystemInfo;
 
 public class VCellLookAndFeel {
 	private final static Logger lg = LogManager.getLogger(VCellLookAndFeel.class);
-	
+
+	/**
+	 * Multiplies every font the look and feel supplies. 1.0 (the default) leaves the UI exactly
+	 * as it was.
+	 * <p>
+	 * This only reaches fonts obtained <em>implicitly</em>, from the look and feel's defaults. A
+	 * component whose font was set explicitly - {@code setFont(new Font("Dialog", PLAIN, 12))} -
+	 * keeps that font, because a plain {@code Font} is not a {@link javax.swing.plaf.UIResource}
+	 * and the look and feel will not replace it. Those sites have to be converted separately.
+	 */
+	public static final String PROPERTY_FONT_SCALE = "vcell.ui.fontScale";
+
+	private static final float MIN_FONT_SCALE = 0.5f;
+	private static final float MAX_FONT_SCALE = 4.0f;
+
+	/**
+	 * @return the requested font scale, or 1.0 if unset, unparseable or out of range - a bad value
+	 *         here must never stop the client from starting.
+	 */
+	static float getFontScale() {
+		final String raw = System.getProperty(PROPERTY_FONT_SCALE);
+		if (raw == null || raw.trim().isEmpty()) {
+			return 1.0f;
+		}
+		final float scale;
+		try {
+			scale = Float.parseFloat(raw.trim());
+		} catch (NumberFormatException e) {
+			lg.warn("ignoring " + PROPERTY_FONT_SCALE + "='" + raw + "': not a number");
+			return 1.0f;
+		}
+		if (scale < MIN_FONT_SCALE || scale > MAX_FONT_SCALE) {
+			lg.warn("ignoring " + PROPERTY_FONT_SCALE + "=" + scale + ": outside ["
+					+ MIN_FONT_SCALE + ", " + MAX_FONT_SCALE + "]");
+			return 1.0f;
+		}
+		return scale;
+	}
+
+	/**
+	 * Scales every {@link Font} in the look and feel's defaults, in place, before any window is
+	 * built. Must run after {@code setLookAndFeel} (which replaces the whole defaults table) and
+	 * before anything reads a font, because Swing components resolve their font once, at
+	 * construction.
+	 */
+	private static void applyFontScale(float scale) {
+		if (scale == 1.0f) {
+			return;
+		}
+		final UIDefaults defaults = UIManager.getLookAndFeelDefaults();
+		// snapshot the keys: resolving a lazy value can add entries, and we are writing as we go
+		final List<Object> keys = new ArrayList<>(defaults.keySet());
+		int count = 0;
+		for (Object key : keys) {
+			final Object value;
+			try {
+				value = defaults.get(key);      // resolves LazyValue / ActiveValue
+			} catch (Exception e) {
+				continue;                       // a defaults entry that cannot be resolved is not ours to fix
+			}
+			if (value instanceof Font) {
+				final Font font = (Font) value;
+				// FontUIResource, not Font: a plain Font would be treated as a user-set override
+				UIManager.put(key, new FontUIResource(font.deriveFont(font.getSize2D() * scale)));
+				count++;
+			}
+		}
+		lg.info("scaled " + count + " look-and-feel fonts by " + scale
+				+ " (" + PROPERTY_FONT_SCALE + ")");
+	}
+
 	public static Font defaultFont = null;
 	public static void setVCellLookAndFeel() {
 		OperatingSystemInfo osi = OperatingSystemInfo.getInstance();
@@ -40,10 +114,14 @@ public class VCellLookAndFeel {
 				lg.warn("Error while setting look and feel:", e);
 			}
 //		}
+		// before anything reads a font: setLookAndFeel above replaced the defaults table, and the
+		// Mac block below derives from Label.font, so it inherits the scale rather than undoing it.
+		applyFontScale(getFontScale());
+
 		final boolean isMac = osi.isMac();
-			
-		if (defaultFont == null) {			
-			defaultFont = UIManager.getFont("Label.font");		
+
+		if (defaultFont == null) {
+			defaultFont = UIManager.getFont("Label.font");
 			if (isMac) {
 				defaultFont = defaultFont.deriveFont(defaultFont.getSize2D() - 2);		
 			}

--- a/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/DocumentEditor.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/DocumentEditor.java
@@ -59,6 +59,7 @@ import org.vcell.util.gui.JTabbedPaneEnhanced;
 import org.vcell.util.gui.VCellIcons;
 
 import cbit.vcell.biomodel.BioModel;
+import cbit.vcell.client.VCellLookAndFeel;
 import cbit.vcell.client.constants.GuiConstants;
 import cbit.vcell.client.desktop.DatabaseWindowPanel;
 import cbit.vcell.client.desktop.biomodel.DocumentEditorTreeModel.DocumentEditorTreeFolderClass;
@@ -511,16 +512,17 @@ private void initialize() {
 		
 		JScrollPane treePanel = new javax.swing.JScrollPane(documentEditorTree);	
 		leftSplitPane.setTopComponent(treePanel);
-		leftBottomTabbedPane.setMinimumSize(new java.awt.Dimension(198, 148));
+		leftBottomTabbedPane.setMinimumSize(new java.awt.Dimension(
+				VCellLookAndFeel.scaleTextPixels(198), VCellLookAndFeel.scaleTextPixels(148)));
 		leftSplitPane.setBottomComponent(leftBottomTabbedPane);
 		leftSplitPane.setResizeWeight(0.5);
-		leftSplitPane.setDividerLocation(300);
+		leftSplitPane.setDividerLocation(VCellLookAndFeel.scaleTextPixels(300));
 		leftSplitPane.setDividerSize(8);
 		leftSplitPane.setOneTouchExpandable(true);
 
 		rightSplitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
 		rightSplitPane.setResizeWeight(0.7);
-		rightSplitPane.setDividerLocation(400);
+		rightSplitPane.setDividerLocation(VCellLookAndFeel.scaleTextPixels(400));
 		rightSplitPane.setDividerSize(8);
 		rightSplitPane.setOneTouchExpandable(true);
 		
@@ -562,11 +564,12 @@ private void initialize() {
 		rightBottomTabbedPane.addTab(TAB_TITLE_OBJECT_PROPERTIES, rightBottomEmptyPanel);		
 		rightBottomTabbedPane.addTab(TAB_TITLE_ANNOTATIONS, rightBottomEmptyAnnotationsPanel);		
 		rightBottomTabbedPane.addTab(TAB_TITLE_PROBLEMS, issuePanel);		
-		rightBottomTabbedPane.setMinimumSize(new java.awt.Dimension(198, 148));		
+		rightBottomTabbedPane.setMinimumSize(new java.awt.Dimension(
+				VCellLookAndFeel.scaleTextPixels(198), VCellLookAndFeel.scaleTextPixels(148)));		
 		rightSplitPane.setBottomComponent(rightBottomTabbedPane);
 		
 		JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
-		splitPane.setDividerLocation(270);
+		splitPane.setDividerLocation(VCellLookAndFeel.scaleTextPixels(270));
 		splitPane.setOneTouchExpandable(true);
 		splitPane.setResizeWeight(0.3);
 		splitPane.setDividerSize(8);


### PR DESCRIPTION
Groundwork for a user-settable UI font size, plus the first round of layout fallout. **Inert at the default scale of 1.0** — nothing changes unless `-Dvcell.ui.fontScale` is set.

> Reopens the work from #1902, which was closed without comment or review. Neither file it touches has changed on master since (`VCellLookAndFeel.java` last modified 2024-03-26, `DocumentEditor.java` 2026-08-02), and no font or DPI scaling work landed independently, so nothing here is superseded. Rebased onto current master — 138 commits of drift, no conflicts — recompiled, and re-verified. **If #1902 was closed deliberately, close this too and I'll drop the branch properly.**

## Why not `-Dsun.java2d.uiScale`

That was evaluated first, since it would have made most of this unnecessary. It won't:

```
macOS    uiScale=null/1.5/2.0      -> Label.font 13.0pt, pref 130x16, gcScaleX 2.00 (identical)
Linux    uiScale=null/1.5/2.0/3.0  -> Label.font 12.0pt, pref 141x15, stringWidth 141 (identical)
```

On macOS the JDK derives scale from the display and ignores the property outright. Where it *is* honored it multiplies only the device transform — Swing lays out in logical units, which the flag never touches. That is why it can never clip, and equally why it cannot make text more readable at a fixed window size. **It magnifies; it does not enlarge.** Still worth knowing as a separate, zero-code answer to "VCell is tiny on my 4K monitor".

## What this does

**`VCellLookAndFeel`** walks the look-and-feel defaults after `setLookAndFeel` and multiplies every `Font`, before any window is built — a Swing component resolves its font once, at construction. Fonts are written back as `FontUIResource`, not plain `Font`: a plain one reads as a user-set override and the look and feel would stop managing it.

The scaling also now runs on **every platform**. The existing 39-key `UIManager.put` block sits inside `if (isMac)`, so Windows and Linux had no font handling at all. Scaling is applied *before* that block, so the Mac path derives from it rather than undoing it.

Bad input cannot stop the client starting — unparseable or out-of-range values log and fall back to 1.0:

```
scale=1.0    Label=11.0  Button=11.0  Table=11.0  Tree=11.0   labelPref=110x14
scale=1.25   Label=14.3  Button=14.3  Table=14.3  Tree=14.3   labelPref=145x17
scale=abc    Label=11.0  ...  (rejected, falls back)
scale=99     Label=11.0  ...  (rejected, out of range)
```

## What broke at 1.25x, and why

Measured against a live client via the debug bridge — 93 components matched across two runs, **17 grew wider, 71 kept their width**.

Every visible defect was in the left navigation panel: tree labels clipped with no ellipsis (`Parameters, Functions, Units, etc.` lost its period), counts truncated mid-digit (`(538)` → `(53`), the database tab strip pushed `Pathway Comm` out into scroll mode, and a spurious horizontal scrollbar appeared.

**None of it came from a font.** It came from `splitPane.setDividerLocation(270)` in `DocumentEditor`, pinning the panel's width in pixels. The component data is unambiguous: inside that panel `LeftBottomTabbedPane`, `DatabaseWindowPanel` and all three tree panels held their exact widths, while `ModelDeleteButton` (77→88) and `ShowWarningsCheckBox` (113→138) grew normally elsewhere. GridBag cells size from preferred size and adapt; pinned dividers don't.

Adds `VCellLookAndFeel.scaleTextPixels` for constants that **bound text**, applied to the two divider locations and two minimum sizes here. Icon sizes, insets and borders are deliberately out of scope — they should not move with the font.

After the fix at 1.25x: `LeftBottomTabbedPane` 264 → 332 and `BioModelDbTreePanel1` 222 → 290, both exactly the requested scale, and all four defects resolved.

## What this deliberately does not do

The ~138 sites that construct a `Font` with a literal point size keep theirs — a plain `Font` is immune to the look and feel. Converting them is the next phase.

Notably, **none of those caused a visible defect at 1.25x**, because most sit in layouts that adapt. That reorders the work: the pinned pixel constants matter more than the font constants. There are 26 further hard-coded `setDividerLocation` calls across the client that want the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)