### PR TITLE
docs: record how VCell actually versions, and tag the verified commit

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -25,23 +25,35 @@ VCell uses a 4-part version: `MAJOR.MINOR.PATCH.BUILD`.
 
 | Part | Meaning | Triggered by |
 |---|---|---|
-| `MAJOR` | User-facing breaking change **or** public release event | Release-engineering decision. Examples: 8.0.0 = SpringSaLaD GA. |
-| `MINOR` | Significant new feature, backwards-compatible | Release-engineering decision. |
-| `PATCH` | Bugfix-only release | Release-engineering decision. |
+| `MAJOR` | A very large new capability. Rare. | Release-engineering decision. |
+| `MINOR` | A public release event — a version announced to users. | Release-engineering decision. |
+| `PATCH` | **Every ordinary release.** The default. | Release-engineering decision. |
 | `BUILD` | CI auto-incrementing build counter | Automatic. Each push that produces a release artifact increments this. |
+
+**Cutting "a release" means a PATCH release.** That is the normal case and the
+one to assume unless told otherwise: 8.1.0.01 → 8.1.1.01 → 8.1.2.01. A release
+is not held back from PATCH because it contains a new feature, and does not earn
+a MINOR by containing one. Almost every release VCell ships is a PATCH.
+
+MINOR marks a **public release event**: a version given a name, announced to
+users, and written up as its own narrative under `release-notes/major/` and its
+own vcell.org accordion entry. It is a decision about announcing, not about the
+size of the diff.
+
+MAJOR is for a very large new capability and is rare.
 
 The first three parts are intentional human decisions; the fourth is
 mechanical. `7.7.0.77` and `7.7.0.78` are the 77th and 78th builds of the
 `7.7.0` line. `8.0.0.01` is the first build of the `8.0.0` line.
 
-**What counts as a "user-facing breaking change":**
-- File format incompatibility (cannot open older `.vcml` / cannot be opened by older VCell)
-- Behavior change that silently produces different simulation results
-- Removal or rename of a UI feature users depend on
-
-**What counts as a "public release event":**
-- A new modeling modality with its own identity (e.g. SpringSaLaD GA → 8.0.0)
+**What counts as a public release event:**
+- A new modeling modality with its own identity (e.g. SpringSaLaD GA)
 - A major UI or workflow overhaul worth highlighting on vcell.org
+
+**A user-facing breaking change** — a file-format incompatibility, a silent
+change in simulation results, the removal of a feature users depend on — is
+called out prominently in the release's `Highlights.` paragraph. It does not by
+itself force a MAJOR or MINOR bump.
 
 API breaking changes are tracked under `CHANGELOG.md` `### Changed` and
 `### Removed` rather than forcing a MAJOR bump, since API consumers track

--- a/tools/release/release-and-deploy.sh
+++ b/tools/release/release-and-deploy.sh
@@ -72,7 +72,9 @@ fi
 if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
 	echo "release $VERSION already exists -- not recreating it"
 else
-	gh release create "$VERSION" --repo "$REPO" --target master \
+	# Tag the commit regression actually passed on, not whatever master is now. A merge
+	# landing between gate 1 and here would otherwise be released untested.
+	gh release create "$VERSION" --repo "$REPO" --target "$MASTER_SHA" \
 		--title "$VERSION" --notes-file "$NOTES" \
 		|| { echo "release create failed" >&2; exit 1; }
 	echo "created release $VERSION"


### PR DESCRIPTION
## 1. Versioning

`docs/RELEASING.md` described `MINOR` as "significant new feature" and `MAJOR` as "breaking change **or** public release event". That reads like semantic versioning, and it isn't how this project versions — it invites a deliberation at every release cut that has one answer.

How VCell actually versions:

| | |
|---|---|
| **PATCH** | **every ordinary release** — the default, and nearly all of them |
| **MINOR** | a *public release event*: a version announced to users, with its own `release-notes/major/` narrative and vcell.org entry |
| **MAJOR** | a very large new capability; rare |

So **"cut a release" means a PATCH bump.** A release is not held back from PATCH because it contains a feature, and does not earn a MINOR by containing one. MINOR is a decision about *announcing*, not about the size of the diff.

A user-facing breaking change is called out in the release's `Highlights.` paragraph rather than forcing a bump.

I got this wrong on #2015, where I reasoned about "why PATCH rather than MINOR" — the answer was never in doubt, the doc just implied it was.

## 2. `--target master` could tag an unverified commit

`release-and-deploy.sh` pins `MASTER_SHA` at the start and runs regression against it, then did:

```bash
gh release create "$VERSION" --repo "$REPO" --target master
```

The regression gate takes several minutes. Anything merged in that window would be tagged and shipped **without having been through regression** — and the log would still show the pinned SHA as the verified one, so it would not look wrong.

Now `--target "$MASTER_SHA"`.

Found concretely: this PR was written during the 8.1.1.01 cut and I held the merge until the tag existed, specifically because of this. The tag landed on `ad59f32ad4` as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUd61NUJgz88h4PZs5MqHn