### PR TITLE
docs(backlog): triage all 272 open issues into docs/backlog/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,6 @@ users_*.txt
 users_*.csv
 active_users*.csv
 /users.txt
+
+# backlog tooling output
+obsolescence-sweep.json

--- a/docs/backlog/00-method.md
+++ b/docs/backlog/00-method.md
@@ -100,8 +100,9 @@ was. Estimates are for the grooming, not the engineering work.
 
 **Step 1 — Reconcile the prioritization mechanisms.** *(~30 min, one person)*
 The board's scoring model is sound — `Priority = Importance + Simplicity`, a real value/cost
-tradeoff ([03](03-board-hygiene.md)) — but it is undocumented, one row's arithmetic has drifted,
-and four scored issues were never ranked. Write the formula down, fix those five, then pick *one*
+tradeoff ([03](03-board-hygiene.md)). The five rows whose arithmetic had drifted or was never
+computed **have been fixed** and the board is now formula-consistent; what remains is to write the
+formula down where it will survive, then pick *one*
 mechanism: recommend keeping the numeric fields, deleting the `High Priority` label, and stripping
 the four stale release labels. Right now three mechanisms disagree and the disagreement is silent.
 

--- a/docs/backlog/00-method.md
+++ b/docs/backlog/00-method.md
@@ -110,9 +110,10 @@ the four stale release labels. Right now three mechanisms disagree and the disag
 14 issues in [01](01-close-and-verify.md), each with its evidence. Six are already verified against
 the repo; eight need a yes/no from a named person.
 
-**Step 3 — Put the 55 off-board issues on the board.** *(~30 min)*
-[03](03-board-hygiene.md). These are the best-described issues in the repo and they are invisible
-to anyone planning from the board. This is the cheapest high-value step in the list.
+**Step 3 — Put the 55 off-board issues on the board.** ~~*(~30 min)*~~ **— done 2026-08-19.**
+[03](03-board-hygiene.md). These were the best-described issues in the repo and were invisible to
+anyone planning from the board. All 56 were added with `backlog_lint.py --fix-board`; they still
+need triaging into `Pool` and scoring.
 
 **Step 4 — Take the 5 strategic decisions.** *(one meeting)*
 [04](04-epic-map.md). Postgres, the two competing UI epics, the desktop-vs-web viewer direction,

--- a/docs/backlog/00-method.md
+++ b/docs/backlog/00-method.md
@@ -1,0 +1,151 @@
+# The Triage Plan
+
+How to get from 272 undifferentiated open issues to a backlog the team can actually work from,
+without spending a week on it.
+
+---
+
+## The core problem
+
+It is not that there are 272 issues. It is that **the backlog does not distinguish between four
+very different kinds of thing**, and they are all filed the same way:
+
+1. **Work items** — a defect or a feature, described well enough to schedule. Maybe 90 of the 272.
+2. **Reminders** — a title someone wrote so an idea wouldn't be lost. No body, no acceptance
+   criteria, often 4 years old. About 107 (see [02](02-needs-refinement.md)).
+3. **Containers** — 23 epics, several of which overlap or have been overtaken (see [04](04-epic-map.md)).
+4. **Not-backlog** — support requests, bot notifications, done-but-open, questions from
+   contributors. About 14 (see [01](01-close-and-verify.md)).
+
+Grooming means sorting these four apart *first*. Prioritizing before that sort is how a backlog
+ends up with a ranked list of things nobody can estimate — which is roughly the current state.
+
+---
+
+## Dispositions
+
+Every issue gets exactly one. These are deliberately few; a taxonomy with ten buckets does not get used.
+
+| Disposition | Meaning | What happens |
+|---|---|---|
+| **CLOSE** | Done, obsolete, duplicate, or not a backlog item | Close with a one-line reason. Reversible. |
+| **REFINE** | Real, but unactionable as written | Assign a *refiner* (not an implementer) to add repro steps / acceptance criteria, or close it |
+| **GROUP** | Real and clear, belongs to a theme | File under its group doc; rank within the group |
+| **DECIDE** | Blocked on a product/architecture call, not on work | Escalate to the named decider; do not rank until answered |
+| **SHELVE** | Real, understood, deliberately not now | Board status `Shelved`, with a note saying *why* and what would revive it |
+
+The distinction that matters most is **REFINE vs SHELVE**. A four-year-old one-line issue is not
+automatically shelved — it may be a real bug nobody can reproduce because nobody wrote down how.
+Shelving it hides the ambiguity; refining it or closing it resolves the ambiguity. Prefer one of
+those two.
+
+---
+
+## Decision rules
+
+Apply in order. The first rule that fires wins.
+
+**1. Is it a backlog item at all?**
+Support requests (`#1609`), contributor questions (`#1598`), and bot-generated status issues
+(`#1777`) are not backlog. → CLOSE, redirect to the right channel.
+
+**2. Does the board say `Done`?**
+Four issues are open with board status `Done` (`#166`, `#748`, `#1646`, `#1647`). Either the work
+landed and nobody closed the issue, or the status is wrong. → verify, then CLOSE or correct the status.
+
+**3. Has the code moved past it?**
+Check the working tree before assuming. `#1647` (inverse cotangent) has a commit that says
+`Fixed incorrect acot math!!!`; `#1686` has a merged PR. Both are close candidates on evidence,
+not on vibes. → CLOSE with the commit/PR cited.
+
+**4. Is it a release-planning artifact from a shipped version?**
+`Next Release` (19 issues) and `VCell-7.5.0`/`7.5.1`/`7.6.0` (33 issues) date from three majors
+back; we ship 8.0.27.01. `#1543` and `#1599` ask for release notes for 7.7. → CLOSE the notes
+issues, strip the stale labels wholesale.
+
+**5. Can a competent engineer who did not write it start work from the body?**
+If no → REFINE. This is the 107-issue question and the reason [02](02-needs-refinement.md) is
+structured by *what is missing*, not by topic.
+
+**6. Does progress depend on a decision nobody has made?**
+→ DECIDE. Five of these gate large chunks of the backlog; they are named in [04](04-epic-map.md).
+Ranking work behind an unmade decision is wasted ranking.
+
+**7. Otherwise** → GROUP, and rank inside the group.
+
+---
+
+## Who decides what
+
+Grooming stalls when every question routes to one person. These route differently:
+
+| Question type | Decider | Examples |
+|---|---|---|
+| Is this still a real user-facing problem? | Domain/user-facing owners (Ann, Michael, Les) | most of the 2022 UI and RBM cohort |
+| Is this already fixed / obsoleted by a rewrite? | The engineer who owns that subsystem | `#877`, `#1048`, `#1152` |
+| Do we still want to go this direction? | Jim (architecture) | the 5 DECIDE items in [04](04-epic-map.md) |
+| What ships next? | Whoever owns release planning | the `Queued` slate, the stale release labels |
+
+**Explicit recommendation:** the 2022 cohort (73 issues, mostly one bulk import, mostly bodyless)
+should be reviewed by its *authors* in one sitting, not by engineers one at a time. Most of those
+titles mean something specific to the person who wrote them and nothing to anyone else. A single
+90-minute pass by Ann + Michael would likely resolve 50 of them to CLOSE or a one-sentence refinement.
+
+---
+
+## Suggested sequencing
+
+Each step is independently useful; stopping after any of them leaves the backlog better than it
+was. Estimates are for the grooming, not the engineering work.
+
+**Step 1 — Reconcile the prioritization mechanisms.** *(~30 min, one person)*
+Answer the polarity question on `Priority`/`Importance` ([03](03-board-hygiene.md)), then pick
+*one* mechanism. Recommend: keep the numeric board fields, delete the `High Priority` label, and
+strip the four stale release labels. Right now three mechanisms disagree and the disagreement is
+silent.
+
+**Step 2 — Close the close-list.** *(~30 min)*
+14 issues in [01](01-close-and-verify.md), each with its evidence. Six are already verified against
+the repo; eight need a yes/no from a named person.
+
+**Step 3 — Put the 55 off-board issues on the board.** *(~30 min)*
+[03](03-board-hygiene.md). These are the best-described issues in the repo and they are invisible
+to anyone planning from the board. This is the cheapest high-value step in the list.
+
+**Step 4 — Take the 5 strategic decisions.** *(one meeting)*
+[04](04-epic-map.md). Postgres, the two competing UI epics, the desktop-vs-web viewer direction,
+the SpringSaLaD epic structure, the export-refactor overlap. Each one determines whether a
+double-digit number of issues is worth ranking at all. **Do this before Step 5**, not after.
+
+**Step 5 — Run the refinement pass.** *(the 90-minute 2022-cohort session, plus follow-ups)*
+[02](02-needs-refinement.md). Outcome per issue is a one-sentence acceptance criterion or a close.
+
+**Step 6 — Rank within groups.** *(per-group, by group owner)*
+Only now is ranking meaningful. Rank inside each group doc (10–19); do not maintain a single
+global 272-item order — nobody reads past item 20 of one.
+
+---
+
+## What "groomed" should mean here
+
+A proposed definition of done for this exercise, so it is possible to tell when it is finished:
+
+- [ ] Every open issue has a board status, and `Active` means someone is actually working on it this month
+- [ ] No open issue carries a label naming a shipped release
+- [ ] One prioritization mechanism, with documented polarity
+- [ ] Every `Queued` issue has a body an outside engineer could start from
+- [ ] Every epic either has an owner and a live child list, or is closed
+- [ ] Issues with 3+ assignees are reduced to one owner (33 issues today)
+
+---
+
+## A caution on the group boundaries
+
+The ten thematic groups in this pass are a *reading aid*, not a proposed team structure or label
+scheme. Several issues genuinely belong to two groups — `#167` (field-data API for local runs) is
+equally an API item and a visualization item; `#1564` (automate the SpringSaLaD build) is equally
+SpringSaLaD and CI. Each was assigned to one group so the counts sum cleanly and nothing gets read
+twice or missed. Where the second home is material, the group doc says so.
+
+Do not convert these groups into GitHub labels without a separate conversation — the repo already
+has 32 labels and part of the current problem is that several of them overlap.

--- a/docs/backlog/00-method.md
+++ b/docs/backlog/00-method.md
@@ -99,10 +99,11 @@ Each step is independently useful; stopping after any of them leaves the backlog
 was. Estimates are for the grooming, not the engineering work.
 
 **Step 1 — Reconcile the prioritization mechanisms.** *(~30 min, one person)*
-Answer the polarity question on `Priority`/`Importance` ([03](03-board-hygiene.md)), then pick
-*one* mechanism. Recommend: keep the numeric board fields, delete the `High Priority` label, and
-strip the four stale release labels. Right now three mechanisms disagree and the disagreement is
-silent.
+The board's scoring model is sound — `Priority = Importance + Simplicity`, a real value/cost
+tradeoff ([03](03-board-hygiene.md)) — but it is undocumented, one row's arithmetic has drifted,
+and four scored issues were never ranked. Write the formula down, fix those five, then pick *one*
+mechanism: recommend keeping the numeric fields, deleting the `High Priority` label, and stripping
+the four stale release labels. Right now three mechanisms disagree and the disagreement is silent.
 
 **Step 2 — Close the close-list.** *(~30 min)*
 14 issues in [01](01-close-and-verify.md), each with its evidence. Six are already verified against
@@ -132,7 +133,7 @@ A proposed definition of done for this exercise, so it is possible to tell when 
 
 - [ ] Every open issue has a board status, and `Active` means someone is actually working on it this month
 - [ ] No open issue carries a label naming a shipped release
-- [ ] One prioritization mechanism, with documented polarity
+- [ ] One prioritization mechanism, with its scoring formula documented on the board
 - [ ] Every `Queued` issue has a body an outside engineer could start from
 - [ ] Every epic either has an owner and a live child list, or is closed
 - [ ] Issues with 3+ assignees are reduced to one owner (33 issues today)

--- a/docs/backlog/01-close-and-verify.md
+++ b/docs/backlog/01-close-and-verify.md
@@ -131,6 +131,8 @@ add the PR link and a scope sentence.
 | [#1718](https://github.com/virtualcell/vcell/issues/1718) | 🗂 VCell — Zenodo release archiving | 2026-07 | **off-board** | — | — | — |
 | [#1777](https://github.com/virtualcell/vcell/issues/1777) | Zenodo release archiving has drifted | 2026-07 | **off-board** | — | — | — |
 
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars
+
 ---
 
 ## `#748` — the one I could not resolve

--- a/docs/backlog/01-close-and-verify.md
+++ b/docs/backlog/01-close-and-verify.md
@@ -1,0 +1,145 @@
+# Close / Verify-Then-Close — 14 issues
+
+Issues that look done, obsolete, or not a backlog item. **Nothing here has been closed** — each
+entry states the evidence and who should confirm.
+
+Six are verified against the repo and can be closed on the evidence shown. Eight need a yes/no
+from a named person first.
+
+---
+
+## A. Verified against the repo — close on this evidence
+
+### `#1647` — VCell has been doing inverse co-tangent wrong
+Board status is already `Done`. `git log` carries **`e79926b50a Fixed incorrect acot math!!!`**.
+The issue body notes "a fix is being pushed" — it was.
+
+> **One caveat before closing:** the body says this "has ramifications for results in the past."
+> If nothing was ever done about previously-computed results, that follow-up deserves its own
+> issue rather than dying with this one. Ask @CodeByDrescher whether that tail exists.
+
+### `#1686` — Dan ss structural sites
+Board status `Active`. Body is a pointer to **PR #1685, which is merged.** The issue is a PR
+tracker with nothing left in it. Close; the remaining structural-site work already lives in
+`#1688` (graphical interface) and `#1689` (3D visualization).
+
+### `#1646` — VCell does not properly handle -0.0 in IEEE Expressions
+Board status `Done`. Substantial 5.5k-char writeup, marked done by whoever moved the card.
+**Not independently confirmed in the tree** — I could not isolate a commit, and the change is
+diffuse by nature. → confirm with @CodeByDrescher, then close. Listed here rather than in section B
+because the board already asserts it.
+
+### `#1718` — 🗂 VCell — Zenodo release archiving
+Master tracking issue. `.github/workflows/` now contains **`zenodo-archive.yml` and
+`zenodo-drift.yml`** — the pipeline it asked for exists and runs. Close, or reduce to whatever
+single item is genuinely outstanding.
+
+### `#1777` — Zenodo release archiving has drifted
+Opened by `app/github-actions` — this is the **drift bot's own alert**, reporting
+`Latest GitHub release 8.0.2.01` against `Latest Zenodo version ?`. We are on 8.0.27.01; the alert
+is nine months stale. Close it. If drift monitoring is still firing, that is a live signal to act
+on, not a backlog item to carry.
+
+### `#1320` — Help needs changes (for Importing Images, after change)
+Entire body is **"See #1172"**, and **`#1172` is closed**. Either the help change was made with
+the fix, or this needs re-stating as its own request with actual content. Currently it is a
+dangling pointer that has been `Queued` at Priority 6 since 2024. → @ACowan0105.
+
+---
+
+## B. Not a backlog item — close and redirect
+
+### `#1609` — Issue With VCELL Server.
+A **user support request** ("I am trying to sign in to VCell today, but keep having this
+Message…"), filed by an external user in Dec 2025. Off-board, no assignee, no triage.
+
+If the underlying RPC failure was real it should be a described defect; if it was environmental it
+should be an email reply. Either way it should not sit open in the backlog for eight months —
+that is a bad experience for the reporter more than it is a problem for us. → answer the user, close.
+
+### `#1598` — Looking to re-engage and contribute, any beginner friendly issues available?
+A **contributor asking a question** (`@gmarupilla`, a former VCell contributor of two years,
+offering to come back). Open and unanswered since Nov 2025.
+
+This is worth noticing for its own sake: someone with two years of VCell experience volunteered
+and got no reply for nine months. Answer it, point them at a real starter issue, close. This pass
+produces good candidates — see the `Simple (5)` rows in [10-desktop-ui.md](10-desktop-ui.md).
+
+### `#1552` — [RECURRING] Credentials for Docker Singularity Token need renewing
+Body states **"Current Expiration: Sept 2025"** — eleven months past. Board status `Blocked`.
+
+A recurring operational chore is not backlog; it is either automated or it is a calendar entry.
+Close it and do one of those two. (If the token has in fact been renewed since, that also confirms
+the issue is not tracking anything.)
+
+---
+
+## C. Release-planning residue — close
+
+### `#1543` — Create Release Notes for Next Production Release
+### `#1599` — Make new release notes for vcell 7.7
+
+`#1599` asks for notes for **7.7.0.47**. The current line is **8.0.27.01**, and
+`release-notes/major/` already contains `7.7.md`, `7.7-initial-release.md`,
+`7.7-feature-update.md`, `7.7-stability-update.md`, and `8.0.0.md`. The 7.7 notes exist.
+
+`#1543` ("next production release") is unfalsifiable by construction — it can never be closed,
+because there is always a next release. Release notes are part of the release procedure
+(`docs/RELEASING.md`), not a backlog item. Close both.
+
+Both are currently marked `Active`, which is a good illustration of why the `Active` column
+cannot be trusted for planning — see [03-board-hygiene.md](03-board-hygiene.md).
+
+---
+
+## D. Needs a decision before closing
+
+### `#166` — Relax restrictions on reaction kinetics for stochastic applications
+Board status `Done`, but the issue is also a **live child of epic `#1035`** (general reactions
+with stochastic simulations), which is itself `Active` and has three unchecked sibling tasks
+(Gibson / NFSim / Smoldyn).
+
+So either `#166` shipped and `#1035` should be updated to reflect it, or the `Done` status is
+wrong. These cannot both be true. → @jcschaff, as `#1035`'s owner.
+
+### `#1655` — finish publication/curation PR
+Body is its own title, verbatim: *"finish publication/curation PR"*. `Active` since April 2026,
+assigned to @jcschaff. No PR linked.
+
+Either the PR is identifiable — in which case link it and let the PR carry the work — or this is a
+four-month-old note-to-self. It cannot be handed to anyone else in its current form. → close, or
+add the PR link and a scope sentence.
+
+---
+
+## Summary table
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#1320](https://github.com/virtualcell/vcell/issues/1320) | Help needs changes (for Importing Images, after change) | 2024-07 | Queued | 6/6 | Unknown&nbsp;(0) | BLK thin |
+| [#166](https://github.com/virtualcell/vcell/issues/166) | Relax restrictions on reaction kinetics for stochastic applications | 2022-07 | Done | — | — | — |
+| [#748](https://github.com/virtualcell/vcell/issues/748) | need script to configure vcell ssl keystore from LetsEncrypt | 2023-01 | Done | — | — | thin |
+| [#1543](https://github.com/virtualcell/vcell/issues/1543) | Create Release Notes for Next Production Release | 2025-06 | Active | — | — | — |
+| [#1552](https://github.com/virtualcell/vcell/issues/1552) | [RECURRING] Credentails for Docker Singularty Token need renewing when they expire | 2025-06 | Blocked | — | Moderate&nbsp;(4) | — |
+| [#1598](https://github.com/virtualcell/vcell/issues/1598) | Looking to re-engage and contribute, any beginner friendly issues available? | 2025-11 | **off-board** | — | — | — |
+| [#1599](https://github.com/virtualcell/vcell/issues/1599) | Make new release notes for vcell 7.7 | 2025-12 | Active | — | Complex&nbsp;(3) | — |
+| [#1609](https://github.com/virtualcell/vcell/issues/1609) | Issue With VCELL Server. | 2025-12 | **off-board** | — | — | — |
+| [#1646](https://github.com/virtualcell/vcell/issues/1646) | VCell does not properly handle -0.0 in the IEEE standard within Expressions, creating … | 2026-02 | Done | — | — | — |
+| [#1647](https://github.com/virtualcell/vcell/issues/1647) | VCell has been doing inverse co-tangent wrong. | 2026-02 | Done | — | — | — |
+| [#1655](https://github.com/virtualcell/vcell/issues/1655) | finish publication/curation PR | 2026-04 | Active | — | — | thin |
+| [#1686](https://github.com/virtualcell/vcell/issues/1686) | Dan ss structural sites | 2026-05 | Active | — | Complex&nbsp;(3) | HP thin |
+| [#1718](https://github.com/virtualcell/vcell/issues/1718) | 🗂 VCell — Zenodo release archiving | 2026-07 | **off-board** | — | — | — |
+| [#1777](https://github.com/virtualcell/vcell/issues/1777) | Zenodo release archiving has drifted | 2026-07 | **off-board** | — | — | — |
+
+---
+
+## `#748` — the one I could not resolve
+
+**need script to configure vcell ssl keystore from LetsEncrypt.** Board status `Done`. The body is
+the title repeated. I searched for a LetsEncrypt or keystore-provisioning script and found only
+`vcell-api/keystore_macbook.jks` and `docker/build/installers/NO-WIN-KEYSTORE` — neither is the
+script described.
+
+It is plausible this was overtaken by the Kubernetes migration (cert management would now be
+cluster-side, in `vcell-fluxcd`, not in a VCell script), in which case it is obsolete rather than
+done. **I did not verify that.** → @jcschaff: obsolete, or done elsewhere?

--- a/docs/backlog/02-needs-refinement.md
+++ b/docs/backlog/02-needs-refinement.md
@@ -1,0 +1,167 @@
+# Needs Refinement — 50 issues that cannot be worked as written
+
+**107 of 272 open issues (39%) have a body under 200 characters.** This document covers the worst
+50 — those whose body is **under 80 characters**, meaning the title is effectively the entire
+issue. Median body length across the whole backlog is 295 characters.
+
+These are not necessarily bad issues. Most are real problems. But none of them can be handed to an
+engineer who was not in the room when they were written, and several cannot be handed to anyone at
+all any more, because the room was four years ago.
+
+**The disposition for every issue here is the same: a refiner adds one paragraph, or the issue is
+closed.** Refinement is not implementation — it should take two minutes per issue from the right
+person, and the right person is usually the author.
+
+---
+
+## Why this is concentrated in 2022
+
+34 of these 50 were opened on **2022-07-19 or 2022-07-20**. That is a bulk import: a pre-existing
+to-do list (probably a spreadsheet) converted into GitHub issues one row per issue, titles intact,
+bodies empty. `#201`'s entire body is the giveaway — *"Original Todo list has ?? by this item."*
+
+That import was a reasonable thing to do at the time. The consequence four years later is that a
+quarter of the backlog is written in a shorthand only its authors can read. **`#176`, `#180`,
+`#182`, `#192`, `#194`, `#205`, `#207`, `#210`, `#211`, `#215`, `#218`, `#221`, `#224`, `#225`
+have a completely empty body.**
+
+**Recommendation:** do not refine these one at a time through the normal process. Book one
+90-minute session with @ACowan0105 and @vcellmike (authors of most of them) and walk the list.
+Expected outcome: roughly half close outright, half get a one-sentence criterion. Doing this
+individually, by ticket, will take a year and will not finish.
+
+---
+
+## Grouped by what is actually missing
+
+### 1. Empty body — meaning lives only with the author (14)
+
+Nothing can be inferred. These need their author or they need to be closed.
+
+| # | Title | Group | Author |
+|---|---|---|---|
+| [#176](https://github.com/virtualcell/vcell/issues/176) | Expand identification of catalysts with dashed line to situations where catalyst species is part of a global parameter | UI | ACowan0105 |
+| [#180](https://github.com/virtualcell/vcell/issues/180) | Allow for clusters in NFSim | MATH | ACowan0105 |
+| [#182](https://github.com/virtualcell/vcell/issues/182) | Allow choice of concentrations or counts for observables and generated species for RBM | MATH | ACowan0105 |
+| [#192](https://github.com/virtualcell/vcell/issues/192) | Integrate VCell Model Browser with VCell Website, CCB website and RunBioSimulations | DOCS | ACowan0105 |
+| [#194](https://github.com/virtualcell/vcell/issues/194) | Geometry editor bug: padding adds new "background" compartment if original background was renamed | UI | ACowan0105 |
+| [#205](https://github.com/virtualcell/vcell/issues/205) | Improve methods for assigning published models in VCellDB and posting to website | DOCS | ACowan0105 |
+| [#207](https://github.com/virtualcell/vcell/issues/207) | Update RBM help from version 6 to version 7.5 | DOCS | ACowan0105 |
+| [#210](https://github.com/virtualcell/vcell/issues/210) | Create list of operations for "undo" ability | UI | ACowan0105 |
+| [#211](https://github.com/virtualcell/vcell/issues/211) | VCell compliance with SBML spatial | STD | ACowan0105 |
+| [#215](https://github.com/virtualcell/vcell/issues/215) | Allow parameter expressions in RBM for reversible reactions | MATH | ACowan0105 |
+| [#218](https://github.com/virtualcell/vcell/issues/218) | Export rule-based applications in OMEX format via BNGL | STD | ACowan0105 |
+| [#221](https://github.com/virtualcell/vcell/issues/221) | Add progress bar or hourglass to time plot to indicate something is happening | UI | ACowan0105 |
+| [#224](https://github.com/virtualcell/vcell/issues/224) | Revive SabioRK using their native search tools | UI | ACowan0105 |
+| [#225](https://github.com/virtualcell/vcell/issues/225) | Allow other panes besides reaction diagram to tear off from main workspace | UI | ACowan0105 |
+
+Two of these deserve individual attention rather than batch treatment:
+
+- **`#194`** is `Queued` at **Priority 8 / Importance 8** — the joint-highest Importance in the
+  ranked slate — with an empty body and 5 comments. Whatever justifies that rank is in the
+  comments or in someone's head, not in the issue. It also has the most specific title in the set,
+  so it is probably a genuine, reproducible geometry-editor bug worth writing up properly.
+- **`#207`** asks to update RBM help "from version 6 to version 7.5". We ship 8.0. The version
+  numbers in the title are stale even if the underlying need is not — the help may well still be
+  on version 6 content. Restate against the current release.
+
+### 2. Insider shorthand — a sentence that assumes context (12)
+
+There is a body, but it is a note-to-self, not a specification.
+
+| # | Body, in full | Group |
+|---|---|---|
+| [#213](https://github.com/virtualcell/vcell/issues/213) | *"Actually assigned to Les but he does not yet have a handle."* | EXEC |
+| [#201](https://github.com/virtualcell/vcell/issues/201) | *"Original Todo list has ?? by this item."* | INFRA |
+| [#206](https://github.com/virtualcell/vcell/issues/206) | *"May need to clarify issue"* | MATH |
+| [#189](https://github.com/virtualcell/vcell/issues/189) | *"Ion will create test model"* | INFRA |
+| [#172](https://github.com/virtualcell/vcell/issues/172) | *"Needs move to new backend (Moraru)"* | API |
+| [#191](https://github.com/virtualcell/vcell/issues/191) | *"New design created and approved by group. Need to identify who will code"* | VIZ |
+| [#185](https://github.com/virtualcell/vcell/issues/185) | *"In addition to current, compare runs of published models."* | INFRA |
+| [#178](https://github.com/virtualcell/vcell/issues/178) | *"Needs algorithm to base on D given to seed species."* | MATH |
+| [#209](https://github.com/virtualcell/vcell/issues/209) | *"contact Jim Faeder for potential link to NFSim on VCell Github"* | MATH |
+| [#222](https://github.com/virtualcell/vcell/issues/222) | *"May currently work only when adding field data"* | UI |
+| [#184](https://github.com/virtualcell/vcell/issues/184) | *"Replicate right click search used in reaction diagram"* | UI |
+| [#153](https://github.com/virtualcell/vcell/issues/153) | *"change current default setting / decide whether colors for species need to be changed"* | UI |
+
+`#213` is the clearest case for closing: it is a four-year-old note that a named person did not
+yet understand a problem. Whatever it referred to, that state no longer exists.
+
+`#191` is the opposite — it says a **design was created and approved by the group**, and the only
+open question was staffing. It carries Importance 6. If that design still exists somewhere, this
+is a well-understood piece of work with a missing artifact link, not a vague idea. Find the design,
+attach it. (See also the desktop-vs-web viewer decision in [04-epic-map.md](04-epic-map.md) —
+that decision may moot this entirely, which is a reason to take the decision first.)
+
+### 3. Title is the whole spec, and might be enough (13)
+
+These are terse but arguably self-describing. The refinement needed is small: acceptance criteria,
+or confirmation the behavior is still current.
+
+| # | Title | Group | Board |
+|---|---|---|---|
+| [#167](https://github.com/virtualcell/vcell/issues/167) | API endpoint for field data retrieval for local runs | VIZ | Queued 12/8 |
+| [#168](https://github.com/virtualcell/vcell/issues/168) | Improve efficiency of slurm job arrays for multiple stochastic trajectories | EXEC | Shelved |
+| [#169](https://github.com/virtualcell/vcell/issues/169) | Investigate whether parameter scans can be improved in Slurm | EXEC | Shelved |
+| [#174](https://github.com/virtualcell/vcell/issues/174) | Create results view with envelope and SD for multiple stochastic runs | VIZ | Pool |
+| [#175](https://github.com/virtualcell/vcell/issues/175) | Create annotation fields for Application elements | UI | Pool |
+| [#181](https://github.com/virtualcell/vcell/issues/181) | When "Force Continuous" applied in spatial stochastic app, don't allow species displayed as particle counts | MATH | Pool |
+| [#551](https://github.com/virtualcell/vcell/issues/551) | `ExpressionUtils.getLinearFactor()` should use SymbolTableEntries | MATH | Pool |
+| [#1268](https://github.com/virtualcell/vcell/issues/1268) | Set z coordinate of membrane-bound site to 0 | SALAD | off-board |
+| [#1299](https://github.com/virtualcell/vcell/issues/1299) | VCell Guest should not have file browser items of "My BioModels" nor "Shared With Me" | UI | Queued 6/1 |
+| [#1343](https://github.com/virtualcell/vcell/issues/1343) | Biomodels of the same publication should be packaged into a single sbml-omex | STD | Queued 7/2 |
+| [#1344](https://github.com/virtualcell/vcell/issues/1344) | SBML-OMEX archived VCell publications should use normalized ASCII names | STD | Queued 5/1 |
+| [#1449](https://github.com/virtualcell/vcell/issues/1449) | Maintain ordering when toggling global flag on variable | UI | Queued 5/2 |
+| [#1494](https://github.com/virtualcell/vcell/issues/1494) | Lazy load microscopy data in PDE data viewer | VIZ | off-board |
+
+`#551` is the best-formed issue in this whole document despite being one line: it names the exact
+method and the exact change. It needs nothing except someone to do it. **Good candidate for the
+contributor in `#1598`.**
+
+### 4. Terse but recent — refine at the source (11)
+
+Opened 2024 or later, so the author is present and the context is fresh. Cheap to fix now,
+expensive in two years.
+
+| # | Title | Group | Opened |
+|---|---|---|---|
+| [#1048](https://github.com/virtualcell/vcell/issues/1048) | VCell needs to output spatial simulation data in a way Biosimulations approves of | STD | 2023-11 |
+| [#1074](https://github.com/virtualcell/vcell/issues/1074) | Upload All Nonspatial VCell Projects to BioSimulations | STD | 2023-12 |
+| [#1152](https://github.com/virtualcell/vcell/issues/1152) | VCell Health Check in Quarkus needs conversion to API Package | API | 2024-02 |
+| [#1260](https://github.com/virtualcell/vcell/issues/1260) | Sites that lack states in physiology are not accepted by SS application | SALAD | 2024-05 |
+| [#1365](https://github.com/virtualcell/vcell/issues/1365) | VCell Client Update appears after login, loses focus with auth0 login | API | 2024-10 |
+| [#1534](https://github.com/virtualcell/vcell/issues/1534) | General Help Updates for 7.7 | DOCS | 2025-06 |
+| [#1636](https://github.com/virtualcell/vcell/issues/1636) | Upgrade BioNetGen Version | INFRA | 2026-02 |
+| [#1637](https://github.com/virtualcell/vcell/issues/1637) | Upgrade NFSim Version | INFRA | 2026-02 |
+| [#1657](https://github.com/virtualcell/vcell/issues/1657) | simularium export for SpringSaLaD | SALAD | 2026-04 |
+| [#1658](https://github.com/virtualcell/vcell/issues/1658) | export SpringSaLaD sim results for external viewing/analysis | SALAD | 2026-04 |
+| [#429](https://github.com/virtualcell/vcell/issues/429) | Local sim results window pops behind the main VCell window | UI | 2022-09 |
+
+Notes:
+
+- **`#1048`** is `Blocked` with an **empty body**, and it is one of only two children of epic
+  `#1069`. An epic whose content is a blocked, bodyless issue is not tracking anything. See
+  [04-epic-map.md](04-epic-map.md).
+- **`#1636` / `#1637`** ("Self explanatory, we need to update") are the two children of `#1635`.
+  What is missing is not the intent but the *target version and the blast radius* — a BioNetGen or
+  NFSim bump changes simulation results, so this needs a validation plan, not just a version bump.
+- **`#1534`** is `Active` and asks for help updates for 7.7, which has shipped. Same stale-version
+  problem as `#207`; restate for 8.0 or close.
+- **`#1657` / `#1658`** are both `Active` with empty bodies, both about getting SpringSaLaD results
+  out for external viewing. These two are probably one issue — see [12-springsalad.md](12-springsalad.md).
+- **`#429`** is old but has 6 comments and a specific, checkable symptom. The window z-order
+  family it belongs to (`#429`, `#1441`, `#1078`) is being actively worked under `#1751`; refine it
+  by linking those together.
+
+---
+
+## The other 57
+
+Beyond these 50 there are 57 more issues with bodies between 80 and 200 characters. They are less
+acute — usually one real sentence — and are listed inline in their group documents rather than
+here. The same rule applies: if a `Queued` issue cannot be started from its body, it is not
+actually ready, whatever the board says.
+
+**Suggested gate:** nothing moves from `Pool` to `Queued` without a body that states the observed
+behavior, the expected behavior, and how to tell when it is fixed. Applying that rule retroactively
+to today's 63 `Queued` issues would move a good number of them back.

--- a/docs/backlog/02-needs-refinement.md
+++ b/docs/backlog/02-needs-refinement.md
@@ -57,8 +57,8 @@ Nothing can be inferred. These need their author or they need to be closed.
 
 Two of these deserve individual attention rather than batch treatment:
 
-- **`#194`** is `Queued` at **Priority 8 / Importance 8** — the joint-highest Importance in the
-  ranked slate — with an empty body and 5 comments. Whatever justifies that rank is in the
+- **`#194`** is `Queued` at **Priority 8 / Importance 8** — well up the ranked slate — with an
+  empty body and 5 comments. Whatever justifies that rank is in the
   comments or in someone's head, not in the issue. It also has the most specific title in the set,
   so it is probably a genuine, reproducible geometry-editor bug worth writing up properly.
 - **`#207`** asks to update RBM help "from version 6 to version 7.5". We ship 8.0. The version

--- a/docs/backlog/02-needs-refinement.md
+++ b/docs/backlog/02-needs-refinement.md
@@ -143,8 +143,11 @@ Notes:
   `#1069`. An epic whose content is a blocked, bodyless issue is not tracking anything. See
   [04-epic-map.md](04-epic-map.md).
 - **`#1636` / `#1637`** ("Self explanatory, we need to update") are the two children of `#1635`.
-  What is missing is not the intent but the *target version and the blast radius* — a BioNetGen or
-  NFSim bump changes simulation results, so this needs a validation plan, not just a version bump.
+  The missing target versions have since been established
+  ([05-obsolescence-sweep.md](05-obsolescence-sweep.md)): BioNetGen is **vendored Perl at 2.3.0,
+  untouched since 2017-06-05**, against upstream **2.9.3** (2025-04-21); NFSim is not in this repo
+  at all — it is a `vcell-solvers` binary, upstream **v1.14.3**. What is still missing is the blast
+  radius: a solver version change moves simulation results, so both need a validation plan.
 - **`#1534`** is `Active` and asks for help updates for 7.7, which has shipped. Same stale-version
   problem as `#207`; restate for 8.0 or close.
 - **`#1657` / `#1658`** are both `Active` with empty bodies, both about getting SpringSaLaD results

--- a/docs/backlog/03-board-hygiene.md
+++ b/docs/backlog/03-board-hygiene.md
@@ -1,0 +1,194 @@
+# Board Hygiene
+
+Findings about the *bookkeeping* rather than the work: where board #1 and the issue tracker
+disagree, and where the metadata has stopped meaning what it says.
+
+These are cheap to fix and they block the rest of grooming, because prioritization done on top of
+bad metadata just relocates the mess.
+
+---
+
+## 1. The Priority / Importance polarity is undocumented — resolve this first
+
+Board #1 carries two numeric fields:
+
+- **`Priority`** — set on **57 issues**, all in status `Queued`, values 1–12
+- **`Importance`** — set on **61 issues**, values 1–10
+
+They are **strongly correlated (r = 0.84, n = 57)**, so they move together and largely encode one
+judgment expressed twice.
+
+**I could not determine which end is "more important," and the data does not settle it.**
+
+The obvious tiebreaker fails. Of the 28 issues carrying the `High Priority` label, only 8 also
+carry a numeric `Priority`, and those 8 are spread across the range — `2, 3, 4, 4, 4, 5, 12, 12`.
+Mean Priority for `High Priority`-labelled issues is 5.75 against 6.51 for the rest: a tilt toward
+"lower = more urgent," but on n=8 that is noise, not evidence.
+
+Reading it the two ways gives opposite slates:
+
+| If **1 = most urgent** | If **12 = most urgent** |
+|---|---|
+| `#1082` Testing Framework RPC DataAccessException | `#1384` Give VCell a dedicated submit node |
+| `#563` `#522` `#523` `#912` `#158` (roundtrip/validation cluster) | `#792` Smart copy/paste redesign |
+| `#498` `#1605` (repeated tasks, colorblindness) | `#1292` Webapp uses Auth0 dev keys |
+| | `#1564` `#1555` `#167` `#1607` |
+
+Both readings are coherent, which is exactly why it needs an answer rather than a guess. The
+`Simplicity` field on the same board *is* documented in its option labels (`Simple (5)` …
+`Byzantine (1)`, so **higher = easier**), which mildly suggests higher = more on the other two,
+but `Simplicity` and `Priority` are different kinds of quantity and I would not lean on it.
+
+> **Action:** whoever set these fields — one sentence in the board README, and add the scale to
+> the field description so it survives. Everything downstream in these docs is written
+> polarity-neutral (`Pri/Imp` shown as raw values) until this is answered.
+
+---
+
+## 2. Three prioritization mechanisms that disagree
+
+| Mechanism | Count | Problem |
+|---|---:|---|
+| Board `Priority`/`Importance` | 57 / 61 | Polarity undocumented (above) |
+| `High Priority` label | 28 | Only 8 overlap the numeric fields; **5 are not on the board at all** |
+| Release labels `Next Release`, `VCell-7.5.0/7.5.1/7.6.0` | 45 issues | Name shipped versions; we are on **8.0.27.01** |
+
+The release labels are the clearest cleanup. `VCell-7.6.0` alone is on 26 open issues — a version
+that was superseded before the 8.0 line began. `Next Release` on 19 issues has meant "next release"
+for up to four years across dozens of actual releases.
+
+> **Action:** delete all four release labels. If a genuine "ship in the next release" concept is
+> needed, the board's `Next` status column already exists and is currently unused.
+
+> **Action:** pick one of `High Priority` / numeric `Priority` and retire the other. Two
+> prioritization systems that overlap on 8 of 28 issues are worse than either alone, because a
+> reader cannot tell whether an unlabelled issue was judged unimportant or simply never seen by
+> the other system.
+
+---
+
+## 3. Fifty-five issues are not on the board
+
+**These are disproportionately the best-written issues in the repo**, and they are invisible to
+anyone planning from board #1. The board is stale at the *new* end, not the old end.
+
+Notably absent: the **entire 2026 SpringSaLaD grooming set** (`#1719`–`#1734`, 14 issues, all with
+structured bodies and provenance), the **field-viewer train** (`#1859`, `#1867`, `#1879`, `#1894`,
+`#1964`), the **infrastructure set** (`#1888`, `#1921`, `#1922`, `#1926`, `#1978`, `#1994`), and
+three epics (`#1729`, `#1751`, `#1803`).
+
+Five of the 55 carry the `High Priority` label — so the board omits work the labels call urgent.
+
+<details>
+<summary><b>All 55 off-board issues</b></summary>
+
+`#1262` `#1268` `#1330` `#1338` `#1341` `#1365` `#1423` `#1494` `#1577` `#1578` `#1598` `#1609`
+`#1644` `#1712` `#1718` `#1719` `#1720` `#1721` `#1722` `#1723` `#1724` `#1725` `#1726` `#1727`
+`#1728` `#1729` `#1730` `#1731` `#1732` `#1734` `#1747` `#1751` `#1777` `#1786` `#1803` `#1848`
+`#1849` `#1859` `#1867` `#1874` `#1875` `#1876` `#1879` `#1888` `#1894` `#1905` `#1921` `#1922`
+`#1926` `#1964` `#1978` `#1980` `#1981` `#1984` `#1994`
+
+</details>
+
+> **Action:** bulk-add all 55 to the board with status `Pool`, then triage. This is one of the
+> cheapest meaningful improvements available — perhaps 30 minutes — and it roughly doubles the
+> board's coverage of 2026 work.
+
+**Root cause worth fixing separately:** issues are evidently being added to the board by hand.
+A GitHub Actions workflow or the project's built-in auto-add rule would stop this recurring.
+
+---
+
+## 4. Four issues are `Done` on the board but open in the tracker
+
+`#166`, `#748`, `#1646`, `#1647` — covered individually in
+[01-close-and-verify.md](01-close-and-verify.md). Two are confirmed complete against the repo.
+
+Either the close step is being skipped after the card moves, or the card is moved optimistically.
+Worth a one-line convention: **the issue is the source of truth; the card follows it.**
+
+---
+
+## 5. `Active` does not mean active
+
+16 issues are in status `Active`. Their last-updated dates:
+
+| # | Last updated | Title |
+|---|---|---|
+| `#1035` | **2024-01-10** | Epic: general reactions with stochastic simulations |
+| `#1037` | **2024-07-19** | Epic: modern auth with Keycloak and Auth0 OIDC |
+| `#1040` | **2024-07-19** | Epic: new vcell-rest with Quarkus |
+| `#1534` | 2025-06-10 | General Help Updates for 7.7 |
+| `#1543` | 2025-06-19 | Create Release Notes for Next Production Release |
+| `#870` | 2026-04-01 | Epic: MVP for Spring SaLaD in VCell |
+| `#1542` | 2026-04-01 | Export History Should Be Saved on the Server |
+| `#1599` | 2026-04-01 | Make new release notes for vcell 7.7 |
+| `#1654` | 2026-04-01 | Update vcell.org stack |
+| `#1655` | 2026-04-01 | finish publication/curation PR |
+| `#1657` | 2026-04-01 | simularium export for SpringSaLaD |
+| `#1658` | 2026-04-01 | export SpringSaLaD sim results for external viewing/analysis |
+| `#1686` | 2026-05-07 | Dan ss structural sites *(PR merged — close)* |
+| `#1706` | 2026-06-10 | Publication Submission Pipeline seems to be broken |
+| `#1708` | 2026-07-15 | Spatial geometry mapping — HELP section |
+| `#1930` | 2026-08-14 | Copy/paste of overridden parameters in parameter scans |
+
+**Three have not been touched in over two years.** Only `#1930` was updated this month. Six share
+an identical 2026-04-01 timestamp, which is a bulk edit, not six people starting work.
+
+> **Action:** reserve `Active` for work someone is doing *now*. Everything above that is not
+> genuinely in flight moves back to `Queued` or `Pool`. `Active` is the one status a planner needs
+> to be able to trust, and today it cannot be.
+
+---
+
+## 6. Thirty-three issues have three or more assignees
+
+Five people are assigned to `#1591` (show reaction names in the reaction diagram). Four each to
+`#168`, `#611`, `#792`, `#1441`, `#1473`, `#1565`, `#1593`, `#1884`.
+
+In GitHub, multiple assignees means "these people are interested" — it does not create an owner,
+and the practical effect is that nobody is accountable. Every one of these 33 is old or stalled,
+which is consistent with that.
+
+The pattern looks like assignment-as-notification: adding people so they see the issue. Watchers
+or a mention does that without diluting ownership.
+
+> **Action:** one assignee per issue — the person who will move it. Others become watchers.
+> 71 issues currently have **no** assignee at all, so the corollary is that assignment is being
+> used inconsistently in both directions.
+
+---
+
+## 7. The board's `Epic` field and the epics' own checklists disagree
+
+Board #1 has a single-select `Epic` field with 17 options, set on **95 issues**. Separately, the
+23 epic issues maintain markdown task-lists in their bodies, which claim **103 open issues** as
+children.
+
+These are two hand-maintained parallel structures for the same relationship, and they do not
+match. The board field also lists epics from *other repos* (`imageJ MVP vcell-fiji#11`,
+`solver builds vcell-solver#25`) that have no counterpart in this repo's epic set, and it has no
+option for any epic created after `#1147` — so `#1199`, `#1339`, `#1556`, `#1603`, `#1652`,
+`#1729`, `#1751`, `#1803` cannot be represented in it at all.
+
+GitHub now has **native sub-issues** (the board already exposes `Parent issue` and
+`Sub-issues progress` fields, currently unpopulated). That is one mechanism instead of three.
+
+> **Action:** migrate epic→child links to native sub-issues, then delete the custom `Epic`
+> single-select and stop maintaining checklists by hand. See [04-epic-map.md](04-epic-map.md)
+> for what the current links actually contain.
+
+---
+
+## Summary of recommended board actions
+
+| Action | Effort | Effect |
+|---|---|---|
+| Document Priority/Importance polarity | 5 min | Makes the ranked slate readable |
+| Delete 4 stale release labels (45 issues) | 10 min | Removes actively misleading signal |
+| Bulk-add 55 off-board issues | 30 min | Board covers 2026 work |
+| Close the 4 `Done`-but-open issues | 15 min | Tracker and board agree |
+| Demote stale `Active` → `Queued`/`Pool` | 15 min | `Active` becomes trustworthy |
+| Reduce 3+ assignees to one owner | 45 min | Creates accountability on 33 issues |
+| Auto-add rule for new issues | 15 min | Stops the drift recurring |
+| Migrate epic links to native sub-issues | 2 h | One mechanism instead of three |

--- a/docs/backlog/03-board-hygiene.md
+++ b/docs/backlog/03-board-hygiene.md
@@ -8,40 +8,72 @@ bad metadata just relocates the mess.
 
 ---
 
-## 1. The Priority / Importance polarity is undocumented — resolve this first
+## 1. `Priority` is a derived field: **Priority = Importance + Simplicity**
 
-Board #1 carries two numeric fields:
+Board #1 carries three scoring fields:
 
-- **`Priority`** — set on **57 issues**, all in status `Queued`, values 1–12
-- **`Importance`** — set on **61 issues**, values 1–10
+- **`Importance`** — set on **61 issues**, values 1–10. Higher = more valuable.
+- **`Simplicity`** — set on **114 issues**, `Simple (5)` … `Byzantine (1)`, `Unknown (0)`.
+  Higher = easier. (Documented in the option labels themselves.)
+- **`Priority`** — set on **57 issues**, all in status `Queued`, values 1–12.
 
-They are **strongly correlated (r = 0.84, n = 57)**, so they move together and largely encode one
-judgment expressed twice.
+`Priority` is not an independent judgment. It is the sum of the other two, and the fit is
+essentially exact: **56 of 57 rows satisfy `Priority = Importance + Simplicity`**, mean absolute
+error 0.09. No other combination comes close:
 
-**I could not determine which end is "more important," and the data does not settle it.**
+| Formula | Exact matches | Mean abs. error |
+|---|---:|---:|
+| **`I + S`** | **56 / 57** | **0.09** |
+| `I + (6 − S)` | 15 / 57 | 2.40 |
+| `max(I, S)` | 9 / 57 | 1.98 |
+| `I − S` | 9 / 57 | 5.28 |
+| `I × S` | 3 / 57 | 5.28 |
+| `(I + S) / 2` | 1 / 57 | 3.26 |
 
-The obvious tiebreaker fails. Of the 28 issues carrying the `High Priority` label, only 8 also
-carry a numeric `Priority`, and those 8 are spread across the range — `2, 3, 4, 4, 4, 5, 12, 12`.
-Mean Priority for `High Priority`-labelled issues is 5.75 against 6.51 for the rest: a tilt toward
-"lower = more urgent," but on n=8 that is noise, not evidence.
+This resolves the ranking direction, which an earlier draft of this document could not settle:
 
-Reading it the two ways gives opposite slates:
+> **Higher Priority = do sooner.** Priority 12 is the top of the queue; Priority 1 is the bottom.
 
-| If **1 = most urgent** | If **12 = most urgent** |
-|---|---|
-| `#1082` Testing Framework RPC DataAccessException | `#1384` Give VCell a dedicated submit node |
-| `#563` `#522` `#523` `#912` `#158` (roundtrip/validation cluster) | `#792` Smart copy/paste redesign |
-| `#498` `#1605` (repeated tasks, colorblindness) | `#1292` Webapp uses Auth0 dev keys |
-| | `#1564` `#1555` `#167` `#1607` |
+It also explains the `Priority`/`Importance` correlation (r = 0.84) — they are not two opinions
+that happen to agree, they are an input and a total. And it makes the scheme a **value/cost
+model**: important work scores high, easy work scores high, and important *and* easy scores
+highest. `#1384` (Importance 10, `Intricate (2)`) and `#1299` (Importance 1, `Simple (5)`) both
+land at Priority 12 by different routes.
 
-Both readings are coherent, which is exactly why it needs an answer rather than a guess. The
-`Simplicity` field on the same board *is* documented in its option labels (`Simple (5)` …
-`Byzantine (1)`, so **higher = easier**), which mildly suggests higher = more on the other two,
-but `Simplicity` and `Priority` are different kinds of quantity and I would not lean on it.
+One consequence worth stating plainly: because ease is added rather than multiplied, a
+`Byzantine (1)` item can never score above 11 no matter how important it is. `#1606` (font sizes,
+accessibility) is Importance 3 + Simplicity 1 = 4, which is why the hardest accessibility work
+sits low in the queue. That is the model working as designed, not a mis-ranking — but it is worth
+knowing when reading [19-accessibility.md](19-accessibility.md).
 
-> **Action:** whoever set these fields — one sentence in the board README, and add the scale to
-> the field description so it survives. Everything downstream in these docs is written
-> polarity-neutral (`Pri/Imp` shown as raw values) until this is answered.
+### Three rows where the arithmetic has drifted
+
+**`#1495` — the one mismatch.** Stored Priority **5**, but Importance 6 + `Moderate (4)` = **10**.
+Either the Importance was raised after Priority was computed, or it is a data-entry slip.
+Recomputing moves *"VCell Support Automated Email messages are too opaque to be very useful"* from
+mid-pack to near the top of the queue.
+
+**Four issues have `Importance` scored but `Priority` never computed** — all sitting in `Pool`
+rather than `Queued`, so they are invisible to anyone reading the ranked slate:
+
+| # | Importance | Simplicity | Implied Priority | Title |
+|---|---:|---|---:|---|
+| [#1473](https://github.com/virtualcell/vcell/issues/1473) | 7 | `Simple (5)` | **12** | ImageJ N5 export metadata needs time array, origin, extent |
+| [#1451](https://github.com/virtualcell/vcell/issues/1451) | 7 | `Simple (5)` | **12** | Add "Save as Local" to the error message |
+| [#1199](https://github.com/virtualcell/vcell/issues/1199) | 9 | `Intricate (2)` | **11** | Epic: Refactor Data Export Services |
+| [#191](https://github.com/virtualcell/vcell/issues/191) | 6 | `Intricate (2)` | **8** | New GUI design for spatial sim results viewer |
+
+**`#1473` and `#1451` tie the highest score on the board** — they are important *and* rated
+`Simple (5)` — and neither is in the queue. By the team's own formula these are among the best
+available work, and they have been sitting in `Pool` since 2025.
+
+**53 issues have `Simplicity` but no `Importance`**, so they are half-scored and cannot receive a
+Priority until someone rates their value.
+
+> **Action:** record the formula in the board README so it survives (it is currently reconstructable
+> only from the data). Recompute `#1495`. Move `#1473`, `#1451`, `#1199`, `#191` into `Queued` with
+> their computed Priority, or say why not. Consider whether `Priority` should be a computed column
+> rather than a hand-entered one, since hand-entry is what let `#1495` drift.
 
 ---
 
@@ -49,7 +81,7 @@ but `Simplicity` and `Priority` are different kinds of quantity and I would not 
 
 | Mechanism | Count | Problem |
 |---|---:|---|
-| Board `Priority`/`Importance` | 57 / 61 | Polarity undocumented (above) |
+| Board `Importance` + `Simplicity` → `Priority` | 61 / 114 / 57 | Formula undocumented; 4 issues scored but never ranked; 53 half-scored (above) |
 | `High Priority` label | 28 | Only 8 overlap the numeric fields; **5 are not on the board at all** |
 | Release labels `Next Release`, `VCell-7.5.0/7.5.1/7.6.0` | 45 issues | Name shipped versions; we are on **8.0.27.01** |
 
@@ -184,7 +216,8 @@ GitHub now has **native sub-issues** (the board already exposes `Parent issue` a
 
 | Action | Effort | Effect |
 |---|---|---|
-| Document Priority/Importance polarity | 5 min | Makes the ranked slate readable |
+| Document the `Priority = Importance + Simplicity` formula | 5 min | Makes the ranked slate readable and reproducible |
+| Recompute `#1495`; queue `#1473`/`#1451`/`#1199`/`#191` | 10 min | Two top-scoring issues stop hiding in `Pool` |
 | Delete 4 stale release labels (45 issues) | 10 min | Removes actively misleading signal |
 | Bulk-add 55 off-board issues | 30 min | Board covers 2026 work |
 | Close the 4 `Done`-but-open issues | 15 min | Tracker and board agree |

--- a/docs/backlog/03-board-hygiene.md
+++ b/docs/backlog/03-board-hygiene.md
@@ -93,7 +93,7 @@ a Priority until someone rates their value. That is the remaining gap in the sco
 
 | Mechanism | Count | Problem |
 |---|---:|---|
-| Board `Importance` + `Simplicity` → `Priority` | 61 / 114 / 57 | Formula undocumented; 4 issues scored but never ranked; 53 half-scored (above) |
+| Board `Importance` + `Simplicity` → `Priority` | 61 / 114 / 57 | Formula undocumented (the 4 scored-but-unranked issues were fixed — see §1); 53 still half-scored |
 | `High Priority` label | 28 | Only 8 overlap the numeric fields; **5 are not on the board at all** |
 | Release labels `Next Release`, `VCell-7.5.0/7.5.1/7.6.0` | 45 issues | Name shipped versions; we are on **8.0.27.01** |
 

--- a/docs/backlog/03-board-hygiene.md
+++ b/docs/backlog/03-board-hygiene.md
@@ -111,7 +111,7 @@ for up to four years across dozens of actual releases.
 
 ---
 
-## 3. Fifty-five issues are not on the board
+## 3. Fifty-five issues were not on the board — **fixed 2026-08-19**
 
 **These are disproportionately the best-written issues in the repo**, and they are invisible to
 anyone planning from board #1. The board is stale at the *new* end, not the old end.
@@ -134,9 +134,11 @@ Five of the 55 carry the `High Priority` label — so the board omits work the l
 
 </details>
 
-> **Action:** bulk-add all 55 to the board with status `Pool`, then triage. This is one of the
-> cheapest meaningful improvements available — perhaps 30 minutes — and it roughly doubles the
-> board's coverage of 2026 work.
+> **Done.** All 56 (the 55 below plus `#2005`, filed the same day) were added via
+> `backlog_lint.py --fix-board`. They landed in the board's default column and **still need
+> triaging into `Pool` and scoring** — being on the board is not the same as being groomed.
+> The `not-on-board` check now reports zero, and the lint's committed baseline shrank from 233
+> accepted findings to 178.
 
 **Root cause worth fixing separately:** issues are evidently being added to the board by hand.
 A GitHub Actions workflow or the project's built-in auto-add rule would stop this recurring.
@@ -231,7 +233,7 @@ GitHub now has **native sub-issues** (the board already exposes `Parent issue` a
 | Document the `Priority = Importance + Simplicity` formula | 5 min | Makes the ranked slate readable and reproducible |
 | ~~Recompute `#1495`; queue `#1473`/`#1451`/`#1199`/`#191`~~ | — | **Done 2026-08-19** — board is now formula-consistent |
 | Delete 4 stale release labels (45 issues) | 10 min | Removes actively misleading signal |
-| Bulk-add 55 off-board issues | 30 min | Board covers 2026 work |
+| ~~Bulk-add 55 off-board issues~~ | — | **Done 2026-08-19** — board covers 2026 work |
 | Close the 4 `Done`-but-open issues | 15 min | Tracker and board agree |
 | Demote stale `Active` → `Queued`/`Pool` | 15 min | `Active` becomes trustworthy |
 | Reduce 3+ assignees to one owner | 45 min | Creates accountability on 33 issues |

--- a/docs/backlog/03-board-hygiene.md
+++ b/docs/backlog/03-board-hygiene.md
@@ -46,34 +46,46 @@ accessibility) is Importance 3 + Simplicity 1 = 4, which is why the hardest acce
 sits low in the queue. That is the model working as designed, not a mis-ranking — but it is worth
 knowing when reading [19-accessibility.md](19-accessibility.md).
 
-### Three rows where the arithmetic has drifted
+### Applied 2026-08-19: five rows corrected
 
-**`#1495` — the one mismatch.** Stored Priority **5**, but Importance 6 + `Moderate (4)` = **10**.
-Either the Importance was raised after Priority was computed, or it is a data-entry slip.
-Recomputing moves *"VCell Support Automated Email messages are too opaque to be very useful"* from
-mid-pack to near the top of the queue.
+Three defects in the scoring data were found and **have since been fixed on the board**. Recorded
+here because the reasoning matters more than the edit.
 
-**Four issues have `Importance` scored but `Priority` never computed** — all sitting in `Pool`
-rather than `Queued`, so they are invisible to anyone reading the ranked slate:
+**`#1495` — arithmetic had drifted.** Stored Priority **5**, but Importance 6 + `Moderate (4)` =
+**10**. Either the Importance was raised after Priority was computed, or it was a data-entry slip.
+Recomputed to 10, which moves *"VCell Support Automated Email messages are too opaque to be very
+useful"* from mid-pack to near the top of the queue.
 
-| # | Importance | Simplicity | Implied Priority | Title |
-|---|---:|---|---:|---|
-| [#1473](https://github.com/virtualcell/vcell/issues/1473) | 7 | `Simple (5)` | **12** | ImageJ N5 export metadata needs time array, origin, extent |
-| [#1451](https://github.com/virtualcell/vcell/issues/1451) | 7 | `Simple (5)` | **12** | Add "Save as Local" to the error message |
-| [#1199](https://github.com/virtualcell/vcell/issues/1199) | 9 | `Intricate (2)` | **11** | Epic: Refactor Data Export Services |
-| [#191](https://github.com/virtualcell/vcell/issues/191) | 6 | `Intricate (2)` | **8** | New GUI design for spatial sim results viewer |
+**Four issues had `Importance` scored but `Priority` never computed** — so they sat in `Pool` and
+never appeared in the ranked slate at all. All four have been given their computed Priority and
+moved to `Queued`:
 
-**`#1473` and `#1451` tie the highest score on the board** — they are important *and* rated
-`Simple (5)` — and neither is in the queue. By the team's own formula these are among the best
-available work, and they have been sitting in `Pool` since 2025.
+| # | Importance | Simplicity | Priority | Was | Title |
+|---|---:|---|---:|---|---|
+| [#1473](https://github.com/virtualcell/vcell/issues/1473) | 7 | `Simple (5)` | **12** | Pool, unranked | ImageJ N5 export metadata needs time array, origin, extent |
+| [#1451](https://github.com/virtualcell/vcell/issues/1451) | 7 | `Simple (5)` | **12** | Pool, unranked | Add "Save as Local" to the error message |
+| [#1199](https://github.com/virtualcell/vcell/issues/1199) | 9 | `Intricate (2)` | **11** | Pool, unranked | Epic: Refactor Data Export Services |
+| [#191](https://github.com/virtualcell/vcell/issues/191) | 6 | `Intricate (2)` | **8** | Pool, unranked | New GUI design for spatial sim results viewer |
 
-**53 issues have `Simplicity` but no `Importance`**, so they are half-scored and cannot receive a
-Priority until someone rates their value.
+**`#1473` and `#1451` tie the highest score on the board** — important *and* rated `Simple (5)` —
+and had been sitting in `Pool` since 2025. By the team's own formula they are among the best
+available work.
 
-> **Action:** record the formula in the board README so it survives (it is currently reconstructable
-> only from the data). Recompute `#1495`. Move `#1473`, `#1451`, `#1199`, `#191` into `Queued` with
-> their computed Priority, or say why not. Consider whether `Priority` should be a computed column
-> rather than a hand-entered one, since hand-entry is what let `#1495` drift.
+Verified after the edit against a fresh read of the board: **61 issues now carry a Priority, zero
+violate `Priority = Importance + Simplicity`, and nothing remains scored-but-unranked.**
+
+> **Caveat on `#1199`:** it is an *epic* with zero linked children, so it is now queued as an empty
+> container. Populating it (see
+> [04-epic-map.md](04-epic-map.md#b-1199-refactor-data-export-services-vs-1008-vcell-export-needs-a-face-lift))
+> or returning it to `Pool` are both reasonable; queuing it was done as instructed and is trivially
+> reversible.
+
+**53 issues have `Simplicity` but no `Importance`**, so they remain half-scored and cannot receive
+a Priority until someone rates their value. That is the remaining gap in the scoring data.
+
+> **Still to do:** record the formula in the board README so it survives — it is currently
+> reconstructable only from the data. Consider making `Priority` a computed column rather than
+> hand-entered, since hand-entry is what let `#1495` drift in the first place.
 
 ---
 
@@ -217,7 +229,7 @@ GitHub now has **native sub-issues** (the board already exposes `Parent issue` a
 | Action | Effort | Effect |
 |---|---|---|
 | Document the `Priority = Importance + Simplicity` formula | 5 min | Makes the ranked slate readable and reproducible |
-| Recompute `#1495`; queue `#1473`/`#1451`/`#1199`/`#191` | 10 min | Two top-scoring issues stop hiding in `Pool` |
+| ~~Recompute `#1495`; queue `#1473`/`#1451`/`#1199`/`#191`~~ | — | **Done 2026-08-19** — board is now formula-consistent |
 | Delete 4 stale release labels (45 issues) | 10 min | Removes actively misleading signal |
 | Bulk-add 55 off-board issues | 30 min | Board covers 2026 work |
 | Close the 4 `Done`-but-open issues | 15 min | Tracker and board agree |

--- a/docs/backlog/04-epic-map.md
+++ b/docs/backlog/04-epic-map.md
@@ -87,7 +87,7 @@ re-write with modern best practices… inefficiencies… CLI has a 50% slowdown 
 exporter is slow."*
 
 Same subsystem, same complaint, same proposed remedy. `#1199` is the epic and carries Importance 9
-— the highest Importance on the board — but has **zero open children**, while roughly a dozen
+— second only to `#1384` — but has **zero open children**, while roughly a dozen
 export issues sit unlinked in [13-export-visualization.md](13-export-visualization.md).
 **Merge `#1008` into `#1199` and populate `#1199`'s children.**
 

--- a/docs/backlog/04-epic-map.md
+++ b/docs/backlog/04-epic-map.md
@@ -1,0 +1,230 @@
+# Epic Map, Overlaps, and the Five Decisions
+
+24 issues act as epics (23 carry `Type: Epic`; `#1751` is an epic in everything but its label).
+Between them their checklists claim **103 open issues** as children. **150 open issues belong to
+no epic at all.**
+
+This document covers three things: what the epics currently contain, where two epics are competing
+for the same work, and the five decisions that determine whether large parts of the backlog are
+worth ranking.
+
+---
+
+## 1. All 24 epics at a glance
+
+`open-children` counts distinct open issues referenced from the epic body. `done`/`todo` are
+checklist boxes.
+
+| # | Board | Open children | done/todo | Last updated | Title |
+|---|---|---:|---|---|---|
+| [#1038](https://github.com/virtualcell/vcell/issues/1038) | Pool | **33** | 10/37 | 2026-07-29 | Epic: VCell UI fixes |
+| [#1036](https://github.com/virtualcell/vcell/issues/1036) | Queued | **28** | 2/30 | 2026-08-18 | Epic: public vcell models as SBML/Omex |
+| [#1729](https://github.com/virtualcell/vcell/issues/1729) | off-board | **26** | 0/13 | 2026-07-08 | SpringSaLaD in VCell — bugs & high-priority upgrades |
+| [#1033](https://github.com/virtualcell/vcell/issues/1033) | Pool | 6 | 1/6 | 2025-04-29 | Epic: improve NFSim multitrial statistics |
+| [#1039](https://github.com/virtualcell/vcell/issues/1039) | Pool | 4 | 0/4 | 2023-11-15 | Epic: Solver Regression Tests |
+| [#870](https://github.com/virtualcell/vcell/issues/870) | Active | 3 | 8/5 | 2026-04-01 | Epic: MVP for Spring SaLaD in VCell |
+| [#1040](https://github.com/virtualcell/vcell/issues/1040) | Active | 3 | 10/3 | **2024-07-19** | Epic: new vcell-rest with Quarkus |
+| [#1803](https://github.com/virtualcell/vcell/issues/1803) | off-board | 3 | 0/0 | 2026-07-30 | [Epic] Web-based field & geometry visualization (vtk.js/vtk.wasm) |
+| [#1031](https://github.com/virtualcell/vcell/issues/1031) | Pool | 2 | 4/5 | 2025-04-15 | Epic: enhance user docs and training |
+| [#1032](https://github.com/virtualcell/vcell/issues/1032) | Queued | 2 | 4/5 | **2023-11-15** | Epic: migrate to postgresql |
+| [#1046](https://github.com/virtualcell/vcell/issues/1046) | Queued | 2 | 19/2 | 2025-01-07 | Epic: biosimulators_vcell nonspatial |
+| [#1069](https://github.com/virtualcell/vcell/issues/1069) | Queued | 2 | 0/2 | **2023-12-05** | Epic: biosimulators_vcell spatial |
+| [#1147](https://github.com/virtualcell/vcell/issues/1147) | Blocked | 2 | 3/8 | 2025-04-29 | Epic: Quarkus REST endpoints for VCell API |
+| [#1034](https://github.com/virtualcell/vcell/issues/1034) | Pool | 1 | 0/1 | **2023-11-15** | Epic: local use of field data |
+| [#1035](https://github.com/virtualcell/vcell/issues/1035) | Active | 1 | 0/4 | **2024-01-10** | Epic: general reactions with stochastic simulations |
+| [#1339](https://github.com/virtualcell/vcell/issues/1339) | Pool | 1 | 2/1 | 2025-03-06 | Epic: Simulation Control Update |
+| [#1037](https://github.com/virtualcell/vcell/issues/1037) | Active | **0** | 7/4 | **2024-07-19** | Epic: modern auth with Keycloak and Auth0 OIDC |
+| [#1199](https://github.com/virtualcell/vcell/issues/1199) | Pool | **0** | 0/4 | 2026-08-04 | Epic: Refactor Data Export Services in VCell |
+| [#1556](https://github.com/virtualcell/vcell/issues/1556) | Queued | **0** | 0/7 | 2025-06-30 | Add Steady State (COPASI-style) via CVODE |
+| [#1603](https://github.com/virtualcell/vcell/issues/1603) | Queued | **0** | 0/0 | 2026-01-21 | [EPIC] UConn Health Accessibility Guidelines |
+| [#1652](https://github.com/virtualcell/vcell/issues/1652) | Pool | **0** | 0/3 | 2026-03-11 | Rework VFRAP workflows (Geometry + Image Data) |
+| [#1751](https://github.com/virtualcell/vcell/issues/1751) | off-board | **0** | 0/0 | 2026-07-24 | VCell Desktop UI bugs + AI code-test fixturing |
+| [#1508](https://github.com/virtualcell/vcell/issues/1508) | off-board | 0 | 0/0 | 2025-05-20 | Displaying statistics for multiple runs |
+| [#1509](https://github.com/virtualcell/vcell/issues/1509) | off-board | 0 | 0/0 | 2025-05-20 | Displaying cluster analysis results |
+
+### Observations
+
+**Three epics carry 87 of the 103 claimed children** (`#1038`, `#1036`, `#1729`). The rest are
+small, and eight have **no open children at all**.
+
+**`#1508` and `#1509` are labelled `Type: Epic` but are ordinary feature requests** — one-line
+bodies, no children, both about SpringSaLaD multi-run display. They should lose the label and
+become children of the SpringSaLaD epic. (`#1508` overlaps `#1731`; `#1509` overlaps `#1731`'s
+cluster-histogram scope.)
+
+**`#1603` and `#1751` are epics with no children and no checklist** — accessibility and the
+current desktop-UI focus respectively. Both name real initiatives; neither has been decomposed.
+`#1603`'s four obvious children (`#1604`, `#1605`, `#1606`, plus the font work) exist as separate
+issues but are not linked from it.
+
+**Six epics have not been updated in over 18 months** (`#1032`, `#1034`, `#1035`, `#1037`,
+`#1040`, `#1069`) while three of them sit in `Active`.
+
+---
+
+## 2. Four overlapping epic pairs
+
+These are the ones where two containers claim the same work. Each needs a merge or an explicit
+split of scope.
+
+### A. `#1038` (UI fixes, 2023) vs `#1751` (Desktop UI bugs, 2026)
+
+`#1038` is a 33-child, 47-checkbox list from Nov 2023 covering "all VCell UI bugs."
+`#1751` is a July 2026 tracking epic for the **current** desktop-UI effort, described in its body
+as "the current VCell development focus (per the 2026-07-22 VCell bi-weekly)" — notably window
+z-order, which is also `#1038`'s territory (`#429`, `#1441`, `#1078`).
+
+These are the same initiative three years apart. `#1038` has the inventory; `#1751` has the
+mandate and is off-board. **Merge:** keep `#1751` as the live epic, migrate `#1038`'s open
+children into it, close `#1038` — or explicitly scope `#1038` to the 2022-cohort backlog and
+`#1751` to current-focus work. Either is fine; having both silently is not.
+
+### B. `#1199` (Refactor Data Export Services) vs `#1008` (VCell Export needs a face-lift)
+
+`#1008` (Oct 2023): *"The code surrounding export [is] almost 2 decades old, and could use a
+re-write with modern best practices… inefficiencies… CLI has a 50% slowdown vs GUI."*
+`#1199` (Mar 2024): *"VCell Export code mostly works, but is unwieldy… development with the
+exporter is slow."*
+
+Same subsystem, same complaint, same proposed remedy. `#1199` is the epic and carries Importance 9
+— the highest Importance on the board — but has **zero open children**, while roughly a dozen
+export issues sit unlinked in [13-export-visualization.md](13-export-visualization.md).
+**Merge `#1008` into `#1199` and populate `#1199`'s children.**
+
+### C. `#870` (SpringSaLaD MVP) vs `#1729` (SpringSaLaD bugs & upgrades) vs `#1482` (Langevin solver maintenance)
+
+Three overlapping SpringSaLaD containers. `#870` is the 2023 MVP epic, `Active`, with 8 of 13
+boxes done and three open children (`#1482`, `#1508`, `#1509`). `#1729` is the July 2026 epic from
+Les Loew's request list with 13 children. `#1482` is itself a multi-part umbrella ("fix bugs in
+the solver / implement new algorithms / add sanity checks in the client") with 11 comments.
+
+`#870`'s remaining scope ("support for curved surfaces", "support for parallelization") is
+long-term research; `#1729` is the near-term user-driven list. **Recommend:** close `#870` as
+delivered (the MVP shipped), move its two research items to new standalone issues, and make
+`#1729` the single SpringSaLaD epic. See [12-springsalad.md](12-springsalad.md).
+
+### D. `#1040` / `#1147` / `#1339` — three Quarkus/API epics
+
+`#1040` (new vcell-rest with Quarkus, `Active`, 10/13 done), `#1147` (Quarkus REST endpoints,
+`Blocked`, 3/11 done), `#1339` (Simulation Control Update, 2/3 done). All three describe stages of
+the same migration; `#1040`'s remaining "implement Java Serialization-based RPC endpoints as REST
+API" is `#1147`'s entire subject matter.
+
+The Quarkus REST service exists and ships (`vcell-rest/` has 14 resource classes). What remains is
+endpoint-by-endpoint migration, which is what [14-api-platform.md](14-api-platform.md) enumerates.
+**Recommend:** close `#1040` (the service was built), keep `#1147` as the migration epic, fold
+`#1339` into it.
+
+---
+
+## 3. The five decisions
+
+Each of these gates a double-digit number of issues. **Ranking work behind an unmade decision is
+wasted ranking** — this is the argument for taking them before the refinement pass, not after.
+
+### Decision 1 — Is the PostgreSQL migration still happening?
+
+**Gates:** `#1032` (epic), `#172`, `#840`, `#1994`, and the shape of every future DB change.
+
+`#1032` was written to "enable cloud hosting of VCell" and "remove dependency on Oracle." It has
+not been updated since **Nov 2023**, and its three infrastructure tasks (local Postgres dev DB,
+production Postgres in the UCHC cluster, final data migration) are all unchecked.
+
+Meanwhile the working tree shows **production is still Oracle** —
+`vcell-rest/src/main/resources/application.properties` points at
+`jdbc:oracle:thin:@vcell-oracle.cam.uchc.edu:1521/ORCLPDB1` — while tests run on PostgreSQL via
+testcontainers. `#1994` documents the direct cost of that split: **55 SQL-dialect branches across
+33 files are exercised only against PostgreSQL in CI and only against Oracle in production.**
+
+So the migration is half-done in a way that is actively expensive. Three coherent answers:
+
+1. **Finish it** — `#1032` becomes real work, `#1994` is temporary scaffolding.
+2. **Abandon it** — close `#1032` and `#172`, and `#1994` becomes important, because the dual-dialect
+   code is then permanent and permanently under-tested.
+3. **Freeze it** — keep both dialects deliberately, document why.
+
+All three are defensible. What is not defensible is the current state, where the epic implies (1)
+and reality is (3) by accident. → **@jcschaff**
+
+This is the one issue in the backlog whose group assignment is "pending a decision":
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#1032](https://github.com/virtualcell/vcell/issues/1032) | Epic: migrate to postgresql | 2023-11 | Queued | — | — | EPIC |
+
+### Decision 2 — Desktop PDE viewer, or browser viewer?
+
+**Gates:** `#191`, `#1494`, `#898`, `#950`, `#772`, `#986`, `#1859`, `#1867`, `#1879`, `#1803`,
+and much of [13-export-visualization.md](13-export-visualization.md).
+
+There is significant recent investment in the **browser-based** field viewer (`#1803` epic,
+`#1859`, `#1867`, `#1879` — shipped through the 8.0.9/8.0.10 line). There is also a backlog of
+**desktop** PDE-viewer work, including `#191` ("new GUI design… created and approved by group",
+Importance 6) and `#1494` (lazy-load microscopy data).
+
+If the browser viewer is the destination, then several desktop viewer issues are investments in a
+component being retired, and should be closed or explicitly deferred rather than ranked. If the
+desktop viewer remains primary for years, `#191`'s approved design matters and should be scheduled.
+
+This needs to be stated once, in writing, in `#1803`. → **@jcschaff**
+
+### Decision 3 — What is the standing of the 2022 cohort?
+
+**Gates:** 73 issues, roughly 34 of them bodyless.
+
+Covered in [02-needs-refinement.md](02-needs-refinement.md). The decision is not per-issue: it is
+whether to run one authors' review session or to declare a **bulk-close with a stated policy**
+(e.g. "issues opened before 2023 with no body and no activity since 2023 are closed; reopen on
+request"). Both are legitimate. Grinding through them individually is the option that will not
+finish. → **@ACowan0105 + @vcellmike + @jcschaff**
+
+### Decision 4 — Is accessibility a funded mandate with a date?
+
+**Gates:** `#1603`, `#1604`, `#1605`, `#1606` — and potentially a large share of the 51 UI issues.
+
+`#1603` says *"Due to newly implemented accessibility policies introduced at UConn Health"* — an
+external compliance requirement, not a preference. `#1606` (font sizes) is rated **`Byzantine (1)`**,
+the hardest tier on the board, and prior work confirms it: the blocker is pinned pixel constants
+throughout the Swing UI, not font literals.
+
+If there is a compliance deadline, this outranks most of the UI backlog and should be resourced as
+a project. If there is not, it is four large issues competing with everything else. The four are
+`Queued` at Priority 3–5 today, which does not look like either answer.
+→ **@CodeByDrescher / whoever owns the UConn Health relationship**
+
+### Decision 5 — Do we still pursue full BioSimulators/SED-ML conformance?
+
+**Gates:** `#1036` (28 children), `#1046`, `#1069`, and most of
+[11-standards-interop.md](11-standards-interop.md) — 42 issues in total, the second-largest group.
+
+`#1046` (nonspatial) is 19/21 done — nearly finished. `#1069` (spatial) is **0/2 done, both
+children `Blocked`**, one of them (`#1048`) with an empty body, and its blocker is external:
+*"blocked until an official biosimulations spatial standard is both established and integrated."*
+It has not been updated since Dec 2023.
+
+So the nonspatial track is worth finishing and the spatial track is blocked on a standard that may
+never arrive. Treating them as one programme obscures both. **Recommend:** close `#1069` as
+externally blocked with a note on what would revive it, and drive `#1046` to completion — it is two
+issues from done. The separate question of how much of `#1036`'s 28-child roundtrip-fidelity work
+is worth doing is a genuine scope call. → **@moraru / @CodeByDrescher**
+
+---
+
+## 4. The 150 orphans
+
+150 open issues are referenced by no epic. This is not inherently wrong — not everything needs a
+parent — but it does mean the epic structure describes only about a third of the backlog, and the
+part it describes is skewed old.
+
+The orphan set includes nearly all 2026 work: the infrastructure issues (`#1888`, `#1921`, `#1922`,
+`#1926`, `#1978`, `#1994`), the SBML export findings (`#1905`, `#1981`, `#1984`), the data-loss
+investigation (`#1980`), and the desktop crash fixes (`#1747`, `#1848`, `#1849`).
+
+Two readings, both probably true: recent work is better described *and* less ceremonious, so it
+does not get filed into epics; and the epic structure was built in one burst in Nov 2023
+(`#1031`–`#1040` were all created on 2023-11-13/14) and has not been maintained as a live
+instrument since.
+
+> **Recommendation:** do not retro-fit epics onto the orphans. Instead, let the thematic groups in
+> docs 10–19 carry the organization, and keep epics only where an epic has an owner and a real
+> decomposition. On that test, roughly 8 of the 24 current epics survive.

--- a/docs/backlog/05-obsolescence-sweep.md
+++ b/docs/backlog/05-obsolescence-sweep.md
@@ -120,7 +120,7 @@ all confirmed:
 | **Case sensitivity** | `#912` | Issue names `SedmlJob.java`; the file is `SedMLJob.java`. | **Fixed** — now reported as `renamed`, not `missing` |
 | **Stem match across extensions** | `#912` | `experiment/outputs/temp/model.xml` matched `Model.java`. | **Fixed** — extension must match |
 | **Forward-looking references** | `#1921` | Names files *to create*. Absence is the point. | Not fixable mechanically |
-| **Prose that looks like code** | `#986` | `ExportedImage`, `SpatialResultsViewer` are a user describing UI navigation. | Not fixable mechanically |
+| **Prose that looks like code** | `#986` | `ExportedImage`, `SpatialResultsViewer` are a user describing UI navigation. | Partly fixed — library names like `Node.js` no longer read as file paths |
 | **Sibling repos** | `#1578` | `Voronoi32.cpp` lives in `vcell-solvers`. | Flagged `[names another repo]` |
 | **Attachments and docs** | `#648` | `.pptx` filenames are not code. | Filtered |
 | **Upstream library APIs** | `#1964`, `#1859` | `DatasetCreationOptions` is jhdf's; `MediaRecorder` is a browser API. | Not fixable mechanically |
@@ -134,6 +134,23 @@ That is a distinct action from "the code is gone", so the tool now reports three
 `present`, `renamed`, `missing` — rather than two.
 
 After the fix, `#912` is the only `renamed` case and `#1578` the only `missing` one.
+
+### Two defects found by reviewing this tool
+
+A code review of the PR carrying this document found five bugs in the sweep, two of which had
+produced findings recorded *here*:
+
+- **Dependency manifests were read from the source list**, which excludes `requirements.txt`
+  (no matching extension) and `Dockerfile` (no extension at all). So every Dockerfile-declared
+  dependency read as **gone**. That is exactly why `#1635` showed `bionetgen=GONE` above — a false
+  signal, corrected by hand at the time, and now fixed at the source.
+- **The sweep indexed its own report.** `.md` was in the source-extension list, so once this
+  document named `SpatialResultsViewer` and `DatasetCreationOptions`, a re-run reported them
+  *present* — the tool erasing its own evidence. Worse in general: any class deleted from the code
+  stays "present" forever if a CHANGELOG or design doc still mentions it.
+
+Both are fixed. The second is the more instructive: a checker that reads documentation as if it
+were code will confirm whatever its own output claims.
 
 ### A guard worth having
 

--- a/docs/backlog/05-obsolescence-sweep.md
+++ b/docs/backlog/05-obsolescence-sweep.md
@@ -32,8 +32,11 @@ cohort, because the 2022 cohort does not say anything specific enough to check.
 
 ### `#366` — very likely obsolete → close candidate
 
-`seaborn` is **gone** from the tree. Its only remaining appearance is a transitive extras line in
-`vcell-cli-utils/poetry.lock` belonging to another package — not a VCell dependency.
+`seaborn` is **gone** from the tree. Its only remaining appearance is `poetry.lock:1126`, inside
+the optional `example` extras list belonging to **networkx** — not a VCell dependency. Nothing
+imports it either: no `import seaborn`, no `sns.` in any `.py` file. And the replacement exists —
+`vcell-cli/src/main/java/org/vcell/cli/run/plotting/` holds `Results2DLinePlot`, `ResultsLinePlot`,
+`PlottingDataExtractor` and friends.
 
 The issue asks to restructure "CLI-python code for creating plots" to control the seaborn palette.
 `#1472` independently records *"Python reliance removed, and plotting / logging done java side
@@ -147,13 +150,16 @@ confirmed by hand before being written down.
 
 ## Recommended actions
 
-| # | Action | Confidence |
-|---|---|---|
-| `#366` | Close as obsolete (seaborn gone; `#1472` corroborates) | High — two independent signals |
-| `#877` | Re-rank **upward**; jHDF is now the sole HDF5 reader | High — verified in the pom |
-| `#1341` | Note that jlibsedml is vendored; this is a local patch, not an upstream ask | High — 148 files in-tree |
-| `#1470` | Re-scope: no version to bump, this is a fork-reconciliation job like `#1978` | High |
-| `#1636` | Rewrite with the real numbers: 2.3.0 (2017) → 2.9.3 (2025) | High |
+**Applied 2026-08-19.** The four highest-confidence actions were carried out on the issues
+themselves; the rest still need a person.
+
+| # | Action | Confidence | Status |
+|---|---|---|---|
+| `#366` | Close as obsolete (seaborn gone; `#1472` corroborates) | High — three independent signals | **Closed** (`not planned`), evidence in a closing comment inviting reopen |
+| `#1341` | Note that jlibsedml is vendored; this is a local patch, not an upstream ask | High — 148 files in-tree | **Commented** |
+| `#1470` | Re-scope: no version to bump, this is a fork-reconciliation job like `#1978` | High | **Commented** |
+| `#1636` | Rewrite with the real numbers: 2.3.0 (2017) → 2.9.3 (2025) | High | **Commented** — added as a comment rather than editing @CodeByDrescher's body |
+| `#877` | Re-rank **upward**; jHDF is now the sole HDF5 reader | High — verified in the pom | Not applied — needs a scoring decision |
 | `#1637` | Move to `vcell-solvers`, or state that the version lives there | Medium — NFSim's in-tree version not established from here |
 | `#912` | No action on the code; optionally correct `SedmlJob.java` → `SedMLJob.java` in the issue text | High |
 | `#1384`, `#842`, `#1674`, `#1552` | Still need human verification | — |

--- a/docs/backlog/05-obsolescence-sweep.md
+++ b/docs/backlog/05-obsolescence-sweep.md
@@ -1,0 +1,134 @@
+# Obsolescence Sweep
+
+Does the code an issue names still exist? Run 2026-08-19 over all 272 open issues, against the
+working tree at `d083a0ee41`.
+
+Reproduce with `python3 tools/obsolescence-sweep.py`.
+
+**A missing reference is a signal, not a verdict.** Code gets renamed, moved, or lives in a sibling
+repo. Everything asserted below was confirmed by hand after the tool flagged it; the tool's raw
+output is not trustworthy on its own, and the false-positive modes are documented at the end.
+
+---
+
+## Headline: the sweep can only reach a fifth of the backlog
+
+**Only 58 of 272 open issues name anything checkable at all** — a class, a method, a file path, or
+a library. The rest name nothing a machine can look up, which is the same 39%-thin-body problem
+that [02-needs-refinement.md](02-needs-refinement.md) documents, showing up in a different guise.
+
+That is the honest ceiling on automated obsolescence checking here. It cannot triage the 2022
+cohort, because the 2022 cohort does not say anything specific enough to check.
+
+---
+
+## What it settled
+
+### `#366` — very likely obsolete → close candidate
+
+`seaborn` is **gone** from the tree. Its only remaining appearance is a transitive extras line in
+`vcell-cli-utils/poetry.lock` belonging to another package — not a VCell dependency.
+
+The issue asks to restructure "CLI-python code for creating plots" to control the seaborn palette.
+`#1472` independently records *"Python reliance removed, and plotting / logging done java side
+[COMPLETE]"*. Two independent lines of evidence that the subject of this issue no longer exists.
+
+→ **Confirm with @CodeByDrescher and close.** This was flagged "verify before ranking" in
+[13-export-visualization.md](13-export-visualization.md); it is now verified.
+
+### `#877` — NOT obsolete. My earlier guess was wrong in the other direction
+
+I had flagged this as *"the dependency picture has changed substantially since 2023 — may be
+obsolete."* The sweep says the opposite: **`jhdf` is present** (`io.jhdf 0.13.0` in the root pom),
+and **`ncsa.hdf` is gone**.
+
+So jHDF is not merely still used — it is now the *only* HDF5 reader, the native binding having
+been deleted. A JRE bug affecting jHDF on Windows is therefore **more** consequential than when
+the issue was filed, not less.
+
+→ Correct the note in [13-export-visualization.md](13-export-visualization.md); re-rank upward
+rather than closing.
+
+### `#1341` and `#1470` — jlibsedml is **vendored**, not a dependency
+
+There is no jlibsedml artifact in any pom. Instead there are **148 Java source files** under
+`vcell-core/src/main/java/org/jlibsedml/`, carrying `jlibsedmlVersion = "3.0.0"`, plus vendored
+upstream site docs at `vcell-core/src/main/java/site/`.
+
+This materially changes both issues:
+
+- `#1470` ("upgrade jlibsedml to read SED-ML L1V5") is **not a version bump**. There is no version
+  to bump. Upstream changes have to be merged into 148 vendored files, or the fork has to be
+  reconciled with upstream the way [`#1978`](https://github.com/virtualcell/vcell/issues/1978)
+  proposes for JSBML.
+- `#1341` ("jlibsedml should accept relative paths, not just URI syntax") is therefore a **local
+  patch we can simply make**, not an upstream request to file and wait on. That makes it much
+  cheaper than its framing suggests.
+
+→ Record the vendoring in both issues. `#1341` is a good small win; `#1470` is larger than it looks.
+
+### `#1635` / `#1636` — the missing target version, supplied
+
+Both issues say only *"Self explanatory, we need to update"*, which
+[02-needs-refinement.md](02-needs-refinement.md) flagged as unactionable. The facts:
+
+| | In tree | Upstream latest | Gap |
+|---|---|---|---|
+| **BioNetGen** | **2.3.0** (`bionetgen/VERSION`, untouched since **2017-06-05**) | **2.9.3** (2025-04-21) | 6 minor versions, ~8 years |
+| **NFSim** | not in this repo — solver binary from `vcell-solvers` | **v1.14.3** (2025-04-17) | unknown from here |
+
+BioNetGen is **vendored Perl** (`bionetgen/BNG2.pl`), so upgrading means replacing an in-tree
+distribution, not editing a manifest.
+
+→ `#1636` can now be written properly. `#1637` should be reassigned to the `vcell-solvers` repo, or
+at least state that the version lives there. Both still need the validation plan flagged in
+[02](02-needs-refinement.md) — a solver version change moves simulation results.
+
+### `#1964` — premise confirmed
+
+`ncsa.hdf` is absent from every manifest, `io.jhdf` is present. Exactly what the issue asserts.
+Useful mainly as a check that the tool detects a real removal.
+
+---
+
+## What it could not settle
+
+`#1384` (dedicated submit node), `#842` and `#1674` (invalid XML character on save), `#1552`
+(Singularity token) name no code, so the sweep is silent on them. They were flagged
+verify-before-ranking in [17-execution-hpc.md](17-execution-hpc.md) and
+[11-standards-interop.md](11-standards-interop.md) and **remain unverified** — they need a person,
+not a script.
+
+---
+
+## False-positive modes (read before trusting a re-run)
+
+The raw tool output flagged roughly a third more issues than survived checking. The failure modes,
+all confirmed:
+
+| Mode | Example | What happened |
+|---|---|---|
+| **Case sensitivity** | `#912` | Issue names `SedmlJob.java`; the file is `SedMLJob.java`. Renamed case, not deleted. |
+| **Forward-looking references** | `#1921` | Names `vcell-legacy-env-names.properties` and `LegacyEnvironmentNamesTest` as things *to create*. Absence is the point, not a finding. |
+| **Prose that looks like code** | `#986` | `ExportedImage`, `SpatialResultsViewer` are a user describing UI navigation, not class names. |
+| **Sibling repos** | `#1578` | `vcellroot/MBSolver/Solver/src/Voronoi32.cpp` lives in `vcell-solvers`. Not checkable from here. |
+| **Attachments and docs** | `#648` | `.pptx` filenames are not code. |
+| **Upstream library APIs** | `#1964`, `#1859` | `DatasetCreationOptions` is jhdf's; `MediaRecorder` is a browser API. |
+
+The tool filters most of these, but not all — `#912`'s case-rename in particular is a bug worth
+fixing before any re-run (make basename matching case-insensitive).
+
+---
+
+## Recommended actions
+
+| # | Action | Confidence |
+|---|---|---|
+| `#366` | Close as obsolete (seaborn gone; `#1472` corroborates) | High — two independent signals |
+| `#877` | Re-rank **upward**; jHDF is now the sole HDF5 reader | High — verified in the pom |
+| `#1341` | Note that jlibsedml is vendored; this is a local patch, not an upstream ask | High — 148 files in-tree |
+| `#1470` | Re-scope: no version to bump, this is a fork-reconciliation job like `#1978` | High |
+| `#1636` | Rewrite with the real numbers: 2.3.0 (2017) → 2.9.3 (2025) | High |
+| `#1637` | Move to `vcell-solvers`, or state that the version lives there | Medium — NFSim's in-tree version not established from here |
+| `#912` | No action; the file was renamed, not removed | High |
+| `#1384`, `#842`, `#1674`, `#1552` | Still need human verification | — |

--- a/docs/backlog/05-obsolescence-sweep.md
+++ b/docs/backlog/05-obsolescence-sweep.md
@@ -3,7 +3,13 @@
 Does the code an issue names still exist? Run 2026-08-19 over all 272 open issues, against the
 working tree at `d083a0ee41`.
 
-Reproduce with `python3 tools/obsolescence-sweep.py`.
+Reproduce from the repo root:
+
+```bash
+gh issue list --repo virtualcell/vcell --state open --limit 500 \
+    --json number,title,body,createdAt > issues.json
+python3 tools/obsolescence-sweep.py issues.json
+```
 
 **A missing reference is a signal, not a verdict.** Code gets renamed, moved, or lives in a sibling
 repo. Everything asserted below was confirmed by hand after the tool flagged it; the tool's raw
@@ -106,17 +112,36 @@ not a script.
 The raw tool output flagged roughly a third more issues than survived checking. The failure modes,
 all confirmed:
 
-| Mode | Example | What happened |
-|---|---|---|
-| **Case sensitivity** | `#912` | Issue names `SedmlJob.java`; the file is `SedMLJob.java`. Renamed case, not deleted. |
-| **Forward-looking references** | `#1921` | Names `vcell-legacy-env-names.properties` and `LegacyEnvironmentNamesTest` as things *to create*. Absence is the point, not a finding. |
-| **Prose that looks like code** | `#986` | `ExportedImage`, `SpatialResultsViewer` are a user describing UI navigation, not class names. |
-| **Sibling repos** | `#1578` | `vcellroot/MBSolver/Solver/src/Voronoi32.cpp` lives in `vcell-solvers`. Not checkable from here. |
-| **Attachments and docs** | `#648` | `.pptx` filenames are not code. |
-| **Upstream library APIs** | `#1964`, `#1859` | `DatasetCreationOptions` is jhdf's; `MediaRecorder` is a browser API. |
+| Mode | Example | What happened | Status |
+|---|---|---|---|
+| **Case sensitivity** | `#912` | Issue names `SedmlJob.java`; the file is `SedMLJob.java`. | **Fixed** — now reported as `renamed`, not `missing` |
+| **Stem match across extensions** | `#912` | `experiment/outputs/temp/model.xml` matched `Model.java`. | **Fixed** — extension must match |
+| **Forward-looking references** | `#1921` | Names files *to create*. Absence is the point. | Not fixable mechanically |
+| **Prose that looks like code** | `#986` | `ExportedImage`, `SpatialResultsViewer` are a user describing UI navigation. | Not fixable mechanically |
+| **Sibling repos** | `#1578` | `Voronoi32.cpp` lives in `vcell-solvers`. | Flagged `[names another repo]` |
+| **Attachments and docs** | `#648` | `.pptx` filenames are not code. | Filtered |
+| **Upstream library APIs** | `#1964`, `#1859` | `DatasetCreationOptions` is jhdf's; `MediaRecorder` is a browser API. | Not fixable mechanically |
 
-The tool filters most of these, but not all — `#912`'s case-rename in particular is a bug worth
-fixing before any re-run (make basename matching case-insensitive).
+### A third outcome: `renamed`
+
+The case-sensitivity fix does not just suppress the false positive — it turns it into a
+different, useful finding. A reference that resolves only case-insensitively means **the code
+exists and the issue text is stale**, which calls for correcting the issue, not closing it.
+That is a distinct action from "the code is gone", so the tool now reports three outcomes —
+`present`, `renamed`, `missing` — rather than two.
+
+After the fix, `#912` is the only `renamed` case and `#1578` the only `missing` one.
+
+### A guard worth having
+
+An early run indexed **zero** source files (wrong working directory) and cheerfully reported
+**42 issues with every reference missing** — output that reads as "a sixth of the backlog is
+obsolete" and is entirely an artifact. The tool now refuses to run when the index looks empty
+rather than producing that. A sweep like this fails silently and confidently by default; the
+guard is not optional.
+
+The three modes marked "not fixable mechanically" are why every finding in this document was
+confirmed by hand before being written down.
 
 ---
 
@@ -130,5 +155,5 @@ fixing before any re-run (make basename matching case-insensitive).
 | `#1470` | Re-scope: no version to bump, this is a fork-reconciliation job like `#1978` | High |
 | `#1636` | Rewrite with the real numbers: 2.3.0 (2017) → 2.9.3 (2025) | High |
 | `#1637` | Move to `vcell-solvers`, or state that the version lives there | Medium — NFSim's in-tree version not established from here |
-| `#912` | No action; the file was renamed, not removed | High |
+| `#912` | No action on the code; optionally correct `SedmlJob.java` → `SedMLJob.java` in the issue text | High |
 | `#1384`, `#842`, `#1674`, `#1552` | Still need human verification | — |

--- a/docs/backlog/10-desktop-ui.md
+++ b/docs/backlog/10-desktop-ui.md
@@ -38,10 +38,10 @@ this.
 in `ScrollTable` can crash the JVM), `#858` (`ArrayIndexOutOfBounds` in
 `FunctionRangeGenerator.getFunctionStatistics()`, from a user error report), `#1593` (black screen).
 
-`#1747` and `#1848` have precise diagnoses naming the class and the mechanism. **All three of
-`#1747`, `#1848` are off-board** and unranked, while vaguer enhancement requests sit `Queued`.
-That inversion is the strongest argument in this document for doing the off-board sweep in
-[03-board-hygiene.md](03-board-hygiene.md) first.
+`#1747` and `#1848` have precise diagnoses naming the class and the mechanism. **Both were
+off-board** and unranked on 2026-08-19, while vaguer enhancement requests sat `Queued`. That
+inversion was the strongest argument in this document for doing the off-board sweep in
+[03-board-hygiene.md](03-board-hygiene.md) first — which has since been done.
 
 ### Copy / paste (2)
 

--- a/docs/backlog/10-desktop-ui.md
+++ b/docs/backlog/10-desktop-ui.md
@@ -1,0 +1,169 @@
+# Group: Desktop Client UI (Swing) — 51 issues
+
+The largest group, and the one with the widest quality spread: it contains both the most
+under-described issues in the backlog (the 2022 cohort) and some of the best (the 2026 crash
+analyses).
+
+**Epics:** `#1038` (2023, 33 children) and `#1751` (2026, current focus). **These overlap and
+should be merged** — see [04-epic-map.md](04-epic-map.md#a-1038-ui-fixes-2023-vs-1751-desktop-ui-bugs-2026).
+
+**Related group:** [19-accessibility.md](19-accessibility.md) is UI work too, separated because it
+is driven by an external compliance mandate rather than by user reports.
+
+---
+
+## Sub-themes
+
+Sorting these 51 by *what is broken* rather than by age gives a clearer picture than the flat list.
+
+### Window z-order and modality (5) — a single recurring defect
+
+`#429` (local sim results window pops behind the main window), `#1441` (Add Annotations pop-up
+launches below the main window, Mac), `#1078` (uninstall window behind the Windows uninstall menu),
+`#304` (spurious save prompt on startup), `#1593` (black screen moving right).
+
+`#429` is from 2022 and `#1441` from 2025, and both describe a window appearing behind its parent.
+`#1441` is `Queued` at Priority 9 / Importance 6 and rated `Complex (3)`; `#429` has 6 comments and
+sat in `Pool`. Prior work on this codebase found z-order to be a systemic Swing dialog-parenting
+problem rather than five unrelated bugs — `docs/windowing-design-patterns.md` exists for exactly
+this.
+
+> **Recommendation:** treat these as one defect with several reports. Fix the parenting pattern
+> once, verify against all five, close them together. Ranking them separately guarantees the same
+> root cause is diagnosed five times.
+
+### Crashes and stability (4) — the highest-confidence work in the group
+
+`#1747` (NPE in `CheckBoxScrollList` cell renderer, crashes on the EDT), `#1848` (`java.awt.Robot`
+in `ScrollTable` can crash the JVM), `#858` (`ArrayIndexOutOfBounds` in
+`FunctionRangeGenerator.getFunctionStatistics()`, from a user error report), `#1593` (black screen).
+
+`#1747` and `#1848` have precise diagnoses naming the class and the mechanism. **All three of
+`#1747`, `#1848` are off-board** and unranked, while vaguer enhancement requests sit `Queued`.
+That inversion is the strongest argument in this document for doing the off-board sweep in
+[03-board-hygiene.md](03-board-hygiene.md) first.
+
+### Copy / paste (2)
+
+`#792` (smart copy/paste with multiple reactions — NPE, `High Priority`, Priority 12 / Importance 9,
+`Complex (3)`) and `#1930` (cannot copy/paste overridden parameters when the override is a
+parameter scan — `Active`, with a precise root cause: scan overrides are `ConstantArraySpec`s but
+the copy/paste system expects `Expression`s).
+
+`#1930` reads like a specific instance of `#792`'s general problem. Worth checking whether fixing
+the copy/paste model properly covers both.
+
+### Orphaned-object cleanup (2)
+
+`#574` (orphaned shapes after deleting species/reactions) and `#575` (orphaned RDF metadata after
+the same). Both from Nov 2022, both rated **`Byzantine (1)`** — the hardest tier. Same root:
+deletion does not cascade through all the model's parallel representations. These two should be
+one issue or an explicit pair; they will be fixed by the same work.
+
+### Annotation UI (4)
+
+`#1440` (Organism field not typeable), `#1441` (pop-up z-order), `#1486` (broken ontology links —
+a detailed 2.1k-char body listing exact wrong-vs-right URLs, rated `Simple (5)`), `#223` (expand
+search to annotations). `#1486` is unusually well-specified and easy; it is unranked in `Pool`.
+
+### Small, well-defined, low-risk (6) — starter-issue candidates
+
+`#1569` (delete the Set Proxy function — `Simple (5)`, Priority 6), `#1299` (hide My BioModels /
+Shared With Me for guests — `Simple (5)`), `#1886` (Mac splash screen still says VCell 7.0),
+`#1884` (rename "Revert to Saved" → "Discard Unsaved Changes"), `#1451` (add a "Save as Local"
+button to the error message — `Simple (5)`, Importance 7), `#1738` (make BioModel info text
+selectable).
+
+> These are the answer to `#1598`, the contributor asking for beginner-friendly work
+> ([01-close-and-verify.md](01-close-and-verify.md)). `#1884` in particular is a label change with
+> a documented rationale.
+
+### Geometry and mapping UI (5)
+
+`#194` (padding creates a spurious "background" compartment — Priority 8 / **Importance 8**, the
+joint-highest, but an **empty body**), `#289` (subdomain-name error dialog ignored), `#290`
+(kinematics spatial process always binds the first volume object — good 736-char body), `#1712`
+(Geometry Mapping window clipped beyond 7 compartments), `#147` (some .stl imports fail, with
+specific test files named).
+
+`#194` is the clearest example of the backlog's central problem: the highest-Importance UI issue
+on the board cannot be worked because nobody wrote down what it does.
+
+### The 2022 enhancement cohort (13)
+
+`#153` `#175` `#176` `#184` `#210` `#221` `#222` `#223` `#224` `#225` — plus `#187`, `#611`, `#1024`.
+Ten of these have empty or one-line bodies. Covered in
+[02-needs-refinement.md](02-needs-refinement.md); they should be resolved as a batch by their
+authors, not ranked individually.
+
+`#224` ("Revive SabioRK using their native search tools") deserves a specific check: SABIO-RK is an
+external service and this has been `Shelved` for four years. Confirm the integration is still
+wanted and the service still offers what we need before refining it.
+
+---
+
+## Cross-cutting observation
+
+Nineteen of the 51 are from July 2022 and eleven are from 2026. The middle years are thin. The
+2022 issues are feature requests written as one-liners; the 2026 issues are defects written with
+stack traces. They need completely different handling, and the flat backlog treats them the same.
+
+---
+
+## All 51
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#1449](https://github.com/virtualcell/vcell/issues/1449) | Maintain ordering when toggling global flag on variable | 2025-03 | Queued | 5/2 | Complex&nbsp;(3) | thin |
+| [#1460](https://github.com/virtualcell/vcell/issues/1460) | VCell names must be unique, but only sbml Ids are required and unqiue; users meanwhile… | 2025-03 | Queued | 5/3 | Intricate&nbsp;(2) | — |
+| [#1495](https://github.com/virtualcell/vcell/issues/1495) | VCell Support Automated Email message are too opaque to be very useful | 2025-05 | Queued | 5/6 | Moderate&nbsp;(4) | — |
+| [#1572](https://github.com/virtualcell/vcell/issues/1572) | Built-in brower does not work on mac when accessing PubMed annotations | 2025-08 | Queued | 5/4 | Byzantine&nbsp;(1) | — |
+| [#1299](https://github.com/virtualcell/vcell/issues/1299) | VCell Guest should not have file browser items of "My BioModels" nor "Shared With Me: | 2024-07 | Queued | 6/1 | Simple&nbsp;(5) | thin |
+| [#1440](https://github.com/virtualcell/vcell/issues/1440) | Organism is unavailable in Add Annotations pop-up | 2025-02 | Queued | 6/2 | Moderate&nbsp;(4) | — |
+| [#1569](https://github.com/virtualcell/vcell/issues/1569) | Delete function to Set Proxy in Account Menu | 2025-08 | Queued | 6/1 | Simple&nbsp;(5) | — |
+| [#194](https://github.com/virtualcell/vcell/issues/194) | Geometry editor bug: padding to add background pixels at edges of domain adds new "bac… | 2022-07 | Queued | 8/8 | Unknown&nbsp;(0) | REF thin |
+| [#835](https://github.com/virtualcell/vcell/issues/835) | Error Reports from Contact-Us improvements | 2023-03 | Queued | 8/4 | Moderate&nbsp;(4) | — |
+| [#1441](https://github.com/virtualcell/vcell/issues/1441) | Add Annotations pop-up window is below the main VCell window | 2025-02 | Queued | 9/6 | Complex&nbsp;(3) | — |
+| [#1565](https://github.com/virtualcell/vcell/issues/1565) | Give users a choice when changing unit systems to either dimensionally transform value… | 2025-07 | Queued | 10/6 | Moderate&nbsp;(4) | — |
+| [#792](https://github.com/virtualcell/vcell/issues/792) | Smart Copy/Paste behavior with multiple reactions redesign and implement | 2023-02 | Queued | 12/9 | Complex&nbsp;(3) | HP |
+| [#1607](https://github.com/virtualcell/vcell/issues/1607) | Rule based models cannot delete reactions in graphical editor using right mouse menu. | 2025-12 | Queued | 12/8 | Moderate&nbsp;(4) | — |
+| [#147](https://github.com/virtualcell/vcell/issues/147) | Some .stl files import fails | 2022-05 | Shelved | — | — | — |
+| [#153](https://github.com/virtualcell/vcell/issues/153) | Make molecular composition layout default in rule-based models | 2022-06 | Pool | — | Unknown&nbsp;(0) | — |
+| [#175](https://github.com/virtualcell/vcell/issues/175) | Create annotation fields for Application elements | 2022-07 | Pool | — | Moderate&nbsp;(4) | thin |
+| [#176](https://github.com/virtualcell/vcell/issues/176) | Expand identification of catalysts with dashed line to situations where catalyst speci… | 2022-07 | Shelved | — | Unknown&nbsp;(0) | thin |
+| [#184](https://github.com/virtualcell/vcell/issues/184) | Add right click to search reactions for Reaction Table under add a new reaction | 2022-07 | Pool | — | Moderate&nbsp;(4) | thin |
+| [#187](https://github.com/virtualcell/vcell/issues/187) | Allow assignment of .vcml files to open in VCell in macs | 2022-07 | Blocked | — | Unknown&nbsp;(0) | REF |
+| [#210](https://github.com/virtualcell/vcell/issues/210) | Create list of operations for "undo" ability | 2022-07 | Shelved | — | — | REF thin |
+| [#221](https://github.com/virtualcell/vcell/issues/221) | Add progress bar or hourglass to time plot to indicate something is happening | 2022-07 | Pool | — | Moderate&nbsp;(4) | REF thin |
+| [#222](https://github.com/virtualcell/vcell/issues/222) | Allow right click to paste into initial conditions | 2022-07 | Pool | — | Moderate&nbsp;(4) | REF thin |
+| [#223](https://github.com/virtualcell/vcell/issues/223) | Expand search to include annotations | 2022-07 | Shelved | — | — | REF |
+| [#224](https://github.com/virtualcell/vcell/issues/224) | Revive SabioRK using their native search tools | 2022-07 | Shelved | — | — | thin |
+| [#225](https://github.com/virtualcell/vcell/issues/225) | Allow other panes besides reaction diagram to tear off from main workspace | 2022-07 | Shelved | — | — | thin |
+| [#289](https://github.com/virtualcell/vcell/issues/289) | Bug when creating geometry if change subdomain name error window pops up that is subse… | 2022-08 | Pool | — | Moderate&nbsp;(4) | REF |
+| [#290](https://github.com/virtualcell/vcell/issues/290) | Defining new Volume Spatial Process in Kinematics always associated with first listed … | 2022-08 | Pool | — | — | — |
+| [#304](https://github.com/virtualcell/vcell/issues/304) | Opening VCell brings prompt to save previously exported sim results. | 2022-08 | Pool | — | — | — |
+| [#429](https://github.com/virtualcell/vcell/issues/429) | Local sim results window pops behind the main VCell window | 2022-09 | Pool | — | — | REF thin |
+| [#574](https://github.com/virtualcell/vcell/issues/574) | Orphaned shapes remain after deleting species / reactions. | 2022-11 | Pool | — | Byzantine&nbsp;(1) | REF |
+| [#575](https://github.com/virtualcell/vcell/issues/575) | Orphaned metadata remains after deleting species / reactions with RDF annotations. | 2022-11 | Pool | — | Byzantine&nbsp;(1) | — |
+| [#611](https://github.com/virtualcell/vcell/issues/611) | Global parameters are not listed under the Kinetics tab of a Rule-based Reaction | 2022-11 | Pool | — | — | — |
+| [#858](https://github.com/virtualcell/vcell/issues/858) | Bug reported: ArrayIndexOutOfBounds in FunctionRangeGenerator.getFunctionStatistics() | 2023-04 | Pool | — | — | — |
+| [#1024](https://github.com/virtualcell/vcell/issues/1024) | Parameter Estimation Window retains old values when switching to a new application in … | 2023-11 | Pool | — | Moderate&nbsp;(4) | — |
+| [#1038](https://github.com/virtualcell/vcell/issues/1038) | Epic: VCell UI fixes | 2023-11 | Pool | — | — | EPIC |
+| [#1078](https://github.com/virtualcell/vcell/issues/1078) | Uninstall window in alpha does not appear on top of Windows Uninstall menu | 2023-12 | Pool | — | Unknown&nbsp;(0) | — |
+| [#1451](https://github.com/virtualcell/vcell/issues/1451) | Add "Save as Local" to the error message | 2025-03 | Pool | —/7 | Simple&nbsp;(5) | — |
+| [#1486](https://github.com/virtualcell/vcell/issues/1486) | Broken existing links in Annotations (both Rel and Alpha) | 2025-04 | Pool | — | Simple&nbsp;(5) | — |
+| [#1591](https://github.com/virtualcell/vcell/issues/1591) | Option to show reaction names in reaction diagram | 2025-09 | Pool | — | — | — |
+| [#1593](https://github.com/virtualcell/vcell/issues/1593) | Black screen over VCell, moving to the right | 2025-10 | Shelved | — | — | — |
+| [#1701](https://github.com/virtualcell/vcell/issues/1701) | BNGL import error for actions block | 2026-05 | Pool | — | — | — |
+| [#1712](https://github.com/virtualcell/vcell/issues/1712) | Geometry Mapping window does not show entire view if too many compartments in model. | 2026-06 | **off-board** | — | — | — |
+| [#1738](https://github.com/virtualcell/vcell/issues/1738) | Selectable text in VCell Biomodel | 2026-07 | Pool | — | — | — |
+| [#1743](https://github.com/virtualcell/vcell/issues/1743) | Save File dialog box change to put new model name at the top, not the bottom of the di… | 2026-07 | Pool | — | — | — |
+| [#1747](https://github.com/virtualcell/vcell/issues/1747) | Client crash (NPE) in CheckBoxScrollList cell renderer when JCheckBox is null | 2026-07 | **off-board** | — | — | — |
+| [#1751](https://github.com/virtualcell/vcell/issues/1751) | VCell Desktop UI bugs + AI code-test fixturing (current focus) | 2026-07 | **off-board** | — | — | EPIC |
+| [#1785](https://github.com/virtualcell/vcell/issues/1785) | Database Subpanel is rather cluttered and cumbersome to use | 2026-07 | Pool | — | Intricate&nbsp;(2) | — |
+| [#1848](https://github.com/virtualcell/vcell/issues/1848) | Remove legacy java.awt.Robot use from the Swing UI (ScrollTable) — it can crash the JVM | 2026-08 | **off-board** | — | — | — |
+| [#1884](https://github.com/virtualcell/vcell/issues/1884) | "Revert to Saved" is wrong - change to "Discard Unsaved Changes" | 2026-08 | Pool | — | — | — |
+| [#1886](https://github.com/virtualcell/vcell/issues/1886) | Mac splash screen for VCell Rel still shows VCell 7.0 | 2026-08 | Pool | — | — | — |
+| [#1930](https://github.com/virtualcell/vcell/issues/1930) | User cannot copy / paste overrided parameters (in edit simulation panel) when the over… | 2026-08 | Active | — | — | — |
+
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars

--- a/docs/backlog/10-desktop-ui.md
+++ b/docs/backlog/10-desktop-ui.md
@@ -116,7 +116,6 @@ stack traces. They need completely different handling, and the flat backlog trea
 |---|---|---|---|---|---|---|
 | [#1449](https://github.com/virtualcell/vcell/issues/1449) | Maintain ordering when toggling global flag on variable | 2025-03 | Queued | 5/2 | Complex&nbsp;(3) | thin |
 | [#1460](https://github.com/virtualcell/vcell/issues/1460) | VCell names must be unique, but only sbml Ids are required and unqiue; users meanwhile… | 2025-03 | Queued | 5/3 | Intricate&nbsp;(2) | — |
-| [#1495](https://github.com/virtualcell/vcell/issues/1495) | VCell Support Automated Email message are too opaque to be very useful | 2025-05 | Queued | 5/6 | Moderate&nbsp;(4) | — |
 | [#1572](https://github.com/virtualcell/vcell/issues/1572) | Built-in brower does not work on mac when accessing PubMed annotations | 2025-08 | Queued | 5/4 | Byzantine&nbsp;(1) | — |
 | [#1299](https://github.com/virtualcell/vcell/issues/1299) | VCell Guest should not have file browser items of "My BioModels" nor "Shared With Me: | 2024-07 | Queued | 6/1 | Simple&nbsp;(5) | thin |
 | [#1440](https://github.com/virtualcell/vcell/issues/1440) | Organism is unavailable in Add Annotations pop-up | 2025-02 | Queued | 6/2 | Moderate&nbsp;(4) | — |
@@ -124,8 +123,10 @@ stack traces. They need completely different handling, and the flat backlog trea
 | [#194](https://github.com/virtualcell/vcell/issues/194) | Geometry editor bug: padding to add background pixels at edges of domain adds new "bac… | 2022-07 | Queued | 8/8 | Unknown&nbsp;(0) | REF thin |
 | [#835](https://github.com/virtualcell/vcell/issues/835) | Error Reports from Contact-Us improvements | 2023-03 | Queued | 8/4 | Moderate&nbsp;(4) | — |
 | [#1441](https://github.com/virtualcell/vcell/issues/1441) | Add Annotations pop-up window is below the main VCell window | 2025-02 | Queued | 9/6 | Complex&nbsp;(3) | — |
+| [#1495](https://github.com/virtualcell/vcell/issues/1495) | VCell Support Automated Email message are too opaque to be very useful | 2025-05 | Queued | 10/6 | Moderate&nbsp;(4) | — |
 | [#1565](https://github.com/virtualcell/vcell/issues/1565) | Give users a choice when changing unit systems to either dimensionally transform value… | 2025-07 | Queued | 10/6 | Moderate&nbsp;(4) | — |
 | [#792](https://github.com/virtualcell/vcell/issues/792) | Smart Copy/Paste behavior with multiple reactions redesign and implement | 2023-02 | Queued | 12/9 | Complex&nbsp;(3) | HP |
+| [#1451](https://github.com/virtualcell/vcell/issues/1451) | Add "Save as Local" to the error message | 2025-03 | Queued | 12/7 | Simple&nbsp;(5) | — |
 | [#1607](https://github.com/virtualcell/vcell/issues/1607) | Rule based models cannot delete reactions in graphical editor using right mouse menu. | 2025-12 | Queued | 12/8 | Moderate&nbsp;(4) | — |
 | [#147](https://github.com/virtualcell/vcell/issues/147) | Some .stl files import fails | 2022-05 | Shelved | — | — | — |
 | [#153](https://github.com/virtualcell/vcell/issues/153) | Make molecular composition layout default in rule-based models | 2022-06 | Pool | — | Unknown&nbsp;(0) | — |
@@ -150,7 +151,6 @@ stack traces. They need completely different handling, and the flat backlog trea
 | [#1024](https://github.com/virtualcell/vcell/issues/1024) | Parameter Estimation Window retains old values when switching to a new application in … | 2023-11 | Pool | — | Moderate&nbsp;(4) | — |
 | [#1038](https://github.com/virtualcell/vcell/issues/1038) | Epic: VCell UI fixes | 2023-11 | Pool | — | — | EPIC |
 | [#1078](https://github.com/virtualcell/vcell/issues/1078) | Uninstall window in alpha does not appear on top of Windows Uninstall menu | 2023-12 | Pool | — | Unknown&nbsp;(0) | — |
-| [#1451](https://github.com/virtualcell/vcell/issues/1451) | Add "Save as Local" to the error message | 2025-03 | Pool | —/7 | Simple&nbsp;(5) | — |
 | [#1486](https://github.com/virtualcell/vcell/issues/1486) | Broken existing links in Annotations (both Rel and Alpha) | 2025-04 | Pool | — | Simple&nbsp;(5) | — |
 | [#1591](https://github.com/virtualcell/vcell/issues/1591) | Option to show reaction names in reaction diagram | 2025-09 | Pool | — | — | — |
 | [#1593](https://github.com/virtualcell/vcell/issues/1593) | Black screen over VCell, moving to the right | 2025-10 | Shelved | — | — | — |

--- a/docs/backlog/10-desktop-ui.md
+++ b/docs/backlog/10-desktop-ui.md
@@ -80,14 +80,14 @@ selectable).
 
 ### Geometry and mapping UI (5)
 
-`#194` (padding creates a spurious "background" compartment — Priority 8 / **Importance 8**, the
-joint-highest, but an **empty body**), `#289` (subdomain-name error dialog ignored), `#290`
+`#194` (padding creates a spurious "background" compartment — Priority 8 / **Importance 8**, well
+up the ranked slate, but an **empty body**), `#289` (subdomain-name error dialog ignored), `#290`
 (kinematics spatial process always binds the first volume object — good 736-char body), `#1712`
 (Geometry Mapping window clipped beyond 7 compartments), `#147` (some .stl imports fail, with
 specific test files named).
 
-`#194` is the clearest example of the backlog's central problem: the highest-Importance UI issue
-on the board cannot be worked because nobody wrote down what it does.
+`#194` is the clearest example of the backlog's central problem: one of the highest-Importance UI
+issues on the board cannot be worked because nobody wrote down what it does.
 
 ### The 2022 enhancement cohort (13)
 

--- a/docs/backlog/11-standards-interop.md
+++ b/docs/backlog/11-standards-interop.md
@@ -1,0 +1,157 @@
+# Group: Standards & Interop — SBML / SED-ML / OMEX / BioSimulators — 42 issues
+
+The second-largest group, and the most internally coherent: nearly all of it is about VCell
+exchanging models and results with the wider systems-biology ecosystem without losing fidelity.
+
+**Epics:** `#1036` (public VCell models as SBML/OMEX, 28 children), `#1046` (biosimulators
+nonspatial, **19/21 done**), `#1069` (biosimulators spatial, **0/2 done, both blocked**).
+
+**Strategic decision required** — see
+[04-epic-map.md](04-epic-map.md#decision-5--do-we-still-pursue-full-biosimulatorssed-ml-conformance).
+The nonspatial track is two issues from finished; the spatial track is blocked on an external
+standard that has not materialized since Dec 2023. They should stop being managed as one programme.
+
+---
+
+## Sub-themes
+
+### Roundtrip fidelity — the core of `#1036` (8)
+
+`#522` (math equivalency failures on 18 simcontexts), `#523` (one-of-a-kind failures on 7
+simcontexts, 7 named biomodels), `#563` (CLI conversion should use saved math), `#490` (species
+sharing a name with a local parameter — *"solver runs but produces incorrect results"*), `#356`,
+`#642`, `#718`, `#430`.
+
+`#522` and `#523` are the residue of a systematic campaign: *"All math equivalency failures on
+roundtrip in published models have been fixed. However, extending the validation test suite to
+1,038 public models identified additional failures."* That is a mature, well-instrumented effort —
+these are the long tail of it, and they are correctly ranked together (Priority 2, the tightest
+cluster on the board).
+
+`#490` deserves separate attention regardless of the epic's fate: it can produce **silently
+incorrect simulation results**, not just an export failure. That is a different severity class
+from the rest of this group.
+
+### SED-ML export defects (7)
+
+`#890` (bad XPaths, 3 named models), `#891` (non-unique SIds), `#1237` (empty/incomplete SED-ML),
+`#1148` (RepeatedTasks with multiple ranges), `#863` (HDF5 missing datasets for repeated tasks),
+`#1581` (log axes not honored), `#1582` (species-vs-species plot points connected in the wrong
+order).
+
+`#890` and `#891` were both **caught by `SEDMLExporterTest`** — the test suite is finding these,
+which means they are reproducible and have a ready-made verification harness. Both are `Queued`
+with low Importance (2) despite that. Cheap wins.
+
+`#1581` and `#1582` come from @luciansmith with screenshots and exact XML — externally reported,
+precisely described, and about output correctness that other people can see.
+
+### SED-ML/jlibsedml capability gaps (5)
+
+`#498` (sequential / multi-sub-task RepeatedTasks — Priority 3, `Intricate (2)`), `#1469`
+(many-SubTasks in RepeatedTask), `#1470` (upgrade jlibsedml to handle L1V5), `#1341` (jlibsedml
+rejects plain relative paths, accepting only URI syntax), `#1571` (stochastic test suite OMEX).
+
+These are a ladder: `#1470` (parse newer SED-ML at all) plausibly precedes `#498`/`#1469`
+(support the features). `#1341` is a small, well-diagnosed upstream-shaped fix and is **off-board**.
+Sequencing these four as a chain would make more sense than ranking them independently.
+
+### SBML import/export correctness (9)
+
+`#423` (CSG geometry roundtrip NPE, with the exact test model cited), `#515` (SBMLImporter
+silently consumes errors — *"should instead throw and abort with informative error message"*),
+`#956` / `#1460` (SBML ids used as VCell names, hurting usability of imported models), `#354`
+(disabled reactions, with a concrete proposed encoding), `#804` (MathML parse errors on 10 named
+BMDB models), `#1674` (invalid XML character when re-saving a BMDB model), `#1984` (SBMLExporter
+drops `SimulationContextParameter`), `#211` (SBML spatial compliance — empty body).
+
+`#515` is worth promoting on principle: an importer that logs and continues produces silently
+wrong models, and every other issue in this section is harder to diagnose because of it. Fixing
+the error discipline first would make the rest of this list cheaper.
+
+`#956` and `#1460` are the same complaint from two angles (ids vs names on import) and should be
+merged.
+
+### BioSimulations / BSTS integration (7)
+
+`#912` (stochastic simulation fails in the biosimulators container — full repro with a docker
+command and an attached OMEX), `#1573` (models stuck in endless `PROCESSING` — a 3.1k-char report
+with a model list), `#972` (SED-ML for remaining biomodels, with a CSV of every failing model),
+`#1074`, `#1343`, `#1344`, `#91`.
+
+`#912`, `#1573` and `#972` are all externally reported by ecosystem partners with reproduction
+data attached. These are the issues where other projects can see whether VCell works.
+
+### Recent findings from the BMDB pipeline (3)
+
+`#1905` (BIOMD0000000459/460/461 — CSV export fails mapping an SBML compartment size to a VCell
+structure size parameter), `#1981` (four BMDB models failing at a second point, revealed once the
+COPASI annotation cast was fixed), `#1984` (SBMLExporter drops `SimulationContextParameter`).
+
+All three are 2026, all three are precise, **all three are off-board.** They came out of the
+nightly BMDB gate, which means they have a standing regression harness behind them — the most
+actionable subset of this entire group, and the least visible.
+
+---
+
+## Recommended sequencing within this group
+
+1. **Close `#1069`** as externally blocked (with revival criteria), per Decision 5.
+2. **Finish `#1046`** — 19/21 done; the remaining children are `#863` and `#1074`.
+3. **`#515` first** among the SBML fixes — error discipline before error fixes.
+4. **Merge `#956` + `#1460`**; merge the `#890`/`#891` test-caught pair into one work item.
+5. **Board the three 2026 BMDB findings** (`#1905`, `#1981`, `#1984`) — they have harnesses.
+6. **Sequence the jlibsedml ladder** (`#1470` → `#498` / `#1469`) rather than ranking flat.
+7. Leave `#1036`'s 28-child roundtrip tail as a background campaign; it is progressing and does not
+   need reprioritizing so much as a decision on how complete "complete" needs to be.
+
+---
+
+## All 42
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#522](https://github.com/virtualcell/vcell/issues/522) | roundtrip fails due to math equivalency failure | 2022-10 | Queued | 2/2 | Unknown&nbsp;(0) | — |
+| [#523](https://github.com/virtualcell/vcell/issues/523) | roundtrip fails due to various errors | 2022-10 | Queued | 2/2 | Unknown&nbsp;(0) | — |
+| [#912](https://github.com/virtualcell/vcell/issues/912) | VCell Biosimulators CLI: stochastic simulation not working | 2023-06 | Queued | 2/2 | Unknown&nbsp;(0) | — |
+| [#498](https://github.com/virtualcell/vcell/issues/498) | VCell does not support Sequential/Multi-sub-task Repeated Tasks  | 2022-10 | Queued | 3/1 | Intricate&nbsp;(2) | REF |
+| [#423](https://github.com/virtualcell/vcell/issues/423) | SBML export/import for CSG Geometry not working | 2022-09 | Queued | 4/2 | Intricate&nbsp;(2) | — |
+| [#804](https://github.com/virtualcell/vcell/issues/804) | MathML parsing errors during BMDB import | 2023-02 | Queued | 4/2 | Intricate&nbsp;(2) | — |
+| [#719](https://github.com/virtualcell/vcell/issues/719) | update importer and executor for VCML language format combine archives | 2022-12 | Queued | 5/2 | Complex&nbsp;(3) | — |
+| [#891](https://github.com/virtualcell/vcell/issues/891) | SEDML Exporter provides non-unique IDs  | 2023-05 | Queued | 5/2 | Complex&nbsp;(3) | REF |
+| [#1237](https://github.com/virtualcell/vcell/issues/1237) | VCell SEDML Export sometimes results in an "empty"/incomplete SEDML File | 2024-05 | Queued | 5/2 | Complex&nbsp;(3) | — |
+| [#1344](https://github.com/virtualcell/vcell/issues/1344) | SBML-OMEX archived VCell publications should use normalized ASCII names | 2024-08 | Queued | 5/1 | Moderate&nbsp;(4) | thin |
+| [#1428](https://github.com/virtualcell/vcell/issues/1428) | CLI Strict Mode toggle needs to be created | 2025-01 | Queued | 5/2 | Complex&nbsp;(3) | — |
+| [#1573](https://github.com/virtualcell/vcell/issues/1573) | Endless 'PROCESSING' of VCell results on Biosimulations | 2025-08 | Queued | 5/2 | Complex&nbsp;(3) | — |
+| [#1581](https://github.com/virtualcell/vcell/issues/1581) | SED-ML: plot log axes | 2025-08 | Queued | 5/2 | Complex&nbsp;(3) | — |
+| [#1582](https://github.com/virtualcell/vcell/issues/1582) | Species vs. species plot not connected correctly | 2025-08 | Queued | 5/2 | Complex&nbsp;(3) | — |
+| [#1673](https://github.com/virtualcell/vcell/issues/1673) | Solver Handler needs clearer and/or better handling of vcml-backed SedML vs. sbml-back… | 2026-04 | Queued | 5/2 | Complex&nbsp;(3) | — |
+| [#863](https://github.com/virtualcell/vcell/issues/863) | Sedml HDF5 is missing some data sets with repeated tasks. | 2023-04 | Queued | 6/2 | Moderate&nbsp;(4) | — |
+| [#1148](https://github.com/virtualcell/vcell/issues/1148) | Bug: RepeatedTasks with multiple ranges exported funny | 2024-02 | Queued | 6/2 | Moderate&nbsp;(4) | — |
+| [#890](https://github.com/virtualcell/vcell/issues/890) | SedML export gives bad XPATH | 2023-05 | Queued | 7/2 | Simple&nbsp;(5) | — |
+| [#1343](https://github.com/virtualcell/vcell/issues/1343) | Biomodels of the same publication should be packaged into a single sbml-omex | 2024-08 | Queued | 7/2 | Simple&nbsp;(5) | thin |
+| [#91](https://github.com/virtualcell/vcell/issues/91) | Review simulator specs for model changes and observables | 2021-09 | Pool | — | Complex&nbsp;(3) | — |
+| [#140](https://github.com/virtualcell/vcell/issues/140) | Open zip files as omex files | 2022-04 | Pool | — | — | — |
+| [#211](https://github.com/virtualcell/vcell/issues/211) | VCell compliance with SBML spatial | 2022-07 | Pool | — | — | thin |
+| [#218](https://github.com/virtualcell/vcell/issues/218) | Export rule-based applications in OMEX format via BNGL | 2022-07 | Shelved | — | — | REF thin |
+| [#354](https://github.com/virtualcell/vcell/issues/354) | Round trip Disabled reactions to SBML (especially in SEDML context). | 2022-09 | Pool | — | — | — |
+| [#515](https://github.com/virtualcell/vcell/issues/515) | SBMLImporter consumes errors | 2022-10 | Pool | — | — | HP |
+| [#562](https://github.com/virtualcell/vcell/issues/562) | Importer brings in unused models | 2022-11 | Pool | — | — | REF |
+| [#956](https://github.com/virtualcell/vcell/issues/956) | SBML id's are used as VCell names | 2023-08 | Pool | — | Unknown&nbsp;(0) | — |
+| [#972](https://github.com/virtualcell/vcell/issues/972) | Support the SED-ML for remaining biomodels | 2023-09 | Pool | — | Moderate&nbsp;(4) | — |
+| [#1036](https://github.com/virtualcell/vcell/issues/1036) | Epic: public vcell models as SBML/Omex | 2023-11 | Queued | — | — | EPIC |
+| [#1046](https://github.com/virtualcell/vcell/issues/1046) | Epic: fix remaining issues in biosimulators_vcell for nonspatial simulations | 2023-11 | Queued | — | — | EPIC |
+| [#1048](https://github.com/virtualcell/vcell/issues/1048) | VCell needs to output spatial simulation data in a way that Biosimulations/Biosimulato… | 2023-11 | Blocked | — | Moderate&nbsp;(4) | thin |
+| [#1068](https://github.com/virtualcell/vcell/issues/1068) | Spatial HDF5 needs to conform to Biosimulators Standard | 2023-12 | Blocked | — | Complex&nbsp;(3) | BLK |
+| [#1069](https://github.com/virtualcell/vcell/issues/1069) | Epic: fix remaining issues with biosimulators_vcell for spatial simulations | 2023-12 | Queued | — | — | EPIC |
+| [#1074](https://github.com/virtualcell/vcell/issues/1074) | Upload All Nonspatial VCell Projects to BioSimulations | 2023-12 | Pool | — | Moderate&nbsp;(4) | thin |
+| [#1341](https://github.com/virtualcell/vcell/issues/1341) | Jlibsedml needs to accept common file path syntax, not just URI syntax | 2024-08 | **off-board** | — | — | — |
+| [#1469](https://github.com/virtualcell/vcell/issues/1469) | Update VCell to handle many-SubTasks in SedML's RepeatedTask | 2025-04 | Pool | — | Intricate&nbsp;(2) | — |
+| [#1470](https://github.com/virtualcell/vcell/issues/1470) | Jlibsedml and SedmlImporter should be upgraded to be able to read and appropriately ha… | 2025-04 | Pool | — | Complex&nbsp;(3) | — |
+| [#1571](https://github.com/virtualcell/vcell/issues/1571) | Handle stochastic test suite OMEX files | 2025-08 | Pool | — | — | — |
+| [#1674](https://github.com/virtualcell/vcell/issues/1674) | Errors when saving updated models from BioModels DB | 2026-05 | Pool | — | — | — |
+| [#1905](https://github.com/virtualcell/vcell/issues/1905) | BIOMD0000000459/460/461: results CSV export fails to map an SBML compartment size to a… | 2026-08 | **off-board** | — | — | — |
+| [#1981](https://github.com/virtualcell/vcell/issues/1981) | Four BMDB models fail at a second point, revealed once the COPASI annotation cast was … | 2026-08 | **off-board** | — | — | — |
+| [#1984](https://github.com/virtualcell/vcell/issues/1984) | SBMLExporter drops SimulationContextParameter; exporting it needs a rule for names tha… | 2026-08 | **off-board** | — | — | — |
+
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars

--- a/docs/backlog/11-standards-interop.md
+++ b/docs/backlog/11-standards-interop.md
@@ -53,8 +53,15 @@ precisely described, and about output correctness that other people can see.
 rejects plain relative paths, accepting only URI syntax), `#1571` (stochastic test suite OMEX).
 
 These are a ladder: `#1470` (parse newer SED-ML at all) plausibly precedes `#498`/`#1469`
-(support the features). `#1341` is a small, well-diagnosed upstream-shaped fix and is **off-board**.
-Sequencing these four as a chain would make more sense than ranking them independently.
+(support the features). Sequencing them as a chain beats ranking them independently.
+
+**jlibsedml is vendored, not a dependency** — 148 source files under
+`vcell-core/src/main/java/org/jlibsedml/` at version 3.0.0
+([05-obsolescence-sweep.md](05-obsolescence-sweep.md)). That cuts both ways: `#1341` is a **local
+patch we can just make**, not an upstream request to file and wait on, which makes it much cheaper
+than its framing suggests; while `#1470` is **not a version bump** — there is no version to bump,
+so it is a fork-reconciliation job of the kind `#1978` proposes for JSBML. Both issues should say
+so.
 
 ### SBML import/export correctness (9)
 

--- a/docs/backlog/12-springsalad.md
+++ b/docs/backlog/12-springsalad.md
@@ -1,0 +1,160 @@
+# Group: SpringSaLaD / Langevin — 32 issues
+
+The most striking group in the backlog: **26 of 32 are off the project board**, including all 14
+issues from the July 2026 grooming pass and the epic that organizes them.
+
+This is a well-described, coherent, largely user-driven body of work that is invisible to anyone
+planning from board #1.
+
+**Epics:** three of them, overlapping — `#870` (MVP, 2023, `Active`), `#1729` (bugs & upgrades,
+2026, off-board), and `#1482`, which is an umbrella in all but label. See
+[04-epic-map.md](04-epic-map.md#c-870-springsalad-mvp-vs-1729-springsalad-bugs--upgrades-vs-1482-langevin-solver-maintenance).
+
+---
+
+## The `#1729` set — 14 issues, already groomed
+
+`#1719`–`#1732` were created on 2026-07-08 from a request list by **Leslie Loew**, decomposed into
+standalone issues with the original request quoted in each body and provenance recorded. They are
+the best-structured cluster in the repo.
+
+They divide cleanly into three programmes, and the grouping is already stated in the issue bodies:
+
+**a) SpringSaLaD ↔ rule-based Physiology compatibility (5)** — `#1719` (drop the required
+Extracellular/Membrane/Intracellular names, `High Priority`), `#1720` (tolerate extra
+compartments, `High Priority`), `#1721` (allosteric reactions without explicit bound/unbound
+states), `#1722` (volumetric rate constants for membrane-tethered binding), `#1723` (allow
+reversible state changes).
+
+These five together are one design change: making SS applications accept ordinary rule-based
+physiology instead of a special-cased subset. Doing them piecemeal risks five partial relaxations
+of the same validator. **Recommend treating as one work item with five acceptance criteria.**
+
+**b) Multiple-sim-run infrastructure (4)** — `#1726` (raise the cap to 50), `#1727` (proper
+per-run status), `#1728` (allow more than 2 runs, with a comprehensible quota message).
+Plus `#1734` (batch jobs stay `RUNNING` in the DB after SLURM completion — a detailed 3.9k-char
+reconciliation-gap analysis).
+
+`#1734` is a prerequisite hiding in plain sight: raising the run cap while completed runs still
+show as `RUNNING` makes the status problem worse, not better. **Sequence `#1734` before `#1726`.**
+
+**c) Results & visualization (3)** — `#1730` (3D visualizations/movies as in native SS), `#1731`
+(cluster-size-distribution histograms in multi-run results), plus `#1732` (parameter overrides and
+scans — *"until this is implemented, do not allow them"*).
+
+`#1732` contains its own interim fix: **disable the broken path**. That guard is small, independent
+of the feature, and stops users hitting a workflow that silently does nothing. It pairs exactly
+with `#1713` ("User is allowed to change rate constants for Spring SaLaD apps, but change is not
+applied and no error is announced") — **`#1713` and `#1732` are the same defect**, one reported and
+one groomed. Merge them, and ship the guard now regardless of when the feature lands.
+
+---
+
+## Validation correctness (3) — the 2026-08 findings
+
+`#1874` (the diffusion-limited rate check is not unit-aware, so some `Kf` values are read **~600×
+too lenient**), `#1875` (`checkOnRate`'s own documented "marginally acceptable" example fails its
+own check), `#1876` (four published applications fail validation and cannot generate math).
+
+These came out of adding SpringSaLaD coverage to `MathGenCompareTest`, and they interlock: `#1874`
+is a wrong unit conversion in the check, `#1875` is evidence the check has been wrong since it was
+written, and `#1876` is four real models it now rejects. They should be fixed and verified as one.
+
+**All three are off-board.** `#1874` in particular says validation has been accepting rates that
+are physically impossible by a factor of ~600 — that is a correctness claim about published
+science, and it is not on any planning surface.
+
+---
+
+## Structural sites (2 open + 1 to close)
+
+`#1686` (**close** — PR #1685 is merged, see [01](01-close-and-verify.md)), `#1688` (structural
+site specification needs a graphical interface — currently pair-by-pair manual selection and
+hand-edited coordinates), `#1689` (3D visualization of structural sites).
+
+`#1689`'s body carries a useful design judgment: the original SpringSaLaD used a 3D editing
+interface and *"editing was an extremely difficult task"*, which is why VCell chose a 2D
+cross-section. So `#1689` is explicitly view-only, not an editor. Worth preserving that
+distinction — it is the kind of rationale that gets lost and re-litigated.
+
+---
+
+## Export and external analysis (2, probably 1)
+
+`#1657` ("simularium export for SpringSaLaD") and `#1658` ("export SpringSaLaD sim results for
+external viewing/analysis") — both `Active`, **both with completely empty bodies**, both created
+2026-04-01, both by @jcschaff.
+
+`#1657` looks like a specific implementation of `#1658`'s general goal (Simularium being one
+external viewer). Either merge, or make `#1657` a child of `#1658`. Also overlaps `#1730` (3D
+visualizations in VCell). Three issues, one underlying question: *where do SpringSaLaD results get
+looked at?*
+
+---
+
+## Solver and infrastructure (4)
+
+`#1482` (Langevin solver code maintenance — `High Priority`, 11 comments, three distinct workstreams
+in a 154-char body: fix bugs, implement new algorithms, add client sanity checks), `#1564`
+(automate Dan's SpringSaLaD build, which currently requires Apple certs and manual steps — Priority
+12/8, the highest-ranked SpringSaLaD item on the board), `#1660` (NPE in
+`ParticleMathMapping.refreshMathDescription`, with the offending code quoted), `#1260` (sites
+lacking states rejected by SS applications).
+
+`#1482` should be split. An umbrella with 11 comments and three unrelated workstreams cannot be
+closed, and "add sanity checks in the client" is plausibly already covered by `#1874`/`#1875`.
+
+---
+
+## Recommendations
+
+1. **Board all 26 off-board issues.** This is the single highest-value action for this group.
+2. **Consolidate to one epic** (`#1729`); close `#870` as MVP-delivered, moving its two research
+   items (curved surfaces, parallelization) to standalone issues.
+3. **Merge `#1713` into `#1732`** and ship the disable-the-broken-path guard independently.
+4. **Sequence `#1734` before `#1726`/`#1727`/`#1728`.**
+5. **Treat `#1719`–`#1723` as one compatibility work item.**
+6. **Fix `#1874`/`#1875`/`#1876` together**, and treat `#1874` as the highest-severity item in the
+   group — it is a silent correctness failure, not a usability gap.
+7. **Split `#1482`**; merge `#1657`/`#1658`; demote `#1508`/`#1509` from `Type: Epic` to children.
+
+---
+
+## All 32
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#1564](https://github.com/virtualcell/vcell/issues/1564) | Automate Dans SpringSalad Build | 2025-07 | Queued | 12/8 | Moderate&nbsp;(4) | — |
+| [#870](https://github.com/virtualcell/vcell/issues/870) | Epic: MVP for Spring SaLaD in VCell | 2023-04 | Active | — | — | HP EPIC |
+| [#1260](https://github.com/virtualcell/vcell/issues/1260) | Sites that lack states in physiolology are not accepted by SS application (but should … | 2024-05 | Pool | — | Intricate&nbsp;(2) | thin |
+| [#1262](https://github.com/virtualcell/vcell/issues/1262) | Update Object Properties for Molecular Structures | 2024-05 | **off-board** | — | — | — |
+| [#1268](https://github.com/virtualcell/vcell/issues/1268) | Set z coordinate of membrane-bound site to 0 | 2024-05 | **off-board** | — | — | thin |
+| [#1482](https://github.com/virtualcell/vcell/issues/1482) | Langevin Solver code maintenance | 2025-04 | Pool | — | Unknown&nbsp;(0) | HP |
+| [#1508](https://github.com/virtualcell/vcell/issues/1508) | Displaying statistics for multiple runs | 2025-05 | — | — | — | HP EPIC |
+| [#1509](https://github.com/virtualcell/vcell/issues/1509) | Displaying cluster analysis results | 2025-05 | — | — | — | HP EPIC |
+| [#1657](https://github.com/virtualcell/vcell/issues/1657) | simularium export for SpringSaLaD | 2026-04 | Active | — | — | thin |
+| [#1658](https://github.com/virtualcell/vcell/issues/1658) | export SpringSaLaD sim results for external viewing/analysis | 2026-04 | Active | — | — | thin |
+| [#1660](https://github.com/virtualcell/vcell/issues/1660) | Null pointer in ParticleMathMapping.refreshMathDescription | 2026-04 | Pool | — | — | — |
+| [#1688](https://github.com/virtualcell/vcell/issues/1688) | Structural Site specification should have graphical interface | 2026-05 | Pool | — | — | — |
+| [#1689](https://github.com/virtualcell/vcell/issues/1689) | 3D vizualization of structural sites | 2026-05 | Pool | — | — | — |
+| [#1713](https://github.com/virtualcell/vcell/issues/1713) | Parameter overrides are not allowed in spring SaLaD | 2026-06 | Pool | — | — | — |
+| [#1719](https://github.com/virtualcell/vcell/issues/1719) | SpringSaLaD: do not require Extracellular/Membrane/Intracellular compartment names | 2026-07 | **off-board** | — | — | HP |
+| [#1720](https://github.com/virtualcell/vcell/issues/1720) | SpringSaLaD: allow additional compartments that are ignored in an SS Application | 2026-07 | **off-board** | — | — | HP |
+| [#1721](https://github.com/virtualcell/vcell/issues/1721) | SpringSaLaD: support allosteric reactions without explicit bound/unbound states + swit… | 2026-07 | **off-board** | — | — | — |
+| [#1722](https://github.com/virtualcell/vcell/issues/1722) | SpringSaLaD: allow volumetric rate constants for binding of membrane-tethered sites | 2026-07 | **off-board** | — | — | — |
+| [#1723](https://github.com/virtualcell/vcell/issues/1723) | SpringSaLaD: relax the requirement that all state changes be irreversible | 2026-07 | **off-board** | — | — | — |
+| [#1724](https://github.com/virtualcell/vcell/issues/1724) | SpringSaLaD: copying an SS Application does not correctly copy molecular structures | 2026-07 | **off-board** | — | — | HP |
+| [#1725](https://github.com/virtualcell/vcell/issues/1725) | SpringSaLaD: review error/warning handling when a reaction is too fast for the diffusi… | 2026-07 | **off-board** | — | — | HP |
+| [#1726](https://github.com/virtualcell/vcell/issues/1726) | SpringSaLaD: increase the number of simultaneous multiple sim runs to 50 | 2026-07 | **off-board** | — | — | — |
+| [#1727](https://github.com/virtualcell/vcell/issues/1727) | SpringSaLaD: provide proper status for multiple sim runs | 2026-07 | **off-board** | — | — | — |
+| [#1728](https://github.com/virtualcell/vcell/issues/1728) | SpringSaLaD: allow more than 2 multiple sim runs (or a permission/request flow) with a… | 2026-07 | **off-board** | — | — | — |
+| [#1729](https://github.com/virtualcell/vcell/issues/1729) | SpringSaLaD in VCell — bugs & high-priority upgrades (epic) | 2026-07 | **off-board** | — | — | EPIC |
+| [#1730](https://github.com/virtualcell/vcell/issues/1730) | SpringSaLaD: create 3D visualizations/movies as in the native SS | 2026-07 | **off-board** | — | — | — |
+| [#1731](https://github.com/virtualcell/vcell/issues/1731) | SpringSaLaD: include cluster-size-distribution histograms in multiple-run results | 2026-07 | **off-board** | — | — | — |
+| [#1732](https://github.com/virtualcell/vcell/issues/1732) | SpringSaLaD: enable parameter overrides & parameter scans (disable until implemented) | 2026-07 | **off-board** | — | — | HP |
+| [#1734](https://github.com/virtualcell/vcell/issues/1734) | SpringSaLaD/Langevin batch jobs stay RUNNING in DB after SLURM completion (reconciliat… | 2026-07 | **off-board** | — | — | — |
+| [#1874](https://github.com/virtualcell/vcell/issues/1874) | SpringSaLaD: diffusion-limited rate check is not unit-aware, so some Kf values are rea… | 2026-08 | **off-board** | — | — | — |
+| [#1875](https://github.com/virtualcell/vcell/issues/1875) | SpringSaLaD: checkOnRate's documented "marginally acceptable" example fails its own ch… | 2026-08 | **off-board** | — | — | REF |
+| [#1876](https://github.com/virtualcell/vcell/issues/1876) | SpringSaLaD: four published applications fail validation and cannot generate math | 2026-08 | **off-board** | — | — | — |
+
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars

--- a/docs/backlog/13-export-visualization.md
+++ b/docs/backlog/13-export-visualization.md
@@ -1,0 +1,162 @@
+# Group: Data Export & Visualization — 32 issues
+
+Covers everything between "the simulation finished" and "the user can see or reuse the results":
+the export subsystem, the N5/ImageJ path, HDF5 writing, the desktop results viewers, and the new
+browser-based field viewer.
+
+**Epics:** `#1199` (Refactor Data Export Services — **Importance 9, the highest on the board**, but
+zero linked children), `#1034` (local use of field data), `#1652` (VFRAP/geometry rework), `#1803`
+(web-based field & geometry visualization, off-board).
+
+**Strategic decision required** — see
+[04-epic-map.md](04-epic-map.md#decision-2--desktop-pde-viewer-or-browser-viewer). Several issues
+here are investments in a desktop viewer that may be being superseded by the browser viewer. That
+call determines whether roughly eight of these are worth ranking at all.
+
+---
+
+## Sub-themes
+
+### The export subsystem rewrite (6) — one initiative filed as several
+
+`#1199` (epic), `#1008` (*"almost 2 decades old… could use a re-write"*), `#1330` (enhance export
+process), `#1115` (post-processed variables don't show export progress), `#1668` (store the export
+request as JSON so a job can be understood after the fact), `#1542` (move export history
+server-side).
+
+`#1199` and `#1008` are **the same proposal written twice** — see
+[04-epic-map.md](04-epic-map.md#b-1199-refactor-data-export-services-vs-1008-vcell-export-needs-a-face-lift).
+The epic has the highest Importance on the entire board and no children, while the work that
+belongs to it sits unlinked around it. Populating `#1199` would be a cheap and unusually
+high-leverage bit of grooming.
+
+`#1668` is worth calling out as a small enabler rather than a feature: being unable to read back
+what an export job actually requested makes every other bug in this list harder to diagnose.
+
+### N5 / ImageJ (5)
+
+`#1338` (N5 metadata lacks unit length, time unit, time intervals — hard-coded or absent), `#1352`
+(every export creates a new N5 dataset → storage balloons on re-export), `#1385` (auto-export N5
+on job dispatch), `#1473` (N5 metadata needs the time array plus origin and extent — `Simple (5)`,
+Importance 7), `#1555` (export control through the new API, Priority 12/8).
+
+`#1338` and `#1473` are the same defect — N5 output is missing the spatial/temporal metadata that
+makes it interpretable — reported ten months apart, and `#1338` is off-board. **Merge.**
+
+`#1352` is the one with an operational cost attached (unbounded storage growth), and it is
+unranked in `Pool`.
+
+### HDF5 (3)
+
+`#877` (jHDF suffers a JRE bug on Windows, `Blocked`), `#1894` (`Hdf5PostProcessor` rejects the
+statistic name `mean` written by the Chombo solver — and the rejection **aborts all data access for
+the run**), `#1964` (`ASCIIExporter` is the last thing needing native HDF5 for writing, blocked on
+upstream jhdf#654), `#138` (results not correctly exported to CSV or HDF5 for VCML models).
+
+`#877` needs a status check: the root pom now carries `io.jhdf 0.13.0` and the `ncsa.hdf` binding
+is gone, so the dependency picture has changed substantially since 2023. The issue may be obsolete
+or may have narrowed — **verify before ranking**.
+
+`#1894` is the highest-severity item in this section: one unrecognized statistic name makes an
+entire run's data unreadable. Small fix, large blast radius, off-board.
+
+### The browser field viewer (4) — active, off-board
+
+`#1803` (epic), `#1859` (labels, color bar, axes, cut plane, picking, time plots, movie export),
+`#1867` (color-scale modes), `#1879` (VTK visualization for moving-boundary results).
+
+This is live, recently shipped work (through the 8.0.9/8.0.10 line) and **none of it is on the
+board**. `#1859` is a well-organized follow-up list grouped by what each item actually requires.
+
+### Desktop results viewers (7)
+
+`#191` (new GUI design for the spatial results viewer — *design already created and approved*,
+Importance 6), `#898` (auto-scale-at-all-times truncates values top and bottom; out-of-scale
+elements render black on screen and white on export — Priority 8/6), `#950` (local parameter-scan
+results appear only partially, filling in as you toggle between parameters — Priority 7/5), `#832`
+(multiple stochastic runs are not displayed — the release notes claim statistics that are not
+actually produced), `#174` (results view with envelope and SD for multi-run stochastic), `#772`
+(surface-view `.mov` files unreadable by Windows Media Player), `#986` (GIF export produces wildly
+incorrect output after the first one, `High Priority`, affects an external collaboration).
+
+`#832` is notable for an honesty problem as much as a technical one: *"In release notes we say
+'Statistics displayed and exported for multiple trajectory stochastic simulations'. In fact, we
+just run and display an average."* It pairs with `#174` (envelope/SD display) and with SpringSaLaD's
+`#1508` — three issues, one missing capability: **proper multi-run statistics display**.
+
+`#986` and `#772` are both export-format defects with named external users affected.
+
+### Field / image data (4)
+
+`#648` (field data needs better geometry integration — a concept deck is attached), `#1034` (epic:
+local use of field data), `#167` (API endpoint for field-data retrieval for local runs, Priority
+12/8, `High Priority`), `#1652` (rework VFRAP workflows to merge geometry and image data),
+`#1494` (lazy-load microscopy data in the PDE viewer).
+
+`#1652` states the underlying problem well: *"Field Data is very complex and most users cannot
+figure out 1) that it exists and 2) how to use it."* That is a product problem, and `#648`,
+`#1034` and `#167` are all partial technical responses to it. `#1652` should probably be the
+parent of the other three rather than a sibling.
+
+### Plotting (1)
+
+`#366` — the CLI Python plotting code needs restructuring to control the seaborn colour palette,
+because correlated data currently renders indistinguishably. Note that `#1472` records *"Python
+reliance removed, and plotting / logging done java side [COMPLETE]"* — so **this may be obsolete.**
+Verify against the current CLI before ranking.
+
+---
+
+## Recommendations
+
+1. **Merge `#1008` into `#1199`** and populate `#1199` with children (`#1115`, `#1330`, `#1668`,
+   `#1542`, `#986`, `#772`). It has the board's highest Importance and no content.
+2. **Merge `#1338` into `#1473`** (same N5 metadata gap).
+3. **Board the 8 off-board issues**, especially `#1894`.
+4. **Verify-before-ranking:** `#877` (jHDF/JRE — dependency has changed) and `#366` (Python
+   plotting — may be superseded).
+5. **Group the multi-run statistics trio** (`#832`, `#174`, SpringSaLaD `#1508`) as one capability.
+6. **Take Decision 2** before ranking `#191`, `#1494`, `#898`, `#950`.
+7. `#1894` and `#1352` are the two items here with concrete ongoing costs (unreadable runs;
+   unbounded storage) and both are unranked. Consider promoting regardless of the rest.
+
+---
+
+## All 32
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#950](https://github.com/virtualcell/vcell/issues/950) | Local run Par Scan doesn't show full results | 2023-08 | Queued | 7/5 | Intricate&nbsp;(2) | — |
+| [#898](https://github.com/virtualcell/vcell/issues/898) | Display of simulation results for spatial does not redraw properly when using auto sca… | 2023-05 | Queued | 8/6 | Intricate&nbsp;(2) | — |
+| [#167](https://github.com/virtualcell/vcell/issues/167) | API endpoint for field data retrieval for local runs | 2022-07 | Queued | 12/8 | Moderate&nbsp;(4) | HP thin |
+| [#1555](https://github.com/virtualcell/vcell/issues/1555) | Export Control Through The New API | 2025-06 | Queued | 12/8 | Moderate&nbsp;(4) | — |
+| [#138](https://github.com/virtualcell/vcell/issues/138) | Results are not correctly exported to CSV or HDF5 for VCML models | 2022-03 | Pool | — | Complex&nbsp;(3) | — |
+| [#174](https://github.com/virtualcell/vcell/issues/174) | Create results view with envelope and SD for multiple stochastic runs | 2022-07 | Pool | — | Intricate&nbsp;(2) | HP thin |
+| [#191](https://github.com/virtualcell/vcell/issues/191) | Implement new GUI design for spatial sim results viewer | 2022-07 | Pool | —/6 | Intricate&nbsp;(2) | REF thin |
+| [#366](https://github.com/virtualcell/vcell/issues/366) | CLI-python code for creating plots needs refactor to control color palette | 2022-09 | Pool | — | — | — |
+| [#648](https://github.com/virtualcell/vcell/issues/648) | Field data needs update and better integration with geometry | 2022-12 | Pool | — | Unknown&nbsp;(0) | — |
+| [#772](https://github.com/virtualcell/vcell/issues/772) | Movie files from surface view not opened by windows player | 2023-01 | Pool | — | — | — |
+| [#832](https://github.com/virtualcell/vcell/issues/832) | Multiple stochastic runs are not displayed | 2023-03 | Pool | — | — | — |
+| [#877](https://github.com/virtualcell/vcell/issues/877) | VCell uses jHDF, which suffers from JRE bug <JDK-4715154> | 2023-05 | Blocked | — | Intricate&nbsp;(2) | BLK |
+| [#986](https://github.com/virtualcell/vcell/issues/986) | Issues with Gif export from VCell | 2023-10 | Pool | — | — | HP |
+| [#1008](https://github.com/virtualcell/vcell/issues/1008) | VCell Export needs a face-lift | 2023-10 | Pool | — | — | — |
+| [#1034](https://github.com/virtualcell/vcell/issues/1034) | Epic: local use of field data | 2023-11 | Pool | — | — | EPIC |
+| [#1115](https://github.com/virtualcell/vcell/issues/1115) | Post-Processed Variables Don't Display Export Progress | 2024-01 | Pool | — | Complex&nbsp;(3) | — |
+| [#1199](https://github.com/virtualcell/vcell/issues/1199) | Epic: Refactor Data Export Services in VCell | 2024-03 | Pool | —/9 | Intricate&nbsp;(2) | HP EPIC |
+| [#1330](https://github.com/virtualcell/vcell/issues/1330) | Enhance Export Process in VCell Application | 2024-07 | **off-board** | — | — | — |
+| [#1338](https://github.com/virtualcell/vcell/issues/1338) | N5 Calibration | 2024-08 | **off-board** | — | — | — |
+| [#1352](https://github.com/virtualcell/vcell/issues/1352) | N5 Export Storage appears to produce Overconsumption | 2024-09 | Pool | — | Moderate&nbsp;(4) | — |
+| [#1385](https://github.com/virtualcell/vcell/issues/1385) | Add option for automatic export of simulation n5 data with job dispatch | 2024-11 | Pool | — | Complex&nbsp;(3) | — |
+| [#1473](https://github.com/virtualcell/vcell/issues/1473) | ImageJ N5 data export metadata needs to include time array as well origin and extent | 2025-04 | Pool | —/7 | Simple&nbsp;(5) | — |
+| [#1494](https://github.com/virtualcell/vcell/issues/1494) | Lazy load microscopy data in PDE data viewer | 2025-04 | **off-board** | — | — | thin |
+| [#1542](https://github.com/virtualcell/vcell/issues/1542) | Export History Should Be Saved on the Server instead of Locally | 2025-06 | Active | — | — | — |
+| [#1652](https://github.com/virtualcell/vcell/issues/1652) | Rework VFRAP workflows to merge Geometry and Image (formerly Field) Data | 2026-03 | Pool | — | — | EPIC |
+| [#1668](https://github.com/virtualcell/vcell/issues/1668) | Have the Export Job Table Store JSON Version of the Export Request | 2026-04 | Pool | — | — | — |
+| [#1803](https://github.com/virtualcell/vcell/issues/1803) | [Epic] Web-based field & geometry visualization in webapp-ng (vtk.js/vtk.wasm) | 2026-07 | **off-board** | — | — | — |
+| [#1859](https://github.com/virtualcell/vcell/issues/1859) | 3D field viewer: nice-to-haves (labels, color bar, axes, cut plane, picking, time plot… | 2026-08 | **off-board** | — | — | — |
+| [#1867](https://github.com/virtualcell/vcell/issues/1867) | 3D field viewer: color-scale modes — autoscale at current time, autoscale over the tim… | 2026-08 | **off-board** | — | — | — |
+| [#1879](https://github.com/virtualcell/vcell/issues/1879) | Field viewer: VTK-based visualization for moving boundary problems (mbsolver) | 2026-08 | **off-board** | — | — | — |
+| [#1894](https://github.com/virtualcell/vcell/issues/1894) | Hdf5PostProcessor rejects statistic name 'mean' (written by the chombo solver) and abo… | 2026-08 | **off-board** | — | — | — |
+| [#1964](https://github.com/virtualcell/vcell/issues/1964) | ASCIIExporter still needs native HDF5 for writing — blocked on jhdf incremental chunk … | 2026-08 | **off-board** | — | — | — |
+
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars

--- a/docs/backlog/13-export-visualization.md
+++ b/docs/backlog/13-export-visualization.md
@@ -4,7 +4,7 @@ Covers everything between "the simulation finished" and "the user can see or reu
 the export subsystem, the N5/ImageJ path, HDF5 writing, the desktop results viewers, and the new
 browser-based field viewer.
 
-**Epics:** `#1199` (Refactor Data Export Services — **Importance 9, the highest on the board**, but
+**Epics:** `#1199` (Refactor Data Export Services — **Importance 9, second-highest on the board**, but
 zero linked children), `#1034` (local use of field data), `#1652` (VFRAP/geometry rework), `#1803`
 (web-based field & geometry visualization, off-board).
 
@@ -26,9 +26,15 @@ server-side).
 
 `#1199` and `#1008` are **the same proposal written twice** — see
 [04-epic-map.md](04-epic-map.md#b-1199-refactor-data-export-services-vs-1008-vcell-export-needs-a-face-lift).
-The epic has the highest Importance on the entire board and no children, while the work that
+The epic has Importance 9 — the second-highest on the board — and no children, while the work that
 belongs to it sits unlinked around it. Populating `#1199` would be a cheap and unusually
 high-leverage bit of grooming.
+
+Note that `#1199` was scored but **never given a Priority**, so it does not appear in the ranked
+queue at all. Under the board's own formula (`Importance + Simplicity`) it computes to **11** —
+second from the top. Two other issues in this group are in the same position: `#1473` computes to
+**12**, tying the highest score on the board, and both it and `#1451` have been sitting in `Pool`
+since 2025. See [03-board-hygiene.md](03-board-hygiene.md).
 
 `#1668` is worth calling out as a small enabler rather than a feature: being unable to read back
 what an export job actually requested makes every other bug in this list harder to diagnose.
@@ -110,7 +116,7 @@ Verify against the current CLI before ranking.
 ## Recommendations
 
 1. **Merge `#1008` into `#1199`** and populate `#1199` with children (`#1115`, `#1330`, `#1668`,
-   `#1542`, `#986`, `#772`). It has the board's highest Importance and no content.
+   `#1542`, `#986`, `#772`). It scores Importance 9 and has no content.
 2. **Merge `#1338` into `#1473`** (same N5 metadata gap).
 3. **Board the 8 off-board issues**, especially `#1894`.
 4. **Verify-before-ranking:** `#877` (jHDF/JRE — dependency has changed) and `#366` (Python

--- a/docs/backlog/13-export-visualization.md
+++ b/docs/backlog/13-export-visualization.md
@@ -30,11 +30,12 @@ The epic has Importance 9 — the second-highest on the board — and no childre
 belongs to it sits unlinked around it. Populating `#1199` would be a cheap and unusually
 high-leverage bit of grooming.
 
-Note that `#1199` was scored but **never given a Priority**, so it does not appear in the ranked
-queue at all. Under the board's own formula (`Importance + Simplicity`) it computes to **11** —
-second from the top. Two other issues in this group are in the same position: `#1473` computes to
-**12**, tying the highest score on the board, and both it and `#1451` have been sitting in `Pool`
-since 2025. See [03-board-hygiene.md](03-board-hygiene.md).
+`#1199` had been scored but **never given a Priority**, so it did not appear in the ranked queue at
+all. Under the board's formula (`Importance + Simplicity`) it computes to **11**, second from the
+top; it has since been set and moved to `Queued` — though note it is an epic with zero children, so
+it is currently queued as an empty container. `#1473` was in the same position and computes to
+**12**, tying the highest score on the board. Both fixed 2026-08-19; see
+[03-board-hygiene.md](03-board-hygiene.md).
 
 `#1668` is worth calling out as a small enabler rather than a feature: being unable to read back
 what an export job actually requested makes every other bug in this list harder to diagnose.
@@ -133,12 +134,14 @@ Verify against the current CLI before ranking.
 | # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
 |---|---|---|---|---|---|---|
 | [#950](https://github.com/virtualcell/vcell/issues/950) | Local run Par Scan doesn't show full results | 2023-08 | Queued | 7/5 | Intricate&nbsp;(2) | — |
+| [#191](https://github.com/virtualcell/vcell/issues/191) | Implement new GUI design for spatial sim results viewer | 2022-07 | Queued | 8/6 | Intricate&nbsp;(2) | REF thin |
 | [#898](https://github.com/virtualcell/vcell/issues/898) | Display of simulation results for spatial does not redraw properly when using auto sca… | 2023-05 | Queued | 8/6 | Intricate&nbsp;(2) | — |
+| [#1199](https://github.com/virtualcell/vcell/issues/1199) | Epic: Refactor Data Export Services in VCell | 2024-03 | Queued | 11/9 | Intricate&nbsp;(2) | HP EPIC |
 | [#167](https://github.com/virtualcell/vcell/issues/167) | API endpoint for field data retrieval for local runs | 2022-07 | Queued | 12/8 | Moderate&nbsp;(4) | HP thin |
+| [#1473](https://github.com/virtualcell/vcell/issues/1473) | ImageJ N5 data export metadata needs to include time array as well origin and extent | 2025-04 | Queued | 12/7 | Simple&nbsp;(5) | — |
 | [#1555](https://github.com/virtualcell/vcell/issues/1555) | Export Control Through The New API | 2025-06 | Queued | 12/8 | Moderate&nbsp;(4) | — |
 | [#138](https://github.com/virtualcell/vcell/issues/138) | Results are not correctly exported to CSV or HDF5 for VCML models | 2022-03 | Pool | — | Complex&nbsp;(3) | — |
 | [#174](https://github.com/virtualcell/vcell/issues/174) | Create results view with envelope and SD for multiple stochastic runs | 2022-07 | Pool | — | Intricate&nbsp;(2) | HP thin |
-| [#191](https://github.com/virtualcell/vcell/issues/191) | Implement new GUI design for spatial sim results viewer | 2022-07 | Pool | —/6 | Intricate&nbsp;(2) | REF thin |
 | [#366](https://github.com/virtualcell/vcell/issues/366) | CLI-python code for creating plots needs refactor to control color palette | 2022-09 | Pool | — | — | — |
 | [#648](https://github.com/virtualcell/vcell/issues/648) | Field data needs update and better integration with geometry | 2022-12 | Pool | — | Unknown&nbsp;(0) | — |
 | [#772](https://github.com/virtualcell/vcell/issues/772) | Movie files from surface view not opened by windows player | 2023-01 | Pool | — | — | — |
@@ -148,12 +151,10 @@ Verify against the current CLI before ranking.
 | [#1008](https://github.com/virtualcell/vcell/issues/1008) | VCell Export needs a face-lift | 2023-10 | Pool | — | — | — |
 | [#1034](https://github.com/virtualcell/vcell/issues/1034) | Epic: local use of field data | 2023-11 | Pool | — | — | EPIC |
 | [#1115](https://github.com/virtualcell/vcell/issues/1115) | Post-Processed Variables Don't Display Export Progress | 2024-01 | Pool | — | Complex&nbsp;(3) | — |
-| [#1199](https://github.com/virtualcell/vcell/issues/1199) | Epic: Refactor Data Export Services in VCell | 2024-03 | Pool | —/9 | Intricate&nbsp;(2) | HP EPIC |
 | [#1330](https://github.com/virtualcell/vcell/issues/1330) | Enhance Export Process in VCell Application | 2024-07 | **off-board** | — | — | — |
 | [#1338](https://github.com/virtualcell/vcell/issues/1338) | N5 Calibration | 2024-08 | **off-board** | — | — | — |
 | [#1352](https://github.com/virtualcell/vcell/issues/1352) | N5 Export Storage appears to produce Overconsumption | 2024-09 | Pool | — | Moderate&nbsp;(4) | — |
 | [#1385](https://github.com/virtualcell/vcell/issues/1385) | Add option for automatic export of simulation n5 data with job dispatch | 2024-11 | Pool | — | Complex&nbsp;(3) | — |
-| [#1473](https://github.com/virtualcell/vcell/issues/1473) | ImageJ N5 data export metadata needs to include time array as well origin and extent | 2025-04 | Pool | —/7 | Simple&nbsp;(5) | — |
 | [#1494](https://github.com/virtualcell/vcell/issues/1494) | Lazy load microscopy data in PDE data viewer | 2025-04 | **off-board** | — | — | thin |
 | [#1542](https://github.com/virtualcell/vcell/issues/1542) | Export History Should Be Saved on the Server instead of Locally | 2025-06 | Active | — | — | — |
 | [#1652](https://github.com/virtualcell/vcell/issues/1652) | Rework VFRAP workflows to merge Geometry and Image (formerly Field) Data | 2026-03 | Pool | — | — | EPIC |

--- a/docs/backlog/13-export-visualization.md
+++ b/docs/backlog/13-export-visualization.md
@@ -109,10 +109,12 @@ parent of the other three rather than a sibling.
 ### Plotting (1)
 
 `#366` — the CLI Python plotting code needs restructuring to control the seaborn colour palette.
-**Verified obsolete:** `seaborn` is gone from the tree (its only trace is a transitive extras line
-in another package's lock file), and `#1472` independently records *"Python reliance removed, and
-plotting / logging done java side [COMPLETE]"*. → close candidate, see
-[05-obsolescence-sweep.md](05-obsolescence-sweep.md).
+**Verified obsolete and CLOSED 2026-08-19.** `seaborn` is gone (its only trace is an optional
+extras line belonging to networkx), nothing imports it, and the replacement is the Java
+`org.vcell.cli.run.plotting` package. See
+[05-obsolescence-sweep.md](05-obsolescence-sweep.md). The residual need — palettes that keep
+correlated series distinguishable — may still be unmet in the Java plots, but that would be a new
+issue against a different package.
 
 ---
 

--- a/docs/backlog/13-export-visualization.md
+++ b/docs/backlog/13-export-visualization.md
@@ -60,9 +60,10 @@ statistic name `mean` written by the Chombo solver — and the rejection **abort
 the run**), `#1964` (`ASCIIExporter` is the last thing needing native HDF5 for writing, blocked on
 upstream jhdf#654), `#138` (results not correctly exported to CSV or HDF5 for VCML models).
 
-`#877` needs a status check: the root pom now carries `io.jhdf 0.13.0` and the `ncsa.hdf` binding
-is gone, so the dependency picture has changed substantially since 2023. The issue may be obsolete
-or may have narrowed — **verify before ranking**.
+`#877` was checked (see [05-obsolescence-sweep.md](05-obsolescence-sweep.md)) and the answer is the
+opposite of what I first guessed: `io.jhdf 0.13.0` is in the root pom and `ncsa.hdf` is **gone**, so
+jHDF is now the *only* HDF5 reader. A JRE bug affecting it on Windows is therefore **more**
+consequential than when the issue was filed. **Re-rank upward, do not close.**
 
 `#1894` is the highest-severity item in this section: one unrecognized statistic name makes an
 entire run's data unreadable. Small fix, large blast radius, off-board.
@@ -107,10 +108,11 @@ parent of the other three rather than a sibling.
 
 ### Plotting (1)
 
-`#366` — the CLI Python plotting code needs restructuring to control the seaborn colour palette,
-because correlated data currently renders indistinguishably. Note that `#1472` records *"Python
-reliance removed, and plotting / logging done java side [COMPLETE]"* — so **this may be obsolete.**
-Verify against the current CLI before ranking.
+`#366` — the CLI Python plotting code needs restructuring to control the seaborn colour palette.
+**Verified obsolete:** `seaborn` is gone from the tree (its only trace is a transitive extras line
+in another package's lock file), and `#1472` independently records *"Python reliance removed, and
+plotting / logging done java side [COMPLETE]"*. → close candidate, see
+[05-obsolescence-sweep.md](05-obsolescence-sweep.md).
 
 ---
 
@@ -120,8 +122,8 @@ Verify against the current CLI before ranking.
    `#1542`, `#986`, `#772`). It scores Importance 9 and has no content.
 2. **Merge `#1338` into `#1473`** (same N5 metadata gap).
 3. **Board the 8 off-board issues**, especially `#1894`.
-4. **Verify-before-ranking:** `#877` (jHDF/JRE — dependency has changed) and `#366` (Python
-   plotting — may be superseded).
+4. **Resolved by the obsolescence sweep:** close `#366` (seaborn gone); re-rank `#877` **upward**
+   (jHDF is now the sole HDF5 reader, not a fading dependency).
 5. **Group the multi-run statistics trio** (`#832`, `#174`, SpringSaLaD `#1508`) as one capability.
 6. **Take Decision 2** before ranking `#191`, `#1494`, `#898`, `#950`.
 7. `#1894` and `#1352` are the two items here with concrete ongoing costs (unreadable runs;

--- a/docs/backlog/14-api-platform.md
+++ b/docs/backlog/14-api-platform.md
@@ -1,0 +1,167 @@
+# Group: API, Platform & Database — 30 issues
+
+The server side: the Quarkus REST service, the legacy API being retired, authentication, the
+database layer, and messaging.
+
+**Epics:** `#1040`, `#1147`, `#1339` — **three overlapping containers for one migration**, see
+[04-epic-map.md](04-epic-map.md#d-1040--1147--1339--three-quarkusapi-epics).
+
+**Strategic decision required** — see
+[04-epic-map.md](04-epic-map.md#decision-1--is-the-postgresql-migration-still-happening). Whether
+`#172`, `#1994` and much of the DB work matters depends on it.
+
+---
+
+## Sub-themes
+
+### The legacy-API migration (7)
+
+`#1147` (epic, `Blocked`, rated **`Byzantine (1)`**), `#1152` (health check → API package),
+`#1548` (group modification, Priority 8/4), `#1549` (species and reactions control, Priority 9/5),
+`#1555` (export control — filed under
+[13-export-visualization.md](13-export-visualization.md)), `#1511` (remove the legacy guest-token
+requirement), `#1488` (give the API client access to the User object).
+
+This is the largest coherent programme in the group and it is progressing endpoint by endpoint.
+`#1147`'s checklist names the remaining areas: Events, Common, Client, Admin, RPC, Server, Users.
+
+`#1488` reads as a **blocker for the others** — *"The VCell API Client currently can not create a
+user object, which is needed for specific object creation within the messaging level"* — but it is
+unranked in `Pool` while `#1548`/`#1549` are `Queued`. Worth checking that dependency direction.
+
+`#1147` is `Blocked` but the body does not say by what. That is worth a sentence; a blocked epic
+with no named blocker cannot be unblocked by anyone but its author.
+
+### Auth (4)
+
+`#1037` (epic, `Active`, **untouched since July 2024**, 7/11 done), `#1292` (the webapp still uses
+**Auth0 dev keys** — Priority 12 / Importance 9, one of the highest-ranked items on the board),
+`#1365` (client update dialog steals focus after Auth0 login), `#1423` (feature flags in user
+preferences, via a JWT claim).
+
+`#1037`'s four unchecked items are exactly `#1292`'s subject: create a production Auth0 tenant,
+register VCell as a Google App for a proper client id, migrate users off the development tenant,
+update configuration. **`#1292` is `#1037`'s remaining work, filed separately.** Link them, and
+either the epic closes when `#1292` does or `#1292` becomes the epic's checklist.
+
+Running production authentication on a development tenant with Google dev keys is a real operational
+exposure, which the Priority 12/9 rank presumably reflects.
+
+### Database (5)
+
+`#840` (DatabaseConstraint exceptions on cleanup and pathological saves — a detailed 1k-char
+analysis: *"~260 times a day, the health monitor saves the exact same BioModel"*, Priority 9/7),
+`#172` (Oracle→PostgreSQL migration scripts), `#1540` (index the DB for common joins, specifically
+the user-ACL joins added with user roles), `#1487` (reduce DB-layer boilerplate), `#1994` (run the
+Quarkus suite against Oracle — **55 dialect branches across 33 files tested only on PostgreSQL**).
+
+`#840` describes real, quantified production misbehaviour and is well-ranked. Note it is also a
+child of the Postgres epic `#1032`, which makes it hostage to Decision 1 — it should not be, since
+the constraint violations happen on Oracle today.
+
+`#1994` is the cost of the half-finished migration made explicit. It is off-board.
+
+### Messaging (2)
+
+`#1153` (integrate VCell messaging with Quarkus, `Shelved`), `#1340` (simulation JMS causes brittle
+coupling — a 984-char analysis of the JMS + ActiveMQ + MongoDB arrangement, `Shelved`).
+
+Both `Shelved`, and `docs/MESSAGING.md` records that Artemis is the intended destination for all
+three broker stacks. These two should be re-read against that document before either is revived —
+`#1153`'s framing (evaluate Quarkus messaging implementations) may already be settled.
+
+### API ergonomics and internals (5)
+
+`#1474` (improve API ergonomics — *"hyper specific or vague names… input too granular"*, rated
+`Simple (5)`), `#1504` (the Java client object mapper reads any string as a workaround for XML
+inside JSON — *"This proves problematic"*), `#1539` (server-side user caching), `#1487`,
+`#1551` (users shared on a model cannot remove themselves).
+
+`#1504` describes a workaround that is known to be wrong and is still in place; those tend to get
+more expensive, not less.
+
+`#1551` is a small, self-contained user-facing fix with a clear description — another
+starter-issue candidate.
+
+### Publication pipeline (3)
+
+`#1706` (the publication submission form generates no confirmation email — reproduced by two
+people, `High Priority`, `Active`), `#1707` (the GUI's database panel shows the wrong date for
+published models — *"this is not a problem with the website, this is a problem with how the
+publication is recorded in the VCell client"*, `High Priority`), `#1885` (published MathModels not
+shown in Alpha but fine in Rel).
+
+Three `High Priority`-adjacent publication defects, none of them ranked numerically. They are
+plausibly related — all three concern how publication state reaches the client — and worth
+investigating together.
+
+### Deployment and compliance (3)
+
+`#1601` (guest login immediately closes the DB connection on Alpha — `High Priority`, Priority 4/2,
+with the full error text), `#1608` (a multi-user install can disrupt the main admin install —
+`Shelved`, but the described failure mode is that non-admin users find no VCell installed),
+`#1648` (California law 1798.501(b) age-collection requirement).
+
+`#1648` is a legal-compliance question, not an engineering one, and it needs a lawyer's or
+administrator's answer before any code is written. It sits unranked in `Pool` with no assignee.
+→ escalate rather than rank.
+
+### Cross-cutting (1)
+
+`#1786` — shared BioModels returned duplicated from `/api/v0/biomodel` due to a two-level
+group-access join fan-out. Precise 2.8k-char diagnosis, off-board. Note this is the *legacy* v0
+API, so its value depends on how long v0 survives the `#1147` migration.
+
+---
+
+## Recommendations
+
+1. **Collapse the three epics to one** (`#1147`); close `#1040` (the service exists and ships).
+2. **Link `#1292` to `#1037`** — they are the same remaining work. Then close `#1037` when
+   `#1292` closes, or convert `#1037` into `#1292`.
+3. **Take Decision 1 (Postgres)** before ranking `#172`, `#1994`, `#1540`, `#1487`.
+4. **Detach `#840` from the Postgres epic** — it is an Oracle problem happening now.
+5. **Check the `#1488` → `#1548`/`#1549` dependency** and reorder if confirmed.
+6. **Name `#1147`'s blocker** or unblock it.
+7. **Escalate `#1648`** out of engineering.
+8. **Investigate `#1706`/`#1707`/`#1885` together** as one publication-state problem.
+9. **Board the 4 off-board issues** (`#1365`, `#1423`, `#1786`, `#1994`).
+
+---
+
+## All 30
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#1601](https://github.com/virtualcell/vcell/issues/1601) | [Alpha] Connection to database immediately closes when signing in as a guest user | 2025-12 | Queued | 4/2 | Intricate&nbsp;(2) | HP |
+| [#1548](https://github.com/virtualcell/vcell/issues/1548) | Group Modification Through The New API | 2025-06 | Queued | 8/4 | Moderate&nbsp;(4) | — |
+| [#840](https://github.com/virtualcell/vcell/issues/840) | fix DatabaseConstraint exceptions upon DB Cleanup and pathological Biomodel saves. | 2023-03 | Queued | 9/7 | Intricate&nbsp;(2) | — |
+| [#1549](https://github.com/virtualcell/vcell/issues/1549) | Control of Species And Reactions Through The New API | 2025-06 | Queued | 9/5 | Moderate&nbsp;(4) | — |
+| [#1292](https://github.com/virtualcell/vcell/issues/1292) | VCell Webapp uses Dev keys  | 2024-07 | Queued | 12/9 | Complex&nbsp;(3) | — |
+| [#172](https://github.com/virtualcell/vcell/issues/172) | develop oracle to postgresql data migration and backup scripts | 2022-07 | Pool | — | — | thin |
+| [#1037](https://github.com/virtualcell/vcell/issues/1037) | Epic: modern auth with Keycloak and Auth0 OIDC | 2023-11 | Active | — | — | EPIC |
+| [#1040](https://github.com/virtualcell/vcell/issues/1040) | Epic: new vcell-rest with Quarkus | 2023-11 | Active | — | — | EPIC |
+| [#1147](https://github.com/virtualcell/vcell/issues/1147) | Epic: Use Quarkus Framework and Implement REST API Endpoints For VCell API | 2024-02 | Blocked | — | Byzantine&nbsp;(1) | EPIC |
+| [#1152](https://github.com/virtualcell/vcell/issues/1152) | VCell Health Check  in Quarkus needs conversion to API Package | 2024-02 | Pool | — | Moderate&nbsp;(4) | thin |
+| [#1153](https://github.com/virtualcell/vcell/issues/1153) | Integrate VCell Messaging with Quarkus | 2024-02 | Shelved | — | Intricate&nbsp;(2) | — |
+| [#1339](https://github.com/virtualcell/vcell/issues/1339) | Epic: Simulation Control Update | 2024-08 | Pool | — | Complex&nbsp;(3) | EPIC |
+| [#1340](https://github.com/virtualcell/vcell/issues/1340) | Simulation JMS causes brittle coupling | 2024-08 | Shelved | — | Complex&nbsp;(3) | — |
+| [#1365](https://github.com/virtualcell/vcell/issues/1365) | VCell Client Update appears after login looses focus with auth0 login | 2024-10 | **off-board** | — | — | thin |
+| [#1423](https://github.com/virtualcell/vcell/issues/1423) | Feature Flags in User Preferences | 2025-01 | **off-board** | — | — | — |
+| [#1474](https://github.com/virtualcell/vcell/issues/1474) | Improve API Ergonomics | 2025-04 | Pool | — | Simple&nbsp;(5) | — |
+| [#1487](https://github.com/virtualcell/vcell/issues/1487) | Introduce Functional Programming to DB Layer | 2025-04 | Pool | — | Moderate&nbsp;(4) | — |
+| [#1488](https://github.com/virtualcell/vcell/issues/1488) | Give VCell Api Client Access to User Object | 2025-04 | Pool | — | Moderate&nbsp;(4) | — |
+| [#1504](https://github.com/virtualcell/vcell/issues/1504) | Less Heavy Handed Middleware for Java Client Object Mapper | 2025-05 | Pool | — | — | — |
+| [#1511](https://github.com/virtualcell/vcell/issues/1511) | Remove Legacy Guest Token Requirement with Requests | 2025-05 | Pool | — | — | — |
+| [#1539](https://github.com/virtualcell/vcell/issues/1539) | User Caching on the Server | 2025-06 | Pool | — | — | — |
+| [#1540](https://github.com/virtualcell/vcell/issues/1540) | Indexing the DB For Common Joins | 2025-06 | Pool | — | — | — |
+| [#1551](https://github.com/virtualcell/vcell/issues/1551) | Users who've been added to a shared model should be able to remove themselves | 2025-06 | Pool | — | — | — |
+| [#1608](https://github.com/virtualcell/vcell/issues/1608) | Multi-User Install Can Distrupt Main Admin Install | 2025-12 | Shelved | — | — | — |
+| [#1648](https://github.com/virtualcell/vcell/issues/1648) | VCell does not comply with California Law 1798.501(b) | 2026-02 | Pool | — | — | — |
+| [#1706](https://github.com/virtualcell/vcell/issues/1706) | Publication Submission Pipeline seems to be broken | 2026-06 | Active | — | — | HP |
+| [#1707](https://github.com/virtualcell/vcell/issues/1707) | VCell database panel on front page of GUI shows incorrect date for list for published … | 2026-06 | Pool | — | — | HP |
+| [#1786](https://github.com/virtualcell/vcell/issues/1786) | Shared BioModels duplicated in /api/v0/biomodel — group-access join fan-out (duplicate… | 2026-07 | **off-board** | — | — | — |
+| [#1885](https://github.com/virtualcell/vcell/issues/1885) | Published MathModels in not shown in VCell Alpha. VCell-Rel is OK | 2026-08 | Pool | — | — | — |
+| [#1994](https://github.com/virtualcell/vcell/issues/1994) | Run the Quarkus test suite against Oracle too: 55 dialect branches across 33 files are… | 2026-08 | **off-board** | — | — | — |
+
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars

--- a/docs/backlog/15-math-solvers.md
+++ b/docs/backlog/15-math-solvers.md
@@ -1,0 +1,157 @@
+# Group: Math Generation & Solvers — 26 issues
+
+Math generation from biology, the expression engine, and the solver lineup. This is the group
+where defects are most likely to produce **silently wrong scientific results** rather than visible
+failures, which argues for weighting it above its raw count.
+
+**Epics:** `#1033` (improve NFSim multitrial statistics), `#1035` (general reactions with
+stochastic simulations, `Active` but untouched since Jan 2024), `#1556` (add COPASI-style steady
+state via CVODE — labelled an epic, 0/7 done, no children).
+
+---
+
+## Sub-themes
+
+### Math generation failures (6) — the correctness core
+
+`#490` (species sharing a name with a local parameter — Priority 8/5, `Complex (3)`), `#642`
+(indirect referencing of species concentrations through a global parameter), `#356` (a global
+parameter `J_r0` colliding with a reaction named `r0`), `#718` (the override resolver does not
+handle distributed volume fractions, orphaning the override), `#506` (membrane voltage namescoping
+inconsistent), `#475` (zero diffusion rates omitted from the constant list, so they cannot be
+overridden at simulation level).
+
+`#490` is the most serious issue in this group and arguably in the backlog. Its body enumerates
+the outcomes: math generation fails; *or* generated math is incorrect and the solver hangs in an
+infinite loop; *or* **the solver runs and produces incorrect results.** A naming collision that
+silently changes the science is a different class of defect from anything else here, and it is
+currently Priority 8 of 12.
+
+`#356`, `#490` and `#642` share a root: **the symbol-resolution rules across scopes are not
+consistent**, so names collide or resolve differently in INITIAL vs runtime context. Worth
+considering whether one piece of work on scoping addresses several of them rather than patching
+each collision.
+
+`#475` includes an unusually clear statement of design intent — *"This is a feature, not a bug"* —
+followed by why it is nonetheless a problem. Preserve that reasoning; do not let a refinement pass
+flatten it into a plain bug report.
+
+### The expression engine (3)
+
+`#430` (improve `ExpressionUtils.functionallyEquivalent()` for expressions with discontinuities —
+a careful 1.5k-char writeup of why random sampling misses discontinuities), `#551`
+(`getLinearFactor()` should use `SymbolTableEntries` — one line, completely actionable), `#214`
+(warn users on circular expressions, e.g. `Kr = Kd*Kr`).
+
+`#430` is `Shelved`. It underpins the roundtrip-equivalence work in
+[11-standards-interop.md](11-standards-interop.md) (`#522` is *"math equivalency failure"*), so
+shelving it while ranking `#522` at Priority 2 is worth a second look — they may be the same
+problem seen from two ends.
+
+### Rule-based modelling / NFSim (8)
+
+`#1033` (epic), `#180` (clusters in NFSim), `#206` (spurious default-compartment observable),
+`#209` (turn off complex bookkeeping), `#708` (multiple anchors in rule-based compartments — a good
+624-char reproduction with a named model), `#178` (better default D for generated species in
+spatial RBM), `#182` (choose concentrations vs counts for observables), `#215` (parameter
+expressions in RBM for reversible reactions).
+
+Six of these eight are from the 2022 cohort with thin or empty bodies, and five are `Shelved`.
+`#708` is the exception — it has a real reproduction and is unranked in `Pool`.
+
+`#1033`'s value depends on Decision-adjacent questions about NFSim's future: `#1635`/`#1636`/`#1637`
+in [16-infrastructure-ci.md](16-infrastructure-ci.md) propose upgrading BioNetGen and NFSim, which
+would change the ground under this epic. **Sequence the version upgrade question before the NFSim
+feature work.**
+
+### Stochastic simulation (4)
+
+`#1035` (epic), `#1464` (models with stochastic applications but no reactions cannot be saved —
+*"There is no reason for this requirement"*, `Simple (5)`, Priority 7), `#181` (Force Continuous
+should suppress particle-count display), `#179` (species with D=0 excluded from post-processing
+stats).
+
+`#1464` is a small, clearly-argued fix with a `Simple (5)` rating — good value at Priority 7.
+
+`#1035` is `Active` with three unchecked solver-specific tasks and has not been touched in over
+two years. See also `#166` in [01-close-and-verify.md](01-close-and-verify.md), which is marked
+`Done` on the board while being a live child of this epic — those two facts contradict.
+
+### Solvers (2)
+
+`#1663` (hook up the new FiniteVolume and CVODES/IDAS solvers — Priority 10/7, `Complex (3)`,
+*"both working across all our standard operating systems"*), `#1556` (add COPASI-style steady state
+through CVODE, 7 unchecked tasks spanning solver, GUI, VCML, and SED-ML import/export).
+
+`#1663` is the higher-value of the two and the more tractable: the solvers already exist and work,
+the work is integration. `#1556` is a genuine multi-layer feature that would need real scoping
+before it could be scheduled — it is currently `Queued` with no numeric rank, which understates its
+size.
+
+### Verification (2)
+
+`#1644` (Python infix generation needs verification — lists specific suspicions: chained
+trigonometry diverging between VCell and Python, `atan2` sign issues, division handling), `#563`
+(CLI conversion should use saved math for validation, Priority 2/2).
+
+`#1644` is off-board and is the natural follow-on from the `acot` bug in `#1647` (closed —
+[01](01-close-and-verify.md)) and the `-0.0` handling in `#1646`. Those two were found; `#1644`
+asks whether more of the same remain. **Given that two arithmetic errors were confirmed in the same
+area this year, this is a systematic-check candidate rather than a nice-to-have.**
+
+### Parameter exploration (1)
+
+`#942` — pseudorandom sampling of simulation parameters (uniform, log-uniform, normal, log-normal;
+possibly Latin Hypercube or Sobol). A well-written 1.8k-char feature proposal with clear
+motivation, unranked in `Pool` since 2023.
+
+---
+
+## Recommendations
+
+1. **Re-rank `#490` upward** on severity grounds — it can silently produce wrong results.
+2. **Consider `#356` / `#490` / `#642` as one scoping problem** rather than three collisions.
+3. **Reconsider `#430`'s `Shelved` status** against `#522`'s Priority 2 — likely the same problem.
+4. **Sequence the BioNetGen/NFSim upgrade** (`#1635`–`#1637`) before `#1033`'s feature work.
+5. **Board and act on `#1644`** — two confirmed arithmetic bugs this year make it a systematic
+   verification question, not a speculative one.
+6. **Scope `#1556` properly or move it out of `Queued`** — a 7-task cross-layer feature with no
+   estimate is not queued in any meaningful sense.
+7. **Resolve the `#166` / `#1035` contradiction** (see [01](01-close-and-verify.md)).
+8. Most of the RBM/NFSim 2022 cohort belongs in the batch refinement session
+   ([02](02-needs-refinement.md)), not in individual ranking.
+
+---
+
+## All 26
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#563](https://github.com/virtualcell/vcell/issues/563) | CLI conversion should use saved math for validation | 2022-11 | Queued | 2/2 | Unknown&nbsp;(0) | REF |
+| [#1464](https://github.com/virtualcell/vcell/issues/1464) | Models with stochastic applications without reactions can not be saved | 2025-03 | Queued | 7/2 | Simple&nbsp;(5) | — |
+| [#490](https://github.com/virtualcell/vcell/issues/490) | Math Generation Fails or is Incorrect when species have the same name as local paramet… | 2022-10 | Queued | 8/5 | Complex&nbsp;(3) | REF |
+| [#1663](https://github.com/virtualcell/vcell/issues/1663) | Hook-up New Deterministic Spatial (FiniteVolume) and Non-Spatial (CVODES/IDAS) Solvers | 2026-04 | Queued | 10/7 | Complex&nbsp;(3) | — |
+| [#178](https://github.com/virtualcell/vcell/issues/178) | Provide better value for D for generated species in spatial RBM | 2022-07 | Pool | — | Complex&nbsp;(3) | REF thin |
+| [#179](https://github.com/virtualcell/vcell/issues/179) | Include species with D=0 in "Post Processing Stats Data" | 2022-07 | Shelved | — | — | — |
+| [#180](https://github.com/virtualcell/vcell/issues/180) | Allow for clusters in NFSim | 2022-07 | Shelved | — | — | REF thin |
+| [#181](https://github.com/virtualcell/vcell/issues/181) | When "Force Continuous" applied in spatial stochastic application, don't allow species… | 2022-07 | Pool | — | Moderate&nbsp;(4) | REF thin |
+| [#182](https://github.com/virtualcell/vcell/issues/182) | Allow choice of concentrations or counts for observables and generated species for RBM | 2022-07 | Pool | — | Simple&nbsp;(5) | REF thin |
+| [#206](https://github.com/virtualcell/vcell/issues/206) | NFSim immediately creates an observable for total in a default compartment when molecu… | 2022-07 | Shelved | — | — | REF thin |
+| [#209](https://github.com/virtualcell/vcell/issues/209) | Allow choice to turn off complex bookkeeping in NFSim | 2022-07 | Shelved | — | — | REF thin |
+| [#214](https://github.com/virtualcell/vcell/issues/214) | Need warning when users enter circular expressions  | 2022-07 | Pool | — | Intricate&nbsp;(2) | thin |
+| [#215](https://github.com/virtualcell/vcell/issues/215) | Allow parameter expressions in RBM for reversible reactions | 2022-07 | Pool | — | — | REF thin |
+| [#356](https://github.com/virtualcell/vcell/issues/356) | math generation fails with global parameter J_r0 and Reaction(r0) | 2022-09 | Pool | — | — | REF |
+| [#430](https://github.com/virtualcell/vcell/issues/430) | improve ExpressionUtils.functionllyEquivalent() for expressions with discontinuities | 2022-09 | Shelved | — | — | — |
+| [#475](https://github.com/virtualcell/vcell/issues/475) | Species diffusion rates with value zero are not in constant list | 2022-10 | Shelved | — | Byzantine&nbsp;(1) | — |
+| [#506](https://github.com/virtualcell/vcell/issues/506) | Membrane voltage namescoping inconsistent | 2022-10 | Pool | — | — | REF |
+| [#551](https://github.com/virtualcell/vcell/issues/551) | ExpressionUtils.getLinearFactor() should use SymbolTableEntries | 2022-11 | Pool | — | — | REF thin |
+| [#642](https://github.com/virtualcell/vcell/issues/642) | Indirect referencing of species concentrations fails math generation | 2022-12 | Pool | — | — | — |
+| [#708](https://github.com/virtualcell/vcell/issues/708) | Bug when using multiple anchors in rule-based compartments NFSim | 2022-12 | Pool | — | Intricate&nbsp;(2) | — |
+| [#718](https://github.com/virtualcell/vcell/issues/718) | override resolver does not handle distributed volume fractions | 2022-12 | Pool | — | — | — |
+| [#942](https://github.com/virtualcell/vcell/issues/942) | pseudorandom sampling of vcell simulation parameters | 2023-07 | Pool | — | — | — |
+| [#1033](https://github.com/virtualcell/vcell/issues/1033) | Epic: improve NFSim multitrial statistics | 2023-11 | Pool | — | — | EPIC |
+| [#1035](https://github.com/virtualcell/vcell/issues/1035) | Epic: general reactions with stochastic simulations | 2023-11 | Active | — | — | EPIC |
+| [#1556](https://github.com/virtualcell/vcell/issues/1556) | Add Steady State (COPASI-style) to VCell through CVODE (VCellODE) | 2025-06 | Queued | — | — | EPIC |
+| [#1644](https://github.com/virtualcell/vcell/issues/1644) | Python Infix generation needs additional verification | 2026-02 | **off-board** | — | — | — |
+
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars

--- a/docs/backlog/16-infrastructure-ci.md
+++ b/docs/backlog/16-infrastructure-ci.md
@@ -1,0 +1,143 @@
+# Group: Infrastructure, CI/CD & Release Ops — 19 issues
+
+Build, test harnesses, dependency upgrades, release mechanics, and configuration hygiene. The
+smallest group with the highest proportion of recent, well-diagnosed work — **six of the 2026
+issues here are off-board.**
+
+**Epic:** `#1039` (Solver Regression Tests, 0/4 done, last touched Nov 2023).
+
+---
+
+## Sub-themes
+
+### Test harness and regression coverage (7)
+
+`#1082` (the testing framework hits an RPC `DataAccessException` — **Priority 1 / Importance 1**,
+the extreme of the ranked slate, though which extreme depends on the polarity question in
+[03](03-board-hygiene.md)), `#1472` (nightly testing fixes — a checklist with two items already
+COMPLETE), `#185` (update the math testing framework, `High Priority`, `Shelved`), `#189`
+(automatic sim testing for all solvers on each build, Priority 9/5), `#201` (apply the test-suite
+data comparator across simulators, `Shelved`), `#728` (collect stochastic validation tests into
+JUnit integration tests), `#1039` (epic), `#1503` (automate SBML import against all BMDB models
+weekly with a Slack discrepancy report, Priority 6/3).
+
+Three of these — `#185`, `#189`, `#201` — are 2022 issues about "test all the solvers on every
+build" and are split across `Shelved` and `Queued` with no coordination. `#1039` is meant to be
+their epic and has not moved since 2023. Meanwhile `#1503` and `#1472` describe *newer* testing
+automation that partly overlaps.
+
+> This is the same pattern as elsewhere: an old epic holding old issues, a newer effort doing
+> similar work, and no link between them. Recommend consolidating the testing story into one
+> current epic and closing `#1039` or repurposing it.
+
+`#1472` is worth reading closely because it **records completed work inline** (`[COMPLETE]` on two
+of its items). That is a good habit and also a warning: the remaining scope is smaller than the
+title suggests, so its `Intricate (2)` rating may now be wrong.
+
+### Dependency upgrades (4)
+
+`#1635` (upgrading biology network generation — the umbrella: *"Due to having older versions of
+BioNetGen / NFSim, there are limitations on how models can be designed"*), `#1636` (upgrade
+BioNetGen), `#1637` (upgrade NFSim), `#1978` (JSBML fork upgrade plan — a 7.7k-char analysis of the
+`virtualcell/vcell-jsbml` fork at `1.6.1-VCELL-4`, what to catch up on, and what to contribute
+upstream).
+
+`#1636` and `#1637` say only *"Self explanatory, we need to update."* They are not self-explanatory:
+a BioNetGen or NFSim version change alters simulation results, so what is missing is the target
+version and the validation plan. See [02-needs-refinement.md](02-needs-refinement.md).
+
+**This trio gates the NFSim feature work** in [15-math-solvers.md](15-math-solvers.md) — `#1635`
+explicitly says the current versions constrain what models can express. Sequence accordingly.
+
+`#1978` is the best-documented dependency issue in the repo and is off-board.
+
+### Release and CI mechanics (3)
+
+`#1888` (release runs intermittently fail on ghcr.io secondary rate limits, with no retry — it
+happened **twice in one run** during 8.0.10.01), `#1926` (`regression-gate` never actually gates,
+because admin merges bypass the merge queue), `#1244` (add URL validation to CI to catch
+`MalformedURLException` — BMDB and Pathway Commons imports broken on both Rel and Alpha,
+`High Priority`).
+
+`#1888` and `#1926` are both about the release path being less reliable than it appears, and both
+are off-board. `#1926` is explicitly framed as documentation of a real state rather than a
+misconfiguration — *"the current state is easy to misread as protection that exists"* — which makes
+it a decision to confirm rather than a bug to fix.
+
+`#1244` is `High Priority` with a concrete user-visible symptom (two import paths broken in
+production) and is unranked in `Pool`. That combination is worth a second look.
+
+### Configuration hygiene (2)
+
+`#1921` (rename the 12 unprefixed config env vars to `VCELL_*`, requiring vcell-fluxcd
+coordination), `#1922` (normalize environment naming — *"Three environments are referred to by four
+different vocabularies, and the most common one implies the opposite of what is true. It has
+already caused one wrong decision"*).
+
+`#1922` is unusual in that it documents a naming problem that has **already caused an incorrect
+decision**. That is a concrete cost, not a tidiness preference. Both off-board.
+
+### Build environment (2)
+
+`#1849` (`vcell.sh` does not pin a JDK, so dev clients can run on a different Java than we ship —
+every other environment pins Java 17), `#1654` (update the vcell.org WordPress stack, `Active`).
+
+`#1849` is small, self-contained, and prevents a class of "works on my machine" confusion.
+
+---
+
+## Observation: this group is where the recent good work lives
+
+Six issues here (`#1849`, `#1888`, `#1921`, `#1922`, `#1926`, `#1978`) were all written in
+August 2026, all carry detailed analysis with tables and citations, and **all six are off the
+board with no assignee and no rank.**
+
+Meanwhile the ranked items in this group are 2022–2025 issues, several of them one line long.
+
+The board is not capturing current work, and this group shows it most starkly. That is the
+argument for making the off-board sweep ([03](03-board-hygiene.md), Step 3) an early step rather
+than a tidy-up at the end.
+
+---
+
+## Recommendations
+
+1. **Board all six 2026 issues** — they are the most actionable items in the group.
+2. **Consolidate the testing story:** one current epic covering `#185`, `#189`, `#201`, `#728`,
+   `#1039`, `#1472`, `#1503`; close or repurpose `#1039`.
+3. **Specify `#1636`/`#1637`** with target versions and a validation plan before scheduling; treat
+   `#1635` as their parent.
+4. **Sequence the BioNetGen/NFSim upgrade before NFSim feature work** in
+   [15-math-solvers.md](15-math-solvers.md).
+5. **Re-rank `#1244`** — `High Priority`, production-visible, unranked.
+6. **`#1926` needs a decision, not an implementation** — confirm the current merge-gate posture is
+   intended, then close or fix.
+7. **Re-check `#1472`'s complexity rating** now that two of its items are done.
+
+---
+
+## All 19
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#1082](https://github.com/virtualcell/vcell/issues/1082) | Testing Framework encounteres a RPC DataAccessException | 2023-12 | Queued | 1/1 | Unknown&nbsp;(0) | — |
+| [#1503](https://github.com/virtualcell/vcell/issues/1503) | Automate running SBML import against all BMDB models | 2025-05 | Queued | 6/3 | Complex&nbsp;(3) | — |
+| [#189](https://github.com/virtualcell/vcell/issues/189) | Create Automatic sim testing for all solvers for new build | 2022-07 | Queued | 9/5 | Moderate&nbsp;(4) | thin |
+| [#185](https://github.com/virtualcell/vcell/issues/185) | Update Math Testing Framework | 2022-07 | Shelved | — | Intricate&nbsp;(2) | HP thin |
+| [#201](https://github.com/virtualcell/vcell/issues/201) | Apply data comparator algorithm from test suite to compare results from different simu… | 2022-07 | Shelved | — | Intricate&nbsp;(2) | REF thin |
+| [#728](https://github.com/virtualcell/vcell/issues/728) | collect stochastic validation tests into JUnit integration tests. | 2023-01 | Pool | — | — | — |
+| [#1039](https://github.com/virtualcell/vcell/issues/1039) | Epic: Solver Regression Tests | 2023-11 | Pool | — | — | EPIC |
+| [#1244](https://github.com/virtualcell/vcell/issues/1244) | Add URL validation to CI/CD to catch MalformedURLException | 2024-05 | Pool | — | — | HP |
+| [#1472](https://github.com/virtualcell/vcell/issues/1472) | Nightly testing needs further fixing / upgrades | 2025-04 | Pool | — | Intricate&nbsp;(2) | — |
+| [#1635](https://github.com/virtualcell/vcell/issues/1635) | Upgrading Biology Network Generation | 2026-02 | Pool | — | — | — |
+| [#1636](https://github.com/virtualcell/vcell/issues/1636) | Upgrade BioNetGen Version | 2026-02 | Pool | — | — | thin |
+| [#1637](https://github.com/virtualcell/vcell/issues/1637) | Upgrade NFSim Version | 2026-02 | Pool | — | — | thin |
+| [#1654](https://github.com/virtualcell/vcell/issues/1654) | Update vcell.org stack | 2026-04 | Active | — | — | — |
+| [#1849](https://github.com/virtualcell/vcell/issues/1849) | vcell.sh does not pin a JDK — dev clients can run on a different Java than we ship | 2026-08 | **off-board** | — | — | — |
+| [#1888](https://github.com/virtualcell/vcell/issues/1888) | Release runs intermittently fail on ghcr.io secondary rate limits (push and pull), wit… | 2026-08 | **off-board** | — | — | — |
+| [#1921](https://github.com/virtualcell/vcell/issues/1921) | Rename the 12 unprefixed config env vars to VCELL_* (needs vcell-fluxcd coordination) | 2026-08 | **off-board** | — | — | — |
+| [#1922](https://github.com/virtualcell/vcell/issues/1922) | Normalize environment naming: four vocabularies for three environments, and the names … | 2026-08 | **off-board** | — | — | — |
+| [#1926](https://github.com/virtualcell/vcell/issues/1926) | regression-gate never gates: the merge queue is bypassed by admin merges | 2026-08 | **off-board** | — | — | — |
+| [#1978](https://github.com/virtualcell/vcell/issues/1978) | JSBML fork upgrade plan: catch up to upstream, and what to send back | 2026-08 | **off-board** | — | — | — |
+
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars

--- a/docs/backlog/16-infrastructure-ci.md
+++ b/docs/backlog/16-infrastructure-ci.md
@@ -13,8 +13,10 @@ issues here are off-board.**
 ### Test harness and regression coverage (7)
 
 `#1082` (the testing framework hits an RPC `DataAccessException` — **Priority 1 / Importance 1**,
-the extreme of the ranked slate, though which extreme depends on the polarity question in
-[03](03-board-hygiene.md)), `#1472` (nightly testing fixes — a checklist with two items already
+the *bottom* of the ranked slate: Importance 1 and `Unknown (0)` simplicity, so it scores lowest
+under the board's `Importance + Simplicity` formula, see [03](03-board-hygiene.md). Note that the
+`Unknown (0)` rating is doing half the work here — rating its difficulty at all would raise it),
+`#1472` (nightly testing fixes — a checklist with two items already
 COMPLETE), `#185` (update the math testing framework, `High Priority`, `Shelved`), `#189`
 (automatic sim testing for all solvers on each build, Priority 9/5), `#201` (apply the test-suite
 data comparator across simulators, `Shelved`), `#728` (collect stochastic validation tests into

--- a/docs/backlog/17-execution-hpc.md
+++ b/docs/backlog/17-execution-hpc.md
@@ -1,0 +1,126 @@
+# Group: Simulation Execution & HPC — 12 issues
+
+Getting simulations to run on the cluster, tracking their state honestly, and not losing their
+results. The smallest technical group, but it contains the backlog's only **data-loss** issue.
+
+No epic covers this group.
+
+---
+
+## Sub-themes
+
+### Data integrity — results vs. what the database claims (3)
+
+`#537` (reconcile database status with the filesystem — Priority 4/4, `High Priority`), `#158`
+(run all published models currently marked "never ran" — Priority 2/2, `High Priority`), `#1980`
+(five confirmed dataset losses on published models, all from 2004–2005 — find the extent and the
+cause).
+
+These three are one problem seen at three moments. `#537` sets out a two-step reconciliation:
+where the DB claims results exist but the filesystem disagrees, correct the DB; where results
+exist but the DB says otherwise, correct the DB the other way. `#158` is about published models
+whose status says they never ran. `#1980` is the 2026 forensic follow-up that found actual losses.
+
+`#1980` is the only issue in the backlog documenting **permanently lost scientific data on
+published models**, and it is off-board with no assignee. Whatever its priority relative to feature
+work, it should at minimum be visible.
+
+> **Recommendation:** treat `#537`, `#158`, `#1980` as one workstream with a single owner. Doing
+> `#537`'s reconciliation without `#1980`'s cause analysis risks writing "never ran" over records
+> that are actually evidence of a loss.
+
+### Moving-boundary solver (4)
+
+`#146` (time plots and kymographs fail for moving-boundary simulations — `Shelved`), `#1577`
+(retrieving remote moving-boundary results fails, with the full RPC error), `#1578` (remote
+moving-boundary simulation fails with an integer overflow — `-2.71505e+09 < min value -2147483648`
+at a named source line in `Voronoi32.cpp`), `#566` (simulations stick on mesh initialization for a
+large planar membrane in flat 3D geometry — with a shared reproduction BioModel).
+
+`#1577` and `#1578` were filed on the same day from the same investigation and are almost certainly
+related; both are off-board. `#146` is `Shelved` and describes a third symptom of the same
+subsystem being under-exercised.
+
+`#1578`'s overflow is a concrete, located C++ bug with the value and the line number. That is
+rare enough in this backlog to be worth acting on directly.
+
+> **Recommendation:** group all four as "moving-boundary solver reliability." The mbsolver work in
+> [13-export-visualization.md](13-export-visualization.md) (`#1879`) is touching the same area, so
+> there may be shared context available now that was not available when `#146` was shelved.
+
+### SLURM and scheduling (3)
+
+`#1384` (give VCell a dedicated submit node — **Priority 12 / Importance 10, the highest Importance
+on the board**; when HPC users launch big jobs on shared submit nodes, VCell submissions block),
+`#168` (improve SLURM job-array efficiency for multiple stochastic trajectories, `High Priority`,
+`Shelved`), `#169` (investigate whether parameter scans can be improved in SLURM — empty body,
+`Shelved`).
+
+`#1384` is an infrastructure request as much as a code change, and it is the kind of thing that
+needs someone with a relationship to the HPC operators rather than an engineer. Note it may be
+partly superseded — it is a 2024 issue and the deployment has moved substantially since.
+**Verify it still describes current behaviour before acting.**
+
+`#168` and `#169` are both `Shelved` SLURM-efficiency questions with thin bodies; they belong in
+the refinement batch ([02](02-needs-refinement.md)).
+
+### Server-vs-local discrepancies (2)
+
+`#842` (a model runs locally but fails on the server with an invalid-character error — full RPC
+error text, from @pmendes, an external user), `#213` (investigate errors in the "Actin Dendritic
+Nucleation Detailed Branching" model — *"Actually assigned to Les but he does not yet have a
+handle"*).
+
+`#842` reads as the same class of problem as `#1674` in
+[11-standards-interop.md](11-standards-interop.md) — an invalid XML character surviving into a
+document that then fails to save. Worth checking whether they are the same bug; `#1674` has a much
+fuller diagnosis.
+
+`#213` should be closed or completely rewritten — see [02](02-needs-refinement.md).
+
+---
+
+## Observation
+
+This group has the highest concentration of `Shelved` status (5 of 12) and the highest
+concentration of `High Priority` labels relative to size (4 of 12). Those two facts sitting
+together is itself a signal: work was labelled urgent and then parked, without the label being
+removed or the parking being explained.
+
+Shelving is legitimate. Shelving something still labelled `High Priority` and leaving no note about
+why is how a backlog stops meaning anything.
+
+---
+
+## Recommendations
+
+1. **One owner for the data-integrity trio** (`#537`, `#158`, `#1980`); sequence `#1980`'s cause
+   analysis before `#537`'s corrective writes.
+2. **Board `#1577`, `#1578`, `#1980`.**
+3. **Group the four moving-boundary issues**; `#1578` is directly actionable today.
+4. **Verify `#1384` still describes current behaviour** — highest Importance on the board, but from
+   2024 and infrastructure-dependent.
+5. **Check whether `#842` and `#1674` are the same defect.**
+6. **Resolve the `Shelved` + `High Priority` contradiction** on `#168` and `#185` — either
+   un-shelve or drop the label, and record why.
+
+---
+
+## All 12
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#158](https://github.com/virtualcell/vcell/issues/158) | Run all published models with status never ran | 2022-07 | Queued | 2/2 | Unknown&nbsp;(0) | HP REF |
+| [#537](https://github.com/virtualcell/vcell/issues/537) | Reconcile database status with filesystem for sim results | 2022-11 | Queued | 4/4 | Unknown&nbsp;(0) | HP |
+| [#1384](https://github.com/virtualcell/vcell/issues/1384) | Give Dedicated Submit Node to VCell (and/ or give more inteligent code to select submi… | 2024-11 | Queued | 12/10 | Intricate&nbsp;(2) | — |
+| [#146](https://github.com/virtualcell/vcell/issues/146) | Results Graphing Functions errors for Moving Boundary Simulations | 2022-05 | Shelved | — | Unknown&nbsp;(0) | — |
+| [#168](https://github.com/virtualcell/vcell/issues/168) | Improve efficiency of slurm job arrays for multiple stochastic trajectories | 2022-07 | Shelved | — | — | HP thin |
+| [#169](https://github.com/virtualcell/vcell/issues/169) | Investigate whether parameter scans can be improved in Slurm. | 2022-07 | Shelved | — | — | REF thin |
+| [#213](https://github.com/virtualcell/vcell/issues/213) | Investigate errors in simulations in "Actin Dendritic Nucleation Detailed Branching | 2022-07 | Shelved | — | — | REF thin |
+| [#566](https://github.com/virtualcell/vcell/issues/566) | Simulations get stuck on initializing mesh for large planar membrane in flat 3D geometry | 2022-11 | Shelved | — | — | — |
+| [#842](https://github.com/virtualcell/vcell/issues/842) | Error running in the server but no problem running local (invalid character) | 2023-03 | Pool | — | — | — |
+| [#1577](https://github.com/virtualcell/vcell/issues/1577) | retrieving remote moving boundary results fails | 2025-08 | **off-board** | — | — | — |
+| [#1578](https://github.com/virtualcell/vcell/issues/1578) | remote moving boundary simulation fails with integer overflow | 2025-08 | **off-board** | — | — | — |
+| [#1980](https://github.com/virtualcell/vcell/issues/1980) | Missing simulation datasets: 5 confirmed losses on published models, all 2004-2005 — f… | 2026-08 | **off-board** | — | — | — |
+
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars

--- a/docs/backlog/18-user-docs.md
+++ b/docs/backlog/18-user-docs.md
@@ -1,0 +1,125 @@
+# Group: User Documentation & Materials — 9 issues
+
+In-app help (`vcell-client/UserDocumentation/`, compiled to JavaHelp and to HTML at
+vcell.org/webstart), plus website integration and the VCML specification.
+
+**Epic:** `#1031` (enhance user docs and training, 4/9 done, two of its remaining items point at
+the separate `virtualcell/usermaterials` repo).
+
+---
+
+## The version-lag problem
+
+Three of the nine issues name a version we shipped long ago:
+
+- `#207` — "Update RBM help from version 6 to **version 7.5**" (2022, empty body)
+- `#1534` — "General Help Updates for **7.7**" (2025, `Active`, one-line body)
+- `#1708` — spatial geometry mapping help (2026, `Active`)
+
+We are on **8.0.27.01**. `#207` and `#1534` are stale in their titles, but the *underlying* need is
+probably still real — if RBM help was on version-6 content in 2022, it is unlikely to have been
+updated since. The stale version number hides a live gap rather than indicating the gap closed.
+
+> **Recommendation:** restate `#207` and `#1534` against the current release, or fold both into a
+> single "help content audit against 8.0" item. A recurring per-release help-review step in
+> `docs/RELEASING.md` would stop this pattern regenerating.
+
+---
+
+## Sub-themes
+
+### In-app help content (4)
+
+`#207` (RBM help), `#1534` (general 7.7 updates, `Active`), `#1370` (instructions for converting to
+OME-TIFF for image import — Priority 8/4, needed because **bioformats was removed from the VCell
+runtime**, so users must now convert externally), `#1708` (spatial geometry mapping for distributed
+compartments needs help text, a tooltip, or a popup explaining what surface-to-volume and volume
+fractions refer to — `Active`, 5 comments).
+
+`#1370` is the one with a forcing function behind it: a capability was removed and users need to be
+told what to do instead. Until that help exists, image import is harder than it was. It is
+correctly the highest-ranked doc issue.
+
+`#1708` is a good example of documentation as a bug fix rather than a chore — the underlying
+complaint is that users misinterpret what a field means, which produces wrong models.
+
+### VCML specification (1)
+
+`#315` — *"We need to post an updated, even if minimal, documentation of VCML (plus update our
+namespace URI)."* `Shelved` since 2022.
+
+VCML is VCell's native model format and it has no published specification. That matters more than
+its `Shelved` status suggests: `docs/architecture-layers.md` and the SBML/SED-ML interop work in
+[11-standards-interop.md](11-standards-interop.md) all rest on VCML semantics that exist only in
+code. This is also the kind of artifact that academic users and reviewers ask for.
+
+Worth an explicit decision rather than indefinite shelving: either it is not worth writing, or it
+is — but leaving the flagship format undocumented by default is a choice being made passively.
+
+### Website and model-browser integration (3)
+
+`#192` (integrate the VCell model browser with vcell.org, the CCB website, and RunBioSimulations —
+empty body, `Shelved`), `#204` (from the website, let users load a model in VCell or run the sim in
+BioSimulations — *"coordinate with Michael regarding use of the Modelbricks interface"*, `Shelved`),
+`#205` (improve how published models are assigned in VCellDB and posted to the website — empty
+body).
+
+All three are 2022, all three concern the boundary between VCell and its public web presence, and
+all three are `Shelved` or unranked with thin bodies. They should be handled as one question —
+*what is the intended relationship between vcell.org, the model database, and BioSimulations?* —
+rather than three vague issues.
+
+Note `#1654` ("Update vcell.org stack", in [16-infrastructure-ci.md](16-infrastructure-ci.md)) is
+`Active` and touches the same territory. If the WordPress stack is being rebuilt, that is the
+moment to answer this question, not after.
+
+### Epic (1)
+
+`#1031` — 4 of 9 items done. Two remaining items are issues in the separate
+`virtualcell/usermaterials` repository, and one is *"update README.md for vcell-solvers repo."*
+
+An epic whose remaining scope lives mostly in other repositories is hard to track from here. Either
+the cross-repo items move onto a shared board, or the epic should be scoped to this repo and the
+others tracked where they live.
+
+---
+
+## Observation
+
+Documentation issues in this backlog are consistently thin, old, and unranked — six of the nine
+have bodies under 200 characters, four are `Shelved` or `Pool` with no rank, and only one carries a
+numeric priority.
+
+That is a recognisable pattern and not unique to VCell. It is worth noting explicitly because for
+academic software the documentation *is* part of the product: it is what lets other groups
+reproduce results and cite the tool correctly. The `User Materials` label exists on 9 issues;
+there is no evidence in the board data of any of them being scheduled.
+
+---
+
+## Recommendations
+
+1. **Restate `#207` and `#1534`** against 8.0, or merge into one help-content audit.
+2. **Add a help-review step to `docs/RELEASING.md`** so version lag stops accumulating.
+3. **Decide on `#315` (VCML spec)** explicitly rather than leaving it shelved.
+4. **Merge `#192`, `#204`, `#205`** into one question about VCell ↔ web presence, and answer it
+   alongside `#1654` while the stack is being updated.
+5. **Rescope `#1031`** to this repo, or move its cross-repo children somewhere they are visible.
+
+---
+
+## All 9
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#1370](https://github.com/virtualcell/vcell/issues/1370) | Create instructions for users within dialog(s) on how to convert to OME-TIFF to import… | 2024-10 | Queued | 8/4 | Moderate&nbsp;(4) | — |
+| [#192](https://github.com/virtualcell/vcell/issues/192) | Integrate VCell Model Browser with VCell Website, CCB website and RunBioSimulations | 2022-07 | Shelved | — | Unknown&nbsp;(0) | REF thin |
+| [#204](https://github.com/virtualcell/vcell/issues/204) | From website create ability to either load model inVCell website or run sim in BioSimu… | 2022-07 | Shelved | — | — | REF |
+| [#205](https://github.com/virtualcell/vcell/issues/205) | Improve methods for assigning published models in VCellDB and posting to website | 2022-07 | Pool | — | — | REF thin |
+| [#207](https://github.com/virtualcell/vcell/issues/207) | Update RBM help from version 6 to version 7.5 | 2022-07 | Pool | — | — | thin |
+| [#315](https://github.com/virtualcell/vcell/issues/315) | Create Documentation of VCML | 2022-09 | Shelved | — | — | — |
+| [#1031](https://github.com/virtualcell/vcell/issues/1031) | Epic: enhance user docs and training | 2023-11 | Pool | — | — | EPIC |
+| [#1534](https://github.com/virtualcell/vcell/issues/1534) | General Help Updates for 7.7 | 2025-06 | Active | — | — | thin |
+| [#1708](https://github.com/virtualcell/vcell/issues/1708) | Spatial geometry mapping for distributed compartments needs updated HELP section,"tool… | 2026-06 | Active | — | — | — |
+
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars

--- a/docs/backlog/19-accessibility.md
+++ b/docs/backlog/19-accessibility.md
@@ -1,0 +1,122 @@
+# Group: Accessibility — 4 issues
+
+The smallest group, and the only one driven by an **external compliance requirement** rather than
+by user requests or engineering judgment. Separated from
+[10-desktop-ui.md](10-desktop-ui.md) for that reason: if the mandate is real and dated, these four
+do not compete with ordinary UI work — they precede it.
+
+**Epic:** `#1603`, which has **no children and no checklist** despite the other three plainly
+being its content.
+
+**Strategic decision required** — see
+[04-epic-map.md](04-epic-map.md#decision-4--is-accessibility-a-funded-mandate-with-a-date).
+
+---
+
+## The four
+
+All four (`#1603` the epic, plus `#1604`, `#1605`, `#1606`) were created on 2025-12-05 by @CodeByDrescher, all four carry `High Priority`, all four
+are assigned to @danv61 and @CodeByDrescher, and all four are `Queued`.
+
+**Two of the four are rated `Byzantine (1)` — the hardest tier on the board.** Only 7 issues in the
+entire backlog carry that rating and two of them are here. This is a large programme wearing the
+clothes of four tickets.
+
+---
+
+## What each one actually involves
+
+### `#1603` — the mandate
+*"Due to newly implemented accessibility policies introduced at UConn Health, we need to take steps
+to ensure all our GUI components are satisfactorily displayed, and use color blind pallets — both
+for dark and light modes. This is a massive end[eavor]…"*
+
+The body is a statement of the requirement, not a plan. What is missing and matters:
+**is there a deadline, and is there an audit we will be measured against?** Those two answers
+change everything downstream. If UConn Health has a compliance date, this outranks essentially all
+other UI work. If it is aspirational, it is four large issues competing normally.
+
+### `#1606` — font sizes
+*"Right now, the only way to change font sizes is through manually changing resolutions. This is
+unreasonable to ask users to do for accessibility reasons. This…is going to be a lot of work."*
+
+The `Byzantine (1)` rating is accurate. Prior investigation of this codebase established that the
+obstacle is **pinned pixel constants** (e.g. `setDividerLocation`) rather than font literals, and
+that a JVM-level UI-scaling flag is not a solution — it magnifies rather than reflows, and does
+nothing on macOS. A meaningful fraction of the client's layout code has to change for text to grow
+without breaking panels.
+
+This is the single largest piece of work in the accessibility group and probably one of the largest
+in the backlog. It should be scoped as a project with its own phasing, not carried as one ticket.
+
+### `#1604` — cross-OS appearance and dark mode
+*"While originally we had a unified appearance for each operating system, over time we've let the
+appearance fall by the wayside, even as 'dark mode' became featured in operating systems."*
+
+Also `Byzantine (1)`. Overlaps `#1606` substantially — both require touching the same layout and
+theming code — and overlaps `#1886` (Mac splash screen still showing VCell 7.0) and `#1785`
+(cluttered database subpanel) in [10-desktop-ui.md](10-desktop-ui.md).
+
+Dark mode is a strict superset of the colour work in `#1605`: any palette decision has to hold in
+both modes.
+
+### `#1605` — colorblindness
+*"We need to verify that all views, menus, windows, etc. are colorblind-safe. The obvious targets
+are model and results viewers but all areas should be evaluated."*
+
+Rated `Intricate (2)` — the least hard of the three, and the most separable. It naturally splits
+into an **audit** (cheap, produces a concrete list) and **remediation** (sized by what the audit
+finds).
+
+Note that the reaction diagram and the spatial results viewers encode meaning in colour by design —
+species colours, catalyst indication (see `#176`), field colour scales (`#1867`). Those are not
+incidental decoration, so remediation here is a genuine design problem, not a palette swap.
+
+---
+
+## Structural observations
+
+**`#1603` should have `#1604`, `#1605`, `#1606` as children.** It does not, which is why the board's
+`Epic` field shows nothing for them. This is the cheapest fix in this document.
+
+**The three non-epic issues overlap heavily.** All three touch theming and layout; `#1604` and
+`#1606` touch the same layout constants. Scheduling them independently means paying the
+learning cost three times and risks three inconsistent partial solutions. **Recommend one
+programme with staged delivery**, ordered:
+
+1. **Audit** (`#1605`'s audit half, plus a survey of pinned layout constants for `#1606`) —
+   produces scope, cheap, unblocks estimation.
+2. **Theming/palette** (`#1605` remediation + `#1604`'s dark-mode work) — shared foundation.
+3. **Scaling** (`#1606`) — the largest, and the one that most needs the audit first.
+
+**The Priority values disagree with the Simplicity values.** `#1605` is Priority 3 and
+`Intricate (2)`; `#1606` is Priority 4 and `Byzantine (1)`; `#1604` is Priority 5 and
+`Byzantine (1)`. Under either polarity reading, the ranking does not obviously reflect that two of
+these are the hardest work available. That may be deliberate sequencing (easiest first) — worth
+confirming.
+
+---
+
+## Recommendations
+
+1. **Answer the mandate question first** (deadline? audit? measured against what?) — everything
+   else follows from it.
+2. **Link `#1604`/`#1605`/`#1606` as children of `#1603`.**
+3. **Split `#1605` into audit and remediation**; do the audit early regardless of the rest.
+4. **Scope `#1606` as a project**, not a ticket — pinned layout constants, not font literals.
+5. **Merge `#1604`'s dark-mode work with `#1605`'s palette work** — one theming foundation.
+6. **Cross-reference `#1785` and `#1886`** from [10-desktop-ui.md](10-desktop-ui.md); they will be
+   touched by the same effort.
+
+---
+
+## All 4
+
+| # | Title | Opened | Board status | Pri/Imp | Simplicity | Flags |
+|---|---|---|---|---|---|---|
+| [#1605](https://github.com/virtualcell/vcell/issues/1605) | VCell GUI needs to be evaluated for Colorblindness | 2025-12 | Queued | 3/1 | Intricate&nbsp;(2) | HP |
+| [#1606](https://github.com/virtualcell/vcell/issues/1606) | VCell needs ability to change font sizes | 2025-12 | Queued | 4/3 | Byzantine&nbsp;(1) | HP |
+| [#1604](https://github.com/virtualcell/vcell/issues/1604) | Need to Update and Unify Appearance of GUI across operating systems (Windows, Mac, Lin… | 2025-12 | Queued | 5/4 | Byzantine&nbsp;(1) | HP |
+| [#1603](https://github.com/virtualcell/vcell/issues/1603) | [EPIC] VCell GUI must adhere to new UConn Health Accessibility Guidelines | 2025-12 | Queued | — | — | HP EPIC |
+
+**Flags:** `HP` = High Priority label · `EPIC` = Type: Epic

--- a/docs/backlog/19-accessibility.md
+++ b/docs/backlog/19-accessibility.md
@@ -89,11 +89,28 @@ programme with staged delivery**, ordered:
 2. **Theming/palette** (`#1605` remediation + `#1604`'s dark-mode work) — shared foundation.
 3. **Scaling** (`#1606`) — the largest, and the one that most needs the audit first.
 
-**The Priority values disagree with the Simplicity values.** `#1605` is Priority 3 and
-`Intricate (2)`; `#1606` is Priority 4 and `Byzantine (1)`; `#1604` is Priority 5 and
-`Byzantine (1)`. Under either polarity reading, the ranking does not obviously reflect that two of
-these are the hardest work available. That may be deliberate sequencing (easiest first) — worth
-confirming.
+**The scoring model actively suppresses this group, and that is worth understanding before
+reading the ranks.** Board `Priority` is `Importance + Simplicity` (see
+[03-board-hygiene.md](03-board-hygiene.md)), so difficulty subtracts from rank. These three score:
+
+| # | Importance | Simplicity | Priority |
+|---|---:|---:|---:|
+| `#1605` colorblindness | 1 | 2 | 3 |
+| `#1606` font sizes | 3 | 1 | 4 |
+| `#1604` cross-OS appearance | 4 | 1 | 5 |
+
+All three land in the bottom half of a 1–12 scale, and they cannot climb: a `Byzantine (1)` item
+caps at Priority 11 even at Importance 10. So the ranking is not a judgment that accessibility
+does not matter — it is arithmetic, and the arithmetic is hostile to any large, hard programme.
+
+That is fine for ordinary work and wrong for a compliance mandate, because a mandate is not
+optional at any cost. **If the answer to Decision 4 is "yes, this is dated and we will be
+audited," this group should be resourced as a project and taken out of the Priority queue
+entirely** rather than competing on a value/cost score it is structurally guaranteed to lose.
+
+Note also that `#1605`'s Importance is scored **1** — the lowest value on the board — while
+carrying the `High Priority` label. Those two cannot both be right, and it is the clearest single
+example of the two prioritization mechanisms contradicting each other.
 
 ---
 

--- a/docs/backlog/19-accessibility.md
+++ b/docs/backlog/19-accessibility.md
@@ -136,4 +136,4 @@ example of the two prioritization mechanisms contradicting each other.
 | [#1604](https://github.com/virtualcell/vcell/issues/1604) | Need to Update and Unify Appearance of GUI across operating systems (Windows, Mac, Lin… | 2025-12 | Queued | 5/4 | Byzantine&nbsp;(1) | HP |
 | [#1603](https://github.com/virtualcell/vcell/issues/1603) | [EPIC] VCell GUI must adhere to new UConn Health Accessibility Guidelines | 2025-12 | Queued | — | — | HP EPIC |
 
-**Flags:** `HP` = High Priority label · `EPIC` = Type: Epic
+**Flags:** `HP` = High Priority label · `BLK` = Blocked · `EPIC` = Type: Epic · `REF` = To Refine · `thin` = body under 80 chars

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -4,8 +4,16 @@ A snapshot-and-triage pass over **all 272 open issues** in `virtualcell/vcell`, 
 against [project board #1](https://github.com/orgs/virtualcell/projects/1).
 
 **Snapshot taken:** 2026-08-19
-**Nothing in this pass edits GitHub.** These are proposals. Every disposition is a recommendation
-for a human to accept, reject, or amend.
+
+**These documents are proposals.** Every disposition — every close, merge, refine, and re-rank — is
+a recommendation for a human to accept, reject, or amend. No issue, label, or epic has been changed.
+
+**One exception, applied at Jim's instruction on 2026-08-19:** five project-board *scores* were
+corrected, after the board's `Priority = Importance + Simplicity` formula was confirmed. `#1495`'s
+Priority was recomputed (5 → 10), and `#1473`, `#1451`, `#1199`, `#191` were given their computed
+Priority and moved from `Pool` to `Queued`. These were arithmetic corrections to the team's own
+model, not new judgments; details and the verification in
+[03-board-hygiene.md](03-board-hygiene.md). Status counts below reflect the board *after* that edit.
 
 ---
 
@@ -16,7 +24,7 @@ for a human to accept, reject, or amend.
 | [00-method.md](00-method.md) | The triage plan: dispositions, decision rules, who decides what, suggested sequencing |
 | [01-close-and-verify.md](01-close-and-verify.md) | 14 issues that look done, obsolete, or not-a-backlog-item — with the evidence |
 | [02-needs-refinement.md](02-needs-refinement.md) | 50 issues too thin to act on; what each one needs before it can be estimated |
-| [03-board-hygiene.md](03-board-hygiene.md) | 55 issues off the board, 4 marked Done but open, the Priority-field ambiguity, label/field duplication |
+| [03-board-hygiene.md](03-board-hygiene.md) | The scoring model (`Priority = Importance + Simplicity`), 55 issues off the board, 4 marked Done but open, stale `Active`, label/field duplication |
 | [04-epic-map.md](04-epic-map.md) | Epic → child coverage, the 4 overlapping epic pairs, and the 5 strategic decisions that gate large chunks of the backlog |
 
 ## Thematic groups
@@ -66,8 +74,8 @@ field-viewer train, the infra issues). The board is drifting out of date at the 
 
 | Board status | Count | Reading |
 |---|---:|---|
-| Pool | 99 | Accepted but unscheduled — the actual backlog |
-| Queued | 63 | Ranked and ready; 57 of these carry a numeric Priority |
+| Pool | 95 | Accepted but unscheduled — the actual backlog |
+| Queued | 67 | Ranked and ready; 61 of these carry a numeric Priority |
 | Shelved | 27 | Deliberately parked |
 | Active | 16 | Claimed as in-progress (**several are stale — see [03](03-board-hygiene.md)**) |
 | Blocked | 6 | External dependency |
@@ -104,9 +112,10 @@ recommendation #1 in [00-method.md](00-method.md).
    and a genuine value/cost model. `Priority` is **derived**: it is the sum of `Importance`
    (1–10, higher = more valuable) and `Simplicity` (1–5, higher = easier), exact on 56 of 57
    ranked issues. **Higher Priority = do sooner.** The formula is undocumented on the board and
-   was reconstructed from the data; see [03-board-hygiene.md](03-board-hygiene.md), which also
-   catches one row whose arithmetic has drifted (`#1495`) and four scored-but-never-ranked issues
-   — two of which tie the highest score on the board and are sitting in `Pool`.
+   was reconstructed from the data; see [03-board-hygiene.md](03-board-hygiene.md). That pass caught
+   one row whose arithmetic had drifted (`#1495`) and four scored-but-never-ranked issues — two of
+   which tie the highest score on the board. **All five were corrected on 2026-08-19**; the board
+   is now formula-consistent, with 53 issues still half-scored (`Simplicity` but no `Importance`).
 2. **`High Priority` label** — 28 issues. Only 8 of them also carry a numeric Priority, and those
    8 spread across the whole 2–12 range, so the label and the field are *not* saying the same thing.
 3. **`Next Release` label** — 19 issues, and the `VCell-7.5.0` / `7.5.1` / `7.6.0` labels on 33

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -100,11 +100,13 @@ exists as its own document.
 Three separate, partly redundant prioritization mechanisms are in play. Reconciling them is
 recommendation #1 in [00-method.md](00-method.md).
 
-1. **Board `Priority` / `Importance` numeric fields** — set on 57 and 61 issues respectively, all
-   in status `Queued`. This is the most deliberate signal in the system: someone sat down and
-   ranked a slate. **Its polarity is undocumented and I could not determine it from the data**
-   (see [03-board-hygiene.md](03-board-hygiene.md)) — resolving that is a five-second answer from
-   whoever set it, and it changes the reading of every table in these docs.
+1. **Board `Importance` + `Simplicity` → `Priority`** — the most deliberate signal in the system,
+   and a genuine value/cost model. `Priority` is **derived**: it is the sum of `Importance`
+   (1–10, higher = more valuable) and `Simplicity` (1–5, higher = easier), exact on 56 of 57
+   ranked issues. **Higher Priority = do sooner.** The formula is undocumented on the board and
+   was reconstructed from the data; see [03-board-hygiene.md](03-board-hygiene.md), which also
+   catches one row whose arithmetic has drifted (`#1495`) and four scored-but-never-ranked issues
+   — two of which tie the highest score on the board and are sitting in `Pool`.
 2. **`High Priority` label** — 28 issues. Only 8 of them also carry a numeric Priority, and those
    8 spread across the whole 2–12 range, so the label and the field are *not* saying the same thing.
 3. **`Next Release` label** — 19 issues, and the `VCell-7.5.0` / `7.5.1` / `7.6.0` labels on 33

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -19,7 +19,12 @@ nothing in this pass is invisible:
 2. **Four issues updated from the obsolescence sweep** — `#366` closed as obsolete with its
    evidence and an invitation to reopen; `#1341`, `#1470` and `#1636` given findings as comments
    rather than body edits, so their authors' words are intact. See
-   [05-obsolescence-sweep.md](05-obsolescence-sweep.md).
+   [05-obsolescence-sweep.md](05-obsolescence-sweep.md). `#1730` was also annotated: the pure-Java
+   trajectory viewer it asks for shipped in 8.0.4.01, three weeks after it was filed.
+3. **All 56 off-board issues were added to project board #1**, which is Step 3 of the plan in
+   [00-method.md](00-method.md). The board-coverage figures below therefore describe **what was
+   found on 2026-08-19, not what is true now** — that gap is the recommendation having been taken,
+   and `tools/backlog-lint` now guards against it recurring.
 
 **The backlog is therefore 271 open, not 272, as of this writing.** The tables below are the
 2026-08-19 snapshot and deliberately have not been regenerated — `#366` still appears in
@@ -34,7 +39,7 @@ nothing in this pass is invisible:
 | [00-method.md](00-method.md) | The triage plan: dispositions, decision rules, who decides what, suggested sequencing |
 | [01-close-and-verify.md](01-close-and-verify.md) | 14 issues that look done, obsolete, or not-a-backlog-item — with the evidence |
 | [02-needs-refinement.md](02-needs-refinement.md) | 50 issues too thin to act on; what each one needs before it can be estimated |
-| [03-board-hygiene.md](03-board-hygiene.md) | The scoring model (`Priority = Importance + Simplicity`), 55 issues off the board, 4 marked Done but open, stale `Active`, label/field duplication |
+| [03-board-hygiene.md](03-board-hygiene.md) | The scoring model (`Priority = Importance + Simplicity`), the 55 issues that were off the board, 4 marked Done but open, stale `Active`, label/field duplication |
 | [04-epic-map.md](04-epic-map.md) | Epic → child coverage, the 4 overlapping epic pairs, and the 5 strategic decisions that gate large chunks of the backlog |
 | [05-obsolescence-sweep.md](05-obsolescence-sweep.md) | Does the code an issue names still exist? Settles 6 issues; documents why it can only reach a fifth of the backlog |
 
@@ -79,9 +84,14 @@ and it shows: many have an empty body and a title that was a line item in a spre
 
 ### Board coverage
 
-217 of 272 issues are on project board #1; **55 are not on it at all** — and those 55 are
+217 of 272 issues were on project board #1; **55 were not on it at all** — and those 55 were
 disproportionately the *recent, well-written* ones (all the 2026 SpringSaLaD grooming issues, the
-field-viewer train, the infra issues). The board is drifting out of date at the new end, not the old end.
+field-viewer train, the infra issues). The board was drifting out of date at the new end, not the
+old end.
+
+**All 56 have since been added** (see the preamble). The table below is the 2026-08-19 finding,
+kept because the *pattern* is the point: left alone, this recurs. `tools/backlog-lint` now fails
+daily on any issue that is not on the board, which is the durable fix.
 
 | Board status | Count | Reading |
 |---|---:|---|

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -8,12 +8,22 @@ against [project board #1](https://github.com/orgs/virtualcell/projects/1).
 **These documents are proposals.** Every disposition — every close, merge, refine, and re-rank — is
 a recommendation for a human to accept, reject, or amend. No issue, label, or epic has been changed.
 
-**One exception, applied at Jim's instruction on 2026-08-19:** five project-board *scores* were
-corrected, after the board's `Priority = Importance + Simplicity` formula was confirmed. `#1495`'s
-Priority was recomputed (5 → 10), and `#1473`, `#1451`, `#1199`, `#191` were given their computed
-Priority and moved from `Pool` to `Queued`. These were arithmetic corrections to the team's own
-model, not new judgments; details and the verification in
-[03-board-hygiene.md](03-board-hygiene.md). Status counts below reflect the board *after* that edit.
+**Two sets of changes were applied at Jim's instruction on 2026-08-19**, both recorded here so
+nothing in this pass is invisible:
+
+1. **Five project-board scores corrected**, after the board's `Priority = Importance + Simplicity`
+   formula was confirmed. `#1495`'s Priority was recomputed (5 → 10), and `#1473`, `#1451`,
+   `#1199`, `#191` were given their computed Priority and moved from `Pool` to `Queued`. These
+   were arithmetic corrections to the team's own model, not new judgments — see
+   [03-board-hygiene.md](03-board-hygiene.md). Status counts below reflect the board *after* that edit.
+2. **Four issues updated from the obsolescence sweep** — `#366` closed as obsolete with its
+   evidence and an invitation to reopen; `#1341`, `#1470` and `#1636` given findings as comments
+   rather than body edits, so their authors' words are intact. See
+   [05-obsolescence-sweep.md](05-obsolescence-sweep.md).
+
+**The backlog is therefore 271 open, not 272, as of this writing.** The tables below are the
+2026-08-19 snapshot and deliberately have not been regenerated — `#366` still appears in
+[13-export-visualization.md](13-export-visualization.md), annotated as closed.
 
 ---
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -139,9 +139,10 @@ recommendation #1 in [00-method.md](00-method.md).
    is now formula-consistent, with 53 issues still half-scored (`Simplicity` but no `Importance`).
 2. **`High Priority` label** — 28 issues. Only 8 of them also carry a numeric Priority, and those
    8 spread across the whole 2–12 range, so the label and the field are *not* saying the same thing.
-3. **`Next Release` label** — 19 issues, and the `VCell-7.5.0` / `7.5.1` / `7.6.0` labels on 33
-   more. The current release line is **8.0.27.01**. These labels are release-planning residue from
-   three major versions ago and are now actively misleading.
+3. **Release labels** — `Next Release` (19), `VCell-7.6.0` (26), `VCell-7.5.0` (5),
+   `VCell-7.5.1` (2). That is 52 label applications across **45 distinct issues**, since seven
+   carry two. The current release line is **8.0.27.01**, so these are release-planning residue
+   from three major versions ago and are now actively misleading.
 
 ---
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -26,6 +26,7 @@ model, not new judgments; details and the verification in
 | [02-needs-refinement.md](02-needs-refinement.md) | 50 issues too thin to act on; what each one needs before it can be estimated |
 | [03-board-hygiene.md](03-board-hygiene.md) | The scoring model (`Priority = Importance + Simplicity`), 55 issues off the board, 4 marked Done but open, stale `Active`, label/field duplication |
 | [04-epic-map.md](04-epic-map.md) | Epic → child coverage, the 4 overlapping epic pairs, and the 5 strategic decisions that gate large chunks of the backlog |
+| [05-obsolescence-sweep.md](05-obsolescence-sweep.md) | Does the code an issue names still exist? Settles 6 issues; documents why it can only reach a fifth of the backlog |
 
 ## Thematic groups
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -1,0 +1,121 @@
+# VCell Backlog Grooming — Index
+
+A snapshot-and-triage pass over **all 272 open issues** in `virtualcell/vcell`, cross-referenced
+against [project board #1](https://github.com/orgs/virtualcell/projects/1).
+
+**Snapshot taken:** 2026-08-19
+**Nothing in this pass edits GitHub.** These are proposals. Every disposition is a recommendation
+for a human to accept, reject, or amend.
+
+---
+
+## Read in this order
+
+| Doc | What it is |
+|---|---|
+| [00-method.md](00-method.md) | The triage plan: dispositions, decision rules, who decides what, suggested sequencing |
+| [01-close-and-verify.md](01-close-and-verify.md) | 14 issues that look done, obsolete, or not-a-backlog-item — with the evidence |
+| [02-needs-refinement.md](02-needs-refinement.md) | 50 issues too thin to act on; what each one needs before it can be estimated |
+| [03-board-hygiene.md](03-board-hygiene.md) | 55 issues off the board, 4 marked Done but open, the Priority-field ambiguity, label/field duplication |
+| [04-epic-map.md](04-epic-map.md) | Epic → child coverage, the 4 overlapping epic pairs, and the 5 strategic decisions that gate large chunks of the backlog |
+
+## Thematic groups
+
+Every open issue lands in exactly one group. Counts sum to 272.
+
+| Group | Count | Doc |
+|---|---:|---|
+| Desktop client UI (Swing) | 51 | [10-desktop-ui.md](10-desktop-ui.md) |
+| Standards & interop (SBML / SED-ML / OMEX / BioSimulators) | 42 | [11-standards-interop.md](11-standards-interop.md) |
+| SpringSaLaD / Langevin | 32 | [12-springsalad.md](12-springsalad.md) |
+| Data export & visualization | 32 | [13-export-visualization.md](13-export-visualization.md) |
+| API, platform & database | 30 | [14-api-platform.md](14-api-platform.md) |
+| Math generation & solvers | 26 | [15-math-solvers.md](15-math-solvers.md) |
+| Infrastructure, CI/CD & release ops | 19 | [16-infrastructure-ci.md](16-infrastructure-ci.md) |
+| Close / verify-then-close | 14 | [01-close-and-verify.md](01-close-and-verify.md) |
+| Simulation execution & HPC | 12 | [17-execution-hpc.md](17-execution-hpc.md) |
+| User documentation & materials | 9 | [18-user-docs.md](18-user-docs.md) |
+| Accessibility (UConn Health mandate) | 4 | [19-accessibility.md](19-accessibility.md) |
+| Strategic decision (Postgres migration) | 1 | [04-epic-map.md](04-epic-map.md) |
+
+---
+
+## The shape of the backlog
+
+**272 open issues. Half of them predate 2025.**
+
+| Opened | Count |
+|---|---:|
+| 2021 | 1 |
+| 2022 | 73 |
+| 2023 | 41 |
+| 2024 | 26 |
+| 2025 | 57 |
+| 2026 | 74 |
+
+The 2022 cohort is the largest historical block and the weakest described — it came in as a bulk
+import of a pre-existing to-do list (73 issues, mostly authored by `ACowan0105` on 2022-07-19/20),
+and it shows: many have an empty body and a title that was a line item in a spreadsheet.
+**71 issues have not been touched since 2024.**
+
+### Board coverage
+
+217 of 272 issues are on project board #1; **55 are not on it at all** — and those 55 are
+disproportionately the *recent, well-written* ones (all the 2026 SpringSaLaD grooming issues, the
+field-viewer train, the infra issues). The board is drifting out of date at the new end, not the old end.
+
+| Board status | Count | Reading |
+|---|---:|---|
+| Pool | 99 | Accepted but unscheduled — the actual backlog |
+| Queued | 63 | Ranked and ready; 57 of these carry a numeric Priority |
+| Shelved | 27 | Deliberately parked |
+| Active | 16 | Claimed as in-progress (**several are stale — see [03](03-board-hygiene.md)**) |
+| Blocked | 6 | External dependency |
+| Done | 4 | **Open but marked done — close candidates** |
+| (unset) | 2 | |
+| off-board | 55 | Never triaged onto the board |
+
+### Description quality
+
+| Body length | Count |
+|---|---:|
+| < 80 chars (title-only, effectively) | 54 |
+| < 200 chars | 107 |
+| median | 295 chars |
+
+**107 of 272 issues — 39% — cannot be estimated or assigned from what is written in them.**
+This is the single biggest obstacle to grooming, and it is why [02-needs-refinement.md](02-needs-refinement.md)
+exists as its own document.
+
+### Ownership
+
+- **71 issues have no assignee.**
+- **33 issues have 3 or more assignees** — which in practice means nobody owns them. `#611` and
+  `#1591` each carry five.
+
+---
+
+## Where the team's prioritization already lives
+
+Three separate, partly redundant prioritization mechanisms are in play. Reconciling them is
+recommendation #1 in [00-method.md](00-method.md).
+
+1. **Board `Priority` / `Importance` numeric fields** — set on 57 and 61 issues respectively, all
+   in status `Queued`. This is the most deliberate signal in the system: someone sat down and
+   ranked a slate. **Its polarity is undocumented and I could not determine it from the data**
+   (see [03-board-hygiene.md](03-board-hygiene.md)) — resolving that is a five-second answer from
+   whoever set it, and it changes the reading of every table in these docs.
+2. **`High Priority` label** — 28 issues. Only 8 of them also carry a numeric Priority, and those
+   8 spread across the whole 2–12 range, so the label and the field are *not* saying the same thing.
+3. **`Next Release` label** — 19 issues, and the `VCell-7.5.0` / `7.5.1` / `7.6.0` labels on 33
+   more. The current release line is **8.0.27.01**. These labels are release-planning residue from
+   three major versions ago and are now actively misleading.
+
+---
+
+## Method note
+
+This pass read every issue title, label set, board field, and body (truncated to 450 chars), plus
+the full checklists of all 23 epics. Where a disposition rests on a claim about the code — "this
+was fixed", "this dependency is gone" — the claim was checked against the working tree or git log,
+and the check is cited inline. Claims that were *not* verified are marked as such.

--- a/tools/obsolescence-sweep.py
+++ b/tools/obsolescence-sweep.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
-"""Obsolescence sweep v2 -- two complementary checks.
+"""Obsolescence sweep -- two complementary checks over the open issue backlog.
 
   A. code identifiers   -- does the class/method/file an issue names still exist?
   B. dependency names   -- is the library an issue is about still declared anywhere?
 
 A miss is a SIGNAL, not a verdict: code is renamed, moved, or lives in a sibling repo.
-Output is a triage queue, never a close list.
-"""
-import json, re, subprocess, collections, os
+Output is a triage queue, never a close list -- confirm every finding by hand.
+Known false-positive modes are documented in docs/backlog/05-obsolescence-sweep.md.
 
-S = '/private/tmp/claude-504/-Users-jimschaff-Documents-workspace-vcell/fee80085-3f84-4d6a-a600-018fbae0ead1/scratchpad/bl/'
-REPO = '/Users/jimschaff/Documents/workspace/vcell/.claude/worktrees/bug+backlog'
+Usage:
+    gh issue list --repo virtualcell/vcell --state open --limit 500 \\
+        --json number,title,body,createdAt > issues.json
+    python3 tools/obsolescence-sweep.py [issues.json] [--repo PATH]
+"""
+import json, re, subprocess, collections, os, sys
+
+args = [a for a in sys.argv[1:] if not a.startswith('-')]
+ISSUES_JSON = args[0] if args else 'issues.json'
+REPO = os.environ.get('VCELL_REPO') or subprocess.run(
+    ['git', 'rev-parse', '--show-toplevel'], capture_output=True, text=True).stdout.strip() or '.'
+OUT = 'obsolescence-sweep.json'
 SRC_EXT = ('.java', '.py', '.xml', '.sh', '.ts', '.properties', '.yml', '.yaml',
            '.json', '.js', '.html', '.md', '.c', '.cpp', '.h', '.sql', '.cff', '.toml')
 FILE_EXT = re.compile(r'\.(java|py|xml|sh|ts|properties|yml|yaml|cpp|h|md|json|js|sql|txt|pptx|docx|csv|zip|omex|vcml|jar)$', re.I)
@@ -21,6 +30,16 @@ src = [f for f in files if f.endswith(SRC_EXT)]
 paths = set(files)
 basenames = {os.path.basename(f) for f in files}
 stems = {os.path.splitext(os.path.basename(f))[0] for f in files}
+
+# Case-folded indexes. A token that matches only when case is ignored is NOT a miss --
+# the code is there, the issue text is just stale. Reported separately as "renamed",
+# because that is a different action (correct the issue) from "gone" (consider closing).
+paths_ci = collections.defaultdict(set)
+for f in files:
+    paths_ci[f.lower()].add(f)
+    b = os.path.basename(f)
+    paths_ci[b.lower()].add(f)
+    paths_ci[os.path.splitext(b)[0].lower()].add(f)
 
 IDENT = re.compile(rb'[A-Za-z_][A-Za-z0-9_]{2,}')
 corpus = set()
@@ -38,10 +57,23 @@ for f in src:
     if os.path.basename(f) in ('pom.xml', 'requirements.txt', 'pyproject.toml',
                                'package.json', 'Dockerfile'):
         DEPFILES.append(raw.decode('utf8', 'replace').lower())
+corpus_ci = collections.defaultdict(set)
+for ident in corpus:
+    corpus_ci[ident.lower()].add(ident)
+for s_ in stems:
+    corpus_ci[s_.lower()].add(s_)
 DEPBLOB = '\n'.join(DEPFILES)
 print(f'indexed {len(src)} source files, {len(corpus)} identifiers, {len(DEPFILES)} dependency manifests')
 
-issues = {i['number']: i for i in json.load(open(S + 'issues.json'))}
+# An empty index makes EVERY reference look missing -- the most dangerous possible output,
+# because it reads as "the whole backlog is obsolete". Refuse to run rather than mislead.
+if len(src) < 1000 or not DEPFILES:
+    sys.exit(f"error: indexed only {len(src)} source files and {len(DEPFILES)} manifests from "
+             f"{REPO!r}.\nThis is not a VCell checkout, or git ls-files failed. Run from inside "
+             f"the repo, or set VCELL_REPO=/path/to/vcell. Refusing to report every reference "
+             f"as missing.")
+
+issues = {i['number']: i for i in json.load(open(ISSUES_JSON))}
 
 OTHER_REPO = re.compile(
     r'vcell-solvers|vcell-fluxcd|vcell-jsbml|pyvcell|LangevinNoVis|cam-center/|vcell-fiji'
@@ -91,40 +123,76 @@ def classify(body):
     return out
 
 
-def exists(kind, tok):
+def resolve(kind, tok):
+    """-> ('present', None) | ('renamed', what-it-actually-is) | ('missing', None).
+
+    'renamed' means the token matched only case-insensitively. The code exists; the issue
+    text is stale. Keeping this distinct from 'missing' is the whole point -- conflating
+    them once made #912 look obsolete when SedmlJob.java had merely become SedMLJob.java.
+    """
     if kind == 'path':
         b = os.path.basename(tok)
-        return tok in paths or b in basenames or os.path.splitext(b)[0] in stems
+        stem, ext = os.path.splitext(b)
+        # A stem match across different extensions is not a match -- 'model.xml' is not
+        # 'Model.java'. Only fall back to the bare stem when the token has no extension.
+        if tok in paths or b in basenames or (not ext and stem in stems):
+            return 'present', None
+        keys = [tok.lower(), b.lower()] + ([] if ext else [stem.lower()])
+        for key in keys:
+            for cand_path in sorted(paths_ci.get(key, ())):
+                if not ext or os.path.splitext(cand_path)[1].lower() == ext.lower():
+                    return 'renamed', cand_path
+        return 'missing', None
+
+    parts = [p for p in tok.split('.') if p] if kind == 'symbol' else [tok]
     if kind == 'symbol':
-        return all(p in corpus for p in tok.split('.') if p)
-    return tok in corpus or tok in stems
+        if all(p in corpus for p in parts):
+            return 'present', None
+        gone = [p for p in parts if p not in corpus]
+        fixed = [sorted(corpus_ci[p.lower()])[0] for p in gone if corpus_ci.get(p.lower())]
+        if len(fixed) == len(gone):
+            return 'renamed', '/'.join(fixed)
+        return 'missing', None
+
+    if tok in corpus or tok in stems:
+        return 'present', None
+    hit = corpus_ci.get(tok.lower())
+    return ('renamed', sorted(hit)[0]) if hit else ('missing', None)
 
 
 rows = []
 for n, iss in sorted(issues.items()):
     body = iss['body'] or ''
     cand = classify(body)
-    missing, present = [], []
+    missing, present, renamed = [], [], []
     for kind, toks in cand.items():
         for t in sorted(toks):
-            (present if exists(kind, t) else missing).append((kind, t))
+            verdict, actual = resolve(kind, t)
+            if verdict == 'present':
+                present.append((kind, t))
+            elif verdict == 'renamed':
+                renamed.append((kind, t, actual))
+            else:
+                missing.append((kind, t))
     deps = {}
     low = body.lower()
     for name, needle in DEPS.items():
         if re.search(r'\b' + re.escape(name) + r'\b', low):
             deps[name] = needle in DEPBLOB
-    if not (missing or present or deps):
+    if not (missing or present or renamed or deps):
         continue
     rows.append({'n': n, 'title': iss['title'], 'created': iss['createdAt'][:7],
-                 'missing': missing, 'present': present, 'deps': deps,
+                 'missing': missing, 'present': present, 'renamed': renamed, 'deps': deps,
                  'other_repo': bool(OTHER_REPO.search(body))})
 
-json.dump(rows, open(S + 'obsolete2.json', 'w'), indent=1)
+json.dump(rows, open(OUT, 'w'), indent=1)
 
 gone_dep = [r for r in rows if r['deps'] and not any(r['deps'].values())]
-all_missing = [r for r in rows if r['missing'] and not r['present']]
+all_missing = [r for r in rows if r['missing'] and not r['present'] and not r['renamed']]
+stale_text = [r for r in rows if r['renamed']]
 print(f'\nissues naming something checkable: {len(rows)} of {len(issues)} open')
-print(f'  every code reference missing : {len(all_missing)}')
+print(f'  every code reference missing : {len(all_missing)}   <- obsolescence signal')
+print(f'  stale text (case-only rename): {len(stale_text)}   <- fix the issue, not the code')
 print(f'  every named dependency gone  : {len(gone_dep)}')
 
 print('\n===== A. every code reference missing =====')
@@ -133,6 +201,12 @@ for r in sorted(all_missing, key=lambda r: -len(r['missing'])):
     print(f"#{r['n']} ({r['created']}){tag} {r['title'][:64]}")
     for kind, t in r['missing'][:5]:
         print(f'      {kind:7} {t}')
+
+print('\n===== A2. stale references -- code exists under different case =====')
+for r in sorted(stale_text, key=lambda r: r['n']):
+    print(f"#{r['n']} ({r['created']}) {r['title'][:64]}")
+    for kind, t, actual in r['renamed'][:5]:
+        print(f'      {kind:7} {t}  ->  {actual}')
 
 print('\n===== B. dependency status =====')
 for r in sorted(rows, key=lambda r: r['n']):

--- a/tools/obsolescence-sweep.py
+++ b/tools/obsolescence-sweep.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Obsolescence sweep v2 -- two complementary checks.
+
+  A. code identifiers   -- does the class/method/file an issue names still exist?
+  B. dependency names   -- is the library an issue is about still declared anywhere?
+
+A miss is a SIGNAL, not a verdict: code is renamed, moved, or lives in a sibling repo.
+Output is a triage queue, never a close list.
+"""
+import json, re, subprocess, collections, os
+
+S = '/private/tmp/claude-504/-Users-jimschaff-Documents-workspace-vcell/fee80085-3f84-4d6a-a600-018fbae0ead1/scratchpad/bl/'
+REPO = '/Users/jimschaff/Documents/workspace/vcell/.claude/worktrees/bug+backlog'
+SRC_EXT = ('.java', '.py', '.xml', '.sh', '.ts', '.properties', '.yml', '.yaml',
+           '.json', '.js', '.html', '.md', '.c', '.cpp', '.h', '.sql', '.cff', '.toml')
+FILE_EXT = re.compile(r'\.(java|py|xml|sh|ts|properties|yml|yaml|cpp|h|md|json|js|sql|txt|pptx|docx|csv|zip|omex|vcml|jar)$', re.I)
+
+files = [f for f in subprocess.run(['git', 'ls-files'], cwd=REPO, capture_output=True, text=True)
+         .stdout.split('\n') if f]
+src = [f for f in files if f.endswith(SRC_EXT)]
+paths = set(files)
+basenames = {os.path.basename(f) for f in files}
+stems = {os.path.splitext(os.path.basename(f))[0] for f in files}
+
+IDENT = re.compile(rb'[A-Za-z_][A-Za-z0-9_]{2,}')
+corpus = set()
+DEPFILES = []
+for f in src:
+    p = os.path.join(REPO, f)
+    try:
+        if os.path.getsize(p) > 2_000_000:
+            continue
+        raw = open(p, 'rb').read()
+    except OSError:
+        continue
+    for m in IDENT.finditer(raw):
+        corpus.add(m.group().decode('ascii', 'ignore'))
+    if os.path.basename(f) in ('pom.xml', 'requirements.txt', 'pyproject.toml',
+                               'package.json', 'Dockerfile'):
+        DEPFILES.append(raw.decode('utf8', 'replace').lower())
+DEPBLOB = '\n'.join(DEPFILES)
+print(f'indexed {len(src)} source files, {len(corpus)} identifiers, {len(DEPFILES)} dependency manifests')
+
+issues = {i['number']: i for i in json.load(open(S + 'issues.json'))}
+
+OTHER_REPO = re.compile(
+    r'vcell-solvers|vcell-fluxcd|vcell-jsbml|pyvcell|LangevinNoVis|cam-center/|vcell-fiji'
+    r'|usermaterials|zenodo-maint|Biosimulators_test_suite|temp-biomodels|MBSolver|vcellroot', re.I)
+
+NOISE = {
+    'Exception','Error','RuntimeException','NullPointerException','String','Object','Java',
+    'Windows','Linux','Mac','MacOS','VCell','BioModel','MathModel','GitHub','Docker','Oracle',
+    'SBML','SEDML','SedML','OMEX','HDF5','JSON','XML','API','REST','HTTP','HTTPS','URL','URI',
+    'DataAccessException','IllegalArgumentException','ClassCastException','LetsEncrypt',
+    'ArrayIndexOutOfBoundsException','NFSim','BioNetGen','Smoldyn','COPASI','Simulation',
+    'Application','Geometry','TODO','NOTE','FIXME','PDE','ODE','CSV','PNG','Priority',
+    'Importance','BioModels','BioSimulations','BioSimulators','SpringSaLaD','SpringSalad',
+    'Langevin','Quarkus','Keycloak','PubMed','ImageJ','README','CLAUDE','MEMORY','SKILL',
+}
+# documentation / attachment files are not code -- their absence proves nothing
+DOC_EXT = re.compile(r'\.(md|pptx|docx|csv|zip|omex|vcml|txt|png|jpg|pdf)$', re.I)
+
+DOTTED = re.compile(r'\b([A-Z][A-Za-z0-9]*(?:\.[A-Za-z][A-Za-z0-9_]*)+)\b')
+CAMEL  = re.compile(r'\b([A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+){1,})\b')
+PATH   = re.compile(r'\b((?:[\w.-]+/){1,}[\w.-]+\.(?:java|py|xml|sh|ts|properties|yml|yaml|cpp|h))\b')
+
+# libraries VCell has or had; check whether still declared in a manifest
+DEPS = {
+    'jhdf': 'io.jhdf', 'ncsa.hdf': 'ncsa', 'bioformats': 'bioformats', 'seaborn': 'seaborn',
+    'jlibsedml': 'jlibsedml', 'jsbml': 'jsbml', 'restlet': 'restlet', 'activemq': 'activemq',
+    'artemis': 'artemis', 'mongodb': 'mongo', 'vtk': 'vtk', 'n5': 'n5', 'matplotlib': 'matplotlib',
+    'log4j': 'log4j', 'hdf5': 'hdf5', 'bionetgen': 'bionetgen', 'copasi': 'copasi',
+}
+
+
+def classify(body):
+    body = re.sub(r'```.*?```', ' ', body or '', flags=re.S)
+    out = {'path': set(), 'symbol': set(), 'class': set()}
+    for m in PATH.finditer(body):
+        out['path'].add(m.group(1))
+    for m in DOTTED.finditer(body):
+        tok = m.group(1)
+        if tok.split('.')[0] in NOISE or DOC_EXT.search(tok):
+            continue
+        out['path' if FILE_EXT.search(tok) else 'symbol'].add(tok)
+    for m in CAMEL.finditer(body):
+        tok = m.group(1)
+        if tok in NOISE or len(tok) < 6:
+            continue
+        out['class'].add(tok)
+    return out
+
+
+def exists(kind, tok):
+    if kind == 'path':
+        b = os.path.basename(tok)
+        return tok in paths or b in basenames or os.path.splitext(b)[0] in stems
+    if kind == 'symbol':
+        return all(p in corpus for p in tok.split('.') if p)
+    return tok in corpus or tok in stems
+
+
+rows = []
+for n, iss in sorted(issues.items()):
+    body = iss['body'] or ''
+    cand = classify(body)
+    missing, present = [], []
+    for kind, toks in cand.items():
+        for t in sorted(toks):
+            (present if exists(kind, t) else missing).append((kind, t))
+    deps = {}
+    low = body.lower()
+    for name, needle in DEPS.items():
+        if re.search(r'\b' + re.escape(name) + r'\b', low):
+            deps[name] = needle in DEPBLOB
+    if not (missing or present or deps):
+        continue
+    rows.append({'n': n, 'title': iss['title'], 'created': iss['createdAt'][:7],
+                 'missing': missing, 'present': present, 'deps': deps,
+                 'other_repo': bool(OTHER_REPO.search(body))})
+
+json.dump(rows, open(S + 'obsolete2.json', 'w'), indent=1)
+
+gone_dep = [r for r in rows if r['deps'] and not any(r['deps'].values())]
+all_missing = [r for r in rows if r['missing'] and not r['present']]
+print(f'\nissues naming something checkable: {len(rows)} of {len(issues)} open')
+print(f'  every code reference missing : {len(all_missing)}')
+print(f'  every named dependency gone  : {len(gone_dep)}')
+
+print('\n===== A. every code reference missing =====')
+for r in sorted(all_missing, key=lambda r: -len(r['missing'])):
+    tag = '  [names another repo]' if r['other_repo'] else ''
+    print(f"#{r['n']} ({r['created']}){tag} {r['title'][:64]}")
+    for kind, t in r['missing'][:5]:
+        print(f'      {kind:7} {t}')
+
+print('\n===== B. dependency status =====')
+for r in sorted(rows, key=lambda r: r['n']):
+    if not r['deps']:
+        continue
+    st = ', '.join(f'{k}={"PRESENT" if v else "GONE"}' for k, v in sorted(r['deps'].items()))
+    mark = '  <-- all gone' if not any(r['deps'].values()) else ''
+    print(f"#{r['n']:<5} {st:<52}{mark}  {r['title'][:44]}")

--- a/tools/obsolescence-sweep.py
+++ b/tools/obsolescence-sweep.py
@@ -13,15 +13,26 @@ Usage:
         --json number,title,body,createdAt > issues.json
     python3 tools/obsolescence-sweep.py [issues.json] [--repo PATH]
 """
-import json, re, subprocess, collections, os, sys
+import json, re, subprocess, collections, os, sys, argparse
 
-args = [a for a in sys.argv[1:] if not a.startswith('-')]
-ISSUES_JSON = args[0] if args else 'issues.json'
-REPO = os.environ.get('VCELL_REPO') or subprocess.run(
+_p = argparse.ArgumentParser(description='Obsolescence sweep over the open issue backlog.')
+_p.add_argument('issues_json', nargs='?', default='issues.json',
+                help='gh issue list --json number,title,body,createdAt output')
+_p.add_argument('--repo', default=None,
+                help='path to the VCell checkout (default: $VCELL_REPO, else git rev-parse)')
+_a = _p.parse_args()
+ISSUES_JSON = _a.issues_json
+REPO = _a.repo or os.environ.get('VCELL_REPO') or subprocess.run(
     ['git', 'rev-parse', '--show-toplevel'], capture_output=True, text=True).stdout.strip() or '.'
 OUT = 'obsolescence-sweep.json'
+# Deliberately NO '.md': indexing documentation into `corpus` makes the sweep report its own
+# findings as 'present' -- and keeps any deleted class alive forever if a CHANGELOG or design
+# doc still names it. Markdown paths still resolve; those come from `files`, not `src`.
 SRC_EXT = ('.java', '.py', '.xml', '.sh', '.ts', '.properties', '.yml', '.yaml',
-           '.json', '.js', '.html', '.md', '.c', '.cpp', '.h', '.sql', '.cff', '.toml')
+           '.json', '.js', '.html', '.c', '.cpp', '.h', '.sql', '.cff', '.toml')
+# Dependency manifests are matched by name, so they must come from `files` -- `requirements.txt`
+# and `Dockerfile` do not match SRC_EXT and would otherwise never be read at all.
+MANIFESTS = ('pom.xml', 'requirements.txt', 'pyproject.toml', 'package.json', 'Dockerfile')
 FILE_EXT = re.compile(r'\.(java|py|xml|sh|ts|properties|yml|yaml|cpp|h|md|json|js|sql|txt|pptx|docx|csv|zip|omex|vcml|jar)$', re.I)
 
 files = [f for f in subprocess.run(['git', 'ls-files'], cwd=REPO, capture_output=True, text=True)
@@ -54,9 +65,15 @@ for f in src:
         continue
     for m in IDENT.finditer(raw):
         corpus.add(m.group().decode('ascii', 'ignore'))
-    if os.path.basename(f) in ('pom.xml', 'requirements.txt', 'pyproject.toml',
-                               'package.json', 'Dockerfile'):
-        DEPFILES.append(raw.decode('utf8', 'replace').lower())
+
+for f in files:
+    if os.path.basename(f) not in MANIFESTS:
+        continue
+    try:
+        DEPFILES.append(open(os.path.join(REPO, f), 'rb').read().decode('utf8', 'replace').lower())
+    except OSError:
+        pass
+
 corpus_ci = collections.defaultdict(set)
 for ident in corpus:
     corpus_ci[ident.lower()].add(ident)
@@ -91,6 +108,9 @@ NOISE = {
 }
 # documentation / attachment files are not code -- their absence proves nothing
 DOC_EXT = re.compile(r'\.(md|pptx|docx|csv|zip|omex|vcml|txt|png|jpg|pdf)$', re.I)
+# 'Node.js', 'Vue.js', 'Three.js', 'Config.json' are library and prose names, not filenames.
+# For these extensions a token only counts as a path if it actually looks like one (has a '/').
+AMBIGUOUS_EXT = {'js', 'ts', 'json'}
 
 DOTTED = re.compile(r'\b([A-Z][A-Za-z0-9]*(?:\.[A-Za-z][A-Za-z0-9_]*)+)\b')
 CAMEL  = re.compile(r'\b([A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+){1,})\b')
@@ -114,7 +134,11 @@ def classify(body):
         tok = m.group(1)
         if tok.split('.')[0] in NOISE or DOC_EXT.search(tok):
             continue
-        out['path' if FILE_EXT.search(tok) else 'symbol'].add(tok)
+        m_ext = FILE_EXT.search(tok)
+        if m_ext and (('/' in tok) or m_ext.group(1).lower() not in AMBIGUOUS_EXT):
+            out['path'].add(tok)
+        else:
+            out['symbol'].add(tok)
     for m in CAMEL.finditer(body):
         tok = m.group(1)
         if tok in NOISE or len(tok) < 6:
@@ -144,8 +168,12 @@ def resolve(kind, tok):
                     return 'renamed', cand_path
         return 'missing', None
 
-    parts = [p for p in tok.split('.') if p] if kind == 'symbol' else [tok]
+    # IDENT only indexes identifiers of 3+ chars, so shorter segments are unknowable rather
+    # than absent -- judging on them turned 'Expression.io' into a missing symbol.
+    parts = [p for p in tok.split('.') if len(p) >= 3] if kind == 'symbol' else [tok]
     if kind == 'symbol':
+        if not parts:
+            return 'present', None
         if all(p in corpus for p in parts):
             return 'present', None
         gone = [p for p in parts if p not in corpus]


### PR DESCRIPTION
A grooming pass over **all 272 open issues** in this repo, cross-referenced against
[project board #1](https://github.com/orgs/virtualcell/projects/1), written up as 16 documents
under `docs/backlog/`.

**This PR changes no issues, labels, or board fields.** Everything in it is a proposal for a human
to accept, reject, or amend. Snapshot date: 2026-08-19.

## What's in it

| Doc | What it is |
|---|---|
| `README.md` | Index + the shape of the backlog (age, board coverage, description quality, ownership) |
| `00-method.md` | The triage plan — 5 dispositions, 7 decision rules, who decides what, 6-step sequencing |
| `01-close-and-verify.md` | 14 close candidates, with evidence |
| `02-needs-refinement.md` | 50 unworkable issues, grouped by *what is missing* rather than by topic |
| `03-board-hygiene.md` | Metadata problems that block the rest of grooming |
| `04-epic-map.md` | 24 epics, 4 overlapping pairs, and 5 strategic decisions |
| `10`–`19` | Ten thematic groups |

Every open issue appears in **exactly one** group table. Verified programmatically: 271 rows across
the group docs plus `#1032` in the epic map, no duplicates, no omissions.

## Findings worth acting on

**The board's scoring model is `Priority = Importance + Simplicity`** — exact on 56 of 57 ranked
issues, mean absolute error 0.09, with no competing formula above 15/57. Jim identified the shape
of this; the data confirms it. It resolves the ranking direction (**higher Priority = do sooner**)
and shows `Priority` is a derived total rather than an independent judgment. Three things follow:
`#1495`'s arithmetic has drifted (stored 5, computes to 10); four issues have `Importance` scored
but `Priority` never computed, so they never enter the queue — **`#1473` and `#1451` both compute
to 12, tying the highest score on the board, and have been in `Pool` since 2025**; and because
ease is *added* rather than multiplied, a `Byzantine (1)` item caps at Priority 11 however
important it is, which is why the accessibility programme ranks low and why it probably belongs
outside the queue rather than competing on a score it cannot win.

**55 open issues are not on the board at all** — and they skew *recent and well-described*: the
entire 2026 SpringSaLaD grooming set, the field-viewer train, all six August infrastructure
issues, three epics. The board is stale at the new end, not the old end. Bulk-adding them is
roughly 30 minutes and is the cheapest high-value step in the plan.

**45 issues carry labels naming shipped releases** (`VCell-7.6.0` on 26 alone, `Next Release` on
19). The current line is 8.0.27.01.

**107 of 272 issues (39%) have a body under 200 characters.** 73 issues are a July-2022 bulk
import of a spreadsheet, ~34 of them with empty bodies — `#201`'s body is the tell:
*"Original Todo list has ?? by this item."* These need one session with their authors, not a year
of individual refinement.

**Four issues are marked `Done` on the board but are still open.** 14 close candidates in total;
six are verified against the working tree or git log (e.g. `#1647` has commit
`e79926b50a Fixed incorrect acot math!!!`; `#1686`'s PR #1685 is merged).

**Four pairs of epics overlap** (`#1038`/`#1751`, `#1199`/`#1008`, the three SpringSaLaD
containers, and three Quarkus/API epics), and **five strategic decisions** each gate a
double-digit number of issues — Postgres migration, desktop-vs-browser PDE viewer, standing of the
2022 cohort, whether accessibility is a dated mandate, and how far to pursue BioSimulators
conformance.

Two items I'd flag as under-ranked on severity: **`#490`** (name collisions can make the solver
"run and produce incorrect results" — silent wrong science, currently mid-rank) and **`#1874`**
(SpringSaLaD's diffusion-limit check is off by ~600× and is off-board).

## Caveats

- **`#748`** could not be resolved — the board says `Done`, I found no such script, and it may have
  been obsoleted by the Kubernetes migration. Flagged as an open question, not asserted.
- **`#1646`** is relayed from the board's `Done` status; I could not isolate a commit confirming it.
- The ten thematic groups are a **reading aid, not a proposed label scheme**. Several issues
  genuinely belong to two groups; each was assigned one so counts sum cleanly. Converting these
  into GitHub labels deserves its own conversation — the repo already has 32.

## Reviewing this

The useful review is on the *judgments*, not the prose: whether the close candidates are really
closeable, whether the epic merges are right, and whether the five decisions are the right five.
Corrections are cheap — this is documentation, and it is explicitly a snapshot.

The scoring-model question that the first commit left open has since been answered and the docs
amended (second commit), so nothing in here is knowingly stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kr8SbzXtwW3gMVUgMfDDt
