### PR TITLE
fix(geometry): stop GeometrySpec pinning the image's inflated pixel array

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/geometry/GeometrySpec.java
+++ b/vcell-core/src/main/java/cbit/vcell/geometry/GeometrySpec.java
@@ -64,7 +64,6 @@ public class GeometrySpec implements Matchable, PropertyChangeListener, Vetoable
 	private static final Logger lg = LogManager.getLogger(GeometrySpec.class);
 	
 	private VCImage vcImage = null;
-	private transient byte[] uncompressedPixels = null;
 	private transient State<VCImage> sampledImage = new State<VCImage>(null);
 	private transient State<ThumbnailImage> thumbnailImage = new State<ThumbnailImage>(null);
 	
@@ -957,12 +956,25 @@ public SubVolume getSubVolumes(int index) {
  * @return byte[]
  */
 byte[] getUncompressedPixels() throws cbit.image.ImageException {
-	if (uncompressedPixels==null){
-		if (getImage()!=null){
-			uncompressedPixels = getImage().getPixels();
-		}
+	//
+	// Deliberately NOT cached here. This used to hold the array in a transient field, which made
+	// GeometrySpec a SECOND strong reference to the very same array that VCImageCompressed already
+	// caches -- so the inflated pixels stayed reachable for as long as the geometry did, whatever
+	// the image did with its own copy. At 62 MP that is 62 MB pinned per geometry (#2021), and it
+	// would defeat any later attempt to make the image's own cache reclaimable.
+	//
+	// Nothing is lost by delegating: VCImageCompressed.getPixels() already caches the inflated
+	// array and VCImageUncompressed.getPixels() returns its field directly, so this is a virtual
+	// call and a null check rather than a re-inflate.
+	//
+	// The path this feeds is cold in any case. The only caller that reaches an ImageSubVolume is
+	// getSubVolume(x,y,z), whose sole caller is curveSatisfyGeometryConstraints -- 100 sampled
+	// points per curve.
+	//
+	if (getImage()==null){
+		return null;
 	}
-	return uncompressedPixels;
+	return getImage().getPixels();
 }
 
 
@@ -1186,7 +1198,6 @@ public void setImage(VCImage image) throws PropertyVetoException {
 	//
 	
 	if (this.vcImage != image){
-		uncompressedPixels = null;
 		if (image!=null){
 			setExtent(image.getExtent());
 			if (image.getNumY()==1 && image.getNumZ()==1){

--- a/vcell-core/src/test/java/cbit/vcell/geometry/GeometrySpecPixelRetentionTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/geometry/GeometrySpecPixelRetentionTest.java
@@ -1,0 +1,136 @@
+package cbit.vcell.geometry;
+
+import cbit.image.VCImage;
+import cbit.image.VCImageCompressed;
+import cbit.image.VCImageUncompressed;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.vcell.util.Extent;
+
+import java.lang.ref.WeakReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * GeometrySpec must not hold its own reference to the image's inflated pixel array.
+ *
+ * It used to: a transient {@code uncompressedPixels} field cached
+ * {@code getImage().getPixels()}, making GeometrySpec a second strong reference to the very same
+ * array {@link VCImageCompressed} already caches. The inflated pixels then stayed reachable for as
+ * long as the geometry did, whatever the image did with its own copy — 62 MB per geometry at the
+ * size that killed two prod api pods (#2021), and the thing that would defeat any later attempt to
+ * make the image's own cache reclaimable.
+ *
+ * These tests assert reachability rather than structure, so they would still catch the problem if
+ * the reference came back somewhere other than that field.
+ */
+@Tag("Fast")
+public class GeometrySpecPixelRetentionTest {
+
+    private static final int EDGE = 40;             // 64,000 px — enough to be a real array
+
+    private static VCImageCompressed compressedImage() throws Exception {
+        byte[] pixels = new byte[EDGE * EDGE * EDGE];
+        for (int i = 0; i < pixels.length; i++) {
+            pixels[i] = (byte) (i % 3);             // compressible, and >1 pixel class
+        }
+        VCImageUncompressed raw = new VCImageUncompressed(null, pixels, new Extent(1, 1, 1),
+                EDGE, EDGE, EDGE);
+        return new VCImageCompressed(raw);
+    }
+
+    /** Ask the collector several times; one call is not a guarantee. */
+    private static void collect() {
+        for (int i = 0; i < 6; i++) {
+            System.gc();
+            try {
+                Thread.sleep(30);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * The regression this fix is for. Once the image drops its own cache, nothing should keep the
+     * inflated array alive — before the fix, GeometrySpec did.
+     */
+    @Test
+    public void geometrySpecDoesNotPinTheInflatedPixels() throws Exception {
+        VCImageCompressed image = compressedImage();
+        GeometrySpec spec = new GeometrySpec("retention", image);
+
+        byte[] pixels = spec.getUncompressedPixels();
+        assertNotNull(pixels);
+        assertEquals(EDGE * EDGE * EDGE, pixels.length);
+
+        WeakReference<byte[]> watch = new WeakReference<>(pixels);
+        pixels = null;
+        image.nullifyUncompressedPixels();          // the image releases its own cache
+        collect();
+
+        // assertTrue, not assertNull: on failure assertNull renders the whole 64,000-byte array
+        // into the message, which buries the actual problem under 375 KB of output.
+        assertTrue(watch.get() == null,
+                "GeometrySpec must not hold a second reference to the image's inflated pixels");
+
+        // and the geometry is still usable afterwards — the array is regenerated on demand
+        assertNotNull(spec.getImage(), "the spec must still hold the image itself");
+        assertEquals(EDGE * EDGE * EDGE, spec.getUncompressedPixels().length,
+                "the pixels must be recoverable after the cache was dropped");
+    }
+
+    /**
+     * The negative control for the test above: while the image is still holding its own cache the
+     * array must NOT be collectable. Without this, a test that always passed — because nothing ever
+     * kept the array — would look like a working fix.
+     */
+    @Test
+    public void theImagesOwnCacheStillPinsThePixels() throws Exception {
+        VCImageCompressed image = compressedImage();
+        GeometrySpec spec = new GeometrySpec("retention", image);
+
+        byte[] pixels = spec.getUncompressedPixels();
+        WeakReference<byte[]> watch = new WeakReference<>(pixels);
+        pixels = null;
+        collect();                                   // note: no nullifyUncompressedPixels()
+
+        assertTrue(watch.get() != null,
+                "while VCImageCompressed still caches the pixels they must stay reachable — "
+                        + "if this fails the other test proves nothing");
+        assertNotNull(image);
+    }
+
+    @Test
+    public void repeatedCallsReturnTheImagesCachedArray() throws Exception {
+        VCImage image = compressedImage();
+        GeometrySpec spec = new GeometrySpec("identity", image);
+
+        // Delegating rather than caching must not mean re-inflating on every call: the image's own
+        // cache should hand back the same array.
+        assertSame(spec.getUncompressedPixels(), spec.getUncompressedPixels());
+        assertSame(image.getPixels(), spec.getUncompressedPixels(),
+                "the spec should hand back the image's array, not a copy of it");
+    }
+
+    @Test
+    public void contentSurvivesTheRoundTrip() throws Exception {
+        VCImageCompressed image = compressedImage();
+        GeometrySpec spec = new GeometrySpec("content", image);
+
+        byte[] before = spec.getUncompressedPixels().clone();
+        image.nullifyUncompressedPixels();
+        byte[] after = spec.getUncompressedPixels();
+
+        assertArrayEquals(before, after,
+                "re-inflating after the cache was dropped must reproduce the same pixels");
+    }
+
+    @Test
+    public void aGeometryWithoutAnImageIsUnaffected() throws Exception {
+        GeometrySpec spec = new GeometrySpec("analytic", 3);
+        assertNull(spec.getImage());
+        assertNull(spec.getUncompressedPixels(),
+                "a non-image geometry must still return null rather than throwing");
+    }
+}


### PR DESCRIPTION
Removes the one blocker identified by the `getPixels()` audit (#2025 §3.8).

`GeometrySpec` cached `getImage().getPixels()` in a transient `uncompressedPixels` field, making it
a **second strong reference to the very same array `VCImageCompressed` already caches**. The
inflated pixels then stayed reachable for as long as the geometry did, whatever the image did with
its own copy — **62 MB pinned per geometry** at the size that killed two prod api pods (#2021).

## Why removing it is safe rather than a trade

**The cache was redundant.** `VCImageCompressed.getPixels()` already caches the inflated array, and
`VCImageUncompressed.getPixels()` returns its field directly. Delegating costs a virtual call and a
null check — not a re-inflate. The field only ever added a second reference.

**And it fed a cold path.** The audit established that the only caller reaching an `ImageSubVolume`
is `getSubVolume(x,y,z)`, whose sole caller is `curveSatisfyGeometryConstraints` — **100 sampled
points per curve**. The other call site, `GeometrySpec:898`, is a diagnostic that prints
*"there was no subVolume defined"*. Nothing here runs per-pixel over a volume.

(That mattered because the audit's other finding was a thrash hazard on per-pixel access. It turns
out not to apply to this particular field.)

## Tests assert reachability, not structure

So they still catch the problem if the reference reappears somewhere other than that field:

```java
WeakReference<byte[]> watch = new WeakReference<>(pixels);
pixels = null;
image.nullifyUncompressedPixels();   // the image releases its own cache
collect();
assertTrue(watch.get() == null, "GeometrySpec must not hold a second reference ...");
```

`theImagesOwnCacheStillPinsThePixels` is the **negative control for the control** — it asserts the
array is *not* collectable while the image still caches it. Without that, a test which always passed
because nothing ever retained the array would look like a working fix.

**Verified the suite detects the defect.** With the old caching field restored:

```
geometrySpecDoesNotPinTheInflatedPixels
  GeometrySpec must not hold a second reference to the image's inflated pixels
  ==> expected: <null> but was: <[0, 1, 2, 0, 1, 2, ...]>
Tests run: 5, Failures: 1
```

The other four passed. That failure also exposed a usability problem worth fixing: `assertNull`
rendered the whole 64,000-byte array into the message — **375 KB of output** burying the actual
assertion — so the two reachability assertions now use `assertTrue` on an explicit comparison.

## A note on the diff

`GeometrySpec.java` is **CRLF** (1445 CRLF lines, no bare LF). My first edit went through Python's
text mode and silently rewrote every line ending, turning a 10-line change into a **2900-line diff**.
Redone in binary mode; `git diff --stat` now reads **18 insertions / 7 deletions**, which is what it
should have been.

## Verification

- `GeometrySpecPixelRetentionTest`: 5/5.
- **`MathGen_IT`: 1045 tests, 0 failures, 0 errors** — 705 math-generation comparisons over real
  stored VCML. Re-run clean after the binary-mode patch; an earlier run was recompiled mid-flight
  and discarded rather than reported.
- `vcell-core` Fast: 580 run, 0 failures, 8 errors — the `MathOverrideRoundTripTest` /
  `VCellDataTest` errors `docs/BUILDING.md` documents for a worktree without the Poetry
  environments.

## Relationship to the other branches

This stands on its own — it removes a redundant reference to a 62 MB array. It is also a
**prerequisite** for #2025 §5.3b: making `VCImageCompressed.uncompressed` a `SoftReference` would
do nothing while a second strong reference pinned the array regardless.

Unlike #2022 / #2023 / #2024, this one is small, self-contained, and does not depend on any of the
decisions still open in #2025.

Refs #2021, #2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kr8SbzXtwW3gMVUgMfDDt
