### PR TITLE
docs: scope the trajectory viewer to SpringSaLaD Applications

### DIFF
--- a/release-notes/major/8.1.md
+++ b/release-notes/major/8.1.md
@@ -19,13 +19,13 @@ build numbers; from 8.1.0.01 the build number carries the release name.
 
 **SpringSaLaD runs can now be watched, and they stop getting lost.**
 
-VCell 8.1 adds a 3D trajectory viewer that plays back the motion of
-individual molecules over a SpringSaLaD run, and fixes a defect that
-made long runs unreliable to manage: starting one simulation marked
-every other simulation already running in the same application as
-"never ran". Because SpringSaLaD runs take days, and it is normal to
-start one while others are still going, this was a dependable way to
-lose track of work in progress.
+VCell 8.1 adds a 3D trajectory viewer for SpringSaLaD Applications
+that plays back the motion of individual molecules over a run, and
+fixes a defect that made long runs unreliable to manage: starting one
+simulation marked every other simulation already running in the same
+application as "never ran". Because SpringSaLaD runs take days, and it
+is normal to start one while others are still going, this was a
+dependable way to lose track of work in progress.
 
 Around those two, 8.1 collects a substantial amount of repair — model
 import that reaches published models it previously abandoned, desktop
@@ -34,11 +34,11 @@ went wrong, and full support for Apple silicon.
 
 ## What's new
 
-### 3D trajectory viewer for SpringSaLaD results (8.0.3.02)
+### 3D trajectory viewer for SpringSaLaD Applications (8.0.3.02)
 
-SpringSaLaD results gained a **3D Trajectory** tab that plays back the
-motion of individual molecules over a run, rather than only the
-aggregate counts plotted elsewhere. It offers play/pause, a frame
+SpringSaLaD Applications gained a **3D Trajectory** tab that plays
+back the motion of individual molecules over a run, rather than only
+the aggregate counts plotted elsewhere. It offers play/pause, a frame
 scrubber, speed from 2 to 30 frames per second, and rotate, zoom and
 pan, and it draws the simulation box and the membrane for context.
 Molecule colour changes from frame to frame to show a site's state.


### PR DESCRIPTION
Aligns `release-notes/major/8.1.md` with the vcell.org accordion copy and the team preview draft.

The narrative said "3D trajectory viewer for SpringSaLaD **results**", which names the modality but not what the viewer attaches to. VCell has several result viewers, so this says **Applications** — the same term the page already uses for "Langevin Solver for SpringSaLaD Applications".

Three spots: the headline paragraph, the `What's new` subsection heading, and its opening sentence. The two affected paragraphs are reflowed to the file's width; no other content change.

Docs only — no code, no version impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUd61NUJgz88h4PZs5MqHn