### PR TITLE
Characterise what the HDF5 export writes

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/export/server/ASCIIExporter.java
+++ b/vcell-core/src/main/java/cbit/vcell/export/server/ASCIIExporter.java
@@ -1191,7 +1191,9 @@ public class ASCIIExporter {
     }
 
 
-    private class SliceHelper {
+    // Package private rather than private so the export's HDF5 slice writing can be characterised by a
+    // test; it had none.
+    class SliceHelper {
         public long hdf5DataspaceIDSlice = -1;
         public long hdf5GroupVarID = -1;
         long hdf5DataspaceIDValues = -1;

--- a/vcell-core/src/test/java/cbit/vcell/export/server/ASCIIExporterHdf5SliceTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/export/server/ASCIIExporterHdf5SliceTest.java
@@ -1,0 +1,190 @@
+package cbit.vcell.export.server;
+
+import cbit.image.VCImageUncompressed;
+import cbit.vcell.geometry.RegionImage;
+import cbit.vcell.math.VariableType;
+import cbit.vcell.solvers.CartesianMesh;
+import cbit.vcell.solvers.CartesianMeshTestSupport;
+import hdf.hdf5lib.H5;
+import hdf.hdf5lib.HDF5Constants;
+import io.jhdf.HdfFile;
+import io.jhdf.api.Dataset;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.vcell.util.Extent;
+import org.vcell.util.Origin;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Characterises what the ASCII/HDF5 export actually writes for spatial data, one timepoint at a time.
+ * <p>
+ * The export had no tests at all, and its HDF5 writing is being ported off the native hdf.hdf5lib binding to jhdf
+ * (jhdf#654). These assertions are the reference the port has to reproduce: the dataset's name, its shape, and
+ * which value ends up at which index after the slice extraction reorders the raw simulation data.
+ */
+@Tag("Fast")
+public class ASCIIExporterHdf5SliceTest {
+
+	private static final int SIZE_X = 4;
+	private static final int SIZE_Y = 3;
+	private static final int SIZE_Z = 2;
+	private static final int TIME_COUNT = 3;
+
+	/**
+	 * Two subvolumes split along x, so the mesh has real membrane elements between them. A uniform image has none,
+	 * and membrane data would then be zero length -- which the type inference still calls MEMBRANE, so the test
+	 * would pass while measuring nothing.
+	 */
+	private static CartesianMesh mesh() throws Exception {
+		Extent extent = new Extent(1, 1, 1);
+		Origin origin = new Origin(0, 0, 0);
+		byte[] pixels = new byte[SIZE_X * SIZE_Y * SIZE_Z];
+		for (int z = 0; z < SIZE_Z; z++) {
+			for (int y = 0; y < SIZE_Y; y++) {
+				for (int x = 0; x < SIZE_X; x++) {
+					pixels[z * SIZE_X * SIZE_Y + y * SIZE_X + x] = (byte) (x < SIZE_X / 2 ? 0 : 1);
+				}
+			}
+		}
+		VCImageUncompressed image = new VCImageUncompressed(null, pixels, extent, SIZE_X, SIZE_Y, SIZE_Z);
+		RegionImage regionImage = new RegionImage(image, 3, extent, origin, 0.5);
+		return CartesianMesh.createSimpleCartesianMesh(origin, extent,
+			new org.vcell.util.ISize(SIZE_X, SIZE_Y, SIZE_Z), regionImage);
+	}
+
+	/** Drives the export's slice writing for every timepoint and returns the file it wrote. */
+	private static Path writeTimepoints(CartesianMesh mesh, int sliceNumber, DataForTime dataForTime)
+		throws Exception {
+		Path file = Files.createTempFile("asciiExport", ".hdf5");
+		Files.deleteIfExists(file);
+
+		FileDataContainerManager containers = new FileDataContainerManager();
+		long fileId = H5.H5Fcreate(file.toString(), HDF5Constants.H5F_ACC_TRUNC,
+			HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+		long groupId = H5.H5Gcreate(fileId, "SimID_1", HDF5Constants.H5P_DEFAULT,
+			HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT);
+
+		ASCIIExporter exporter = new ASCIIExporter(null);
+		ASCIIExporter.SliceHelper sliceHelper =
+			exporter.new SliceHelper(TIME_COUNT, true, "XY", sliceNumber, false, mesh);
+		sliceHelper.setHDF5GroupVarID(groupId, "Ran_cyt");
+		for (int timeIndex = 0; timeIndex < TIME_COUNT; timeIndex++) {
+			sliceHelper.populate(containers, containers.getNewFileDataContainerID(), dataForTime.at(timeIndex));
+		}
+		sliceHelper.closeHDF5GroupAndValues();
+		H5.H5Gclose(groupId);
+		H5.H5Fclose(fileId);
+		return file;
+	}
+
+	@FunctionalInterface
+	private interface DataForTime {
+		double[] at(int timeIndex);
+	}
+
+	/** Volume data for one timepoint, valued so the index it came from is recoverable. */
+	private static double[] volumeData(int timeIndex) {
+		double[] data = new double[SIZE_X * SIZE_Y * SIZE_Z];
+		for (int i = 0; i < data.length; i++) {
+			data[i] = timeIndex * 1000 + i;
+		}
+		return data;
+	}
+
+	@Test
+	public void wholeVolumePerTimepoint() throws Exception {
+		CartesianMesh mesh = mesh();
+		Path file = writeTimepoints(mesh, -1, ASCIIExporterHdf5SliceTest::volumeData);
+
+		try (HdfFile hdfFile = new HdfFile(file)) {
+			Dataset dataset = hdfFile.getDatasetByPath("SimID_1/Ran_cyt/DataValues (XYZT)");
+			// {outer, inner, slices, time} for an xy slice plane over the whole volume
+			assertArrayEquals(new int[]{SIZE_Y, SIZE_X, SIZE_Z, TIME_COUNT}, dataset.getDimensions());
+
+			double[][][][] values = (double[][][][]) dataset.getData();
+			for (int timeIndex = 0; timeIndex < TIME_COUNT; timeIndex++) {
+				for (int z = 0; z < SIZE_Z; z++) {
+					for (int outer = 0; outer < SIZE_Y; outer++) {
+						for (int inner = 0; inner < SIZE_X; inner++) {
+							double expected = timeIndex * 1000 + z * SIZE_X * SIZE_Y + outer * SIZE_X + inner;
+							assertEquals(expected, values[outer][inner][z][timeIndex],
+								"value at outer=" + outer + " inner=" + inner + " z=" + z + " t=" + timeIndex);
+						}
+					}
+				}
+			}
+		}
+		Files.deleteIfExists(file);
+	}
+
+	/**
+	 * One slice of the volume rather than all of it. The dataset drops the Z dimension and its name loses the Z,
+	 * so a single-slice export is a different shape and a different name from a whole-volume one.
+	 */
+	@Test
+	public void singleSlicePerTimepoint() throws Exception {
+		final int sliceNumber = 1;
+		CartesianMesh mesh = mesh();
+		Path file = writeTimepoints(mesh, sliceNumber, ASCIIExporterHdf5SliceTest::volumeData);
+
+		try (HdfFile hdfFile = new HdfFile(file)) {
+			Dataset dataset = hdfFile.getDatasetByPath("SimID_1/Ran_cyt/DataValues (XYT)");
+			assertArrayEquals(new int[]{SIZE_Y, SIZE_X, TIME_COUNT}, dataset.getDimensions());
+
+			double[][][] values = (double[][][]) dataset.getData();
+			for (int timeIndex = 0; timeIndex < TIME_COUNT; timeIndex++) {
+				for (int outer = 0; outer < SIZE_Y; outer++) {
+					for (int inner = 0; inner < SIZE_X; inner++) {
+						double expected =
+							timeIndex * 1000 + sliceNumber * SIZE_X * SIZE_Y + outer * SIZE_X + inner;
+						assertEquals(expected, values[outer][inner][timeIndex],
+							"value at outer=" + outer + " inner=" + inner + " t=" + timeIndex);
+					}
+				}
+			}
+		}
+		Files.deleteIfExists(file);
+	}
+
+	/**
+	 * Membrane data is not reordered at all: it is written as it arrives, one column per timepoint. The variable
+	 * type is inferred from the data's length, so this depends on the mesh actually having membrane elements.
+	 */
+	@Test
+	public void membranePerTimepoint() throws Exception {
+		final int membraneLength = 7;
+		CartesianMesh mesh = CartesianMeshTestSupport.withMembraneElementCount(mesh(), membraneLength);
+		assertEquals(membraneLength, mesh.getDataLength(VariableType.MEMBRANE),
+			"the test mesh has no membrane elements, so this would measure nothing");
+		assertNotEquals(mesh.getDataLength(VariableType.VOLUME), membraneLength,
+			"volume is checked first, so equal lengths would classify membrane data as volume");
+
+		Path file = writeTimepoints(mesh, -1, timeIndex -> {
+			double[] data = new double[membraneLength];
+			for (int i = 0; i < data.length; i++) {
+				data[i] = timeIndex * 1000 + i;
+			}
+			return data;
+		});
+
+		try (HdfFile hdfFile = new HdfFile(file)) {
+			Dataset dataset = hdfFile.getDatasetByPath("SimID_1/Ran_cyt/DataValues (MT)");
+			assertArrayEquals(new int[]{membraneLength, TIME_COUNT}, dataset.getDimensions());
+
+			double[][] values = (double[][]) dataset.getData();
+			for (int timeIndex = 0; timeIndex < TIME_COUNT; timeIndex++) {
+				for (int i = 0; i < membraneLength; i++) {
+					assertEquals(timeIndex * 1000 + i, values[i][timeIndex],
+						"value at element=" + i + " t=" + timeIndex);
+				}
+			}
+		}
+		Files.deleteIfExists(file);
+	}
+}

--- a/vcell-core/src/test/java/cbit/vcell/solvers/CartesianMeshTestSupport.java
+++ b/vcell-core/src/test/java/cbit/vcell/solvers/CartesianMeshTestSupport.java
@@ -1,0 +1,30 @@
+package cbit.vcell.solvers;
+
+
+
+/**
+ * Test-only access to {@link CartesianMesh} internals, from inside its package.
+ * <p>
+ * Membrane elements are only ever populated by the Geometry based factory, which needs a generated surface
+ * collection. Code that merely classifies data by length, or writes membrane data through unchanged, does not care
+ * what the elements are - only how many there are.
+ */
+public final class CartesianMeshTestSupport {
+
+	private CartesianMeshTestSupport() {
+	}
+
+	/**
+	 * Gives a mesh the stated number of membrane elements, so data of that length is classified as
+	 * {@link cbit.vcell.math.VariableType#MEMBRANE}. The elements themselves are left null: any code that reads
+	 * them needs a real geometry and should not be using this.
+	 *
+	 * @param mesh the mesh to modify
+	 * @param count the number of membrane elements to report
+	 * @return the same mesh, for chaining
+	 */
+	public static CartesianMesh withMembraneElementCount(CartesianMesh mesh, int count) {
+		mesh.membraneElements = new MembraneElement[count];
+		return mesh;
+	}
+}


### PR DESCRIPTION
`ASCIIExporter` has no tests. Its HDF5 writing is the least obvious part of it — raw simulation data is reordered by slice extraction before it lands in the file, and both the dataset's name and its shape depend on what was asked for — so nothing recorded what a user actually downloads.

This pins the three shapes `SliceHelper.populate` produces, one timepoint at a time:

| export | dataset | dimensions |
|---|---|---|
| whole volume | `DataValues (XYZT)` | `{outer=sizeY, inner=sizeX, sizeZ, time}` |
| single slice | `DataValues (XYT)` | `{sizeY, sizeX, time}` |
| membrane | `DataValues (MT)` | `{len, time}`, verbatim |

The single-slice case is the one worth having in writing: it drops Z from the shape **and** from the dataset name, so it is a different dataset from a whole-volume export rather than a one-slice version of it.

## Two things found while writing it

**Membrane data is classified by length, and a mesh with no membranes passes vacuously.** `getVariableTypeFromLength` checks VOLUME first, then MEMBRANE — and a *zero length* array still matches `getDataLength(MEMBRANE) == 0`. `createSimpleCartesianMesh` never populates `membraneElements` (only the `Geometry` based factory does, via a generated `SurfaceCollection`), so the obvious test would have written a `{0, timeCount}` dataset and passed while measuring nothing. The first version of this test caught exactly that, and the assertions now refuse it.

Rather than build a full geometry with surface generation for a code path that writes the array unchanged, `CartesianMeshTestSupport` sets the element count from inside the mesh's own package — the field is `protected`, so it is plain package access, no reflection — and says why the elements themselves are left null.

**The test mesh has two subvolumes.** It made no difference to the count in the end, but a uniform image has no membrane surface at all, and the mesh should at least describe something a membrane could exist between.

## Scope

- Written against the existing native `hdf.hdf5lib` binding and read back with jhdf, so it describes **today's** behaviour and does not depend on anything unreleased.
- `SliceHelper` goes from `private` to package private so a test can reach it. That is the only production change — 3 lines, and the file's CRLF line endings are preserved.

This exists because that writing is being moved off the native binding to jhdf (upstream jhdf#654, PR jamesmudd/jhdf#865), and rewriting an untested export path on the strength of "it still compiles" is not a thing worth doing. But the characterisation is useful whether or not that lands, which is why it is on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdenYzMw35USHDQEATGVq
