### PR TITLE
Stop attaching a stack trace to every cleanup SQL statement

### DIFF
--- a/vcell-server/src/main/java/cbit/vcell/modeldb/DBBackupAndClean.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/DBBackupAndClean.java
@@ -1061,9 +1061,11 @@ public class DBBackupAndClean {
 		try{
 			logStringBuffer.append(sql+";\n");
 			stmt = con.createStatement();
-			if (lg.isDebugEnabled()) {
-				lg.debug("executeUpdate() SQL: '" + sql + "'", new DbDriver.StackTraceGenerationException());
-			}
+			// No StackTraceGenerationException here: the call stack is invariant -- this is only ever
+			// reached from the cleanup thread through this method -- so it identified nothing the
+			// message and logger name do not, while accounting for about a quarter of the db
+			// container's log on production. See issue #1987.
+			lg.debug("executeUpdate() SQL: '{}'", sql);
 			int updateCount = stmt.executeUpdate(sql); // jcs: added logging
 			logStringBuffer.append("Update count=" + updateCount + "\n");
 			con.commit();


### PR DESCRIPTION
Closes #1987.

`DbDriver.StackTraceGenerationException` is an empty marker exception, constructed on purpose and handed to the logger so log4j prints a call stack next to the message. In `DBBackupAndClean.executeUpdate` that stack is **invariant** — the method is only ever reached from the cleanup thread through this one path — so it identified nothing the message and logger name did not.

It is not free. `cbit.vcell.modeldb` is at `debug` on the db container (`docker/build/vcell-db.log4j.xml:25`), so every statement the cleanup runs was logged with a full synthetic stack trace: **~948 lines/day on production, roughly a quarter of that container's 3823.**

## Before / after

Both forms logged side by side through a debug configuration:

```
---- OLD ----
DEBUG DBBackupAndClean - executeUpdate() SQL: 'DELETE FROM vc_simulation WHERE ...'
cbit.vcell.modeldb.DbDriver$StackTraceGenerationException
	at LogShape.main(LogShape.java:10)

---- NEW ----
DEBUG DBBackupAndClean - executeUpdate() SQL: 'DELETE FROM vc_simulation WHERE ...'
```

Same DEBUG line, same SQL, no stack trace. The visibility the `debug` level was presumably enabled for is kept.

Switched to a parameterized call, which also lets the `isDebugEnabled()` guard go — log4j2 does not build the string unless the level is on.

## Deliberately narrow

The idiom appears **56 times** in `vcell-server`, and they should not all be treated alike:

| level | count | |
|---|---|---|
| `lg.error` | 20 | **keep** — fire on genuinely unexpected conditions such as `changed != 1` after an update (`DbDriver:3585`), where the stack is the only thing identifying which of many call paths produced it |
| `lg.trace` | 19 | cost nothing while nothing enables trace |
| `lg.debug` | 16 | only this one is generating volume in a deployed configuration |

One line changed, in the one place that is actually noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)