### PR TITLE
Fix the Langevin trajectory viewer rotating backwards

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/geometry/gui/SurfaceCanvas.java
+++ b/vcell-client/src/main/java/cbit/vcell/geometry/gui/SurfaceCanvas.java
@@ -45,7 +45,10 @@ public class SurfaceCanvas extends javax.swing.JPanel implements java.beans.Prop
 	private double scale = 1.0;
 	private java.awt.image.BufferedImage cachedProjectedImage = null;
 	private cbit.vcell.geometry.surface.SurfaceCollection fieldSurfaceCollection = null;
-	private cbit.vcell.render.Trackball fieldTrackball = new cbit.vcell.render.Trackball(new cbit.vcell.render.Camera());
+	// Left-handed: +z away from the viewer, matching how the slice viewer displays data. The picking
+	// in this canvas rides the same convention -- see Trackball.Handedness.
+	private cbit.vcell.render.Trackball fieldTrackball = new cbit.vcell.render.Trackball(
+			new cbit.vcell.render.Camera(), cbit.vcell.render.Trackball.Handedness.LEFT_HANDED);
 	private org.vcell.util.Origin fieldOrigin = new org.vcell.util.Origin(0, 0, 0);
 	private org.vcell.util.Extent fieldExtent = new org.vcell.util.Extent(1, 1, 1);
 	private boolean fieldEnableDepthCueing = false;

--- a/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SpringSaladViewerCanvas.java
+++ b/vcell-client/src/main/java/cbit/vcell/solver/ode/gui/SpringSaladViewerCanvas.java
@@ -66,7 +66,13 @@ public class SpringSaladViewerCanvas extends JPanel {
 	private SpringSaladTrajectory trajectory;
 	private int frameIndex = 0;
 
-	private final Trackball trackball = new Trackball(new Camera());
+	/**
+	 * Right-handed, because this canvas draws with +z toward the viewer: {@link #project} keeps the
+	 * rotated z as depth and the draw list is sorted far-first on it, so larger depth is nearer.
+	 * The geometry and PDE surface viewers are left-handed, which is the default; asking for it here
+	 * grabs the far side of the ball and turns the scene the wrong way on both axes.
+	 */
+	private final Trackball trackball = new Trackball(new Camera(), Trackball.Handedness.RIGHT_HANDED);
 	private double zoom = 1.0;
 	private double panX = 0, panY = 0;
 	private boolean showLinks = true;

--- a/vcell-core/src/main/java/cbit/vcell/render/Trackball.java
+++ b/vcell-core/src/main/java/cbit/vcell/render/Trackball.java
@@ -49,8 +49,43 @@ public class Trackball {
     private int       numStates;
     private int       currState;
 
-public Trackball(Camera cam) {
+/**
+ * The handedness of the <em>caller's coordinate system</em> -- which way depth runs in the space
+ * this trackball drives, and so which face of the virtual ball a drag grabs.
+ * <p>
+ * <b>This has nothing to do with the user.</b> It is not a left-handed-mouse preference and not a
+ * choice about how anyone grips anything: it is whether the caller's +z points toward the viewer
+ * or away, which is fixed by how that viewer projects and depth-sorts, not by who is using it.
+ */
+public enum Handedness {
+	/**
+	 * +z points away from the viewer, so the grab point has negative z.
+	 * <p>
+	 * The geometry viewer and the PDE surface viewer are both this way, so that they agree with how
+	 * the slice viewer displays data, and they are internally consistent with this trackball as it
+	 * stands. Their picking rides the same convention -- SurfaceRenderer projects screen polygons
+	 * through {@link Camera#unProjectPoint}, SurfaceCanvas hit-tests clicks against those polygons
+	 * -- so a scene can keep looking right while clicks select the wrong surface if it is changed.
+	 */
+	LEFT_HANDED,
+	/**
+	 * +z points toward the viewer, so the grab point has positive z. A viewer that draws this way
+	 * and asks for {@link #LEFT_HANDED} grabs the far side of the ball, and the scene turns the
+	 * wrong way on both axes.
+	 */
+	RIGHT_HANDED
+}
+
+/**
+ * @param cam the camera to drive
+ * @param handedness which way depth runs in the caller's space. There is deliberately no default:
+ *                   a caller that has not decided this has a fifty-fifty chance of a viewer whose
+ *                   drags turn the scene backwards, and it does not show in a still image.
+ *                   See {@link Handedness}.
+ */
+public Trackball(Camera cam, Handedness handedness) {
     camera = cam;
+    this.handedness = handedness;
     bAnimate = false;
     currQuat.zero();
     incQuat.zero();
@@ -204,6 +239,8 @@ System.out.println("play() ... numStates="+numStates+", currState="+currState);
 // Project an xy pair onto a sphere of radius r OR a hyperbolic sheet
 // if we are away from the center of the sphere.
 //
+private final Handedness handedness;
+
 private Vect3d projectToSphere_xy(double x, double y)
 {
 double radius = sizeTrackball;
@@ -225,8 +262,9 @@ double distance_xy, t, z;
 //System.out.println("Trackball.projectToSphere("+x+","+y+") 'hyperbola' --> z = "+z);
    }
 //   vect.set(x,y,-z);
-   return new Vect3d(x,y,-z);
+   return new Vect3d(x,y,handedness == Handedness.RIGHT_HANDED ? z : -z);
 }
+
 
 
 //

--- a/vcell-core/src/main/java/cbit/vcell/render/TrackballTest.java
+++ b/vcell-core/src/main/java/cbit/vcell/render/TrackballTest.java
@@ -29,7 +29,7 @@ public TrackballTest() {
  */
 public static void main(String[] args) {
 	try {
-		Trackball trackball = new Trackball(new Camera());
+		Trackball trackball = new Trackball(new Camera(), Trackball.Handedness.LEFT_HANDED);
 		Vect3d unitX = new Vect3d(1, 2, 3);
 		Vect3d projX = new Vect3d();
 		Vect3d unprojX = new Vect3d();

--- a/vcell-core/src/test/java/cbit/vcell/render/TrackballHandednessTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/render/TrackballHandednessTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 1999-2026 University of Connecticut Health Center
+ *
+ * Licensed under the MIT License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *  http://www.opensource.org/licenses/mit-license.php
+ */
+package cbit.vcell.render;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A drag has to turn the scene the way the mouse went, and which way that is depends on which face
+ * of the virtual ball the drag grabs -- which depends on the caller's depth convention.
+ * <p>
+ * Worth pinning because getting it wrong is invisible in a still image and obvious the moment
+ * anyone drags: the Langevin trajectory viewer shipped inverted on both axes because it draws with
+ * +z toward the viewer while the trackball assumed the opposite.
+ */
+@Tag("Fast")
+public class TrackballHandednessTest {
+
+	/** Where a world point lands after the current rotation. */
+	private static Vect3d seenBy(Trackball tb, Vect3d world) {
+		Affine rot = new Affine();
+		tb.getMatrixGL(rot);
+		return rot.mult(world);
+	}
+
+	/** A trackball at the oblique view the trajectory viewer opens at. */
+	private static Trackball atDefaultView(Trackball.Handedness handedness) {
+		Trackball tb = new Trackball(new Camera(), handedness);
+		tb.getCamera().resetView();
+		tb.setRotation(Math.toRadians(35 - 90), Math.toRadians(30), 0);
+		return tb;
+	}
+
+	/** Normalized coords for a canvas that puts world +y up the screen. */
+	private static void dragRight(Trackball tb) {
+		tb.rotate_xy(0.0, 0.0, 0.2, 0.0);
+	}
+
+	private static void dragDown(Trackball tb) {
+		tb.rotate_xy(0.0, 0.0, 0.0, -0.2);
+	}
+
+	/**
+	 * In a right-handed viewer -- +z toward the camera, as the trajectory viewer draws -- the nearest
+	 * point should follow the mouse: drag right and it goes right, drag down and it goes down.
+	 */
+	@Test
+	public void rightHandedFollowsTheMouse() {
+		Vect3d near = new Vect3d(0, 0, 1);
+
+		Trackball right = atDefaultView(Trackball.Handedness.RIGHT_HANDED);
+		double x0 = seenBy(right, near).getX();
+		dragRight(right);
+		assertTrue(seenBy(right, near).getX() > x0,
+			"dragging right should carry the near point right");
+
+		Trackball down = atDefaultView(Trackball.Handedness.RIGHT_HANDED);
+		double y0 = seenBy(down, near).getY();
+		dragDown(down);
+		assertTrue(seenBy(down, near).getY() < y0,
+			"dragging down should carry the near point down (world +y is up the screen)");
+	}
+
+	/**
+	 * The left-handed convention grabs the other face, so the same drags carry that same point the
+	 * other way. That is correct for the geometry and PDE surface viewers, whose +z points away from
+	 * the viewer; it is only wrong for a caller that draws the other way round.
+	 */
+	@Test
+	public void leftHandedGrabsTheOtherFace() {
+		Vect3d p = new Vect3d(0, 0, 1);
+
+		Trackball right = atDefaultView(Trackball.Handedness.LEFT_HANDED);
+		double x0 = seenBy(right, p).getX();
+		dragRight(right);
+		assertTrue(seenBy(right, p).getX() < x0, "left-handed drag-right carries +z the other way");
+
+		Trackball down = atDefaultView(Trackball.Handedness.LEFT_HANDED);
+		double y0 = seenBy(down, p).getY();
+		dragDown(down);
+		assertTrue(seenBy(down, p).getY() > y0, "left-handed drag-down carries +z the other way");
+	}
+}


### PR DESCRIPTION
Dragging in the SpringSaLaD trajectory viewer turns the scene the wrong way on **both** axes, as if the drag grabbed the far side of the trackball. It does.

## What is happening

`Trackball.projectToSphere_xy` puts the grab point at **negative z**. That is correct for the geometry viewer and the PDE surface viewer, which are **left-handed** — +z away from the viewer — to match how the slice viewer displays data.

`SpringSaladViewerCanvas` is **right-handed**. Its `project()` keeps the rotated z as depth, and the draw list is sorted far-first on it, so *larger depth is nearer*:

```java
return new double[] { ox + v.getX() * pixelScale, oy - v.getY() * pixelScale, v.getZ() };
...
drawables.sort((p, q) -> Double.compare(p.depth, q.depth)); // far first
```

Handing a right-handed canvas a left-handed grab point mirrors the rotation axis, so the near face moves opposite the mouse.

Measured from the view the viewer opens at (35° elevation, 30° azimuth), dragging right 40px, tracking the point nearest the camera:

| drag | before | after |
|---|---|---|
| right | screen x +0.287 → **+0.153** (left) | +0.287 → **+0.402** (right) |
| down | screen y −0.819 → **−0.917** (up) | −0.819 → **−0.669** (down) |

## The fix

`Trackball` now takes the caller's handedness, and **there is no default**. A caller that has not thought about it has even odds of shipping a viewer that turns backwards, and it does not show in a still image — only when someone drags.

Both existing callers now say which they are. Only the trajectory viewer changes behaviour; `SurfaceCanvas` is explicitly `LEFT_HANDED` and is unaffected.

`TrackballHandednessTest` pins both conventions, since this is exactly the kind of thing that gets "tidied" back.

## What this deliberately does not do

It does not change the `-z` itself, which is the tempting one-character fix. Two reasons:

- both viewers call that method and only one was wrong
- the geometry viewers' **picking** rides the same convention — `SurfaceRenderer` builds projected screen polygons via `Camera.unProjectPoint`, and `SurfaceCanvas` hit-tests clicks against them. Change the screen-to-world mapping and a scene can keep looking right while clicks select the wrong surface.

## Provenance

Found while lifting this renderer into the standalone SpringSaLaD desktop application, which hit the same inversion and fixed it on its side. Reported back here because the bug is in VCell too.

## Testing

- `TrackballHandednessTest` — 2 tests, new
- `SpringSalad*Test` in vcell-client — 18 tests, 0 failures, including the render tests that produce PNGs, so drawing is unchanged
- `vcell-core` Fast group — 560 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdenYzMw35USHDQEATGVq
