### PR TITLE
Announcement for the 8.0.23 production deployment

### DIFF
--- a/release-notes/announcements/8.0.23-production.md
+++ b/release-notes/announcements/8.0.23-production.md
@@ -1,0 +1,126 @@
+# VCell 8.0.23 — production announcement
+
+Written for the 14 August 2026 production deployment, which moved vcell.cam.uchc.edu from
+8.0.0.03 to 8.0.23. Two pieces: an email to the group, and a short notice for the website.
+
+Both are written from the user's point of view and drawn from the `Highlights` sections of
+`CHANGELOG.md` for the 26 releases in between. The nine releases whose highlight begins
+"Nothing changes for anyone using VCell" are deliberately condensed into one "Under the hood"
+group rather than listed — they were configuration and packaging work that no user can act on.
+
+---
+
+# Email to the group
+
+**Subject: VCell production updated to 8.0.23**
+
+The VCell production site (vcell.cam.uchc.edu) was updated on 14 August 2026, moving from
+8.0.0.03 (21 May) to 8.0.23 and taking in 26 releases of work. **Please update your desktop
+client** — the client and server versions need to match.
+
+## Desktop windows behave properly again
+
+- **Dialogs and child windows no longer disappear behind the main window.** This affected every
+  user on a current macOS or Windows: VCell raised its windows with `toFront()`, which those
+  systems stopped honoring for a background application, so a dialog could open invisibly behind
+  the main window and look like a freeze.
+- Child windows and dialogs are now **owned by their parent at the OS level**, so they stay in
+  front of it, and minimize and move with it. All dialogs were standardized onto one path as part
+  of the change.
+- The specific cases reported have been fixed alongside it: the geometry viewer opening behind the
+  main window (and blank), and the update alert opening behind it.
+
+## SpringSaLaD
+
+Much of this follows reports from Les Loew and his group, whose long-running SpringSaLaD work
+surfaced problems that shorter runs never reach.
+
+- **Starting a simulation no longer disturbs the ones already running.** Previously, launching a
+  new SpringSaLaD run reset every other simulation in the same application to "never ran" and
+  stranded the job on the cluster. Because SpringSaLaD runs take days, this was a reliable way to
+  lose track of work in progress. Reported by Les Loew, and the reason for this deployment.
+- **Completed results can be retrieved again**, and editing a model behaves correctly when saved.
+  VCell can now tell whether a change to a molecule, site, radius, diffusion rate, bond, colour or
+  reaction actually changed the mathematics: an unchanged model keeps its results, a cosmetic edit
+  keeps them, and a genuine change hides results that no longer correspond to the model.
+- **Results open again** for runs whose solver output lacked a site-ID file — previously this took
+  down the whole results viewer rather than just the legend.
+- **A run that hits its time limit now says so**, instead of reporting "solver stopped
+  unexpectedly", which described a crash. One user waited four days to discover the difference.
+- 3D viewer: per-species visibility selector, MP4 export of trajectory animations, and bonds now
+  drawn to the sphere surfaces rather than into the spheres.
+- Langevin solver updated to 1.4.12.
+
+## Simulation status you can trust
+
+- **A simulation ended by the cluster now reports the real reason** — out of time, out of memory,
+  node lost, preempted — within about a minute. Previously such a job sat "running" until a
+  ten-minute silence timer failed it with "solver stopped unexpectedly".
+- **A simulation you cancel is recorded as stopped, not failed**, so a deliberate stop no longer
+  looks like something went wrong with the model.
+
+## Viewing results
+
+- **MovingBoundary results can be read at every saved time**, rather than only the earliest few.
+- **Chombo and MovingBoundary results now open on Apple-silicon Macs.** Both readers previously
+  required an Intel-only component and failed outright.
+- **Chombo meshes are correct and considerably smaller** — interior walls are no longer
+  reported as though they were the domain surface.
+- Server-side mesh generation for Chombo, smoothed finite-volume and COMSOL results has been
+  repaired; it had been silently failing since July 2023.
+- Parameter estimation and export status work on production again.
+
+## Desktop client
+
+- **Login and model loading are fixed** for a range of accounts that previously failed outright —
+  including shared models, models with undecodable preview images, models with many simulations,
+  and a publication saved without a date, which had broken login for everyone.
+- Model search no longer crashes on a large fraction of a real user's models.
+- Fixed: the ODE/PDE results viewer crashing when a model was edited while results were open; a
+  crash while laying out species-pattern text; "Open Web Link" for Pathway Commons going to the
+  wrong site; Constructed Solid Geometry being offered for 2D geometries, where it cannot work; a
+  failed import crashing rather than explaining itself; and a failed update check preventing VCell
+  from starting.
+- **Problem reports are more useful.** The client's log file now actually contains the errors the
+  client reports — until now they were written somewhere no user could reach, which is why a log
+  sent with a problem report so often showed nothing.
+
+## Security and privacy
+
+- **API access tokens are no longer written to server logs.** Tokens were reaching the logs through
+  database statement text; this is fixed and the affected logging is masked.
+- The Java debug agent is no longer enabled by default on server services.
+
+## New, and off by default
+
+- An experimental browser-based 3D field viewer for spatial results, with a colour bar, labelled
+  axes, cut plane, value-under-mouse picking and click-to-plot time courses. It is disabled unless
+  explicitly switched on and does not affect normal use.
+
+## Under the hood
+
+- A production export fault that generated roughly 4,900 error lines a minute was fixed, along with
+  a chain of messaging problems behind it.
+- A JVM memory-sizing error, masked for six months by an hourly restart, was corrected.
+- Server configuration was consolidated onto a single naming scheme and the five server images into
+  one, so a missing or misspelled setting is now reported at startup rather than surfacing later as
+  an unexplained failure.
+
+Full detail is in `CHANGELOG.md` in the repository.
+
+---
+
+# Website announcement (short)
+
+**VCell 8.0.23 is now live.**
+
+The production site has been updated with three months of fixes and improvements. Dialogs and
+child windows no longer disappear behind the main window on current macOS and Windows — they are
+now owned by their parent window, so they stay in front of it and minimize with it. For SpringSaLaD
+users: starting a simulation no longer disturbs runs already in progress, completed
+results can be retrieved reliably, and a run that reaches its time limit now says so instead of
+reporting a crash. Simulations ended by the compute cluster now report the real reason within a
+minute. Chombo and MovingBoundary results now open on Apple-silicon Macs, and a range of desktop
+client login, model-loading and window-management problems are resolved.
+
+**Please update your VCell desktop client** — the client and server versions need to match.


### PR DESCRIPTION
The text sent to the group and posted to the website when production moved from **8.0.0.03 to 8.0.23** on 14 August 2026 — kept in the repository because the deployment is the record of what users were *told*, and a changelog does not say that.

`release-notes/announcements/8.0.23-production.md` holds both pieces: a one-page email and a short website notice.

## How it was written

Drawn from the `Highlights` sections of the 26 releases in between, restated from the user's point of view.

**The nine releases whose highlight opens "Nothing changes for anyone using VCell"** are condensed into a single "Under the hood" group rather than listed. They were configuration and packaging work; listing them would have crowded out what a reader can act on.

**Ordered by breadth of impact, not by release.** The window-ownership refactor leads. It is filed under `### Changed` in 8.0.2.01 and reads like housekeeping there, but it is six PRs (#1763, #1765–#1769) and it affected *every* user on a current macOS or Windows, where `toFront()` is no longer honored for a background application — a dialog could open invisibly behind the main window and look like a freeze. Nothing in the changelog's structure conveys that, which is worth remembering next time one of these is written.

SpringSaLaD follows, credited to Les Loew and his group — their long-running work is what surfaced defects that shorter runs never reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)