### PR TITLE
Say what the COPASI fix actually skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,19 +18,22 @@ _(Release-manager scratchpad. Populated at release-cut time.)_
 
 ## [8.0.25.01] - 2026-08-17
 
-**Highlights.** SBML models exported by COPASI import again. A number of published BioModels
-carry an annotation block that VCell's SBML reader assumed could only hold one kind of element,
-and the import died outright on the ones that do not. Also in this build: asking the legacy API
-for the results of a simulation that never produced any now answers "not found" instead of
-reporting a server error.
+**Highlights.** SBML models exported by COPASI import again. Where one annotation element is
+nested inside another — which COPASI produces, and which a number of published BioModels contain
+— the import used to fail outright. Also in this build: asking the legacy API for the results of
+a simulation that never produced any now answers "not found" instead of reporting a server error.
 
 ### Fixed
 - SBML documents produced by COPASI no longer fail to import with
   `ClassCastException: class org.sbml.jsbml.xml.XMLNode cannot be cast to class
-  org.sbml.jsbml.Annotation`. JSBML's reader assumed the element left on its stack at the end of
-  an annotation was always an `Annotation` and cast it without checking; some COPASI exports put
-  an `XMLNode` there. The SBML validator considers these documents well formed, so the assumption
-  was the bug, not the file. Twelve archives in the nightly BioModels suite fail on exactly this.
+  org.sbml.jsbml.Annotation`. Closing an annotation, JSBML's reader assumed the element on its
+  stack was always an `Annotation` and cast it without checking. For an annotation nested inside
+  another annotation it is an `XMLNode`, and the import died. The SBML validator considers these
+  documents well formed, so the assumption was the bug, not the file. Nothing is dropped from the
+  model: the cast fed the RDF annotation post-processing for the nested element — work that could
+  not have run anyway, since the object it needed is what was missing — and enclosing annotations
+  are processed exactly as before. In the test model the nested elements are empty, sitting inside
+  a layout annotation. Twelve archives in the nightly BioModels suite fail on exactly this.
   A guard for it was written in March 2025 and merged to our JSBML fork, but to a branch the
   published artifacts were never built from, so no VCell release ever contained it — this is the
   first one that does. (#1974, issue #1461)

--- a/release-notes/major/8.0.0.md
+++ b/release-notes/major/8.0.0.md
@@ -185,11 +185,11 @@ thread-safety fix in unit-of-measurement formatting.)_
   have, so a log sent with a problem report showed nothing. The file is also
   written as it goes rather than only when VCell exits, so a log sent while
   VCell is still open, or after it stops responding, is complete (8.0.23.01).
-- SBML models exported by COPASI import again. VCell's SBML reader assumed a
-  particular element inside an annotation block could only be of one kind and
-  gave up on the models where it is not — including a number of published
-  BioModels. The reader now skips what it does not recognise and imports the
-  rest of the model (8.0.25.01).
+- SBML models exported by COPASI import again. Where one annotation element is
+  nested inside another — a shape COPASI produces, and one a number of published
+  BioModels contain — the reader used to abandon the import. No model content was
+  ever involved: what it stumbled on is the bookkeeping for the nested annotation
+  itself, and the enclosing annotations are read exactly as before (8.0.25.01).
 
 ## API and integration changes
 


### PR DESCRIPTION
Correction to the 8.0.25.01 release-cut docs in #1975. That PR merged while this fix was still in flight, so master currently carries wording Jim flagged as misleading — **and 8.0.25.01 is not tagged yet**, so nothing has shipped with it.

The note said the reader "skips what it does not recognise and imports the rest of the model", which reads as though model content can be dropped. It cannot.

What the failing cast fed was the RDF annotation post-processing for an annotation nested inside another annotation. Checkable claims:

- `SBMLRDFAnnotationParser` is the **only** `AnnotationReader` implementation, so the skipped call is RDF/MIRIAM handling — never species, reactions, compartments or math.
- The skipped work could not have run regardless: it needed `((Annotation) lastElement).getParent()`, and `lastElement` not being an `Annotation` is the entire problem. The old code crashed attempting it.
- Enclosing annotations are processed as before — the test model has 24 annotation elements, 2 of them nested, and the guard logs exactly 2 warnings.
- Both nested elements in that model are empty, inside a `layout:listOfLayouts` block.

The replacement wording says the reader stumbled on "the bookkeeping for the nested annotation itself", rather than claiming nothing anywhere is skipped — a nested annotation carrying real RDF elsewhere would have its CV terms left unparsed, which is still not model content, and still better than refusing the import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)