### PR TITLE
release: cut 8.1.0.01, and fix client/server version-mismatch detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,43 +21,37 @@ _(Release-manager scratchpad. Populated at release-cut time.)_
 **Highlights.** The build number now matches the release name. This work has
 been called VCell 8.1 in the release notes since it began, while its builds
 continued the `8.0.x` sequence; from this build the two agree. This is the
-first release candidate for VCell 8.1. VCell also tells you when the server is
-updated underneath you: if a deployment happens while you are working, the
-reconnect now says a newer version exists and invites you to restart when
-convenient, rather than reconnecting silently to a server your client no
-longer matches.
+first release candidate for VCell 8.1. VCell also checks properly now whether
+your client matches the server it is talking to, including when the server is
+updated part-way through a session — a mismatch it has been unable to detect
+since 2022.
 
 ### Added
 - When the server is updated during a session, VCell now says so. The client
-  reconnects automatically after a deployment, and that reconnect reports the
-  new version and suggests restarting when convenient. The message makes clear
-  the session is safe to continue. Previously the automatic reconnect was
-  silent, so a user could work for hours against a server newer than their
-  client without knowing a new one had been published. (#2012)
+  reconnects on its own after a deployment, and that reconnect now reports the
+  change and asks the user to save, exit and restart to install the matching
+  version. Previously the automatic reconnect was silent, so a user could work
+  on against a server their client no longer matched. (#2012)
 
 ### Fixed
-- `VCellSoftwareVersion` read the PATCH number from the MINOR position, so
-  `getPatchVersion()` returned a copy of `getMinorVersion()`. The line dates
-  from 2018 but was dead until a 2022 fix to the same statement made it live.
-  Its only consumer compared it against an equally wrong value, so nothing
-  ever surfaced. (#2011)
+- VCell could not detect a client/server version mismatch that lay in the
+  PATCH number. `VCellSoftwareVersion` read PATCH from the MINOR position, so
+  the check that compares client against server was comparing MINOR twice and
+  ignoring PATCH entirely. Since a VCell patch release can carry a breaking
+  API change, this is the case that most needed catching. The line dates from
+  2018 but was dead until a 2022 fix to the same statement made it live.
+  (#2011)
 
 ### Changed
 - Version numbering realigned with the release narrative: builds are numbered
   `8.1.x` from here, rather than continuing `8.0.x`. Published numbers up to
   8.0.28.01 are unchanged. (#2010)
-- A desktop client older than this build now shows the "software version
-  mismatch" warning when connecting, asking the user to download the current
-  client. The warning is advisory and does not prevent use. At login VCell
-  reports a difference in the first two parts of the version only, so this
-  stayed silent for every build in the 8.0 line, where those parts were the
-  same throughout; moving to 8.1 gives it something to report. (#2012)
-- The two version checks now apply the policy that suits each. At login, or a
-  reconnect the user asked for, only a MAJOR or MINOR difference is reported —
-  a PATCH difference is ordinary there, since patches ship most releases and
-  installed clients update on their own schedule. After an automatic reconnect
-  any difference is reported, PATCH included, because the server changed
-  underneath a running client and a newer client exists. (#2012)
+- The client/server version warning now appears whenever MAJOR, MINOR **or**
+  PATCH differ — which is what it was always meant to do, and could not.
+  Expect to see it more often than before: it was effectively dormant across
+  the whole 8.0 line, and a patch difference alone is now enough to raise it.
+  The warning is advisory and does not prevent use. Only the BUILD number is
+  ignored. (#2012)
 
 ### Notes for API consumers
 No API changes. Clients that parse the version string should note that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,54 @@ followed by flat Keep-a-Changelog categories. API consumers should scan
 
 _(Release-manager scratchpad. Populated at release-cut time.)_
 
+## [8.1.0.01] - 2026-08-21
+
+**Highlights.** The build number now matches the release name. This work has
+been called VCell 8.1 in the release notes since it began, while its builds
+continued the `8.0.x` sequence; from this build the two agree. This is the
+first release candidate for VCell 8.1. VCell also tells you when the server is
+updated underneath you: if a deployment happens while you are working, the
+reconnect now says a newer version exists and invites you to restart when
+convenient, rather than reconnecting silently to a server your client no
+longer matches.
+
+### Added
+- When the server is updated during a session, VCell now says so. The client
+  reconnects automatically after a deployment, and that reconnect reports the
+  new version and suggests restarting when convenient. The message makes clear
+  the session is safe to continue. Previously the automatic reconnect was
+  silent, so a user could work for hours against a server newer than their
+  client without knowing a new one had been published. (#2012)
+
+### Fixed
+- `VCellSoftwareVersion` read the PATCH number from the MINOR position, so
+  `getPatchVersion()` returned a copy of `getMinorVersion()`. The line dates
+  from 2018 but was dead until a 2022 fix to the same statement made it live.
+  Its only consumer compared it against an equally wrong value, so nothing
+  ever surfaced. (#2011)
+
+### Changed
+- Version numbering realigned with the release narrative: builds are numbered
+  `8.1.x` from here, rather than continuing `8.0.x`. Published numbers up to
+  8.0.28.01 are unchanged. (#2010)
+- A desktop client older than this build now shows the "software version
+  mismatch" warning when connecting, asking the user to download the current
+  client. The warning is advisory and does not prevent use. At login VCell
+  reports a difference in the first two parts of the version only, so this
+  stayed silent for every build in the 8.0 line, where those parts were the
+  same throughout; moving to 8.1 gives it something to report. (#2012)
+- The two version checks now apply the policy that suits each. At login, or a
+  reconnect the user asked for, only a MAJOR or MINOR difference is reported —
+  a PATCH difference is ordinary there, since patches ship most releases and
+  installed clients update on their own schedule. After an automatic reconnect
+  any difference is reported, PATCH included, because the server changed
+  underneath a running client and a newer client exists. (#2012)
+
+### Notes for API consumers
+No API changes. Clients that parse the version string should note that
+`MAJOR.MINOR` moves from `8.0` to `8.1`; the four-part
+`MAJOR.MINOR.PATCH.BUILD` shape is unchanged.
+
 ## [8.0.28.01] - 2026-08-20
 
 **Highlights.** Dragging in the SpringSaLaD trajectory viewer turned the scene the wrong way —

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -122,12 +122,14 @@ This has already happened once. **VCell 8.0** is the 8.0.0 builds only
 — 8.0.0.01 through 8.0.0.03, the SpringSaLaD GA that ran in production
 from 2026-05-21 to 2026-08-14. Everything released after 8.0.0.03 is
 **VCell 8.1**, even though those builds are numbered 8.0.2.01 through
-8.0.28.01 and beyond.
+8.0.28.01. The numbering was realigned at **8.1.0.01**, so the two agree
+again from that build onward; the divergence covers 8.0.2.01–8.0.28.01
+only.
 
 So, at release-cut time, add the user-facing items to the narrative
 file for the release **currently being accumulated** — today
-`8.1.md` — not to the file whose name matches the build's
-`MAJOR.MINOR`. `CHANGELOG.md` is unaffected: it is organised strictly
+`8.1.md` — which is not necessarily the file whose name matches the
+build's `MAJOR.MINOR`. `CHANGELOG.md` is unaffected: it is organised strictly
 by build version and always records the real number.
 
 When a long-running `MAJOR.MINOR` line accumulates multiple distinct

--- a/release-notes/major/8.1.md
+++ b/release-notes/major/8.1.md
@@ -1,15 +1,19 @@
 # VCell 8.1
 
-**Status:** pre-release. Rolled to the production site on 2026-08-14
-and updated since; not yet announced as a public release event.
+**Status:** release candidate — **8.1.0.01**. An earlier form of this
+release has been on the production site since 2026-08-14 under `8.0.x`
+build numbers; from 8.1.0.01 the build number carries the release name.
 
-> **A note on version numbers.** VCell 8.1 is delivered by builds whose
-> version numbers continue the `8.0.x` sequence — 8.0.2.01 through
-> 8.0.28.01 so far. Those numbers are what they are and are not being
-> restated. For release notes and user-facing announcements, **VCell 8.0
-> means the 8.0.0 builds** (8.0.0.01–8.0.0.03, the SpringSaLaD GA that
-> ran in production from 2026-05-21 to 2026-08-14), and **everything
-> released after 8.0.0.03 is VCell 8.1**.
+> **A note on version numbers.** VCell 8.1 was developed under build
+> numbers that continued the `8.0.x` sequence — 8.0.2.01 through
+> 8.0.28.01. Those numbers are published and are not being restated.
+> **From 8.1.0.01 the two agree**, and the explanation below applies
+> only to the builds before it.
+>
+> For release notes and user-facing announcements, **VCell 8.0 means
+> the 8.0.0 builds** (8.0.0.01–8.0.0.03, the SpringSaLaD GA that ran in
+> production from 2026-05-21 to 2026-08-14), and **everything released
+> after 8.0.0.03 is VCell 8.1**.
 
 ## Headline
 
@@ -72,6 +76,11 @@ where spatial visualization is heading, not because it is ready.
 
 ## Improvements
 
+- VCell now tells you when the server is updated while you are working. The
+  client reconnects on its own after a deployment; that reconnect now reports
+  that a newer version exists and suggests restarting when convenient, rather
+  than reconnecting silently. The session remains safe to continue
+  (8.1.0.01).
 - Desktop window behaviour: child windows and dialogs now stay in front
   of the window that opened them — and minimize and travel with it — on
   modern macOS and Windows, where they could previously slip behind the

--- a/release-notes/major/8.1.md
+++ b/release-notes/major/8.1.md
@@ -76,11 +76,12 @@ where spatial visualization is heading, not because it is ready.
 
 ## Improvements
 
-- VCell now tells you when the server is updated while you are working. The
-  client reconnects on its own after a deployment; that reconnect now reports
-  that a newer version exists and suggests restarting when convenient, rather
-  than reconnecting silently. The session remains safe to continue
-  (8.1.0.01).
+- VCell now checks properly whether your client matches the server, and says
+  so when it does not — including when the server is updated part-way through
+  a session, which it previously reconnected to in silence. A VCell patch
+  release can change the API, so a client and server differing in any part of
+  the version may not work together; the check had been unable to see a
+  difference in the patch number since 2022 (8.1.0.01).
 - Desktop window behaviour: child windows and dialogs now stay in front
   of the window that opened them — and minimize and travel with it — on
   modern macOS and Windows, where they could previously slip behind the

--- a/vcell-apiclient/src/main/java/org/vcell/api/server/ClientServerManager.java
+++ b/vcell-apiclient/src/main/java/org/vcell/api/server/ClientServerManager.java
@@ -276,20 +276,13 @@ public MessageEvent[] getMessageEvents() throws RemoteProxyException, IOExceptio
 }
 
 /**
- * Which version differences are worth interrupting the user for.
+ * Why the version check is running. The comparison is the same either way -- any
+ * difference in MAJOR, MINOR or PATCH -- but the two situations need different advice.
  */
 private enum VersionCheck {
-	/**
-	 * At login, or a reconnect the user asked for. A PATCH difference is normal here --
-	 * PATCH moves with nearly every release while installed clients update on the user's
-	 * own schedule -- so only MAJOR or MINOR is reported.
-	 */
+	/** At login, or a reconnect the user asked for: the client was already out of date. */
 	ON_CONNECT,
-	/**
-	 * After an automatic reconnect, which means the server was redeployed underneath a
-	 * running client. Any difference is reported, PATCH included: the user is being told
-	 * that a newer client exists, not that their session is wrong.
-	 */
+	/** After an automatic reconnect: the server was redeployed underneath a running client. */
 	AFTER_SERVER_CHANGED
 }
 
@@ -311,23 +304,21 @@ private void checkClientServerSoftwareVersion(InteractiveClientServerContext req
 					+ "We have adopted a Release Early, Release Often software development approach\n\n"
 					+ "\nPlease exit VCell and download the latest client from VCell Software page (http://vcell.org).");
 			}
-			boolean bDiffers = clientVersion.getMajorVersion()!=serverVersion.getMajorVersion() ||
-				clientVersion.getMinorVersion()!=serverVersion.getMinorVersion();
-			if (when == VersionCheck.AFTER_SERVER_CHANGED) {
-				//
-				// The server was upgraded underneath a running client, so any difference at
-				// all is worth reporting -- a new client exists and the user should restart
-				// to pick it up.
-				//
-				bDiffers = bDiffers || clientVersion.getPatchVersion()!=serverVersion.getPatchVersion();
-			}
-			if (bDiffers) {
+			//
+			// MAJOR, MINOR and PATCH all matter. A VCell PATCH release can carry a breaking
+			// API change, so a client and server differing in any of the three are not known
+			// to be compatible. Only BUILD is ignored. This is what the check has always
+			// meant to do; it could not, because getPatchVersion() returned MINOR (#2011).
+			//
+			if (clientVersion.getMajorVersion()!=serverVersion.getMajorVersion() ||
+				clientVersion.getMinorVersion()!=serverVersion.getMinorVersion() ||
+				clientVersion.getPatchVersion()!=serverVersion.getPatchVersion()) {
 				if (when == VersionCheck.AFTER_SERVER_CHANGED) {
 					requester.showWarningDialog("The VCell server was updated while you were working:\n"
 						+ "client VCell version : " + clientSoftwareVersion + "\n"
 						+ "server VCell version : " + serverSoftwareVersion + "\n"
-						+ "\nYour work is safe and you may keep using this session."
-						+ "\nPlease exit and restart VCell when convenient to install the new version.");
+						+ "\nThis client no longer matches the server."
+						+ "\nPlease save your work, then exit and restart VCell to install the matching version.");
 				} else {
 					requester.showWarningDialog("software version mismatch between client and server:\n"
 						+ "client VCell version : " + clientSoftwareVersion + "\n"

--- a/vcell-apiclient/src/main/java/org/vcell/api/server/ClientServerManager.java
+++ b/vcell-apiclient/src/main/java/org/vcell/api/server/ClientServerManager.java
@@ -275,7 +275,25 @@ public MessageEvent[] getMessageEvents() throws RemoteProxyException, IOExceptio
 	}
 }
 
-private void checkClientServerSoftwareVersion(InteractiveClientServerContext requester, ClientServerInfo clientServerInfo) {
+/**
+ * Which version differences are worth interrupting the user for.
+ */
+private enum VersionCheck {
+	/**
+	 * At login, or a reconnect the user asked for. A PATCH difference is normal here --
+	 * PATCH moves with nearly every release while installed clients update on the user's
+	 * own schedule -- so only MAJOR or MINOR is reported.
+	 */
+	ON_CONNECT,
+	/**
+	 * After an automatic reconnect, which means the server was redeployed underneath a
+	 * running client. Any difference is reported, PATCH included: the user is being told
+	 * that a newer client exists, not that their session is wrong.
+	 */
+	AFTER_SERVER_CHANGED
+}
+
+private void checkClientServerSoftwareVersion(InteractiveClientServerContext requester, ClientServerInfo clientServerInfo, VersionCheck when) {
 	String clientSoftwareVersion = System.getProperty(PropertyLoader.vcellSoftwareVersion);
 	if (clientSoftwareVersion != null &&  clientSoftwareVersion.toLowerCase().contains("devel") ) {
 		return;
@@ -293,13 +311,29 @@ private void checkClientServerSoftwareVersion(InteractiveClientServerContext req
 					+ "We have adopted a Release Early, Release Often software development approach\n\n"
 					+ "\nPlease exit VCell and download the latest client from VCell Software page (http://vcell.org).");
 			}
-			if (clientVersion.getMajorVersion()!=serverVersion.getMajorVersion() ||
-				clientVersion.getMinorVersion()!=serverVersion.getMinorVersion() ||
-				clientVersion.getPatchVersion()!=serverVersion.getPatchVersion()) {
-				requester.showWarningDialog("software version mismatch between client and server:\n"
-					+ "client VCell version : " + clientSoftwareVersion + "\n"
-					+ "server VCell version : " + serverSoftwareVersion + "\n"
-					+ "\nPlease exit VCell and download the latest client from VCell Software page (http://vcell.org).");
+			boolean bDiffers = clientVersion.getMajorVersion()!=serverVersion.getMajorVersion() ||
+				clientVersion.getMinorVersion()!=serverVersion.getMinorVersion();
+			if (when == VersionCheck.AFTER_SERVER_CHANGED) {
+				//
+				// The server was upgraded underneath a running client, so any difference at
+				// all is worth reporting -- a new client exists and the user should restart
+				// to pick it up.
+				//
+				bDiffers = bDiffers || clientVersion.getPatchVersion()!=serverVersion.getPatchVersion();
+			}
+			if (bDiffers) {
+				if (when == VersionCheck.AFTER_SERVER_CHANGED) {
+					requester.showWarningDialog("The VCell server was updated while you were working:\n"
+						+ "client VCell version : " + clientSoftwareVersion + "\n"
+						+ "server VCell version : " + serverSoftwareVersion + "\n"
+						+ "\nYour work is safe and you may keep using this session."
+						+ "\nPlease exit and restart VCell when convenient to install the new version.");
+				} else {
+					requester.showWarningDialog("software version mismatch between client and server:\n"
+						+ "client VCell version : " + clientSoftwareVersion + "\n"
+						+ "server VCell version : " + serverSoftwareVersion + "\n"
+						+ "\nPlease exit VCell and download the latest client from VCell Software page (http://vcell.org).");
+				}
 			}
 		}
 	}
@@ -318,7 +352,7 @@ public void connectNewServer(InteractiveClientServerContext requester, ClientSer
 public void connect(InteractiveClientServerContext requester) {
 	asynchMessageManager.stopPolling();
 	reconnectStat = ReconnectStatus.NOT;
-	checkClientServerSoftwareVersion(requester,clientServerInfo);
+	checkClientServerSoftwareVersion(requester,clientServerInfo,VersionCheck.ON_CONNECT);
 
 	// get new server connection
 	VCellConnection newVCellConnection = connectToServer(requester,true);
@@ -727,6 +761,12 @@ void reconnect() {
 			changeConnection(requester,connection);
 			rc.stop();
 			asynchMessageManager.startPolling();
+			//
+			// Only once the reconnect has succeeded -- a failed attempt says nothing about
+			// the server's version, and this check makes an HTTP call of its own that the
+			// retry loop should not repeat.
+			//
+			checkClientServerSoftwareVersion(requester,clientServerInfo,VersionCheck.AFTER_SERVER_CHANGED);
 			return;
 		}
 		setConnectionStatus(new ClientConnectionStatus(getClientServerInfo().getUsername(), getClientServerInfo().getApihost(), getClientServerInfo().getApiport(), ConnectionStatus.DISCONNECTED));

--- a/vcell-core/src/main/java/org/vcell/util/document/VCellSoftwareVersion.java
+++ b/vcell-core/src/main/java/org/vcell/util/document/VCellSoftwareVersion.java
@@ -77,7 +77,7 @@ public class VCellSoftwareVersion implements Serializable {
 					minorVersion = safeParse(minor);
 				}
 				if (parts.length > 2) {
-					String patch = parts[1];
+					String patch = parts[2];
 					patchVersion = safeParse(patch);
 				}
 			} catch (Exception exc) {

--- a/vcell-core/src/test/java/org/vcell/util/document/VCellSoftwareVersionTest.java
+++ b/vcell-core/src/test/java/org/vcell/util/document/VCellSoftwareVersionTest.java
@@ -1,0 +1,44 @@
+package org.vcell.util.document;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The four-part version is carried as "<EDITION>_Version_<MAJOR.MINOR.PATCH>_build_<BUILD>".
+ * PATCH was read from the MINOR position for four years (issue #2011) without anything
+ * noticing, because its only consumer compared it against a value that was equally wrong.
+ */
+@Tag("Fast")
+public class VCellSoftwareVersionTest {
+
+	@Test
+	public void parsesAllFourParts() {
+		VCellSoftwareVersion v = VCellSoftwareVersion.fromString("Alpha_Version_8.0.28_build_01");
+		assertEquals(VCellSoftwareVersion.VCellSite.alpha, v.getSite());
+		assertEquals(8, v.getMajorVersion());
+		assertEquals(0, v.getMinorVersion());
+		assertEquals(28, v.getPatchVersion());
+		assertEquals("01", v.getBuildNumber());
+	}
+
+	@Test
+	public void patchIsNotAliasedToMinor() {
+		// 8.1.0 and 8.0.1 differ only by which of the two middle numbers is set, so a
+		// parser that reads PATCH from the MINOR position cannot tell them apart.
+		VCellSoftwareVersion a = VCellSoftwareVersion.fromString("Rel_Version_8.1.0_build_01");
+		assertEquals(1, a.getMinorVersion());
+		assertEquals(0, a.getPatchVersion());
+
+		VCellSoftwareVersion b = VCellSoftwareVersion.fromString("Rel_Version_8.0.1_build_01");
+		assertEquals(0, b.getMinorVersion());
+		assertEquals(1, b.getPatchVersion());
+	}
+
+	@Test
+	public void unparseableVersionIsUnknownRatherThanThrowing() {
+		VCellSoftwareVersion v = VCellSoftwareVersion.fromString("nonsense");
+		assertEquals(VCellSoftwareVersion.VCellSite.unknown, v.getSite());
+	}
+}


### PR DESCRIPTION
## What

Cuts **8.1.0.01**, the first release candidate for VCell 8.1, moves the build number onto the `8.1.x` sequence, and repairs the client/server version check — which has been unable to detect a PATCH-level mismatch since 2022.

Published numbers up to 8.0.28.01 are unchanged; nothing already released is renumbered.

## The version check

A VCell **patch release can carry a breaking API change**. So a client and server differing in MAJOR, MINOR *or* PATCH are not known to be compatible, and the check now reports all three. Only BUILD is ignored.

That is what the check was written to do in 2018. It could not, because of the parser bug below: `getPatchVersion()` returned MINOR, so the comparison tested MINOR twice and ignored PATCH entirely. Across the whole 8.0 line every build parsed as (8, 0, 0), so the warning was effectively dormant.

**Expect it to appear more often** — a patch difference alone is now enough. It remains advisory and does not prevent use.

### Mid-session server updates

The client reconnects on its own after a deployment. That path — the package-private `ClientServerManager.reconnect()` the `Reconnector` drives — went straight to `connectToServer()` and **skipped the version check entirely**, so a user could work on against a server their client no longer matched, with no sign anything had changed.

The automatic reconnect now runs the check, **only once the reconnect has succeeded**: a failed attempt says nothing about the server's version, and the check makes an HTTP call of its own that the retry loop must not repeat.

Same comparison either way; only the advice differs:

| found | message |
|---|---|
| at login, or a user-initiated reconnect | download the current client |
| mid-session, after an automatic reconnect | save your work, exit and restart to install the matching version |

The mid-session message does **not** tell the user their session is safe to continue. If a patch can break the API, that promise cannot be made.

## The parser fix (#2011)

`VCellSoftwareVersion` read PATCH from `parts[1]` instead of `parts[2]`, so `getPatchVersion()` returned a copy of `getMinorVersion()`.

The line dates from **2018**, when the same statement used `split(".")` — a regex matching any character, so the split returned an empty array and every part stayed `-1`. A **2022** one-line fix to that argument, inside an unrelated commit about compartment reordering, made MAJOR and MINOR work for the first time and made this typo live alongside them. Its only consumer compared it against an equally wrong value, so nothing surfaced for four years.

Verified against the recompiled class:

| version string | major | minor | patch |
|---|---|---|---|
| `Alpha_Version_8.0.28_build_01` | 8 | 0 | 28 ✓ (was 0) |
| `Alpha_Version_8.1.0_build_01` | 8 | 1 | 0 ✓ (was 1) |

Adds the class's first tests (3, `@Tag("Fast")`), including one distinguishing `8.1.0` from `8.0.1` — a pair the old parser could not tell apart.

Closes #2011.

## Note on the dialog

It is not dismissible. VCell has a "Do not show this warning again" mechanism (`UserPreferences` + `UserMessage`) that this dialog does not use. Left alone deliberately — a separate decision, and more relevant now that the warning will be seen more often.

## Verification

- `mvn -o compile -pl vcell-apiclient -am` — clean
- `VCellSoftwareVersionTest` — 3 tests, 0 failures
- CRLF preserved in all three Java files (checked byte-wise; no LF-only lines introduced)

Deploying to **dev (alpha)** after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUd61NUJgz88h4PZs5MqHn