### PR TITLE
ci(bmdb): pin the BMDB corpus to a sha instead of tracking main

### DIFF
--- a/.github/workflows/NightlyBMDB_CLI.yml
+++ b/.github/workflows/NightlyBMDB_CLI.yml
@@ -136,11 +136,25 @@ jobs:
       - name: Load Downloaded Docker Image
         run: docker load --input /tmp/docker/$(ls /tmp/docker)
 
-        # Get files from BMDB
+        # Get files from BMDB.
+        #
+        # PINNED DELIBERATELY. Without `ref:` this took whatever sys-bio/temp-biomodels
+        # had on main that night, so an upstream commit could change the corpus, flip a
+        # result against test_cases.ndjson, and leave nothing in this repo explaining why
+        # -- the one kind of baseline diff that is near-impossible to diagnose after the
+        # fact. The gate compares against a documented baseline, so its input has to be
+        # as versioned as the baseline is.
+        #
+        # To take a newer corpus: bump the sha here in its own PR, run the nightly via
+        # workflow_dispatch, and accept the resulting baseline diff as a separate,
+        # reviewable commit. That keeps "the models changed" and "VCell changed" apart.
       - name: Checkout Input Files
         uses: actions/checkout@v4
         with:
           repository: sys-bio/temp-biomodels
+          # main @ 2025-06-04 "Species units can't be undefined." -- the commit the
+          # nightly was already resolving to, so pinning it changes no results.
+          ref: 6a09daf46af1bb89e4857436b623a7b8720863ad
 
       - name: Prepare sub directory
         run: |


### PR DESCRIPTION
One line of YAML, but it closes a real hole in the BMDB gate.

## The problem

`NightlyBMDB_CLI.yml` checked out the model corpus with no `ref:`:

```yaml
- name: Checkout Input Files
  uses: actions/checkout@v4
  with:
    repository: sys-bio/temp-biomodels      # whatever main was that night
```

The gate added in #1901 compares nightly results against `test_cases.ndjson`, a baseline committed
**in this repo**. But the comparison has *two* inputs — the baseline and the corpus — and only one
of them was versioned here. An upstream commit to `temp-biomodels` could change a model, flip its
result, and produce a baseline diff with **no corresponding VCell change to point at**.

That is the hardest possible failure to diagnose: the gate correctly says "something changed", and
nothing in this repo's history can tell you what.

## The fix

```yaml
    ref: 6a09daf46af1bb89e4857436b623a7b8720863ad
```

`main @ 2025-06-04` — **the commit the nightly was already resolving to.** That repo's last commit
is over a year old, so this changes no results; it freezes the current input rather than moving it.
The behaviour-neutrality is the point: a pin that also changes results would be two changes wearing
one hat.

The inline comment records why it is pinned and how to bump it deliberately.

## How to take a newer corpus

1. Bump the sha in its own PR.
2. Run the nightly via `workflow_dispatch`.
3. Accept the resulting baseline diff as a **separate, reviewable** commit.

That keeps *"the models changed"* and *"VCell changed"* apart, which is what makes the gate
informative rather than merely red.

## Where this came from

Diagnosing #2000 (`BIOMD0000001065` regressed to `SOLVER_FAILURE`, nightly red since 08-18).
"Did the model file itself change?" was a hypothesis worth ruling out, and answering it took a
GitHub API query against a third-party repo rather than a glance at a diff.

It was **not** the cause there — `BIOMD0000001065.omex` last changed 2025-05-21, and the whole
corpus repo has been static since 2025-06-04 — but the question should have been answerable from
this repository, and now it is.

<sub>Verified: workflow YAML parses, and the resolved `with:` block is `{repository: sys-bio/temp-biomodels, ref: 6a09daf46…}`. `actions/checkout@v4` accepts a full commit sha for a foreign repository.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kr8SbzXtwW3gMVUgMfDDt
