### PR TITLE
Initialize JSBML's parser registry once before the parallel Fast run

### DIFF
--- a/vcell-core/pom.xml
+++ b/vcell-core/pom.xml
@@ -87,6 +87,16 @@
 			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!--
+			Needed to compile JsbmlParserWarmup, a LauncherSessionListener. Surefire already puts
+			this on the runtime classpath; declaring it makes the compile-time use explicit.
+			Version comes from the junit-bom imported in the parent pom.
+		-->
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>

--- a/vcell-core/src/test/java/org/vcell/sbml/JsbmlParserWarmup.java
+++ b/vcell-core/src/test/java/org/vcell/sbml/JsbmlParserWarmup.java
@@ -1,0 +1,58 @@
+package org.vcell.sbml;
+
+import org.junit.platform.launcher.LauncherSession;
+import org.junit.platform.launcher.LauncherSessionListener;
+import org.sbml.jsbml.xml.parsers.ParserManager;
+
+/**
+ * Initializes JSBML's parser registry once, on a single thread, before any test runs.
+ *
+ * <p>JSBML's {@code ParserManager} is not safe to initialize concurrently, and the Fast group runs
+ * test classes in parallel (see the {@code junit.jupiter.execution.parallel.*} flags in
+ * {@code .github/workflows/ci.yml}). Its static initializer creates two single-use ServiceLoader
+ * iterators, and the constructor -- reached through an unsynchronized {@code getManager()} that
+ * does a plain null check -- drains them:
+ *
+ * <pre>
+ * static {
+ *     readingParserList = ServiceLoader.load(ReadingParser.class).iterator();
+ *     writingParserList = ServiceLoader.load(WritingParser.class).iterator();
+ * }
+ * public static ParserManager getManager() {
+ *     if (manager == null) manager = new ParserManager();   // init() drains the statics
+ *     return manager;
+ * }
+ * </pre>
+ *
+ * <p>Two workers can both see a null {@code manager} and both drain the same iterator. Observed on
+ * one commit in two consecutive CI runs, in two different tests, at the same frame: a
+ * NullPointerException out of {@code ServiceLoader$LazyClassPathLookupIterator.parse} and a
+ * NoSuchElementException out of {@code CompoundEnumeration.nextElement}.
+ *
+ * <p>It is a crash, not corruption. A second {@code init()} was measured to produce an identical
+ * 12-namespace parser map, because JSBML's {@code parserDefaults} fallback re-instantiates by name
+ * whatever the drained iterator failed to supply, and that list covers all 17 parsers JSBML ships.
+ *
+ * <p>Touching {@code getManager()} here collapses the race: the singleton and both iterators are
+ * done with before the execution engine starts a second thread, and every later call is a plain
+ * static read.
+ *
+ * <p>This covers vcell-core, which holds every class in the repo that imports {@code org.sbml.jsbml}.
+ * A module whose own tests reach JSBML would need its own copy of this listener and its
+ * {@code META-INF/services} entry; none do today.
+ *
+ * <p>This is a workaround in test scope, not a fix. The fix belongs in {@code getManager()} itself,
+ * which is reachable: jsbml-core here is our fork, {@code com.github.virtualcell/vcell-jsbml}. Until
+ * that lands, production keeps the race -- harmless in a single-threaded importer, not obviously so
+ * in a server that can import two documents at once. See the tracking issue.
+ *
+ * <p>Registered by {@code ServiceLoader} via
+ * {@code src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener}.
+ */
+public class JsbmlParserWarmup implements LauncherSessionListener {
+
+    @Override
+    public void launcherSessionOpened(LauncherSession session) {
+        ParserManager.getManager();
+    }
+}

--- a/vcell-core/src/test/java/org/vcell/sbml/JsbmlParserWarmupTest.java
+++ b/vcell-core/src/test/java/org/vcell/sbml/JsbmlParserWarmupTest.java
@@ -1,0 +1,34 @@
+package org.vcell.sbml;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.sbml.jsbml.xml.parsers.ParserManager;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Guards the wiring of {@link JsbmlParserWarmup}, not its logic.
+ *
+ * <p>The listener is registered by a one-line {@code META-INF/services} file. Delete or misspell it
+ * and nothing fails -- the parallel Fast run just goes back to racing into ParserManager, which
+ * surfaces later as an unrelated-looking SBML test failing perhaps one run in a few hundred. This
+ * test turns that silence into an immediate red.
+ *
+ * <p>Reads the private singleton rather than calling {@code getManager()}, because calling it would
+ * initialize it and the assertion would pass either way.
+ */
+@Tag("Fast")
+public class JsbmlParserWarmupTest {
+
+    @Test
+    public void jsbmlParsersAreInitializedBeforeAnyTestRuns() throws Exception {
+        Field manager = ParserManager.class.getDeclaredField("manager");
+        manager.setAccessible(true);
+        assertNotNull(manager.get(null),
+                "JSBML's ParserManager singleton is not initialized, so JsbmlParserWarmup did not run. "
+                        + "Check vcell-core/src/test/resources/META-INF/services/"
+                        + "org.junit.platform.launcher.LauncherSessionListener.");
+    }
+}

--- a/vcell-core/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/vcell-core/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.vcell.sbml.JsbmlParserWarmup


### PR DESCRIPTION
Fixes the CI flake in #1971. Test scope only — the durable fix is the fork change described there.

## The race

`ParserManager`, disassembled from `jsbml-core-1.6.1-VCELL`:

```java
static {                                                      // class init
  readingParserList = ServiceLoader.load(ReadingParser.class).iterator();
  writingParserList = ServiceLoader.load(WritingParser.class).iterator();
}
public static ParserManager getManager() {                    // NOT synchronized
  if (manager == null) manager = new ParserManager();         // init() drains the statics
  return manager;                                             // manager is not volatile
}
```

The ServiceLoader iterators are **static and single-use**, and `init()` consumes them. The Fast group runs classes concurrently (`ci.yml:288-292`), so two workers can both see a null `manager` and both drain the same iterator. On commit `0d60a7d372`, two consecutive runs failed in two different tests at that exact frame — `VCImageTest` (NPE, `"u" is null`) and `CopasiOptimizationSolverTest` (`NoSuchElementException`) — and a third rerun passed. The second test is an *optimization* test; it reaches JSBML via `MathModel_SBMLExporter` parsing MathML.

**Correction to an earlier claim.** I first wrote that the surviving instance could be left with a parser map silently short its package parsers — a failure worse than the crash. That is wrong. `init()`'s `parserDefaults` fallback re-instantiates by name whatever the drained iterator failed to supply, and that list covers all 17 parsers JSBML ships; a second construction was measured to produce an identical 12-namespace map. Only a parser contributed solely through `META-INF/services` and missing from that list would be dropped, and there is none. **This bug is a crash, not corruption.**

## The change

A `LauncherSessionListener` touches `getManager()` once before the engine starts a second thread. Every later call is a plain static read, and the workers are created after the listener runs, so they see the write despite the field not being volatile.

## Verification

A probe giving each trial a fresh `URLClassLoader` and racing 8 threads into `getManager()`:

| | trials | trials with a failure |
|---|---|---|
| cold | 400 | 1 — the same `NullPointerException` as CI |
| warmed first, single-threaded | 400 | 0 |

A low base rate — the threads serialize behind the classloader lock inside `init()`, which is why this is rare at all — so the warmed arm supports the fix rather than proving it. The guarantee is structural: after warm-up no thread can enter the constructor.

Full `vcell-core` Fast group with CI's exact parallel flags: **547 tests, 1 error**, that error being `VCellDataTest.test_3D`'s poetry-deprecation noise (environmental, per CLAUDE.md). Both previously-failing tests pass.

## The guard test

`JsbmlParserWarmupTest` checks the `META-INF/services` **wiring**, not the logic — delete that one-line file and nothing fails, the suite just resumes racing and shows up later as an unrelated-looking test failing once in a few hundred runs.

I confirmed the guard actually bites by removing the services file and watching it fail. Worth recording: **removing only the source copy does not work** — `test-compile` copies resources but never deletes ones that went away, so the stale copy in `target/test-classes` still registers the listener and the control passes for the wrong reason. It has to be removed from `target/test-classes`.

## Scope

vcell-core only — all 15 classes in the repo importing `org.sbml.jsbml` are there, and no Fast test in another module reaches a JSBML entry point today. One that did would need its own listener and services file.

**A single-threaded shard was considered and rejected**; reasoning is in #1971.

## This is the workaround, not the fix

The root cause is now patched in our fork: **virtualcell/vcell-jsbml#3** synchronizes `getManager()`. Once that is merged, tagged `1.6.1-VCELL-2`, and `jsbml.version` is bumped in the root pom, **this listener and its guard test should be deleted** — they become dead weight.

Upstream `sbmlteam/jsbml` master has the identical unsynchronized `getManager()`, so no catch-up merge would have brought us a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
