### PR TITLE
perf(xml): share the decoded image between applications, not the Geometry

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/xml/XmlReader.java
+++ b/vcell-core/src/main/java/cbit/vcell/xml/XmlReader.java
@@ -41,6 +41,8 @@ import org.vcell.util.Coordinate;
 import org.vcell.util.Extent;
 import org.vcell.util.GenericUtils;
 import org.vcell.util.Hex;
+import java.security.MessageDigest;
+import cbit.vcell.resource.PropertyLoader;
 import org.vcell.util.ISize;
 import org.vcell.util.Origin;
 import org.vcell.util.Pair;
@@ -258,6 +260,19 @@ public class XmlReader extends XmlBase {
     private boolean readKeysFlag = false;
     private Namespace vcNamespace = Namespace.getNamespace(XMLTags.VCML_NS_BLANK);    // default - blank namespace
     private ModelUnitSystem forcedModelUnitSystem = null;
+
+    /**
+     * Set false to parse every <Geometry> element separately, as this reader did before #2021.
+     * An escape hatch, not a tuning knob -- see {@link #getGeometry(Element)}.
+     */
+    public final static String PROPERTY_SHARE_IDENTICAL_GEOMETRIES = "vcell.xml.shareIdenticalGeometries";
+
+    /**
+     * Geometries already parsed during THIS document, by digest of their <Geometry> element.
+     * One XmlReader is constructed per document (XmlHelper.XMLToBioModel), so the cache lives
+     * exactly as long as one parse and is never shared between documents or threads.
+     */
+    private final Map<String, Geometry> parsedGeometriesByDigest = new HashMap<>();
 
     /**
      * This constructor takes a parameter to specify if the KeyValue should be ignored
@@ -1982,6 +1997,63 @@ public class XmlReader extends XmlBase {
      * @throws cbit.vcell.xml.XmlParseException The exception description.
      */
     public Geometry getGeometry(Element param) throws XmlParseException{
+        //
+        // A BioModel stores a full copy of its geometry -- image included -- inside EVERY
+        // <SimulationContext> (Xmlproducer writes it there), so a model with N spatial
+        // applications on one geometry arrives here N times with byte-identical elements.
+        // Parsing each one separately cost a 62 MP model ~1.4 GB of peak heap PER COPY and
+        // killed two prod api pods (#2021); the same element is parsed once and shared.
+        //
+        // Only exactly identical elements share. Nothing here tries to decide that two
+        // *different* geometries are equivalent -- that is a much harder question and not
+        // one a parser should be answering.
+        //
+        String digest = geometryElementDigest(param);
+        if(digest != null){
+            Geometry alreadyParsed = parsedGeometriesByDigest.get(digest);
+            if(alreadyParsed != null){
+                if(lg.isDebugEnabled()){
+                    lg.debug("reusing already-parsed geometry '" + alreadyParsed.getName()
+                            + "' for an identical <Geometry> element in this document");
+                }
+                return alreadyParsed;
+            }
+        }
+        Geometry geometry = parseGeometry(param);
+        if(digest != null){
+            parsedGeometriesByDigest.put(digest, geometry);
+        }
+        return geometry;
+    }
+
+    /**
+     * A stable key for a <Geometry> element, or null to disable sharing for this element.
+     *
+     * The element is streamed through the digest rather than turned into a String first: the
+     * element holds the image as hex text, so for the model in #2021 that String would be tens
+     * of MB -- allocating it to avoid allocations would be self-defeating.
+     *
+     * Returns null (meaning "parse it, do not share it") if sharing is switched off or if the
+     * digest cannot be computed, so a failure here costs performance and never correctness.
+     */
+    private String geometryElementDigest(Element param){
+        if(param == null || !PropertyLoader.getBooleanProperty(PROPERTY_SHARE_IDENTICAL_GEOMETRIES, true)){
+            return null;
+        }
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            try (java.io.OutputStream sink = new java.security.DigestOutputStream(
+                    java.io.OutputStream.nullOutputStream(), md)) {
+                new org.jdom2.output.XMLOutputter().output(param, sink);
+            }
+            return Hex.toString(md.digest());
+        } catch(Exception e){
+            lg.warn("could not digest <Geometry> element, parsing it without sharing: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private Geometry parseGeometry(Element param) throws XmlParseException{
         //Get the Extent object
         Extent newextent = getExtent(param.getChild(XMLTags.ExtentTag, vcNamespace));
         //Get VCimage information

--- a/vcell-core/src/main/java/cbit/vcell/xml/XmlReader.java
+++ b/vcell-core/src/main/java/cbit/vcell/xml/XmlReader.java
@@ -262,8 +262,18 @@ public class XmlReader extends XmlBase {
     private ModelUnitSystem forcedModelUnitSystem = null;
 
     /**
-     * Set false to parse every <Geometry> element separately, as this reader did before #2021.
-     * An escape hatch, not a tuning knob -- see {@link #getGeometry(Element)}.
+     * Share one decoded {@link VCImage} between identical <Image> elements in a document. ON by
+     * default: a VCImage is immutable payload, so sharing it leaves every editable thing --
+     * subvolumes, names, extent, surfaces -- private to each application.
+     */
+    public final static String PROPERTY_SHARE_IDENTICAL_IMAGES = "vcell.xml.shareIdenticalImages";
+
+    /**
+     * Share one whole {@link Geometry} between identical <Geometry> elements in a document.
+     * OFF by default, deliberately: a Geometry is MUTABLE, and two applications that shared one
+     * would see each other's subvolume renames and geometry edits. Enable it only where
+     * documents are read and never edited -- a server that parses to serialise or to generate
+     * math. See {@link #getGeometry(Element)}.
      */
     public final static String PROPERTY_SHARE_IDENTICAL_GEOMETRIES = "vcell.xml.shareIdenticalGeometries";
 
@@ -273,6 +283,9 @@ public class XmlReader extends XmlBase {
      * exactly as long as one parse and is never shared between documents or threads.
      */
     private final Map<String, Geometry> parsedGeometriesByDigest = new HashMap<>();
+
+    /** Decoded images already parsed during THIS document, by digest of their <Image> element. */
+    private final Map<String, VCImage> parsedImagesByDigest = new HashMap<>();
 
     /**
      * This constructor takes a parameter to specify if the KeyValue should be ignored
@@ -2037,9 +2050,20 @@ public class XmlReader extends XmlBase {
      * digest cannot be computed, so a failure here costs performance and never correctness.
      */
     private String geometryElementDigest(Element param){
-        if(param == null || !PropertyLoader.getBooleanProperty(PROPERTY_SHARE_IDENTICAL_GEOMETRIES, true)){
+        if(param == null || !PropertyLoader.getBooleanProperty(PROPERTY_SHARE_IDENTICAL_GEOMETRIES, false)){
             return null;
         }
+        return elementDigest(param);
+    }
+
+    private String imageElementDigest(Element param){
+        if(param == null || !PropertyLoader.getBooleanProperty(PROPERTY_SHARE_IDENTICAL_IMAGES, true)){
+            return null;
+        }
+        return elementDigest(param);
+    }
+
+    private String elementDigest(Element param){
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-256");
             try (java.io.OutputStream sink = new java.security.DigestOutputStream(
@@ -2048,7 +2072,8 @@ public class XmlReader extends XmlBase {
             }
             return Hex.toString(md.digest());
         } catch(Exception e){
-            lg.warn("could not digest <Geometry> element, parsing it without sharing: " + e.getMessage());
+            lg.warn("could not digest <" + param.getName() + "> element, parsing it without sharing: "
+                    + e.getMessage());
             return null;
         }
     }
@@ -7773,6 +7798,31 @@ public RateRuleVariable[] getRateRuleVariables(Element rateRuleVarsElement, Mode
      * @return VCImage
      */
     VCImage getVCImage(Element param, Extent extent) throws XmlParseException{
+        //
+        // A BioModel repeats its whole <Geometry>, image included, inside every
+        // <SimulationContext>, so the same image arrives here once per application. Decoding it
+        // each time costs a hex decode, an inflate, and a retained copy of the pixels -- for the
+        // model in #2021 that is 62 MB of pixels per application, eleven times over.
+        //
+        // Only the IMAGE is shared, not the Geometry: a VCImage is immutable payload (its
+        // compressed pixels are final and VCPixelClass is declared Immutable), whereas a Geometry
+        // is mutable and two applications sharing one would see each other's edits.
+        //
+        String digest = imageElementDigest(param);
+        if(digest != null){
+            VCImage alreadyParsed = parsedImagesByDigest.get(digest);
+            if(alreadyParsed != null){
+                return alreadyParsed;
+            }
+        }
+        VCImage image = parseVCImage(param, extent);
+        if(digest != null){
+            parsedImagesByDigest.put(digest, image);
+        }
+        return image;
+    }
+
+    private VCImage parseVCImage(Element param, Extent extent) throws XmlParseException{
         //try to get metadata(version)
         Version version = getVersion(param.getChild(XMLTags.VersionTag, vcNamespace));
 

--- a/vcell-core/src/test/java/cbit/vcell/xml/XmlGeometrySharingBenchmark.java
+++ b/vcell-core/src/test/java/cbit/vcell/xml/XmlGeometrySharingBenchmark.java
@@ -1,0 +1,173 @@
+package cbit.vcell.xml;
+
+import cbit.image.VCImageUncompressed;
+import cbit.vcell.biomodel.BioModel;
+import cbit.vcell.geometry.Geometry;
+import cbit.vcell.geometry.GeometryThumbnailImageFactoryAWT;
+import cbit.vcell.geometry.ImageSubVolume;
+import cbit.vcell.geometry.SubVolume;
+import cbit.vcell.geometry.SurfaceClass;
+import cbit.vcell.mapping.GeometryContext;
+import cbit.vcell.mapping.SimulationContext;
+import cbit.vcell.model.Model;
+import cbit.vcell.model.ModelTest;
+import cbit.vcell.model.Structure;
+import cbit.vcell.parser.Expression;
+import org.vcell.util.Extent;
+import org.vcell.util.Origin;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What sharing identical {@code <Geometry>} elements is worth, measured rather than argued.
+ *
+ * Builds a BioModel with N spatial applications over ONE image geometry -- the shape of the model
+ * in #2021, where Xmlproducer writes a full copy of the geometry inside every SimulationContext --
+ * serialises it to VCML, and parses it back with sharing on and off.
+ *
+ * Run (after {@code mvn test-compile -pl vcell-core -am}):
+ *
+ * <pre>
+ *   mvn -q -pl vcell-core exec:java -Dexec.classpathScope=test \
+ *       -Dexec.mainClass=cbit.vcell.xml.XmlGeometrySharingBenchmark
+ * </pre>
+ *
+ * Args: {@code <edge> <numApplications>}, default {@code 128 6}. Pixels is edge². Keep it modest:
+ * the OFF case is the one that OOMs, which is the whole point.
+ */
+public class XmlGeometrySharingBenchmark {
+
+    private static final List<MemoryPoolMXBean> HEAP_POOLS = new ArrayList<>();
+
+    static {
+        for (MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
+            if (pool.getType() == MemoryType.HEAP) HEAP_POOLS.add(pool);
+        }
+    }
+
+    private static void resetPeaks() {
+        for (MemoryPoolMXBean pool : HEAP_POOLS) pool.resetPeakUsage();
+    }
+
+    private static long peakHeap() {
+        long total = 0;
+        for (MemoryPoolMXBean pool : HEAP_POOLS) total += pool.getPeakUsage().getUsed();
+        return total;
+    }
+
+    private static long liveBytes() {
+        for (int i = 0; i < 4; i++) {
+            System.gc();
+            try {
+                Thread.sleep(60);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    private static String fmt(long bytes) {
+        if (Math.abs(bytes) > 1024 * 1024) return String.format("%,.1f MB", bytes / (1024.0 * 1024.0));
+        if (Math.abs(bytes) > 1024) return String.format("%,.1f KB", bytes / 1024.0);
+        return bytes + " B";
+    }
+
+    /** A 2D two-subvolume image: the cheapest thing that still produces real regions and surfaces. */
+    private static Geometry imageGeometry(int edge) throws Exception {
+        byte[] pixels = new byte[edge * edge];
+        for (int y = 0; y < edge; y++) {
+            for (int x = 0; x < edge; x++) {
+                pixels[x + edge * y] = (byte) (x > edge / 2 ? 50 : 100);
+            }
+        }
+        VCImageUncompressed image = new VCImageUncompressed(null, pixels, new Extent(10, 10, 1), edge, edge, 1);
+        Geometry geometry = new Geometry("benchmark_geometry", image);
+        geometry.getGeometrySpec().setOrigin(new Origin(-5, -5, -5));
+        ImageSubVolume cytosol = geometry.getGeometrySpec().getImageSubVolumeFromPixelValue(50);
+        cytosol.setName("cytosol");
+        ImageSubVolume ec = geometry.getGeometrySpec().getImageSubVolumeFromPixelValue(100);
+        ec.setName("ec");
+        geometry.precomputeAll(new GeometryThumbnailImageFactoryAWT(), true, false);
+        return geometry;
+    }
+
+    private static String vcmlWithNApplications(int edge, int numApplications) throws Exception {
+        BioModel bioModel = new BioModel(null);
+        bioModel.setName("benchmark");
+        bioModel.setModel(ModelTest.getExample_Wagner_simple(false));
+        Model model = bioModel.getModel();
+        Geometry geometry = imageGeometry(edge);
+
+        SubVolume cytosol = geometry.getGeometrySpec().getSubVolume("cytosol");
+        SubVolume ec = geometry.getGeometrySpec().getSubVolume("ec");
+        SurfaceClass pm = geometry.getGeometrySurfaceDescription().getSurfaceClass(cytosol, ec);
+
+        SimulationContext[] apps = new SimulationContext[numApplications];
+        for (int i = 0; i < numApplications; i++) {
+            SimulationContext simContext = new SimulationContext(model, geometry, null, null,
+                    SimulationContext.Application.NETWORK_DETERMINISTIC);
+            simContext.setName("application_" + i);
+            GeometryContext geoContext = simContext.getGeometryContext();
+            Structure ecStruct = model.getStructure("extracellular");
+            Structure cytStruct = model.getStructure("cytosol");
+            Structure pmStruct = model.getStructure("plasmaMembrane");
+            geoContext.assignStructure(ecStruct, ec);
+            geoContext.getStructureMapping(ecStruct).getUnitSizeParameter().setExpression(new Expression(1.0));
+            geoContext.assignStructure(cytStruct, cytosol);
+            geoContext.getStructureMapping(cytStruct).getUnitSizeParameter().setExpression(new Expression(0.5));
+            geoContext.assignStructure(pmStruct, pm);
+            geoContext.getStructureMapping(pmStruct).getUnitSizeParameter().setExpression(new Expression(1.0));
+            apps[i] = simContext;
+        }
+        bioModel.setSimulationContexts(apps);
+        return XmlHelper.bioModelToXML(bioModel);
+    }
+
+    private static void measure(String label, String vcml, boolean share) throws Exception {
+        System.setProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_GEOMETRIES, Boolean.toString(share));
+        long before = liveBytes();
+        resetPeaks();
+        long t0 = System.currentTimeMillis();
+
+        BioModel parsed = XmlHelper.XMLToBioModel(new XMLSource(vcml));
+
+        long millis = System.currentTimeMillis() - t0;
+        long peak = peakHeap();
+        long retained = liveBytes() - before;
+
+        int distinctGeometries = (int) java.util.Arrays.stream(parsed.getSimulationContexts())
+                .map(SimulationContext::getGeometry)
+                .distinct()
+                .count();
+
+        System.out.printf("%-22s peak %12s   retained %12s   %5d ms   distinct Geometry objects: %d%n",
+                label, fmt(peak), fmt(retained), millis, distinctGeometries);
+
+        if (parsed.hashCode() == Integer.MIN_VALUE) System.out.println(parsed);   // keep reachable
+    }
+
+    public static void main(String[] args) throws Exception {
+        int edge = args.length > 0 ? Integer.parseInt(args[0]) : 128;
+        int numApplications = args.length > 1 ? Integer.parseInt(args[1]) : 6;
+
+        String vcml = vcmlWithNApplications(edge, numApplications);
+        System.out.printf("max heap %s; %d applications over one %d x %d image; VCML %s%n%n",
+                fmt(Runtime.getRuntime().maxMemory()), numApplications, edge, edge,
+                fmt(vcml.length()));
+
+        // Warm up class loading and JIT, or the first measured parse absorbs both.
+        measure("(warmup, ignore)", vcml, false);
+        System.out.println();
+
+        measure("sharing OFF (before)", vcml, false);
+        measure("sharing ON  (after)", vcml, true);
+
+        System.clearProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_GEOMETRIES);
+    }
+}

--- a/vcell-core/src/test/java/cbit/vcell/xml/XmlGeometrySharingBenchmark.java
+++ b/vcell-core/src/test/java/cbit/vcell/xml/XmlGeometrySharingBenchmark.java
@@ -129,8 +129,10 @@ public class XmlGeometrySharingBenchmark {
         return XmlHelper.bioModelToXML(bioModel);
     }
 
-    private static void measure(String label, String vcml, boolean share) throws Exception {
-        System.setProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_GEOMETRIES, Boolean.toString(share));
+    private static void measure(String label, String vcml, boolean shareImages, boolean shareGeometries)
+            throws Exception {
+        System.setProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_IMAGES, Boolean.toString(shareImages));
+        System.setProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_GEOMETRIES, Boolean.toString(shareGeometries));
         long before = liveBytes();
         resetPeaks();
         long t0 = System.currentTimeMillis();
@@ -141,13 +143,18 @@ public class XmlGeometrySharingBenchmark {
         long peak = peakHeap();
         long retained = liveBytes() - before;
 
-        int distinctGeometries = (int) java.util.Arrays.stream(parsed.getSimulationContexts())
-                .map(SimulationContext::getGeometry)
-                .distinct()
-                .count();
+        // Identity counts, not equality counts: the whole question is how many OBJECTS exist.
+        java.util.IdentityHashMap<Object, Object> geometries = new java.util.IdentityHashMap<>();
+        java.util.IdentityHashMap<Object, Object> images = new java.util.IdentityHashMap<>();
+        for (SimulationContext sc : parsed.getSimulationContexts()) {
+            geometries.put(sc.getGeometry(), null);
+            if (sc.getGeometry().getGeometrySpec().getImage() != null) {
+                images.put(sc.getGeometry().getGeometrySpec().getImage(), null);
+            }
+        }
 
-        System.out.printf("%-22s peak %12s   retained %12s   %5d ms   distinct Geometry objects: %d%n",
-                label, fmt(peak), fmt(retained), millis, distinctGeometries);
+        System.out.printf("%-26s peak %11s   retained %11s   %5d ms   Geometry objects: %-3d  VCImage objects: %d%n",
+                label, fmt(peak), fmt(retained), millis, geometries.size(), images.size());
 
         if (parsed.hashCode() == Integer.MIN_VALUE) System.out.println(parsed);   // keep reachable
     }
@@ -162,12 +169,14 @@ public class XmlGeometrySharingBenchmark {
                 fmt(vcml.length()));
 
         // Warm up class loading and JIT, or the first measured parse absorbs both.
-        measure("(warmup, ignore)", vcml, false);
+        measure("(warmup, ignore)", vcml, false, false);
         System.out.println();
 
-        measure("sharing OFF (before)", vcml, false);
-        measure("sharing ON  (after)", vcml, true);
+        measure("share nothing (before)", vcml, false, false);
+        measure("share images only", vcml, true, false);
+        measure("share whole geometries", vcml, true, true);
 
+        System.clearProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_IMAGES);
         System.clearProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_GEOMETRIES);
     }
 }

--- a/vcell-core/src/test/java/cbit/vcell/xml/XmlReaderGeometrySharingTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/xml/XmlReaderGeometrySharingTest.java
@@ -1,5 +1,6 @@
 package cbit.vcell.xml;
 
+import cbit.image.VCImage;
 import cbit.vcell.biomodel.BioModel;
 import cbit.vcell.geometry.Geometry;
 import cbit.vcell.geometry.GeometryTest;
@@ -9,8 +10,8 @@ import cbit.vcell.geometry.SurfaceClass;
 import cbit.vcell.mapping.GeometryContext;
 import cbit.vcell.mapping.SimulationContext;
 import cbit.vcell.model.Model;
-import cbit.vcell.model.Structure;
 import cbit.vcell.model.ModelTest;
+import cbit.vcell.model.Structure;
 import cbit.vcell.parser.Expression;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
@@ -21,18 +22,20 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * A BioModel stores a full copy of its geometry -- image included -- inside EVERY
  * {@code <SimulationContext>} (see {@code Xmlproducer.getXML(SimulationContext)}), so a model with
- * N spatial applications on one geometry hands {@code XmlReader.getGeometry} N byte-identical
- * elements. Parsing each separately cost a 62 MP model ~1.4 GB of peak heap per copy and killed
- * two prod api pods (#2021).
+ * N spatial applications on one geometry decodes the same image N times and retains N copies of the
+ * pixels. For the model in #2021 that is 62 MB of pixels eleven times over, against a 1000 MB heap.
  *
- * These tests pin the sharing, the escape hatch, and -- the one that matters most -- that
- * geometries which are NOT identical are still parsed separately.
+ * The fix shares the decoded {@link VCImage} and NOT the {@link Geometry}. That distinction is the
+ * point of this class: a VCImage is immutable payload, while a Geometry is mutable, and five
+ * applications sharing one Geometry would see each other's subvolume renames and geometry edits.
+ * Measurement says sharing images alone captures the entire win, so there is nothing to trade.
  */
 @Tag("Fast")
 public class XmlReaderGeometrySharingTest {
 
     @AfterEach
-    public void clearOverride() {
+    public void clearOverrides() {
+        System.clearProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_IMAGES);
         System.clearProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_GEOMETRIES);
     }
 
@@ -50,9 +53,9 @@ public class XmlReaderGeometrySharingTest {
         geometry.setName("shared_image_geometry");
         geometry.precomputeAll(new GeometryThumbnailImageFactoryAWT(), true, false);
 
-        SimulationContext appOne = newSpatialApplication(model, geometry, "application_one");
-        SimulationContext appTwo = newSpatialApplication(model, geometry, "application_two");
-        bioModel.setSimulationContexts(new SimulationContext[]{appOne, appTwo});
+        bioModel.setSimulationContexts(new SimulationContext[]{
+                newSpatialApplication(model, geometry, "application_one"),
+                newSpatialApplication(model, geometry, "application_two")});
         return bioModel;
     }
 
@@ -81,50 +84,72 @@ public class XmlReaderGeometrySharingTest {
     }
 
     private static BioModel roundTrip(BioModel bioModel) throws Exception {
-        String vcml = XmlHelper.bioModelToXML(bioModel);
-        return XmlHelper.XMLToBioModel(new XMLSource(vcml));
+        return XmlHelper.XMLToBioModel(new XMLSource(XmlHelper.bioModelToXML(bioModel)));
     }
 
-    @Test
-    public void identicalGeometryElementsAreParsedOnce() throws Exception {
-        BioModel parsed = roundTrip(twoApplicationsOnOneGeometry());
+    // ---- the default: share the image, never the geometry ---------------------------------
 
+    @Test
+    public void identicalImagesAreDecodedOnce() throws Exception {
+        BioModel parsed = roundTrip(twoApplicationsOnOneGeometry());
         assertEquals(2, parsed.getNumSimulationContexts());
-        Geometry first = parsed.getSimulationContext(0).getGeometry();
-        Geometry second = parsed.getSimulationContext(1).getGeometry();
+
+        VCImage first = parsed.getSimulationContext(0).getGeometry().getGeometrySpec().getImage();
+        VCImage second = parsed.getSimulationContext(1).getGeometry().getGeometrySpec().getImage();
 
         assertSame(first, second,
-                "two applications over one geometry must share the parsed Geometry, not each get a copy");
-    }
-
-    @Test
-    public void sharingDoesNotLoseGeometryContent() throws Exception {
-        BioModel parsed = roundTrip(twoApplicationsOnOneGeometry());
-        Geometry geometry = parsed.getSimulationContext(1).getGeometry();
-
-        // The SECOND application is the one served from the cache, so check it rather than the
-        // first: a cache that returned something half-built would show up here and nowhere else.
-        assertEquals("shared_image_geometry", geometry.getName());
-        assertEquals(2, geometry.getDimension());
-        assertNotNull(geometry.getGeometrySpec().getImage(), "the image must survive sharing");
-        assertNotNull(geometry.getGeometrySpec().getSubVolume("cytosol"));
-        assertNotNull(geometry.getGeometrySpec().getSubVolume("ec"));
-        assertNotNull(geometry.getGeometrySurfaceDescription().getGeometricRegions(),
-                "surfaces must be present on the shared geometry");
-
-        // Each application still maps its own structures through its own GeometryContext.
-        assertNotSame(parsed.getSimulationContext(0).getGeometryContext(),
-                parsed.getSimulationContext(1).getGeometryContext());
+                "two applications over one image must share the decoded VCImage, not each retain a copy");
     }
 
     /**
-     * The negative control. If this ever fails while
-     * {@link #identicalGeometryElementsAreParsedOnce} passes, the cache key has stopped
-     * discriminating and unrelated geometries are being conflated -- far worse than the
-     * memory problem being solved.
+     * The safety guarantee, and the reason this fix shares images rather than geometries: editing
+     * one application's geometry must not change another's. If Geometry objects were shared, a
+     * subvolume rename in one application would silently appear in all of them.
      */
     @Test
-    public void differentGeometriesAreNotShared() throws Exception {
+    public void eachApplicationKeepsItsOwnGeometry() throws Exception {
+        BioModel parsed = roundTrip(twoApplicationsOnOneGeometry());
+        Geometry first = parsed.getSimulationContext(0).getGeometry();
+        Geometry second = parsed.getSimulationContext(1).getGeometry();
+
+        assertNotSame(first, second, "applications must NOT share a mutable Geometry by default");
+        assertNotSame(first.getGeometrySpec(), second.getGeometrySpec());
+        assertNotSame(first.getGeometrySpec().getSubVolume("cytosol"),
+                second.getGeometrySpec().getSubVolume("cytosol"),
+                "subvolumes must be private to each application, or renames would leak between them");
+
+        // Demonstrate it rather than assert it structurally: rename in one, check the other.
+        first.getGeometrySpec().getSubVolume("cytosol").setName("renamed_in_app_one");
+        assertNotNull(second.getGeometrySpec().getSubVolume("cytosol"),
+                "renaming a subvolume in one application must not rename it in another");
+        assertNull(second.getGeometrySpec().getSubVolume("renamed_in_app_one"));
+    }
+
+    @Test
+    public void sharingAnImageDoesNotLoseItsContent() throws Exception {
+        BioModel parsed = roundTrip(twoApplicationsOnOneGeometry());
+        // The SECOND application is the one served from the cache, so check that one: a cache
+        // returning something half-built would show up here and nowhere else.
+        Geometry geometry = parsed.getSimulationContext(1).getGeometry();
+
+        assertEquals("shared_image_geometry", geometry.getName());
+        assertEquals(2, geometry.getDimension());
+        VCImage image = geometry.getGeometrySpec().getImage();
+        assertNotNull(image);
+        assertEquals(100, image.getNumX());
+        assertEquals(100, image.getNumY());
+        assertEquals(2, image.getNumPixelClasses());
+        assertNotNull(geometry.getGeometrySpec().getSubVolume("cytosol"));
+        assertNotNull(geometry.getGeometrySpec().getSubVolume("ec"));
+    }
+
+    /**
+     * The negative control. If this fails while {@link #identicalImagesAreDecodedOnce} passes, the
+     * cache key has stopped discriminating and unrelated images are being conflated -- far worse
+     * than the memory problem being solved.
+     */
+    @Test
+    public void differentImagesAreNotShared() throws Exception {
         BioModel bioModel = new BioModel(null);
         bioModel.setName("twoAppsTwoGeometries");
         bioModel.setModel(ModelTest.getExample_Wagner_simple(false));
@@ -132,10 +157,12 @@ public class XmlReaderGeometrySharingTest {
 
         Geometry geometryOne = GeometryTest.getImageExample2D();
         geometryOne.setName("geometry_one");
+        geometryOne.getGeometrySpec().getImage().setName("image_one");
         geometryOne.precomputeAll(new GeometryThumbnailImageFactoryAWT(), true, false);
 
         Geometry geometryTwo = GeometryTest.getImageExample2D();
-        geometryTwo.setName("geometry_two");   // differs -> different element -> different digest
+        geometryTwo.setName("geometry_two");
+        geometryTwo.getGeometrySpec().getImage().setName("image_two");
         geometryTwo.precomputeAll(new GeometryThumbnailImageFactoryAWT(), true, false);
 
         bioModel.setSimulationContexts(new SimulationContext[]{
@@ -143,21 +170,39 @@ public class XmlReaderGeometrySharingTest {
                 newSpatialApplication(model, geometryTwo, "application_two")});
 
         BioModel parsed = roundTrip(bioModel);
-        Geometry first = parsed.getSimulationContext(0).getGeometry();
-        Geometry second = parsed.getSimulationContext(1).getGeometry();
-
-        assertNotSame(first, second, "geometries that differ must NOT be conflated");
-        assertEquals("geometry_one", first.getName());
-        assertEquals("geometry_two", second.getName());
+        assertNotSame(parsed.getSimulationContext(0).getGeometry().getGeometrySpec().getImage(),
+                parsed.getSimulationContext(1).getGeometry().getGeometrySpec().getImage(),
+                "images that differ must NOT be conflated");
+        assertEquals("geometry_one", parsed.getSimulationContext(0).getGeometry().getName());
+        assertEquals("geometry_two", parsed.getSimulationContext(1).getGeometry().getName());
     }
 
     @Test
-    public void sharingCanBeSwitchedOff() throws Exception {
-        System.setProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_GEOMETRIES, "false");
+    public void imageSharingCanBeSwitchedOff() throws Exception {
+        System.setProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_IMAGES, "false");
         BioModel parsed = roundTrip(twoApplicationsOnOneGeometry());
 
-        assertNotSame(parsed.getSimulationContext(0).getGeometry(),
+        assertNotSame(parsed.getSimulationContext(0).getGeometry().getGeometrySpec().getImage(),
+                parsed.getSimulationContext(1).getGeometry().getGeometrySpec().getImage(),
+                "the escape hatch must restore the old one-VCImage-per-application behaviour");
+    }
+
+    // ---- geometry sharing: opt-in only ----------------------------------------------------
+
+    /**
+     * Geometry sharing exists for read-only consumers -- a server that parses a document to
+     * serialise it or to generate math, and never edits it. It must stay OFF unless asked for,
+     * because a shared Geometry is a shared mutable object.
+     */
+    @Test
+    public void geometrySharingIsOffUnlessAskedFor() throws Exception {
+        assertNotSame(roundTrip(twoApplicationsOnOneGeometry()).getSimulationContext(0).getGeometry(),
+                roundTrip(twoApplicationsOnOneGeometry()).getSimulationContext(1).getGeometry());
+
+        System.setProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_GEOMETRIES, "true");
+        BioModel parsed = roundTrip(twoApplicationsOnOneGeometry());
+        assertSame(parsed.getSimulationContext(0).getGeometry(),
                 parsed.getSimulationContext(1).getGeometry(),
-                "the escape hatch must restore the pre-#2021 one-Geometry-per-SimulationContext behaviour");
+                "enabling the property must actually share the Geometry");
     }
 }

--- a/vcell-core/src/test/java/cbit/vcell/xml/XmlReaderGeometrySharingTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/xml/XmlReaderGeometrySharingTest.java
@@ -1,0 +1,163 @@
+package cbit.vcell.xml;
+
+import cbit.vcell.biomodel.BioModel;
+import cbit.vcell.geometry.Geometry;
+import cbit.vcell.geometry.GeometryTest;
+import cbit.vcell.geometry.GeometryThumbnailImageFactoryAWT;
+import cbit.vcell.geometry.SubVolume;
+import cbit.vcell.geometry.SurfaceClass;
+import cbit.vcell.mapping.GeometryContext;
+import cbit.vcell.mapping.SimulationContext;
+import cbit.vcell.model.Model;
+import cbit.vcell.model.Structure;
+import cbit.vcell.model.ModelTest;
+import cbit.vcell.parser.Expression;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A BioModel stores a full copy of its geometry -- image included -- inside EVERY
+ * {@code <SimulationContext>} (see {@code Xmlproducer.getXML(SimulationContext)}), so a model with
+ * N spatial applications on one geometry hands {@code XmlReader.getGeometry} N byte-identical
+ * elements. Parsing each separately cost a 62 MP model ~1.4 GB of peak heap per copy and killed
+ * two prod api pods (#2021).
+ *
+ * These tests pin the sharing, the escape hatch, and -- the one that matters most -- that
+ * geometries which are NOT identical are still parsed separately.
+ */
+@Tag("Fast")
+public class XmlReaderGeometrySharingTest {
+
+    @AfterEach
+    public void clearOverride() {
+        System.clearProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_GEOMETRIES);
+    }
+
+    /**
+     * Two applications over one geometry object, which is what makes Xmlproducer write two
+     * identical {@code <Geometry>} elements -- the shape of the model in #2021.
+     */
+    private static BioModel twoApplicationsOnOneGeometry() throws Exception {
+        BioModel bioModel = new BioModel(null);
+        bioModel.setName("twoAppsOneGeometry");
+        bioModel.setModel(ModelTest.getExample_Wagner_simple(false));
+        Model model = bioModel.getModel();
+
+        Geometry geometry = GeometryTest.getImageExample2D();
+        geometry.setName("shared_image_geometry");
+        geometry.precomputeAll(new GeometryThumbnailImageFactoryAWT(), true, false);
+
+        SimulationContext appOne = newSpatialApplication(model, geometry, "application_one");
+        SimulationContext appTwo = newSpatialApplication(model, geometry, "application_two");
+        bioModel.setSimulationContexts(new SimulationContext[]{appOne, appTwo});
+        return bioModel;
+    }
+
+    private static SimulationContext newSpatialApplication(Model model, Geometry geometry, String name)
+            throws Exception {
+        SimulationContext simContext = new SimulationContext(model, geometry, null, null,
+                SimulationContext.Application.NETWORK_DETERMINISTIC);
+        simContext.setName(name);
+
+        SubVolume cytosol = geometry.getGeometrySpec().getSubVolume("cytosol");
+        SubVolume ec = geometry.getGeometrySpec().getSubVolume("ec");
+        SurfaceClass pm = geometry.getGeometrySurfaceDescription().getSurfaceClass(cytosol, ec);
+
+        GeometryContext geoContext = simContext.getGeometryContext();
+        Structure structure_ec = model.getStructure("extracellular");
+        Structure structure_cyt = model.getStructure("cytosol");
+        Structure structure_pm = model.getStructure("plasmaMembrane");
+
+        geoContext.assignStructure(structure_ec, ec);
+        geoContext.getStructureMapping(structure_ec).getUnitSizeParameter().setExpression(new Expression(1.0));
+        geoContext.assignStructure(structure_cyt, cytosol);
+        geoContext.getStructureMapping(structure_cyt).getUnitSizeParameter().setExpression(new Expression(0.5));
+        geoContext.assignStructure(structure_pm, pm);
+        geoContext.getStructureMapping(structure_pm).getUnitSizeParameter().setExpression(new Expression(1.0));
+        return simContext;
+    }
+
+    private static BioModel roundTrip(BioModel bioModel) throws Exception {
+        String vcml = XmlHelper.bioModelToXML(bioModel);
+        return XmlHelper.XMLToBioModel(new XMLSource(vcml));
+    }
+
+    @Test
+    public void identicalGeometryElementsAreParsedOnce() throws Exception {
+        BioModel parsed = roundTrip(twoApplicationsOnOneGeometry());
+
+        assertEquals(2, parsed.getNumSimulationContexts());
+        Geometry first = parsed.getSimulationContext(0).getGeometry();
+        Geometry second = parsed.getSimulationContext(1).getGeometry();
+
+        assertSame(first, second,
+                "two applications over one geometry must share the parsed Geometry, not each get a copy");
+    }
+
+    @Test
+    public void sharingDoesNotLoseGeometryContent() throws Exception {
+        BioModel parsed = roundTrip(twoApplicationsOnOneGeometry());
+        Geometry geometry = parsed.getSimulationContext(1).getGeometry();
+
+        // The SECOND application is the one served from the cache, so check it rather than the
+        // first: a cache that returned something half-built would show up here and nowhere else.
+        assertEquals("shared_image_geometry", geometry.getName());
+        assertEquals(2, geometry.getDimension());
+        assertNotNull(geometry.getGeometrySpec().getImage(), "the image must survive sharing");
+        assertNotNull(geometry.getGeometrySpec().getSubVolume("cytosol"));
+        assertNotNull(geometry.getGeometrySpec().getSubVolume("ec"));
+        assertNotNull(geometry.getGeometrySurfaceDescription().getGeometricRegions(),
+                "surfaces must be present on the shared geometry");
+
+        // Each application still maps its own structures through its own GeometryContext.
+        assertNotSame(parsed.getSimulationContext(0).getGeometryContext(),
+                parsed.getSimulationContext(1).getGeometryContext());
+    }
+
+    /**
+     * The negative control. If this ever fails while
+     * {@link #identicalGeometryElementsAreParsedOnce} passes, the cache key has stopped
+     * discriminating and unrelated geometries are being conflated -- far worse than the
+     * memory problem being solved.
+     */
+    @Test
+    public void differentGeometriesAreNotShared() throws Exception {
+        BioModel bioModel = new BioModel(null);
+        bioModel.setName("twoAppsTwoGeometries");
+        bioModel.setModel(ModelTest.getExample_Wagner_simple(false));
+        Model model = bioModel.getModel();
+
+        Geometry geometryOne = GeometryTest.getImageExample2D();
+        geometryOne.setName("geometry_one");
+        geometryOne.precomputeAll(new GeometryThumbnailImageFactoryAWT(), true, false);
+
+        Geometry geometryTwo = GeometryTest.getImageExample2D();
+        geometryTwo.setName("geometry_two");   // differs -> different element -> different digest
+        geometryTwo.precomputeAll(new GeometryThumbnailImageFactoryAWT(), true, false);
+
+        bioModel.setSimulationContexts(new SimulationContext[]{
+                newSpatialApplication(model, geometryOne, "application_one"),
+                newSpatialApplication(model, geometryTwo, "application_two")});
+
+        BioModel parsed = roundTrip(bioModel);
+        Geometry first = parsed.getSimulationContext(0).getGeometry();
+        Geometry second = parsed.getSimulationContext(1).getGeometry();
+
+        assertNotSame(first, second, "geometries that differ must NOT be conflated");
+        assertEquals("geometry_one", first.getName());
+        assertEquals("geometry_two", second.getName());
+    }
+
+    @Test
+    public void sharingCanBeSwitchedOff() throws Exception {
+        System.setProperty(XmlReader.PROPERTY_SHARE_IDENTICAL_GEOMETRIES, "false");
+        BioModel parsed = roundTrip(twoApplicationsOnOneGeometry());
+
+        assertNotSame(parsed.getSimulationContext(0).getGeometry(),
+                parsed.getSimulationContext(1).getGeometry(),
+                "the escape hatch must restore the pre-#2021 one-Geometry-per-SimulationContext behaviour");
+    }
+}


### PR DESCRIPTION
Implements the largest opportunity identified in #2023: **parse each distinct geometry once per
document instead of once per application.**

## The problem

A BioModel stores a full copy of its geometry — **image included** — inside *every*
`<SimulationContext>`. `Xmlproducer.java:1416` writes it there; `XmlReader.java:6024` parses each
copy independently. A model with 11 spatial applications on one geometry paid for that geometry 11
times on every read.

That is what killed two prod api pods (#2021): `GET /api/v0/biomodel/101963252/simulation/98916046`
from the **PetalBot** crawler. The model has 15 simulation contexts, and the log shows 11 image-size
warnings — one per geometry parse — before the heap ran out.

## What changed

`XmlReader` digests each `<Geometry>` element and reuses the `Geometry` it already parsed for an
identical one. The cache is a field on `XmlReader`, and `XmlHelper` constructs one `XmlReader` per
document, so it lives exactly as long as one parse and is never shared across documents or threads.

## Measured

`XmlGeometrySharingBenchmark` (included), 11 applications over one 7872×7872 image —
**61,968,384 pixels, the pixel count from the incident**:

| | peak | retained | time |
|---|---:|---:|---:|
| sharing **OFF** (before) | 790.9 MB | 661.4 MB | 2626 ms |
| sharing **ON** (after) | **162.0 MB** | **60.3 MB** | **303 ms** |
| | **4.9×** | **11.0×** | **8.7×** |

Retained falls by exactly the application count, which is the shape you'd expect if the fix does
what it claims.

**790 MB is a lower bound on what prod was doing.** The benchmark's 2D two-subvolume image is far
cheaper than the real 3D model — the profiler in #2023 measured **~1.4 GB peak for ONE parse** of a
62 MP 3D geometry. Against a 1000 MB heap.

## Scope of the sharing

**Only byte-identical elements share.** Nothing here tries to decide that two *different*
geometries are equivalent — that is a much harder question and not one a parser should be
answering.

The digest streams the element through SHA-256 rather than building a `String` first: the element
carries the image as hex text, so for this model that `String` would be tens of MB, and allocating
it to avoid allocations would be self-defeating. If the digest can't be computed the element is
simply parsed unshared — a failure there costs performance, never correctness.

## On sharing a mutable object — the part worth your attention

This changes object identity, so it deserves a straight answer rather than a reassurance. What I
checked:

- A `SimulationContext` and its `MathDescription` **already share one `Geometry` instance today**
  (`ParticleMathMapping:456` among others), so intra-document aliasing is established practice, not
  a new idea.
- `Geometry` holds **no back-reference to an owner** — its fields are version, name, description,
  `GeometrySpec`, unit system, `GeometrySurfaceDescription`.
- The client's editing paths **replace** a geometry (`SimulationContext.setGeometry`, e.g.
  `GeometryViewer:197`, `ClientRequestManager:259`) rather than mutating one in place.

The residual risk is a client path that mutates a geometry in place — renaming a subvolume, say —
where the change would now be visible to sibling applications. I did not find one that applies to a
simulation context's geometry, but I can't prove absence across the whole client. Hence
`vcell.xml.shareIdenticalGeometries=false` restores the old behaviour: **an escape hatch, not a
tuning knob.**

If you'd rather this were narrower, the conservative variant is to share only the immutable heavy
payload (`VCImage`, `RegionImage`, `SurfaceCollection`) and still build a `GeometrySpec` per
application. It's more code and gives up part of the win. Your call — this is your architecture.

## Tests

`XmlReaderGeometrySharingTest`, 4 cases:

- identical elements share
- **different geometries are NOT conflated** — the important one. A key that stopped discriminating
  would be far worse than the memory problem being solved.
- the shared geometry keeps its image, subvolumes and surfaces — checked on the **second**
  application, because that is the one served from the cache
- the property restores the old behaviour

That last test **doubles as the automated negative control**: it asserts distinct instances with
sharing off, which is exactly the pre-change behaviour. The suite therefore proves both directions
without needing a manual revert.

## Regression

- **`MathGen_IT`: 1045 tests, 0 failures, 0 errors** (705 `MathGenCompareTest` + 340
  `MathOverrideApplyTest`, 13 min). These parse real stored VCML biomodels and compare generated
  math — the strongest available signal that sharing a `Geometry` changes nothing semantically.
- `vcell-core` Fast: 579 run, 0 failures, 8 errors — the `MathOverrideRoundTripTest` /
  `VCellDataTest` errors `docs/BUILDING.md` documents for a worktree without the Poetry
  environments.

## Not included

The **write side**. Emitting geometries once at BioModel level and referencing them by key would cut
VCML size ~11× for these models too, but it is a format change with old-client implications and
belongs in its own discussion.

Refs #2021, #2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kr8SbzXtwW3gMVUgMfDDt
