### PR TITLE
docs: split the 8.0 / 8.1 release narratives, and backfill three missing changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -985,6 +985,110 @@ SpringSaLaD bond rendering so bonds stop at sphere surfaces.
   schema changes in this build. A `NOT NULL` constraint on
   `vc_publication.pubdate` accompanies this in the production database.
 
+## [8.0.4.01] - 2026-07-29
+
+**Highlights.** The 3D Trajectory tab now appears for simulations run on the
+cluster, not only for those run locally. The simulation box is also drawn with
+hidden-line removal, so the edges behind the membrane or behind molecules no
+longer show through them.
+
+### Fixed
+- The "3D Trajectory" tab never appeared for a SpringSaLaD simulation run
+  remotely. The client's remote data controller had no delegation for the
+  trajectory request, so the call fell through to a default that returned
+  nothing and no request was ever sent to the server. Locally-run simulations
+  reach the data through a different, correctly wired path, which is why they
+  were unaffected. (#1798)
+- The simulation box was drawn as a flat overlay on top of the scene rather
+  than as part of it, so edges lying behind the opaque membrane or behind
+  molecules were painted over them — misleading under parallel projection,
+  where there is no perspective to say which way is farther. Box edges now take
+  part in the same depth ordering as everything else and dim with distance.
+  (#1798)
+
+### Notes for API consumers
+No API changes.
+
+## [8.0.3.02] - 2026-07-29
+
+**Highlights.** SpringSaLaD results gain a **3D Trajectory** tab: a movie
+player that shows individual molecules moving over the course of a run, rather
+than only the aggregate counts plotted elsewhere. It has play/pause, a frame
+scrubber, adjustable speed, and rotate/zoom/pan, and it draws the simulation
+box and the membrane for context. The viewer is drawn with ordinary Java 2D
+graphics and needs no native 3D library, so it works everywhere VCell runs.
+
+### Added
+- A "3D Trajectory" tab in the SpringSaLaD results viewer: playback with
+  play/pause, a frame scrubber, speed from 2 to 30 frames per second, a links
+  toggle and a reset-view button, and a time and scene readout. Drag rotates,
+  the wheel zooms, shift-drag or right-drag pans. Molecule colour can change
+  from frame to frame, which is how a site's state is shown. (#1796)
+- The per-particle trajectory the Langevin solver writes — the position of
+  every site and the links between them, at each output frame of the first run
+  — is now retrieved from the server. Until now it was written by the solver
+  and never read; only the aggregate `.ida` and `.csv` results were served.
+  (#1795)
+- The simulation box and the membrane are drawn around the molecules, with
+  toolbar toggles for each alongside the existing one for links. The framing
+  is computed once from all frames together, so the scene does not jitter as
+  it plays. (#1797)
+
+### Fixed
+- The trajectory was offered only for batch runs on the cluster, because the
+  tab was tied to the presence of batch results. It is now offered whenever a
+  trajectory exists, including single runs. (#1797)
+- A simulation run locally could not find its own trajectory file. The desktop
+  solver runs only the solver's simulate step and never its post-processing
+  step, so the file is never renamed to the canonical name the server serves;
+  the client now also looks in the solver's own output folder. (#1797)
+
+### Notes for API consumers
+No `/api/v1/` changes. Internally the data server gained a
+`getLangevinTrajectory` call; it is declared with a default that returns
+nothing, so other implementations of that interface are unaffected.
+
+## [8.0.3.01] - 2026-07-29
+
+**Highlights.** The dialog for sharing a model with other users was reworked.
+It now shows which step to take, tells you when you have unsaved changes, and
+revoking someone's access actually clears them from the list. Separately,
+geometry sizes in the simulation summary no longer show floating-point noise
+such as `0.10000000007 microns`.
+
+### Fixed
+- Revoking a user's access in the sharing dialog did not appear to take
+  effect. Removing the last remaining name switched the dialog to "private"
+  rather than leaving an access list with nobody on it, so the change did not
+  read as a removal. (#1745)
+- Geometry sizes in the simulation summary were printed with the full
+  floating-point expansion — `0.10000000007 microns` where `0.1` was meant.
+  They are now shown to six decimal places. A size smaller than that displays
+  as `0`; no geometry in practice is that small. (#1784)
+
+### Changed
+- The sharing dialog's buttons are now "Confirm Changes" and "Cancel", and
+  Confirm stays disabled until something has actually changed, so it is
+  visible whether there is anything to save. The button that drops a user
+  reads "Revoke Access", and the name field shows placeholder text saying what
+  belongs in it. (#1745)
+
+### Added
+- Internal: the five desktop installers are built in parallel, one platform
+  per machine, with the macOS notarization overlapping the Windows and Linux
+  builds instead of following them. The installer stage of a release goes from
+  roughly 50 minutes to about 8. (#1787)
+- Internal: the regression suite is now a merge-queue gate only. It had been
+  declared on pull requests through a trigger that fires only when a draft is
+  marked ready, so a pull request opened as ready was expected to produce a
+  check that could never run, and was blocked from merging with no way to
+  satisfy it. (#1788)
+- Internal: CodeQL analysis of the Java code builds without running tests,
+  cutting about 17% from the scan. (#1789, #1790, #1791)
+
+### Notes for API consumers
+No API changes.
+
 ## [8.0.2.07] - 2026-07-27
 
 **Highlights.** Sixth hotfix on the 8.0.2 line, and a **server-only** deploy.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,7 +12,7 @@ but all artifacts derive from one canonical source in this repository.
 | Artifact | Audience | Granularity | Location | Source of truth? |
 |---|---|---|---|---|
 | `CHANGELOG.md` | Developers, API integrators | One section per **tagged build** | repo root | Yes — canonical engineer-track log |
-| `release-notes/major/<version>.md` | End users / scientists | One file per **public release** (e.g. `7.7.md`, `8.0.0.md`) | this repo | Yes — canonical user-facing narrative |
+| `release-notes/major/<version>.md` | End users / scientists | One file per **public release** (e.g. `7.7.md`, `8.0.md`) | this repo | Yes — canonical user-facing narrative |
 | GitHub release body | Developers (existing channel) | Per tag | github.com | No — copy-pasted from `CHANGELOG.md` at release-cut |
 | vcell.org accordion (`/run-vcell-software`) | End users | One entry per public release | external website | No — transcribed from `release-notes/major/<version>.md` when prod rolls |
 
@@ -108,7 +108,27 @@ not required to — the formal write-up happens at release-cut time.
 Each public release gets a file at `release-notes/major/<version>.md`.
 By default, one file per `MAJOR.MINOR` line, not per build.
 
-- `release-notes/major/8.0.0.md` — covers the entire 8.0.0 line
+- `release-notes/major/8.0.md` — VCell 8.0
+- `release-notes/major/8.1.md` — VCell 8.1
+
+### The narrative name and the build version may differ
+
+The name a release is given for users is a separate decision from the
+version its builds carry, and the two are allowed to diverge. Build
+numbers are never restated once published; the narrative decides which
+builds it covers.
+
+This has already happened once. **VCell 8.0** is the 8.0.0 builds only
+— 8.0.0.01 through 8.0.0.03, the SpringSaLaD GA that ran in production
+from 2026-05-21 to 2026-08-14. Everything released after 8.0.0.03 is
+**VCell 8.1**, even though those builds are numbered 8.0.2.01 through
+8.0.28.01 and beyond.
+
+So, at release-cut time, add the user-facing items to the narrative
+file for the release **currently being accumulated** — today
+`8.1.md` — not to the file whose name matches the build's
+`MAJOR.MINOR`. `CHANGELOG.md` is unaffected: it is organised strictly
+by build version and always records the real number.
 
 When a long-running `MAJOR.MINOR` line accumulates multiple distinct
 production rollouts that each warrant their own public release event,

--- a/docs/backlog/01-close-and-verify.md
+++ b/docs/backlog/01-close-and-verify.md
@@ -81,7 +81,7 @@ the issue is not tracking anything.)
 
 `#1599` asks for notes for **7.7.0.47**. The current line is **8.0.27.01**, and
 `release-notes/major/` already contains `7.7.md`, `7.7-initial-release.md`,
-`7.7-feature-update.md`, `7.7-stability-update.md`, and `8.0.0.md`. The 7.7 notes exist.
+`7.7-feature-update.md`, `7.7-stability-update.md`, and `8.0.md`. The 7.7 notes exist.
 
 `#1543` ("next production release") is unfalsifiable by construction — it can never be closed,
 because there is always a next release. Release notes are part of the release procedure

--- a/release-notes/major/7.7-feature-update.md
+++ b/release-notes/major/7.7-feature-update.md
@@ -80,7 +80,7 @@ schema is included in the generated OpenAPI spec.
 > enabled by default in non-production deployments where the team
 > and beta testers worked with it, and off by default on the
 > production release site. The feature flag is removed in
-> **[VCell 8.0.0](./8.0.0.md)**, where SpringSaLaD is enabled
+> **[VCell 8.0](./8.0.md)**, where SpringSaLaD is enabled
 > across all deployments.
 
 The SpringSaLaD development that landed in this window gave the

--- a/release-notes/major/7.7-initial-release.md
+++ b/release-notes/major/7.7-initial-release.md
@@ -27,7 +27,7 @@ Python plotting bridge is deprecated.
 > users who explicitly enabled it, and on by default in
 > non-production deployments. On the production release site the
 > flag was off by default. The feature flag is removed in
-> **[VCell 8.0.0](./8.0.0.md)**, where SpringSaLaD is enabled
+> **[VCell 8.0](./8.0.md)**, where SpringSaLaD is enabled
 > across all deployments as a first-class modality.
 
 The SpringSaLaD-specific user interface received its first major

--- a/release-notes/major/7.7-stability-update.md
+++ b/release-notes/major/7.7-stability-update.md
@@ -63,7 +63,7 @@ was fixed by serializing `DecimalFormat` access.
 > SpringSaLaD was available under a beta-test feature flag (on by
 > default in non-production deployments, off by default on the
 > release site). The feature flag is removed in
-> **[VCell 8.0.0](./8.0.0.md)**.
+> **[VCell 8.0](./8.0.md)**.
 
 Final SpringSaLaD UI fixes before the 8.0.0 GA event:
 
@@ -91,4 +91,4 @@ The Structural Sites work for SpringSaLaD landed in 7.7.0.78 the
 week after this release, but did not roll to production under
 the 7.7 line — it is the bridge into the next public release event:
 **VCell 8.0.0 — SpringSaLaD GA**. See
-[VCell 8.0.0 release notes](./8.0.0.md).
+[VCell 8.0 release notes](./8.0.md).

--- a/release-notes/major/8.0.md
+++ b/release-notes/major/8.0.md
@@ -1,0 +1,146 @@
+# VCell 8.0
+
+**Released:** 2026-05-21
+
+## Headline
+
+**SpringSaLaD modeling is now a first-class VCell modality.**
+
+VCell 8.0 introduces SpringSaLaD (Michalski & Loew, 2016) as a
+fully supported VCell modality. SpringSaLaD enables spatial,
+stochastic, particle-based simulation of biochemical reaction-
+diffusion systems, representing biomolecules as collections of
+linked spherical sites with explicit excluded-volume interactions
+in three-dimensional space — bridging detailed molecular-dynamics
+approaches and cellular-level reaction-network modeling. Available
+throughout the 7.7 line under a beta-test feature flag, SpringSaLaD
+is now enabled across all VCell deployments and appears in the
+standard application workflow alongside ODE, stochastic, and PDE
+modalities — with a complete authoring environment, multi-run
+simulation on the compute cluster via SLURM array submission, and
+batch-results visualization.
+
+**Citation.** Michalski PJ, Loew LM.
+*SpringSaLaD: A Spatial, Particle-Based Biochemical Simulation
+Platform with Excluded Volume.* Biophys J. 2016;110(3):523–529.
+[doi:10.1016/j.bpj.2015.12.026](https://doi.org/10.1016/j.bpj.2015.12.026)
+· PMID: 26840718
+
+## What's new
+
+### SpringSaLaD modeling — generally available
+
+SpringSaLaD is now enabled by default in VCell. The opt-in property
+that was required during the 7.7 line is no longer needed; the
+SpringSaLaD modality appears alongside ODE, stochastic, and PDE
+modeling in the standard application workflow.
+
+Key capabilities that ship with 8.0:
+
+- **Structural Sites.** Define anchor points in a molecule with
+  positions in space, distinct from molecular components. Useful
+  for representing rigid scaffolds, junction points, and other
+  geometric features that do not participate in reactions but
+  constrain molecular geometry.
+
+- **Multi-run simulations.** Specify a number of trials and a
+  random seed for a Langevin simulation. Concurrent runs are
+  dispatched as SLURM array jobs on the compute cluster, and the
+  batch results transfer back to the desktop client automatically.
+  Sensible default and maximum limits prevent inadvertent cluster
+  resource consumption (default 20 trials, maximum 200; concurrent
+  jobs capped at 20).
+
+- **Batch results visualization.** Plots and tables for general
+  statistics (average, min/max, standard deviation) and cluster
+  analysis (ACS, SD, ACO) across multi-run results.
+
+- **Redesigned SpringSaLaD interface.** New molecular-structure
+  properties panel with editable links, tables for site attributes
+  and links, and a large-shape representation of site attributes
+  in the species-context view. _(Most of this UI work shipped during
+  the 7.7 line and rolls up into the 8.0 GA story.)_
+
+- **Result filtering and physical-limit checks.** Trivial-data
+  result sets are highlighted automatically. Site size, diffusion
+  rate, and partition size are validated before submission.
+
+- **Stricter integrator filtering.** Solver-choice dropdowns hide
+  integrators that are unsuitable for SpringSaLaD applications, so
+  users no longer see options that would silently produce wrong
+  results.
+
+### Plot Options dialog
+
+A new Plot Options dialog gives users finer control over plot
+appearance across visualization panels (line colors, marker styles,
+axes, legends).
+
+### Quick Run guardrails for Langevin
+
+The desktop client's "Quick Run" workflow (intended for fast, local
+single-simulation tests) now refuses to launch multi-job Langevin
+configurations with an explicit error message rather than letting
+them launch and fail later in a non-obvious place.
+
+### Admin and reporting tools
+
+A new `admincli report` subcommand kit produces period-bounded
+NIH-RPPR-style usage reports — counts of new users, simulation jobs
+in the database, cumulative metrics as-of a given date, and a CSV
+export of active users. Designed to be extended each reporting cycle
+without rewriting the toolkit.
+
+### BioNetGen import refinement
+
+BioNetGen BNGL imports now rewrite tilde-prefixed bare digits
+(`~0`, `~1`, ...) to the `~s0`, `~s1` form during preprocessing,
+resolving a parser ambiguity with state labels.
+
+## Improvements
+
+- Langevin simulation-options dialog enforces the invariant that
+  concurrent jobs cannot exceed total jobs, and clamps both to
+  sensible maximum values.
+
+## Bug fixes
+
+_(Per-build fixes are tracked in `CHANGELOG.md`. VCell 8.0
+inherits the stability work shipped at the end of the 7.7 line —
+notably the JMS failover watchdog, the OOM exit handler, the DNS
+negative-cache fix, charset-aware Oracle CLOB reads, and a
+thread-safety fix in unit-of-measurement formatting.)_
+
+## API and integration changes
+
+The REST API surface in VCell 8.0 is the same as the final 7.7 builds.
+If you maintained a client against `/api/v1/` during the 7.7 line,
+no migration is required for VCell 8.0.
+
+- New `/api/v1/` endpoints continue to coexist with legacy
+  `/api/v0/`. New client work should target `/api/v1/`.
+- OIDC authentication via Auth0 is required for `/api/v1/`.
+- The OpenAPI spec at `tools/openapi.yaml` is the source of truth
+  for client generation.
+
+For users coming directly from VCell 7.6, see also the
+[VCell 7.7 release index](./7.7.md), which points at the three
+named 7.7 release events
+([Initial Release](./7.7-initial-release.md) →
+[Feature Update](./7.7-feature-update.md) →
+[Stability Update](./7.7-stability-update.md))
+for the API-migration story and SpringSaLaD groundwork.
+
+## What came next
+
+VCell 8.0 is the 8.0.0 builds — 8.0.0.01 through 8.0.0.03, the last of
+which ran on the production site from 2026-05-21 until 2026-08-14.
+Everything released after it is covered by
+[VCell 8.1](./8.1.md), whose build numbers continue the `8.0.x`
+sequence for release-engineering reasons.
+
+## Known issues
+
+None at release time. Please report issues at
+<https://github.com/virtualcell/vcell/issues>.
+

--- a/release-notes/major/8.1.md
+++ b/release-notes/major/8.1.md
@@ -1,124 +1,99 @@
-# VCell 8.0.0
+# VCell 8.1
 
-**Released:** 2026-05-21
+**Status:** pre-release. Rolled to the production site on 2026-08-14
+and updated since; not yet announced as a public release event.
+
+> **A note on version numbers.** VCell 8.1 is delivered by builds whose
+> version numbers continue the `8.0.x` sequence — 8.0.2.01 through
+> 8.0.28.01 so far. Those numbers are what they are and are not being
+> restated. For release notes and user-facing announcements, **VCell 8.0
+> means the 8.0.0 builds** (8.0.0.01–8.0.0.03, the SpringSaLaD GA that
+> ran in production from 2026-05-21 to 2026-08-14), and **everything
+> released after 8.0.0.03 is VCell 8.1**.
 
 ## Headline
 
-**SpringSaLaD modeling is now a first-class VCell modality.**
+**SpringSaLaD runs can now be watched, and they stop getting lost.**
 
-VCell 8.0.0 introduces SpringSaLaD (Michalski & Loew, 2016) as a
-fully supported VCell modality. SpringSaLaD enables spatial,
-stochastic, particle-based simulation of biochemical reaction-
-diffusion systems, representing biomolecules as collections of
-linked spherical sites with explicit excluded-volume interactions
-in three-dimensional space — bridging detailed molecular-dynamics
-approaches and cellular-level reaction-network modeling. Available
-throughout the 7.7 line under a beta-test feature flag, SpringSaLaD
-is now enabled across all VCell deployments and appears in the
-standard application workflow alongside ODE, stochastic, and PDE
-modalities — with a complete authoring environment, multi-run
-simulation on the compute cluster via SLURM array submission, and
-batch-results visualization.
+VCell 8.1 adds a 3D trajectory viewer that plays back the motion of
+individual molecules over a SpringSaLaD run, and fixes a defect that
+made long runs unreliable to manage: starting one simulation marked
+every other simulation already running in the same application as
+"never ran". Because SpringSaLaD runs take days, and it is normal to
+start one while others are still going, this was a dependable way to
+lose track of work in progress.
 
-**Citation.** Michalski PJ, Loew LM.
-*SpringSaLaD: A Spatial, Particle-Based Biochemical Simulation
-Platform with Excluded Volume.* Biophys J. 2016;110(3):523–529.
-[doi:10.1016/j.bpj.2015.12.026](https://doi.org/10.1016/j.bpj.2015.12.026)
-· PMID: 26840718
+Around those two, 8.1 collects a substantial amount of repair — model
+import that reaches published models it previously abandoned, desktop
+windows that stay where they are put, failures that say what actually
+went wrong, and full support for Apple silicon.
 
 ## What's new
 
-### SpringSaLaD modeling — generally available
+### 3D trajectory viewer for SpringSaLaD results (8.0.3.02)
 
-SpringSaLaD is now enabled by default in VCell. The opt-in property
-that was required during the 7.7 line is no longer needed; the
-SpringSaLaD modality appears alongside ODE, stochastic, and PDE
-modeling in the standard application workflow.
+SpringSaLaD results gained a **3D Trajectory** tab that plays back the
+motion of individual molecules over a run, rather than only the
+aggregate counts plotted elsewhere. It offers play/pause, a frame
+scrubber, speed from 2 to 30 frames per second, and rotate, zoom and
+pan, and it draws the simulation box and the membrane for context.
+Molecule colour changes from frame to frame to show a site's state.
 
-Key capabilities that ship with 8.0.0:
+The viewer is drawn with ordinary Java 2D graphics and needs no native
+3D library, so it works on every platform VCell ships to, including
+Apple silicon. It reached remotely-run simulations in 8.0.4.01, gained
+a per-species visibility selector and MP4 export in 8.0.6.01, and had
+its rotation direction corrected in 8.0.28.01.
 
-- **Structural Sites.** Define anchor points in a molecule with
-  positions in space, distinct from molecular components. Useful
-  for representing rigid scaffolds, junction points, and other
-  geometric features that do not participate in reactions but
-  constrain molecular geometry.
+### Simulations say why they stopped (8.0.14.01)
 
-- **Multi-run simulations.** Specify a number of trials and a
-  random seed for a Langevin simulation. Concurrent runs are
-  dispatched as SLURM array jobs on the compute cluster, and the
-  batch results transfer back to the desktop client automatically.
-  Sensible default and maximum limits prevent inadvertent cluster
-  resource consumption (default 20 trials, maximum 200; concurrent
-  jobs capped at 20).
+When the cluster ends a job — out of time, out of memory, node lost,
+preempted — the job never gets the chance to report back. Such a
+simulation used to sit as "running" until a ten-minute silence timer
+failed it with "solver stopped unexpectedly". VCell now asks the
+scheduler directly and reports the real reason within a minute, and a
+simulation stopped on purpose is recorded as stopped rather than as a
+failure, so a deliberate stop no longer reads as a problem with the
+model.
 
-- **Batch results visualization.** Plots and tables for general
-  statistics (average, min/max, standard deviation) and cluster
-  analysis (ACS, SD, ACO) across multi-run results.
+Separately, a long run ended by its own configured time limit now says
+so (8.0.11.01). It previously reported "solver stopped unexpectedly,
+solver exited (code=124)", which describes a crash, when in fact the
+run was healthy and had simply used the time it was given — a
+distinction that cost one user four days of waiting to discover.
 
-- **Redesigned SpringSaLaD interface.** New molecular-structure
-  properties panel with editable links, tables for site attributes
-  and links, and a large-shape representation of site attributes
-  in the species-context view. _(Most of this UI work shipped during
-  the 7.7 line and rolls up into the 8.0.0 GA story.)_
+### Browser-based 3D field viewer — experimental (8.0.9.01)
 
-- **Result filtering and physical-limit checks.** Trivial-data
-  result sets are highlighted automatically. Site size, diffusion
-  rate, and partition size are validated before submission.
-
-- **Stricter integrator filtering.** Solver-choice dropdowns hide
-  integrators that are unsuitable for SpringSaLaD applications, so
-  users no longer see options that would silently produce wrong
-  results.
-
-### Plot Options dialog
-
-A new Plot Options dialog gives users finer control over plot
-appearance across visualization panels (line colors, marker styles,
-axes, legends).
-
-### Quick Run guardrails for Langevin
-
-The desktop client's "Quick Run" workflow (intended for fast, local
-single-simulation tests) now refuses to launch multi-job Langevin
-configurations with an explicit error message rather than letting
-them launch and fail later in a non-obvious place.
-
-### Admin and reporting tools
-
-A new `admincli report` subcommand kit produces period-bounded
-NIH-RPPR-style usage reports — counts of new users, simulation jobs
-in the database, cumulative metrics as-of a given date, and a CSV
-export of active users. Designed to be extended each reporting cycle
-without rewriting the toolkit.
-
-### BioNetGen import refinement
-
-BioNetGen BNGL imports now rewrite tilde-prefixed bare digits
-(`~0`, `~1`, ...) to the `~s0`, `~s1` form during preprocessing,
-resolving a parser ambiguity with state labels.
+An experimental viewer for spatial simulation results in the browser,
+with a colour bar, labelled axes, an orthogonal cut plane,
+value-under-mouse picking and click-to-plot time courses. It is off by
+default and invisible in normal use; it is noted here because it is
+where spatial visualization is heading, not because it is ready.
 
 ## Improvements
 
-- Langevin simulation-options dialog enforces the invariant that
-  concurrent jobs cannot exceed total jobs, and clamps both to
-  sensible maximum values.
-- Desktop window z-order (8.0.2): child windows and dialogs now stay in
-  front of the window that opened them — and minimize and travel with it —
-  on modern macOS and Windows, where they could previously slip behind the
-  main window. The results viewers also no longer crash when a model is
-  edited while results are open (issue #1746).
+- Desktop window behaviour: child windows and dialogs now stay in front
+  of the window that opened them — and minimize and travel with it — on
+  modern macOS and Windows, where they could previously slip behind the
+  main window (8.0.2).
+- The dialog for sharing a model was reworked: it shows which step to
+  take, indicates when there are unsaved changes, and revoking someone's
+  access now clears them from the list (8.0.3.01).
+- Geometry sizes in the simulation summary no longer show floating-point
+  noise such as `0.10000000007 microns` (8.0.3.01).
 - SpringSaLaD 3D viewer: choose which species are visible, and export a
   trajectory animation to MP4 (8.0.6.01).
 - Langevin solver updated to 1.4.12, which makes the solver's logging
   reliable in the shipped native binary (8.0.8.01).
+- Simulation results stored in HDF5 — Chombo and MovingBoundary — can be
+  read on Apple silicon. Both readers previously needed a native library
+  with no build for those machines (8.0.13.01).
+- MovingBoundary results can be read at every saved time, rather than
+  only the earliest few (8.0.21.01).
 
 ## Bug fixes
 
-_(Per-build fixes are tracked in `CHANGELOG.md`. The 8.0.0 line
-inherits the stability work shipped at the end of the 7.7 line —
-notably the JMS failover watchdog, the OOM exit handler, the DNS
-negative-cache fix, charset-aware Oracle CLOB reads, and a
-thread-safety fix in unit-of-measurement formatting.)_
+_(Per-build detail is in `CHANGELOG.md`.)_
 
 - A publication saved without a date no longer breaks VCell login for all
   users. The publication date is now required in the curation tools, the
@@ -170,6 +145,18 @@ thread-safety fix in unit-of-measurement formatting.)_
   out rather than returning: a reply could be discarded before it was sent
   because the client wrongly believed the queue it was addressed to had already
   been removed (8.0.10.01).
+- API access tokens are no longer written to the server logs. VCell builds
+  its database queries by assembling text, so a token passed as a value
+  became part of the query text, and whole queries were being logged
+  (8.0.12.01).
+- Server-side generation of spatial meshes for the browser viewer worked
+  again: every mesh had been written to a folder path instead of a file
+  since 2023, so Chombo, smoothed finite-volume and comsol meshes never
+  appeared (8.0.12.01).
+- Chombo meshes are correct and considerably smaller: a whole voxel meeting
+  a cut cell no longer leaves an unshared face, so surface extraction stops
+  reporting interior walls as though they were the surface of the domain
+  (8.0.13.01).
 - Starting a SpringSaLaD simulation no longer sets every other simulation
   already running in the same application to "never ran", and no longer strands
   the job that was running on the cluster. Because SpringSaLaD runs take days,
@@ -202,14 +189,6 @@ thread-safety fix in unit-of-measurement formatting.)_
   construct and where. An expression referring to a reaction — which SBML defines as
   that reaction's rate — reported only that a name was "not found", which reads like
   a typo and mentions neither rates nor the unsupported construct (8.0.26.01).
-- The SpringSaLaD trajectory viewer no longer rotates backwards. Dragging turned the
-  scene as though you had hold of the far side of the ball rather than the near one, on
-  both axes. The geometry and PDE surface viewers were never affected — they use the
-  opposite depth convention deliberately, to agree with the slice viewer (8.0.28.01).
-- Spatial (PDE) exports in HDF5 format now work on Apple Silicon. Writing them needed a
-  native library with no arm64 build, so on those machines the export simply failed. The
-  writing is pure Java now, which also takes 24 MB of platform binaries out of every
-  installer. The files themselves are unchanged (8.0.28.01).
 - The BioModels Database tab no longer warns you off models VCell can open. The
   supported/not-supported list behind it was curated by hand and had drifted: 55 of
   the 1057 entries were marked "not compatible with vCell" when they import fine.
@@ -220,33 +199,37 @@ thread-safety fix in unit-of-measurement formatting.)_
   before linking them together, a part could be collected in the moment between, and
   the save failed with a database integrity error. Parts are now left alone for an
   hour before they can be collected (8.0.27.01).
+- The SpringSaLaD trajectory viewer no longer rotates backwards. Dragging turned the
+  scene as though you had hold of the far side of the ball rather than the near one, on
+  both axes. The geometry and PDE surface viewers were never affected — they use the
+  opposite depth convention deliberately, to agree with the slice viewer (8.0.28.01).
+- Spatial (PDE) exports in HDF5 format now work on Apple Silicon. Writing them needed a
+  native library with no arm64 build, so on those machines the export simply failed. The
+  writing is pure Java now, which also takes 24 MB of platform binaries out of every
+  installer. The files themselves are unchanged (8.0.28.01).
 
 ## API and integration changes
 
-The REST API surface in 8.0.0 is the same as the final 7.7 builds.
-If you maintained a client against `/api/v1/` during the 7.7 line,
-no migration is required for 8.0.0.
-
-- New `/api/v1/` endpoints continue to coexist with legacy
-  `/api/v0/`. New client work should target `/api/v1/`.
-- OIDC authentication via Auth0 is required for `/api/v1/`.
-- The OpenAPI spec at `tools/openapi.yaml` is the source of truth
-  for client generation.
-- As of 8.0.2, `getVCInfoContainer` moved from the legacy RPC transport
-  to REST (`GET /api/v1/vcInfoContainer`) and the RPC endpoint was removed;
+- `getVCInfoContainer` moved from the legacy RPC transport to REST
+  (`GET /api/v1/vcInfoContainer`) and the RPC endpoint was removed;
   `BioModelChildSummary` and `MathModelChildSummary` gained a `simKeys`
-  field. Regenerate clients (Java/Python/TypeScript) for this call.
-
-For users coming directly from VCell 7.6, see also the
-[VCell 7.7 release index](./7.7.md), which points at the three
-named 7.7 release events
-([Initial Release](./7.7-initial-release.md) →
-[Feature Update](./7.7-feature-update.md) →
-[Stability Update](./7.7-stability-update.md))
-for the API-migration story and SpringSaLaD groundwork.
+  field. Regenerate clients (Java/Python/TypeScript) for this call
+  (8.0.2).
+- Asking the legacy `/api/v0/` API for the results of a simulation that
+  never produced any now answers "not found" rather than reporting a
+  server error (8.0.25.01).
+- HDF5 exports are written by a pure-Java library rather than a native
+  one. The datasets, their names, shapes and values are unchanged. Two
+  differences exist and are invisible to anything reading the file
+  properly: text is stored as variable-length rather than padded to a
+  fixed width, and one annotation no longer carries a trailing NUL that
+  terminated a C string (8.0.28.01).
 
 ## Known issues
 
-None at release time. Please report issues at
+Please report issues at
 <https://github.com/virtualcell/vcell/issues>.
 
+## Previous release
+
+[VCell 8.0](./8.0.md) — SpringSaLaD general availability.


### PR DESCRIPTION
## What this does

Two related documentation problems, both found while summarizing what changed across the 8.0 line.

### 1. Three releases were never written up

**8.0.3.01, 8.0.3.02 and 8.0.4.01** were tagged and deployed on 2026-07-29 but have no `CHANGELOG.md` entry — the file jumps from 8.0.2.07 to 8.0.5.01.

The gap hides a whole feature. The **SpringSaLaD 3D trajectory viewer** arrived in 8.0.3.02 (#1795/#1796/#1797) and reached remotely-run simulations in 8.0.4.01 (#1798). Everything the changelog *did* say about the viewer was a later refinement, so reading it end to end, the viewer appeared never to have shipped.

Entries were written from each PR's **diff**, not its title. Three came out differently as a result:

- **#1745** — the sharing-dialog bug is that `ACLState.removeUserFromACL` returned the `PRIVATE_TYPE` singleton when the last name was removed, so the dialog flipped to "private" instead of showing an empty list.
- **#1784** — `DecimalFormat("0.######")`, applied to geometry extents in the simulation summary; it renders anything below 1e-6 as `0`, and the entry says so.
- **#1798** — the remote-run failure was a missing delegation in `LocalDataSetControllerMessaging`, masked by the `default` method added in #1795.

### 2. The 8.0 narrative had absorbed three months of 8.1 work

For release notes and announcements, **VCell 8.0 is the 8.0.0 builds** — 8.0.0.01 through 8.0.0.03, the SpringSaLaD GA that ran in production from 2026-05-21 to 2026-08-14. **Everything after 8.0.0.03 is VCell 8.1**, which reached production on 2026-08-14 and is still accumulating.

Published build numbers are untouched. This is a narrative boundary, not a renumbering — 8.1 is delivered by builds numbered `8.0.x`, and both documents say so.

`release-notes/major/8.0.0.md` had been accumulating every build since the GA, so it credited 8.0 with a viewer, an import overhaul and two dozen fixes that no 8.0.0 build contained. **All 26 of its bug-fix bullets were annotated 8.0.5.01 or later** — the boundary showing itself.

## Changes

| File | |
|---|---|
| `CHANGELOG.md` | the three missing entries, in house format |
| `release-notes/major/8.0.md` | renamed from `8.0.0.md`, trimmed to 8.0.0.x content |
| `release-notes/major/8.1.md` | new — the 8.0.2.01 → 8.0.28.01 narrative |
| `docs/RELEASING.md` | records that narrative name and build version may differ, and which file a cut appends to |
| `7.7-*.md`, `docs/backlog/01-close-and-verify.md` | reference updates for the rename |

## Verification

- No tracked reference to `8.0.0.md` remains.
- Changelog entries are in descending version order between 8.0.5.01 and 8.0.2.07; dates taken from the tag objects.
- 8.1 bug fixes sorted by build version (29 bullets).
- `git merge-base --is-ancestor` confirms the viewer commit is not in 8.0.0.03.
- LF endings preserved, no trailing whitespace, wrap width matches neighbours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUd61NUJgz88h4PZs5MqHn