### PR TITLE
Stop reporting skipped deploy jobs as failures

### DIFF
--- a/tools/release/release-and-deploy.sh
+++ b/tools/release/release-and-deploy.sh
@@ -104,7 +104,7 @@ TAG_AND_PUSH=$(gh run view "$RUN" --repo "$REPO" --json jobs \
 echo "tag-and-push=${TAG_AND_PUSH:-ABSENT}"
 if [ "$TAG_AND_PUSH" != "success" ]; then
 	gh run view "$RUN" --repo "$REPO" --json jobs \
-		-q '.jobs[] | select(.conclusion!="success" and .conclusion!=null) | "  FAILED: \(.name)"'
+		-q '.jobs[] | select(.conclusion!="success" and .conclusion!="skipped" and .conclusion!=null) | "  FAILED: \(.name)"'
 	echo "NOT deploying: without tag-and-push the $VERSION image tags may not exist." >&2
 	echo "Recover with: gh run rerun $RUN --failed" >&2
 	exit 1
@@ -128,7 +128,7 @@ for _ in $(seq 1 200); do
 done
 echo "site_deploy: $STATUS"
 gh run view "$DEPLOY" --repo "$REPO" --json jobs \
-	-q '.jobs[] | select(.conclusion!="success" and .conclusion!=null) | "  FAILED: \(.name)"'
+	-q '.jobs[] | select(.conclusion!="success" and .conclusion!="skipped" and .conclusion!=null) | "  FAILED: \(.name)"'
 
 case "$STATUS" in
 	completed/success)


### PR DESCRIPTION
Found while releasing 8.0.25.01 to stage.

`release-and-deploy.sh` printed

```
site_deploy: completed/success
  FAILED: Archive to Zenodo
```

on a deploy that had succeeded. `Archive to Zenodo` was **skipped**, not failed — `site_deploy.yml:383` gates it on `needs.deploy.result == 'success' && github.event.inputs.vcell_site == 'rel'`, so it skips on every stage and alpha deploy by design.

The filter selected any conclusion that was neither `success` nor `null`, and `skipped` is one of those. Now excluded, at both call sites (CI-full job summary and site_deploy job summary).

A false alarm on every non-prod release is worse than no report — it trains you to skim the one line that would matter when a job really does fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)