### PR TITLE
security(deps): close 4 of 6 Maven alerts — jsoup, jose4j, and remove unused htmlunit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
 		<jai-core.version>1.1.3</jai-core.version>
 		<javax-mail.version>1.4</javax-mail.version>
 		<jsbml.version>1.6.1-VCELL-4</jsbml.version>
+		<jose4j.version>0.9.6</jose4j.version>
 		<json-smart.version>2.4.11</json-smart.version>
 		<jung-api.version>2.1.1</jung-api.version>
 		<jung-algorithms.version>2.1.1</jung-algorithms.version>
@@ -319,6 +320,24 @@
 				<version>${junit-jupiter.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<!--
+			  jose4j: forced to a single version across the reactor.
+
+			  vcell-server declares it directly, while vcell-rest also receives it transitively
+			  from quarkus-oidc -> smallrye-jwt, which pins 0.9.3 in Quarkus 3.5.2. Bumping only
+			  vcell-server therefore fails the enforcer's DependencyConvergence rule in vcell-rest.
+			  Managing it here is the single point that both paths resolve through.
+
+			  0.9.6 fixes two DoS advisories (compressed JWE content; crafted JWE). It is a patch
+			  bump within 0.9.x, so smallrye-jwt 4.3.1 keeps the API it was built against.
+			  Revisit when the Quarkus upgrade lands: a newer Quarkus pins a newer jose4j and
+			  this override should then be removed rather than raised.
+			-->
+			<dependency>
+				<groupId>org.bitbucket.b_c</groupId>
+				<artifactId>jose4j</artifactId>
+				<version>${jose4j.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/vcell-cli/pom.xml
+++ b/vcell-cli/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.15.2</version>
+            <version>1.23.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/vcell-rest/pom.xml
+++ b/vcell-rest/pom.xml
@@ -130,18 +130,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.sourceforge.htmlunit</groupId>
-      <artifactId>htmlunit</artifactId>
-      <version>2.70.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>${jetty.version}</version>

--- a/vcell-server/pom.xml
+++ b/vcell-server/pom.xml
@@ -123,7 +123,7 @@
 		<dependency>
 			<groupId>org.bitbucket.b_c</groupId>
 			<artifactId>jose4j</artifactId>
-			<version>0.9.3</version>
+			<version>${jose4j.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Closes **4 of the 6** Maven Dependabot alerts, including the only `critical` one. From the triage
in #2016.

| package | change | module | alerts closed |
|---|---|---|---|
| `org.jsoup:jsoup` | 1.15.2 → **1.23.1** | vcell-cli | 2 medium |
| `org.bitbucket.b_c:jose4j` | 0.9.3 → **0.9.6** | managed in root pom | 1 high, 1 medium |
| `net.sourceforge.htmlunit:htmlunit` | **removed** | vcell-rest | 1 critical |

## Two of these were not one-line bumps

**`htmlunit` was removed, not bumped.** It is `scope=test` and referenced by **no `.java` anywhere
in the repo** — dead weight. And 2.70.0 → 3.0.0 renames the groupId
(`net.sourceforge.htmlunit` → `org.htmlunit`), so a "bump" would be a migration for a dependency
nothing uses. Worth noting what this means for the alert banner: **the repo's only critical Maven
alert was never in shipped code** — it was a headless browser for tests.

**`jose4j` needed managing, not bumping.** `vcell-server` declares it directly, while `vcell-rest`
*also* receives it transitively from `quarkus-oidc → smallrye-jwt`, which pins 0.9.3 in Quarkus
3.5.2:

```
+-vcell-rest
  +-quarkus-oidc → smallrye-jwt → jose4j 0.9.3
  +-vcell-server                → jose4j 0.9.6      ← raising only this side
```

Raising one side made the paths disagree and failed the enforcer's `DependencyConvergence` rule.
It is now pinned once in the root pom's `dependencyManagement` behind a `jose4j.version` property —
the single point both paths resolve through.

> The comment in the pom says this, and it matters: that override should be **removed, not raised**,
> when the Quarkus upgrade lands and pins a newer jose4j itself.

## Deliberately not included: `woodstox-core`

The remaining medium alert (`woodstox-core` 5.0.1 → 5.4.0) collides the same way but **cannot be
managed away safely**:

```
jsbml-core → staxmate 2.3.0 → stax2-api 3.1.4
woodstox-core 5.4.0        → stax2-api 4.2
```

`stax2-api` is pinned nowhere, and 5.0.1 happened to bring 3.1.4 — which is why it converged
before. Forcing 4.x under `staxmate 2.3.0` risks a runtime break in XML parsing, and **no compile
error would catch it**: woodstox is a StAX provider resolved by `ServiceLoader`, which is why
nothing imports it and why the existing pom already excludes it from `jsbml-core` and re-declares
it at a pinned version.

For a *medium* DoS advisory that trade is not obviously worth it, so it is left for its own change
with that analysis rather than smuggled in here. Recorded in #2016.

## Verification

- Full reactor `compile test-compile` across `vcell-core`, `vcell-server`, `vcell-cli`,
  `vcell-rest` — **BUILD SUCCESS**, which also proves the htmlunit removal breaks no test sources.
- Resolved versions read back with `dependency:list` rather than assumed:

```
org.jsoup:jsoup:jar:1.23.1:compile
org.bitbucket.b_c:jose4j:jar:0.9.6:compile
com.fasterxml.woodstox:woodstox-core:jar:5.0.1   (unchanged, as intended)
org.codehaus.woodstox:stax2-api:jar:3.1.4        (unchanged, as intended)
htmlunit                                          (absent)
```

After this, the Maven portion of the alert banner goes from 6 to 1, and that one is the documented
woodstox case.

Refs #2016

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kr8SbzXtwW3gMVUgMfDDt
