### PR TITLE
Stop logging the Bearer challenge warning that is neither actionable nor a fault

### DIFF
--- a/docker/build/vcell-api.log4j.xml
+++ b/docker/build/vcell-api.log4j.xml
@@ -20,6 +20,31 @@
             <!--      !!! Never set JSBML to debug log level will break JSBML. Runtime errors in JSBML.-->
             <!--      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
             <Logger name="org.sbml.jsbml" level="info" />
+
+    <!--
+      Restlet logs this once per request carrying a Bearer token, from
+      org.restlet.engine.security.AuthenticatorUtils:402 - 563 lines in a 30 minute window on
+      production, which is most of what is in this log.
+
+      It is not actionable and it is not a fault. VCellApiApplication configures a
+      ChallengeAuthenticator for ChallengeScheme.HTTP_OAUTH_BEARER, but the AuthenticatorHelper for
+      that scheme lives in org.restlet.ext.oauth, which is not a dependency. BearerTokenVerifier
+      does not need it - it reads cr.getRawValue() directly - so authentication works and Restlet
+      complains anyway. See issue #1969.
+
+      Filtered by message rather than by level, because Restlet logs through the CONTEXT logger and
+      VCell's own application messages share this logger name (they differ only in the class field).
+      Raising the level here would silence those too.
+
+      This changes no behaviour. Do NOT "fix" the warning by adding org.restlet.ext.oauth or
+      registering a Bearer helper: BearerTokenVerifier depends on getRawValue() being populated the
+      way it is today, and the authenticator is built with bAuthOptional=true, so a verifier that
+      stopped recognising tokens would not 401 - requests would silently proceed unauthenticated.
+    -->
+    <Logger name="org.restlet.WadlComponent.InternalRouter.VCellApiApplication" level="info">
+      <RegexFilter regex="Couldn't find any helper support the .* challenge scheme\."
+                   onMatch="DENY" onMismatch="NEUTRAL"/>
+    </Logger>
     <!--    <Logger name="org.vcell" level="warn" />-->
     <!--    <Logger name="cbit.vcell" level="warn" />-->
             <Logger name="cbit.vcell.modeldb" level="debug" />


### PR DESCRIPTION
Step 1 of #1969 — the logging change only. **Authentication is deliberately untouched.**

Restlet logs `Couldn't find any helper support the HTTP_Bearer challenge scheme.` once per request carrying a Bearer token, from `AuthenticatorUtils:402`. **563 lines in a thirty-minute window** on production — 563 of the 592 WARN lines in that log. With the simdata errors gone (#1968), this is the loudest thing left.

It is not a fault: `VCellApiApplication` configures a `ChallengeAuthenticator` for `HTTP_OAUTH_BEARER`, the helper for that scheme lives in `org.restlet.ext.oauth` which is not a dependency, and `BearerTokenVerifier` does not need one — it reads `cr.getRawValue()` directly. Authentication works; Restlet complains anyway.

## Why a message filter and not a level

Restlet logs through the **context** logger, and VCell's own messages share that logger name. They differ only in the `class` field:

| message | logger | class |
|---|---|---|
| `Couldn't find any helper…` | `org.restlet.…VCellApiApplication` | `org.restlet.engine.security.AuthenticatorUtils` |
| `…returning user = null` | `org.restlet.…VCellApiApplication` | `org.vcell.rest.VCellApiApplication` |

A level rule cannot tell them apart, so raising the threshold would have silenced VCell's own messages — including `ApiAccessToken not found in database`.

## Verified against real log4j2, with this exact file

Five messages logged, four emitted:

| message | result |
|---|---|
| `Couldn't find any helper support the HTTP_Bearer challenge scheme.` | **suppressed** |
| `…returning user = null` (same logger) | emitted |
| a real ERROR (same logger) | emitted |
| an ordinary INFO (same logger) | emitted |
| a warning from `RestDatabaseService` | emitted |

## What this does not do

It does not address **why** the warning exists. That is the token-model question in #1969: these are VCell-issued tokens validated against the database, not Auth0 tokens, and whether this path should exist at all given `/api/v1/` decides what a real fix looks like.

**Do not add `org.restlet.ext.oauth` or register a Bearer helper as a follow-up to this.** `BearerTokenVerifier` depends on `getRawValue()` being populated as it is today, and the authenticator is built with `bAuthOptional = true` — so a verifier that stopped recognising tokens would not return 401. Requests would silently proceed unauthenticated, and this log would look *better* while it happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)