### PR TITLE
feat: make support error-report emails legible, add a version 2 report, and fix #835 items 1-2

### DIFF
--- a/vcell-api/src/main/java/org/vcell/rest/users/ContactUsRestlet.java
+++ b/vcell-api/src/main/java/org/vcell/rest/users/ContactUsRestlet.java
@@ -40,13 +40,13 @@ public final class ContactUsRestlet extends Restlet {
 		String smtpPort = PropertyLoader.getRequiredProperty(PropertyLoader.vcellSMTPPort);
 		String from = "vcellserver";
 		String vcellSupportEmail = PropertyLoader.getRequiredProperty(PropertyLoader.vcellSMTPEmailAddress);
-		Gson gson = new Gson();
-		String contentJson = gson.toJson(errorReport);
+		// The body is plain text, not the JSON the report arrived as: a person reads this.
+		String contentText = errorReport.toEmailText();
 
 		try {
-			BeanUtils.sendSMTP(smtpHost, Integer.parseInt(smtpPort), from, vcellSupportEmail, "VCell Support sent through Contact-Us", contentJson);
+			BeanUtils.sendSMTP(smtpHost, Integer.parseInt(smtpPort), from, vcellSupportEmail, "VCell Support sent through Contact-Us", contentText);
 		} catch (MessagingException e) {
-			getLogger().log(Level.SEVERE,"failed to send user error message "+contentJson);
+			getLogger().log(Level.SEVERE,"failed to send user error message "+contentText);
 			throw new RuntimeException(e.getMessage());
 		}
 	}

--- a/vcell-apiclient/src/main/java/org/vcell/api/server/ClientServerManager.java
+++ b/vcell-apiclient/src/main/java/org/vcell/api/server/ClientServerManager.java
@@ -344,6 +344,13 @@ public void connect(InteractiveClientServerContext requester) {
 	asynchMessageManager.stopPolling();
 	reconnectStat = ReconnectStatus.NOT;
 	checkClientServerSoftwareVersion(requester,clientServerInfo,VersionCheck.ON_CONNECT);
+	//
+	// Tell the error reporter who is logged in. It was told once at startup, from the
+	// command line, where the user name is normally absent because people log in through
+	// the dialog -- so every error report was arriving anonymous and support had no way
+	// to follow one up.
+	//
+	ErrorUtils.setClientServerInfo(clientServerInfo);
 
 	// get new server connection
 	VCellConnection newVCellConnection = connectToServer(requester,true);

--- a/vcell-client/src/main/java/org/vcell/client/logicalwindow/LWNamespace.java
+++ b/vcell-client/src/main/java/org/vcell/client/logicalwindow/LWNamespace.java
@@ -148,6 +148,32 @@ public interface LWNamespace {
     }
 
     /**
+     * As {@link #findLWOwner(Component)}, but falls back to the most recently focused
+     * visible top-level window when the component has no logical owner.
+     *
+     * <p>A dialog built with a null owner is not merely unparented: AWT downgrades
+     * {@link java.awt.Dialog.ModalityType#DOCUMENT_MODAL} to modeless when there is no
+     * owner, so such a dialog neither blocks its parent nor is kept in front of it. For
+     * an error dialog that means the message can be lost behind the window that raised
+     * it. Prefer any real window to none.
+     *
+     * @param swingParent could be null
+     * @return logical owner, a fallback window, or null if the application has no
+     * visible top-level window at all
+     */
+    public static LWContainerHandle findLWOwnerOrMostRecent(Component swingParent) {
+        LWContainerHandle owner = findLWOwner(swingParent);
+        if (owner != null) {
+            return owner;
+        }
+        return LWTopFrame.liveWindows()
+                .map(java.lang.ref.WeakReference::get)
+                .filter(java.util.Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
      * @param awtModality not null
      * @return {@link LWModality} that best matches awt modality
      */

--- a/vcell-client/src/main/java/org/vcell/util/gui/DialogUtils.java
+++ b/vcell-client/src/main/java/org/vcell/util/gui/DialogUtils.java
@@ -43,6 +43,9 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
 import cbit.vcell.client.VCellClient;
+import cbit.vcell.resource.ErrorUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import cbit.vcell.client.VCellClientMain;
 import org.vcell.client.logicalwindow.LWContainerHandle;
 import org.vcell.client.logicalwindow.LWDialog;
@@ -70,6 +73,8 @@ import cbit.vcell.resource.OperatingSystemInfo;
  * @author: Ion Moraru
  */
 public class DialogUtils {
+
+    private static final Logger lg = LogManager.getLogger(DialogUtils.class);
 
     /**
      * Virtual Cell variant of {@link JOptionPane#createDialog(Component, String)}
@@ -762,11 +767,23 @@ public class DialogUtils {
                     Integer reply = CastingUtils.downcast(Integer.class, ro);
                     boolean userSaidYes = reply != null ? reply == JOptionPane.YES_OPTION : false;
                     if(userSaidYes){
-                        Throwable throwableToSend = exception;
-                        String extra = dialogMessagePanel.getSupplemental();
-                        extra = BeanUtils.PLAINTEXT_EMAIL_NEWLINE + (extra == null ? "" : extra) + collectRecordedUserEvents();
-                        throwableToSend = new RuntimeException(extra, exception);
-                        VCellClient.getInstance().getClientServerManager().sendErrorReport(throwableToSend);
+                        //
+                        // Send the exception as it was thrown, with the log, the model and the
+                        // recorded events alongside it. This used to wrap all three in the message
+                        // of a new RuntimeException, which put the log into the report twice -- once
+                        // as the exception message and once at the head of the stack trace -- and
+                        // pushed the frames identifying the fault past tens of thousands of
+                        // characters of routine logging.
+                        //
+                        try {
+                            ErrorUtils.sendErrorReport(exception, null,
+                                    dialogMessagePanel.getModelInfo(),
+                                    dialogMessagePanel.getClientLog(),
+                                    collectRecordedUserEvents());
+                        } catch (Exception sendFailure) {
+                            // reporting an error must never raise one of its own
+                            lg.error("failed to send error report", sendFailure);
+                        }
                     }
                 }
             } finally {

--- a/vcell-client/src/main/java/org/vcell/util/gui/DialogUtils.java
+++ b/vcell-client/src/main/java/org/vcell/util/gui/DialogUtils.java
@@ -776,7 +776,7 @@ public class DialogUtils {
                         // characters of routine logging.
                         //
                         try {
-                            ErrorUtils.sendErrorReport(exception, null,
+                            ErrorUtils.sendErrorReport(exception, dialogMessagePanel.getUserNote(),
                                     dialogMessagePanel.getModelInfo(),
                                     dialogMessagePanel.getClientLog(),
                                     collectRecordedUserEvents());

--- a/vcell-client/src/main/java/org/vcell/util/gui/DialogUtils.java
+++ b/vcell-client/src/main/java/org/vcell/util/gui/DialogUtils.java
@@ -724,7 +724,10 @@ public class DialogUtils {
 
     public static void showErrorDialog(final Component requester, final String message, final Throwable exception, final ErrorContext errorContext){
         checkForNull(requester);
-        LWContainerHandle lwParent = LWNamespace.findLWOwner(requester);
+        // An error dialog must not be the one window the user cannot find. Without an
+        // owner AWT downgrades DOCUMENT_MODAL to modeless, so the dialog would neither
+        // block nor stay in front of the window that raised it.
+        LWContainerHandle lwParent = LWNamespace.findLWOwnerOrMostRecent(requester);
 
         Doer doer = () -> {
             String errMsg = message;

--- a/vcell-client/src/main/java/org/vcell/util/gui/MessagePanelFactory.java
+++ b/vcell-client/src/main/java/org/vcell/util/gui/MessagePanelFactory.java
@@ -44,6 +44,22 @@ public class MessagePanelFactory {
 		public abstract String getSupplemental( );
 
 		/**
+		 * @return the model the user was working on, or null if not known.
+		 * Reported separately from {@link #getClientLog()} so neither has to be
+		 * recovered from inside the other.
+		 */
+		public String getModelInfo( ) {
+			return null;
+		}
+
+		/**
+		 * @return the captured client log, or null if none was captured.
+		 */
+		public String getClientLog( ) {
+			return null;
+		}
+
+		/**
 		 * @return message type for {@link JOptionPane#JOptionPane(Object, int,int)} constructor
 		 */
 		public abstract int optionType() ;
@@ -169,6 +185,16 @@ public class MessagePanelFactory {
 		
 		private boolean isHaveContext( ) {
 			return errorContext != null && errorContext.canUse();
+		}
+
+		@Override
+		public String getModelInfo() {
+			return isHaveContext() ? errorContext.modelInfo : null;
+		}
+
+		@Override
+		public String getClientLog() {
+			return logContent;
 		}
 
 		@Override

--- a/vcell-client/src/main/java/org/vcell/util/gui/MessagePanelFactory.java
+++ b/vcell-client/src/main/java/org/vcell/util/gui/MessagePanelFactory.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JTextField;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -56,6 +57,14 @@ public class MessagePanelFactory {
 		 * @return the captured client log, or null if none was captured.
 		 */
 		public String getClientLog( ) {
+			return null;
+		}
+
+		/**
+		 * @return what the user typed about what they were doing, or null if they typed
+		 * nothing or the dialog offered no field.
+		 */
+		public String getUserNote( ) {
 			return null;
 		}
 
@@ -147,6 +156,8 @@ public class MessagePanelFactory {
 		private final ErrorContext errorContext;
 		private String logContent;
 		private int generatedOptionType = JOptionPane.YES_NO_OPTION;
+		/** What the user was doing, in their own words. Null until the field is built. */
+		private JTextField userNoteField;
 		JPanelWithSendOption(String message, ErrorContext errorContext) {
 			commonConstructionCode(this,message);
 			this.errorContext = errorContext;
@@ -161,9 +172,25 @@ public class MessagePanelFactory {
 
 				FlowLayout fl = new FlowLayout(FlowLayout.TRAILING);
 				JPanel buttonPanel = new JPanel(fl);
-				add(buttonPanel, BorderLayout.SOUTH);
 				JLabel label = new JLabel("Send error report to VCell development team to assist debugging?"); 
 				buttonPanel.add(label);
+
+				//
+				// A line for the user to say what they were doing. A log says what VCell did;
+				// only the user can say what they were trying to do, which is often what makes
+				// a report reproducible. Optional -- an empty field sends as before.
+				//
+				JPanel notePanel = new JPanel(new BorderLayout(4, 0));
+				notePanel.setBorder(BorderFactory.createEmptyBorder(4, 4, 0, 4));
+				notePanel.add(new JLabel("What were you doing? (optional)"), BorderLayout.WEST);
+				userNoteField = new JTextField();
+				userNoteField.setToolTipText("Anything you can add about what you were doing helps us reproduce the problem.");
+				notePanel.add(userNoteField, BorderLayout.CENTER);
+
+				JPanel southPanel = new JPanel(new BorderLayout());
+				southPanel.add(notePanel, BorderLayout.NORTH);
+				southPanel.add(buttonPanel, BorderLayout.SOUTH);
+				add(southPanel, BorderLayout.SOUTH);
 
 				JButton helpBtn = new JButton(DialogUtils.swingIcon(JOptionPane.QUESTION_MESSAGE));
 				helpBtn.addActionListener(new ActionListener() {
@@ -195,6 +222,15 @@ public class MessagePanelFactory {
 		@Override
 		public String getClientLog() {
 			return logContent;
+		}
+
+		@Override
+		public String getUserNote() {
+			if (userNoteField == null) {
+				return null;
+			}
+			String note = userNoteField.getText();
+			return note == null || note.trim().isEmpty() ? null : note.trim();
 		}
 
 		@Override

--- a/vcell-core/src/main/java/cbit/vcell/resource/ErrorUtils.java
+++ b/vcell-core/src/main/java/cbit/vcell/resource/ErrorUtils.java
@@ -69,6 +69,94 @@ public class ErrorUtils {
             this.softwareVersion = softwareVersion;
             this.platform = platform;
         }
+
+        /**
+         * Render this report as the plain-text body of a support email.
+         *
+         * <p>The report reaches vcell_support as an email. Serialised as JSON it arrives as
+         * a single line thousands of characters long, with every newline written as a
+         * literal backslash-n and every apostrophe as a unicode escape -- readable by a
+         * parser, not by a person.
+         *
+         * <p>Sections run shortest first, so that what a reader sees -- or what a mail
+         * client shows in a preview, typically the first couple of thousand characters --
+         * is the identifying detail rather than the opening lines of a very long client
+         * log. The log, which can run to hundreds of kilobytes, always comes last.
+         */
+        public String toEmailText(){
+            String log = normalizeNewlines(nullToEmpty(exceptionMessage)).trim();
+            String trace = normalizeNewlines(nullToEmpty(stackTrace)).trim();
+
+            //
+            // The client log usually arrives twice: once as exceptionMessage, and again as
+            // the message of the exception that opens the stack trace, because the report is
+            // raised as new RuntimeException(log). On a real report that is 94% of the body,
+            // and the second copy buries the exception chain behind tens of thousands of
+            // characters of routine logging. Carry it once, at the end.
+            //
+            if (log.length() > MIN_DEDUPE_LENGTH && trace.contains(log)){
+                trace = trace.replace(log, LOG_MOVED_MARKER);
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("VCell error report").append(NL);
+            sb.append("==================").append(NL).append(NL);
+            appendField(sb, "User", username);
+            appendField(sb, "Version", softwareVersion);
+            appendField(sb, "Platform", platform);
+            appendSection(sb, "User message", message);
+            appendSection(sb, "Exception chain and stack trace", trace);
+            appendSection(sb, "Client log", log);
+            return sb.toString();
+        }
+
+        /** Short enough that a coincidental match would not matter; long enough to be the log. */
+        private static final int MIN_DEDUPE_LENGTH = 200;
+        private static final String LOG_MOVED_MARKER = "(client log -- reproduced in full below)";
+
+        private static String nullToEmpty(String s){
+            return s == null || "null".equals(s.trim()) ? "" : s;
+        }
+
+        private static final String NL = "\n";
+        private static final int RULE_WIDTH = 62;
+
+        private static void appendField(StringBuilder sb, String label, String value){
+            String shown = isBlank(value) ? "(not reported)" : oneLine(value);
+            sb.append(pad(label + ":", 10)).append(' ').append(shown).append(NL);
+        }
+
+        private static void appendSection(StringBuilder sb, String title, String value){
+            sb.append(NL).append("--- ").append(title).append(' ');
+            for (int i = title.length() + 5; i < RULE_WIDTH; i++){
+                sb.append('-');
+            }
+            sb.append(NL).append(NL);
+            sb.append(isBlank(value) ? "(none)" : normalizeNewlines(value).trim());
+            sb.append(NL);
+        }
+
+        private static String pad(String s, int width){
+            StringBuilder sb = new StringBuilder(s);
+            while (sb.length() < width){
+                sb.append(' ');
+            }
+            return sb.toString();
+        }
+
+        private static boolean isBlank(String s){
+            return s == null || s.trim().isEmpty() || "null".equals(s.trim());
+        }
+
+        /** Newlines arrive as CRLF from some platforms; normalise so the body renders evenly. */
+        private static String normalizeNewlines(String s){
+            return s.replace("\r\n", "\n").replace('\r', '\n');
+        }
+
+        /** Keep a header field on one line however the value was assembled. */
+        private static String oneLine(String s){
+            return normalizeNewlines(s).replace('\n', ' ').replaceAll(" +", " ").trim();
+        }
     }
 
     public static void sendErrorReport(Throwable exception, String message) throws RuntimeException{

--- a/vcell-core/src/main/java/cbit/vcell/resource/ErrorUtils.java
+++ b/vcell-core/src/main/java/cbit/vcell/resource/ErrorUtils.java
@@ -57,7 +57,36 @@ public class ErrorUtils {
         public String softwareVersion;
         public String platform;
 
+        /**
+         * Absent or 1 for the original report, where the client log arrived inside the
+         * exception message; 2 for the structured form, where each part has its own field.
+         * The server renders both, so a client of either vintage is understood.
+         */
+        public Integer reportVersion;
+        /** Version 2 only: the model the user was working on, previously mixed into the log. */
+        public String modelInfo;
+        /** Version 2 only: the client log, carried once and nowhere else. */
+        public String clientLog;
+        /** Version 2 only: the recorded user events, previously appended to the log. */
+        public String userEvents;
+
         public ErrorReport(){
+        }
+
+        /**
+         * A version 2 report: the exception, the log, the model and the recorded events are
+         * separate fields, so nothing has to be recovered from inside anything else.
+         */
+        public static ErrorReport version2(String username, String userMessage, String exceptionMessage,
+                                           String stackTrace, String softwareVersion, String platform,
+                                           String modelInfo, String clientLog, String userEvents){
+            ErrorReport report = new ErrorReport(username, userMessage, exceptionMessage, stackTrace,
+                    softwareVersion, platform);
+            report.reportVersion = 2;
+            report.modelInfo = modelInfo;
+            report.clientLog = clientLog;
+            report.userEvents = userEvents;
+            return report;
         }
 
         public ErrorReport(String username, String message, String exceptionMessage, String stackTrace, String softwareVersion,
@@ -84,20 +113,6 @@ public class ErrorUtils {
          * log. The log, which can run to hundreds of kilobytes, always comes last.
          */
         public String toEmailText(){
-            String log = normalizeNewlines(nullToEmpty(exceptionMessage)).trim();
-            String trace = normalizeNewlines(nullToEmpty(stackTrace)).trim();
-
-            //
-            // The client log usually arrives twice: once as exceptionMessage, and again as
-            // the message of the exception that opens the stack trace, because the report is
-            // raised as new RuntimeException(log). On a real report that is 94% of the body,
-            // and the second copy buries the exception chain behind tens of thousands of
-            // characters of routine logging. Carry it once, at the end.
-            //
-            if (log.length() > MIN_DEDUPE_LENGTH && trace.contains(log)){
-                trace = trace.replace(log, LOG_MOVED_MARKER);
-            }
-
             StringBuilder sb = new StringBuilder();
             sb.append("VCell error report").append(NL);
             sb.append("==================").append(NL).append(NL);
@@ -105,9 +120,42 @@ public class ErrorUtils {
             appendField(sb, "Version", softwareVersion);
             appendField(sb, "Platform", platform);
             appendSection(sb, "User message", message);
+            if (isVersion2()){
+                appendVersion2Body(sb);
+            } else {
+                appendLegacyBody(sb);
+            }
+            return sb.toString();
+        }
+
+        private boolean isVersion2(){
+            return reportVersion != null && reportVersion >= 2;
+        }
+
+        /** Every part arrived in its own field, so simply lay them out, log last. */
+        private void appendVersion2Body(StringBuilder sb){
+            appendSection(sb, "Exception", exceptionMessage);
+            appendSection(sb, "Stack trace", stackTrace);
+            appendSection(sb, "Model", modelInfo);
+            appendSection(sb, "Recorded user events", userEvents);
+            appendSection(sb, "Client log", clientLog);
+        }
+
+        /**
+         * A version 1 report from an older client. The client log arrives twice: once as
+         * exceptionMessage, and again as the message of the exception that opens the stack
+         * trace, because the report was raised as new RuntimeException(log). On a real report
+         * that was 94% of the body, and the second copy buried the exception chain behind
+         * tens of thousands of characters of routine logging. Carry it once, at the end.
+         */
+        private void appendLegacyBody(StringBuilder sb){
+            String log = normalizeNewlines(nullToEmpty(exceptionMessage)).trim();
+            String trace = normalizeNewlines(nullToEmpty(stackTrace)).trim();
+            if (log.length() > MIN_DEDUPE_LENGTH && trace.contains(log)){
+                trace = trace.replace(log, LOG_MOVED_MARKER);
+            }
             appendSection(sb, "Exception chain and stack trace", trace);
             appendSection(sb, "Client log", log);
-            return sb.toString();
         }
 
         /** Short enough that a coincidental match would not matter; long enough to be the log. */
@@ -156,6 +204,82 @@ public class ErrorUtils {
         /** Keep a header field on one line however the value was assembled. */
         private static String oneLine(String s){
             return normalizeNewlines(s).replace('\n', ' ').replaceAll(" +", " ").trim();
+        }
+    }
+
+    /**
+     * Send a version 2 report: the exception, the client log, the model and the recorded user
+     * events travel in separate fields.
+     *
+     * <p>The original form had the caller wrap everything in
+     * {@code new RuntimeException(log, cause)} before sending, which put the log in the
+     * exception's message and therefore into both {@code exceptionMessage} and the head of
+     * {@code stackTrace}. That duplicate was 94% of a real support email, and it pushed the
+     * frames that identify the fault past fifty thousand characters of routine logging.
+     *
+     * @param exception the exception as thrown, not wrapped
+     */
+    public static void sendErrorReport(Throwable exception, String userMessage, String modelInfo,
+                                       String clientLog, String userEvents) throws RuntimeException{
+        String exceptionMessage = exception != null ? describe(exception) : null;
+        String stackTrace = exception != null ? StackTraceUtils.getStackTrace(exception) : null;
+        ErrorReport report = ErrorReport.version2(currentUsername(), userMessage, exceptionMessage, stackTrace,
+                PropertyLoader.getRequiredProperty(PropertyLoader.vcellSoftwareVersion), currentPlatform(),
+                modelInfo, clientLog, userEvents);
+        postErrorReport(report);
+    }
+
+    /** Type and message, so the section reads as an exception rather than a bare sentence. */
+    private static String describe(Throwable exception){
+        String message = exception.getMessage();
+        return exception.getClass().getName() + (message == null ? "" : ": " + message);
+    }
+
+    private static String currentPlatform(){
+        return "Running under Java " + (System.getProperty("java.version")) +
+                ", published by " + (System.getProperty("java.vendor")) + ", on the " + (System.getProperty("os.arch")) +
+                " architecture running version " + (System.getProperty("os.version")) +
+                " of the " + (System.getProperty("os.name")) + " operating system";
+    }
+
+    private static String currentUsername(){
+        if(clientServerInfo != null && clientServerInfo.getUsername() != null){
+            return clientServerInfo.getUsername();
+        }
+        return null;
+    }
+
+    private static void postErrorReport(ErrorReport errorReport) throws RuntimeException{
+        String serverHost = PropertyLoader.getProperty(PropertyLoader.vcellServerHost, null);
+        String serverPrefixV0 = PropertyLoader.getProperty(PropertyLoader.vcellServerPrefixV0, null);
+        if(clientServerInfo != null && clientServerInfo.getApihost() != null){
+            serverHost = clientServerInfo.getApihost();
+        }
+        if(serverHost == null){
+            throw new RuntimeException("cannot send error report to server, unknown host");
+        }
+        SSLConnectionSocketFactory sslsf;
+        try {
+            SSLContextBuilder builder = new SSLContextBuilder();
+            builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+            sslsf = new SSLConnectionSocketFactory(builder.build());
+        } catch(Exception e){
+            lg.error(e.getMessage(), e);
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        try (CloseableHttpClient httpClient = HttpClients.custom().setSSLSocketFactory(sslsf).build()) {
+            HttpPost httpPost = new HttpPost("https://" + serverHost + serverPrefixV0 + "/contactus");
+            String json = new Gson().toJson(errorReport);
+            httpPost.setEntity(new StringEntity(json));
+            httpPost.setHeader("Content-type", "application/json");
+            CloseableHttpResponse response = httpClient.execute(httpPost);
+            if(response.getStatusLine().getStatusCode() == 200){
+                lg.info("sent error message to /contactus");
+            } else {
+                lg.error("failed to send error message to /contactus");
+            }
+        } catch(IOException e){
+            throw new RuntimeException(e);
         }
     }
 

--- a/vcell-core/src/test/java/cbit/vcell/resource/ErrorUtilsTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/resource/ErrorUtilsTest.java
@@ -150,4 +150,54 @@ public class ErrorUtilsTest {
         while (i >= 0) { n++; i = haystack.indexOf(needle, i + needle.length()); }
         return n;
     }
+
+    @Test
+    @Tag("Fast")
+    public void aVersion2ReportKeepsEachPartInItsOwnSection() {
+        ErrorUtils.ErrorReport r = ErrorUtils.ErrorReport.version2(
+                "bob", "it crashed while saving",
+                "java.lang.IllegalStateException: no geometry",
+                "java.lang.IllegalStateException: no geometry\n\tat cbit.vcell.Foo.bar(Foo.java:1)",
+                "8.1.0", "Java 17 on Windows",
+                "BioModel 'Calcium' / Application0",
+                "Log file content:\nUNIQUE-LOG-SENTINEL\nchatter",
+                "-----Recorded User Events-----\nclicked Save");
+        String text = r.toEmailText();
+
+        assertTrue(text.contains("--- Exception "), text);
+        assertTrue(text.contains("--- Stack trace "), text);
+        assertTrue(text.contains("--- Model "), text);
+        assertTrue(text.contains("--- Recorded user events "), text);
+        assertTrue(text.contains("--- Client log "), text);
+        assertTrue(text.contains("BioModel 'Calcium' / Application0"), text);
+        assertTrue(text.contains("clicked Save"), text);
+    }
+
+    @Test
+    @Tag("Fast")
+    public void aVersion2ReportNeedsNoDeduplication() {
+        // v2 never puts the log inside the exception, so nothing has to be pulled back out
+        ErrorUtils.ErrorReport r = ErrorUtils.ErrorReport.version2(
+                "bob", null, "java.lang.IllegalStateException: no geometry",
+                "java.lang.IllegalStateException: no geometry\n\tat cbit.vcell.Foo.bar(Foo.java:1)",
+                "8.1.0", "Java", null,
+                "Log file content:\nUNIQUE-LOG-SENTINEL\n" + "chatter\n".repeat(60), null);
+        String text = r.toEmailText();
+
+        assertEquals(1, countOccurrences(text, "UNIQUE-LOG-SENTINEL"), "log carried once");
+        assertFalse(text.contains("reproduced in full below"), "no marker needed in v2: " + text);
+        assertTrue(text.indexOf("at cbit.vcell.Foo.bar") < text.indexOf("UNIQUE-LOG-SENTINEL"),
+                "frames still precede the log");
+    }
+
+    @Test
+    @Tag("Fast")
+    public void aVersion2ReportOmitsPartsThatWereNotCaptured() {
+        ErrorUtils.ErrorReport r = ErrorUtils.ErrorReport.version2(
+                null, null, "boom", "at Foo", "8.1.0", "Java", null, null, null);
+        String text = r.toEmailText();
+        assertTrue(text.contains("--- Model "), text);
+        assertEquals(4, countOccurrences(text, "(none)"),
+                "user message, model, events and log each say (none): " + text);
+    }
 }

--- a/vcell-core/src/test/java/cbit/vcell/resource/ErrorUtilsTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/resource/ErrorUtilsTest.java
@@ -2,12 +2,15 @@ package cbit.vcell.resource;
 
 import com.google.gson.Gson;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("Fast")
 public class ErrorUtilsTest {
@@ -35,5 +38,116 @@ public class ErrorUtilsTest {
 
         ErrorUtils.ErrorReport errorReport1 = gson.fromJson(json, ErrorUtils.ErrorReport.class);
         assertEquals(testCase.expectedJson, gson.toJson(errorReport1));
+    }
+
+    @Test
+    @Tag("Fast")
+    public void emailTextCarriesEveryFieldUnderAHeading() {
+        ErrorUtils.ErrorReport r = new ErrorUtils.ErrorReport(
+                "bob", "it crashed", "boom", "java.lang.NullPointerException\n\tat Foo.bar(Foo.java:1)",
+                "Rel_Version_8.0.0_build_03", "Java 17 on Windows");
+        String text = r.toEmailText();
+
+        assertTrue(text.startsWith("VCell error report"), text);
+        assertTrue(text.contains("User:      bob"), text);
+        assertTrue(text.contains("Version:   Rel_Version_8.0.0_build_03"), text);
+        assertTrue(text.contains("Platform:  Java 17 on Windows"), text);
+        assertTrue(text.contains("--- User message"), text);
+        assertTrue(text.contains("it crashed"), text);
+        assertTrue(text.contains("--- Exception chain and stack trace"), text);
+        assertTrue(text.contains("\tat Foo.bar(Foo.java:1)"), text);
+        assertTrue(text.contains("boom"), text);
+    }
+
+    @Test
+    @Tag("Fast")
+    public void emailTextIsNotOneLongLine() {
+        // the whole point: JSON put the report on a single line with escaped newlines
+        ErrorUtils.ErrorReport r = new ErrorUtils.ErrorReport(
+                "bob", "msg", "line one\nline two", "at A\nat B", "8.0", "Java");
+        String text = r.toEmailText();
+        assertTrue(text.lines().count() > 10, "expected a multi-line body, got: " + text);
+        assertFalse(text.contains("\\n"), "body still contains an escaped newline: " + text);
+    }
+
+    @Test
+    @Tag("Fast")
+    public void windowsNewlinesAreNormalised() {
+        ErrorUtils.ErrorReport r = new ErrorUtils.ErrorReport(
+                "bob", null, "first\r\nsecond", null, "8.0", "Java");
+        assertFalse(r.toEmailText().contains("\r"), "CR survived normalisation");
+    }
+
+    @Test
+    @Tag("Fast")
+    public void missingFieldsAreLabelledRatherThanBlank() {
+        ErrorUtils.ErrorReport r = new ErrorUtils.ErrorReport(null, null, null, null, null, null);
+        String text = r.toEmailText();
+        assertTrue(text.contains("User:      (not reported)"), text);
+        assertTrue(text.contains("(none)"), text);
+    }
+
+    @Test
+    @Tag("Fast")
+    public void aMultiLinePlatformStaysOnItsHeaderLine() {
+        ErrorUtils.ErrorReport r = new ErrorUtils.ErrorReport(
+                "bob", null, null, null, "8.0", "Java 17\non Windows");
+        String header = r.toEmailText().lines().filter(l -> l.startsWith("Platform:")).findFirst().orElse("");
+        assertEquals("Platform:  Java 17 on Windows", header);
+    }
+
+    @Test
+    @Tag("Fast")
+    public void theClientLogComesLastSoAPreviewShowsTheDiagnosis() {
+        // mail clients preview the first couple of thousand characters; the log can be
+        // hundreds of kilobytes, so it must not be what a reader sees first.
+        String hugeLog = "Log file content:\n" + "noise noise noise\n".repeat(500);
+        ErrorUtils.ErrorReport r = new ErrorUtils.ErrorReport(
+                "bob", "it crashed", hugeLog, "java.lang.IllegalStateException\n\tat Foo.bar(Foo.java:1)",
+                "8.0", "Java");
+        String text = r.toEmailText();
+        assertTrue(text.indexOf("IllegalStateException") < text.indexOf("noise"),
+                "the stack trace must precede the client log");
+        assertTrue(text.indexOf("IllegalStateException") < 2000,
+                "the stack trace must fall inside a typical preview window");
+    }
+
+    @Test
+    @Tag("Fast")
+    public void theClientLogIsNotCarriedTwice() {
+        // Reports are raised as new RuntimeException(log), so the log arrives both as
+        // exceptionMessage and as the message of the exception opening the stack trace.
+        // On a real support email that duplicate was 94% of the body.
+        String log = "Log file content:\nUNIQUE-LOG-SENTINEL\n" + "routine chatter\n".repeat(60);
+        String trace = "java.lang.RuntimeException: \n" + log
+                + "\n\tat cbit.vcell.Foo.bar(Foo.java:1)\n\tat cbit.vcell.Baz.qux(Baz.java:2)";
+        ErrorUtils.ErrorReport r = new ErrorUtils.ErrorReport(null, null, log, trace, "8.0", "Java");
+        String text = r.toEmailText();
+
+        assertEquals(1, countOccurrences(text, "UNIQUE-LOG-SENTINEL"),
+                "the client log should appear exactly once");
+        assertTrue(text.contains("(client log -- reproduced in full below)"), text);
+        assertTrue(text.contains("\tat cbit.vcell.Foo.bar(Foo.java:1)"), "frames must survive");
+        assertTrue(text.indexOf("at cbit.vcell.Foo.bar") < text.indexOf("UNIQUE-LOG-SENTINEL"),
+                "frames must come before the log");
+    }
+
+    @Test
+    @Tag("Fast")
+    public void aShortExceptionMessageIsLeftAloneInTheTrace() {
+        // Only a body long enough to be the log is worth moving; a short message that
+        // happens to appear in its own stack trace must not be rewritten.
+        ErrorUtils.ErrorReport r = new ErrorUtils.ErrorReport(
+                null, null, "boom", "java.lang.RuntimeException: boom\n\tat Foo.bar(Foo.java:1)",
+                "8.0", "Java");
+        String text = r.toEmailText();
+        assertTrue(text.contains("java.lang.RuntimeException: boom"), text);
+        assertFalse(text.contains("reproduced in full below"), text);
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int n = 0, i = haystack.indexOf(needle);
+        while (i >= 0) { n++; i = haystack.indexOf(needle, i + needle.length()); }
+        return n;
     }
 }


### PR DESCRIPTION
Closes #1495. Addresses items 1 and 2 of #835.

## The problem

An error report reaches `vcell_support@uchc.edu` as the raw JSON it was posted in: **one line**, every newline a literal `\n`, every apostrophe a `'`.

Five real messages, read-only from the support mailbox: **112 KB, 136 KB, 138 KB, 188 KB, 434 KB** — each a single line.

Most of that is duplication. `DialogUtils` built the report as `new RuntimeException(supplemental, exception)`, so the client log became the wrapper's *message* and landed **twice** — as `exceptionMessage` and again at the head of `stackTrace`. On one 124 KB report:

| | chars |
|---|---|
| body | 123,975 |
| client log, carried twice | 116,558 — **94%** |
| actual exception chain + frames | 7,417 |

Frames began at line 219, past 58,000 characters. And because the report was wrapped, **the stack trace was the wrapper's** — rooted at `DialogUtils:766`, with the real fault demoted to a `Caused by:`.

## Changes

**1. Render the email as text** (server side). Header (user, version, platform) plus headed sections. For reports from existing clients it also removes the duplicate log, leaving a marker where the stack trace had inlined it.

**2. A version 2 report** (client side). Each part gets its own field — `modelInfo`, `clientLog`, `userEvents` — and the exception is sent **as thrown**. A `reportVersion` field marks the form; the server renders both, so neither side deploys in lockstep.

**3. #835 item 1 — users can say what they were doing.** An optional one-line field in the error dialog. A log records what VCell did; only the user can say what they were *trying* to do. Empty sends exactly as before.

**4. #835 item 2 — reports identify the reporter.** `ErrorUtils` was told who was logged in once, at startup, from the command-line user name — normally absent, since people log in through the dialog. Every report was therefore anonymous. It is now told again on each successful connect.

**5. The error dialog always has an owner.** `LWNamespace.findLWOwner` returns null when no ancestor implements `LWContainerHandle` (it logs an error when that happens, so it does). AWT **downgrades `DOCUMENT_MODAL` to modeless when the owner is null**, so the error dialog would neither block the window that raised it nor stay in front of it — one way an error ends up behind the main window. `findLWOwnerOrMostRecent` falls back to the most recently focused visible top-level window.

## Result on the real report

| | before | after |
|---|---|---|
| body | 123,975 chars | 66,196 |
| lines | 1 | 1,106 |
| first frame | past 58,000 chars | first screen |

The dialog, rendered from the built classes:

```
Cannot invoke "cbit.vcell.mapping.ElectricalTopology.getGroundElectrode()"

What were you doing? (optional)  [________________________]

Send error report to VCell development team to assist debugging?   [?]
```

## Tests

`ErrorUtilsTest` 3 → 14. The 3 existing JSON round-trip cases pass unchanged — the check that the wire format still serialises as before. New cases cover field rendering, the body not being one long line, CRLF normalisation, missing fields, a multi-line platform staying on its header line, the legacy log appearing exactly once with frames ahead of it, a short exception message left alone, and the v2 form.

## Not addressed

- **#835 item 3** (include database transactions).
- **The subject line** stays `"VCell Support sent through Contact-Us"`. Including the exception type would make the inbox scannable, but these are forwarded by a mail rule that may match the exact subject — worth checking the rule first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUd61NUJgz88h4PZs5MqHn