### PR TITLE
A simulation with no results is not found, not a server error

### DIFF
--- a/vcell-api/src/main/java/org/vcell/rest/server/RestDatabaseService.java
+++ b/vcell-api/src/main/java/org/vcell/rest/server/RestDatabaseService.java
@@ -246,6 +246,27 @@ public class RestDatabaseService {
 		if (simRep == null){
 			throw new ObjectNotFoundException("Simulation with key "+simKey+" not found");
 		}
+		//
+		// Ask the database whether this simulation ever produced results, before asking the data
+		// service for them. Most simulations that reach here never ran: /api/v0/simdata/<simKey> is
+		// public and crawlers walk it for every simulation of every published BioModel. Measured over
+		// 30 days on production, 907 distinct simulations were requested this way and 904 of them had
+		// no data to return - 878 with no vc_simulationjob row at all, 26 with rows where hasData was
+		// not set. Each one cost a JMS session, a temporary queue and an RPC to the data service, and
+		// came back as a DataAccessException reported as a 500 (see issue #1967).
+		//
+		// This is "not found", not a server error, and it is answerable from a row the database
+		// already has.
+		//
+		SimulationStatus simStatus = null;
+		try {
+			simStatus = getSimulationStatus(simKey, vcellUser);
+		} catch (ObjectNotFoundException e) {
+			throw new ObjectNotFoundException("Simulation with key "+simKey+" has no simulation status (never submitted)");
+		}
+		if (simStatus != null && !simStatus.getHasData()){
+			throw new ObjectNotFoundException("Simulation with key "+simKey+" has no results");
+		}
 		User owner = simRep.getOwner();
 		int jobIndex = 0;
 		VCMessageSession rpcSession = vcMessagingService.createProducerSession();

--- a/vcell-api/src/main/java/org/vcell/rest/server/SimDataServerResource.java
+++ b/vcell-api/src/main/java/org/vcell/rest/server/SimDataServerResource.java
@@ -91,6 +91,17 @@ public class SimDataServerResource extends AbstractServerResource implements Sim
 		SimDataRepresentation simData = null;
 		try {
 			simData = getSimDataRepresentation(vcellUser);
+		}catch (ResourceException e){
+			// A simulation with no results is the ordinary case here, not a fault: this endpoint is
+			// public and crawlers walk it for every simulation of every published BioModel, most of
+			// which never ran. The page renders without its data section - simdata.ftl guards on
+			// <#if simdata??> - so the request is answered correctly and there is nothing to report.
+			// Logging it at ERROR produced roughly 3000 entries a month and buried the real faults.
+			if (e.getStatus()!=null && e.getStatus().isClientError()){
+				if (lg.isDebugEnabled()) lg.debug("no simulation data to show: "+e.getMessage());
+			}else{
+				lg.error(e.getMessage(), e);
+			}
 		}catch (Exception e){
 			lg.error(e.getMessage(), e);
 		}
@@ -147,9 +158,12 @@ public class SimDataServerResource extends AbstractServerResource implements Sim
 				lg.error(e);
 				throw new ResourceException(Status.CLIENT_ERROR_UNAUTHORIZED, "not authorized");
 			} catch (ObjectNotFoundException e) {
-				lg.error(e);
-				throw new ResourceException(Status.CLIENT_ERROR_NOT_FOUND, "simulation metadata not found");
+				// expected whenever a simulation has no results; carries the reason from
+				// getDataSetMetadata, which is more useful to a caller than a fixed string
+				if (lg.isDebugEnabled()) lg.debug("no simulation data: "+e.getMessage());
+				throw new ResourceException(Status.CLIENT_ERROR_NOT_FOUND, e.getMessage());
 			} catch (Exception e){
+				lg.error(e.getMessage(), e);
 				throw new ResourceException(Status.SERVER_ERROR_INTERNAL, e.getMessage());
 			}
 //		}


### PR DESCRIPTION
Fixes #1967.

`/api/v0/simdata/<simKey>` asked the data service for results before anything checked whether any existed. The endpoint is public and crawlers walk it for every simulation of every published BioModel, most of which never ran.

Measured over 30 days on production: **907 distinct simulations requested this way, 904 with nothing to return** — 878 with no `vc_simulationjob` row at all, 26 with rows where `hasData` was not set. Each cost a JMS session, a temporary queue and an RPC to the data service, and came back as a `DataAccessException` reported as **500** and logged at **ERROR**: roughly 3000 entries a month, most of the api log, burying the three simulations that really have lost their data.

## The change

`getDataSetMetadata` now asks the database for the simulation status **before** the RPC — a row it already has, via `SimulationDatabaseDirect` — and throws `ObjectNotFoundException` when `hasData` is false.

| case | HTTP | log |
|---|---|---|
| simulation has results | 200 | — |
| never ran / `hasData` false | **404** | debug *(was ERROR + a wasted RPC)* |
| no simulation status row | **404** | debug |
| genuine backend failure | 500 | ERROR *(unchanged)* |

The 404 carries the reason from `getDataSetMetadata` rather than a fixed `"simulation metadata not found"`, so a caller can tell "never submitted" from "no results".

## Correction to the issue

**#1967 claimed `simData` was assigned and never read, and recommended deleting the call from `get_html`. That was wrong.** Line 120 does `dataModel.put("simdata", simData)` and `simdata.ftl` renders it — I had sampled line ranges instead of reading the whole method. The round trip is not wasted when data exists, and the HTML path is not the defect.

So this PR deliberately **does not** change that path's 200. Rendering the page without its data section is the designed behaviour — the template guards on `<#if simdata??>` — and the request is answered correctly. What was wrong was doing an RPC to discover something the database already knew, and shouting about the ordinary result.

I will correct the issue text alongside this.

## Scope

Two files, no behaviour change for simulations that do have results. The three genuine losses will now return 404 rather than 500 — arguably a small loss of signal, but they are identifiable from the database (`hasData='Y'` with no files) rather than from an HTTP status, and that check does not depend on someone requesting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)