### PR TITLE
Release tooling: a check name can appear more than once

### DIFF
--- a/tools/release/merge-when-green.sh
+++ b/tools/release/merge-when-green.sh
@@ -62,7 +62,12 @@ if [ -n "$CHANGED" ] && ! printf '%s\n' "$CHANGED" | grep -qvE '(^docs/|^release
 	echo "documentation-only change"
 fi
 
-rollup_value() { echo "$ROLL" | grep "^${1}=" | cut -d= -f2; }
+# A check name can appear more than once -- `should-run` is reported by both ci.yml and
+# codeql-analysis.yml -- so this must collapse duplicates or every comparison against a single
+# expected value fails. sort -u rather than head -1 on purpose: if two entries of the same name
+# disagree, the result is two lines, nothing matches, and the gate waits. That is the safe way
+# round.
+rollup_value() { echo "$ROLL" | grep "^${1}=" | cut -d= -f2 | sort -u; }
 
 # ci.yml gained a should-run gate (#1925) that skips the whole fast lane when a push cannot
 # affect the build or the tests. A release-notes PR is the normal case, and it is why this


### PR DESCRIPTION
The skipped-lane fix from #1957 **never fired**. It hung on the first release PR that needed it — 8.0.24.01, #1963 — with the same `NOT MERGED -- timed out waiting for` it was written to prevent.

`should-run` is reported by **both** `ci.yml` and `codeql-analysis.yml`, so the rollup carries two entries with that name:

```
   2 should-run=SUCCESS
   1 build=SKIPPED
   1 CI-Test-group-Quarkus=SKIPPED
   1 CI-Test-group-Fast-${{ matrix.name }}=SKIPPED
   1 CI-Test-group-Fast=SUCCESS
```

`rollup_value` returned both lines, `"SUCCESS\nSUCCESS"` never equals `"SUCCESS"`, `lane_skipped()` said no, and the gate waited out its 640 iterations on a PR that was correctly green.

## Why the tests passed anyway

I wrote the fixtures by hand with a single `should-run` line. **They were a model of the rollup, not the rollup.** Case 1 is now the exact output GitHub returned for #1963, duplicate included, and it fails against the previous script.

## sort -u, not head -1

If two entries of the same name disagree, `sort -u` yields two lines, no comparison matches, and the gate waits — the safe direction. `head -1` could collapse a `FAILURE` into a pass, which is the one way this could end up worse than the strictness it replaced. That is now its own fixture case.

| case | expected | result |
|---|---|---|
| docs-only, lane skipped, **should-run twice** | merge | ✅ |
| duplicate should-run **disagreeing** | refuse | ✅ |
| ordinary code PR, all green | merge | ✅ |
| partial skip | refuse | ✅ |
| code PR, checks absent | refuse | ✅ |
| docs-only but lane ran, check absent | refuse | ✅ |
| lane skipped, another check failed | refuse | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)