### PR TITLE
perf(image): hold inflated pixels softly so the heap can reclaim them

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/ClientRequestManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ClientRequestManager.java
@@ -1166,8 +1166,10 @@ private BioModel createDefaultBioModelDocument(BngUnitSystem bngUnitSystem) thro
 	private static FieldData createFDOSFromVCImage(VCImage dbImage) throws ImageException {
 		int[] temp = new int[256];
 		short[] templateShorts = new short[dbImage.getNumXYZ()];
-		for (int i = 0; i < dbImage.getPixels().length; i++) {
-			templateShorts[i] = (short) (0x00FF & dbImage.getPixels()[i]);
+		// hoisted: dbImage may be a VCImageCompressed whose pixels are only softly reachable
+		byte[] dbPixels = dbImage.getPixels();
+		for (int i = 0; i < dbPixels.length; i++) {
+			templateShorts[i] = (short) (0x00FF & dbPixels[i]);
 			temp[templateShorts[i]]++;
 		}
 		for (int j = 0; j < dbImage.getPixelClasses().length; j++) {

--- a/vcell-core/src/main/java/cbit/image/ImageFile.java
+++ b/vcell-core/src/main/java/cbit/image/ImageFile.java
@@ -146,12 +146,14 @@ private void createFromVCImage(VCImage vcImage) throws ImageException {
 	sizeX = vcImage.getNumX();
 	sizeY = vcImage.getNumY();
 	sizeZ = vcImage.getNumZ();
-	if (sizeX*sizeY*sizeZ!=vcImage.getPixels().length){
+	// hoisted: vcImage may be a VCImageCompressed whose pixels are only softly reachable
+	byte[] vcImagePixels = vcImage.getPixels();
+	if (sizeX*sizeY*sizeZ!=vcImagePixels.length){
 		throw new ImageException("pixelData not properly formed");
 	}
 	originalRGB = new int[sizeX*sizeY*sizeZ];
-	for (int i=0;i<vcImage.getPixels().length;i++){
-		int pixel = ((int)vcImage.getPixels()[i])&0xff;
+	for (int i=0;i<vcImagePixels.length;i++){
+		int pixel = ((int)vcImagePixels[i])&0xff;
 		originalRGB[i] = new java.awt.Color(pixel,pixel,pixel).getRGB();
 	}
 	bValid = true;

--- a/vcell-core/src/main/java/cbit/image/VCImageCompressed.java
+++ b/vcell-core/src/main/java/cbit/image/VCImageCompressed.java
@@ -11,8 +11,11 @@
 package cbit.image;
 
 import java.io.IOException;
+import java.lang.ref.SoftReference;
 import java.security.MessageDigest;
 import java.util.zip.DataFormatException;
+
+import cbit.vcell.resource.PropertyLoader;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,7 +27,29 @@ import org.vcell.util.Hex;
 @SuppressWarnings("serial")
 public class VCImageCompressed extends VCImage {
 	private final byte compressedPixels[];
-	private transient byte uncompressed[] = null;
+
+	/**
+	 * Set false to hold the inflated pixels strongly, as this class did before #2021.
+	 * An escape hatch, not a tuning knob.
+	 */
+	public final static String PROPERTY_SOFT_PIXEL_CACHE = "vcell.image.softPixelCache";
+
+	/**
+	 * The inflated pixels, held SOFTLY: the collector may reclaim them when the heap is under
+	 * pressure, and {@link #getPixels()} re-inflates from {@link #compressedPixels} on demand.
+	 * Real geometry images compress 50-100x, so what is retained between uses is the compressed
+	 * form -- roughly 1 MB rather than 62 MB for the image in #2021.
+	 *
+	 * SOFT, deliberately, not weak. A weak reference is cleared at the next GC whatever the heap
+	 * looks like, so a geometry in active use would re-inflate on essentially every collection.
+	 * Soft references are cleared only under actual memory pressure, and the JVM ages them by
+	 * -XX:SoftRefLRUPolicyMSPerMB, which is the behaviour wanted here: free under duress, free of
+	 * charge otherwise.
+	 */
+	private transient SoftReference<byte[]> softPixels = null;
+
+	/** Used instead of {@link #softPixels} when soft caching is switched off. */
+	private transient byte[] strongPixels = null;
 	private static Logger lg = LogManager.getLogger(VCImageCompressed.class);
 /**
  * This method was created in VisualAge.
@@ -49,21 +74,40 @@ public VCImageCompressed(org.vcell.util.document.Version aVersion, byte pixels[]
 	}
 }
 public void nullifyUncompressedPixels(){
-	uncompressed = null;
+	softPixels = null;
+	strongPixels = null;
 }
 
 /**
  * getPixels method comment.
  */
 public byte[] getPixels() throws ImageException {
-	try {
-		if (uncompressed == null){
-			uncompressed = VCImage.inflate(compressedPixels,getNumXYZ());
+	//
+	// Take a STRONG local reference first and hold it for the whole method: reading the
+	// SoftReference twice would let the collector clear it between the null check and the
+	// return, and hand the caller a null array.
+	//
+	byte[] pixels = strongPixels;
+	if (pixels == null){
+		SoftReference<byte[]> ref = softPixels;
+		if (ref != null){
+			pixels = ref.get();
 		}
-		return uncompressed;
+	}
+	if (pixels != null){
+		return pixels;
+	}
+	try {
+		pixels = VCImage.inflate(compressedPixels,getNumXYZ());
 	} catch (IOException | DataFormatException e){
 		throw new ImageException(e.getMessage(), e);
 	}
+	if (PropertyLoader.getBooleanProperty(PROPERTY_SOFT_PIXEL_CACHE, true)){
+		softPixels = new SoftReference<byte[]>(pixels);
+	} else {
+		strongPixels = pixels;
+	}
+	return pixels;
 }
 /**
  * This method was created in VisualAge.

--- a/vcell-core/src/test/java/cbit/image/SoftPixelCacheDemo.java
+++ b/vcell-core/src/test/java/cbit/image/SoftPixelCacheDemo.java
@@ -1,0 +1,94 @@
+package cbit.image;
+
+import org.vcell.util.Extent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Does holding the inflated pixels softly actually change the outcome under the conditions of the
+ * #2021 incident? Not a unit test — it deliberately drives the JVM to the edge of its heap, which
+ * is not something to do inside a shared test run.
+ *
+ * Recreates the shape of the incident: N geometries in one document, each holding the same size of
+ * image, all reachable at once. With the pixels held strongly this exhausts the heap exactly as
+ * production did. With them held softly the collector reclaims what it needs and the work
+ * completes, re-inflating on demand.
+ *
+ * Run both sides:
+ *
+ * <pre>
+ *   java -Xmx256m -Dvcell.image.softPixelCache=false -cp ... cbit.image.SoftPixelCacheDemo 11 220
+ *   java -Xmx256m -Dvcell.image.softPixelCache=true  -cp ... cbit.image.SoftPixelCacheDemo 11 220
+ * </pre>
+ *
+ * Args: number of images, and the cube edge (pixels per image is edge^3).
+ */
+public class SoftPixelCacheDemo {
+
+    private static String fmt(long b) {
+        return String.format("%,.1f MB", b / (1024.0 * 1024.0));
+    }
+
+    private static long usedHeap() {
+        Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    /** Segmented-looking content: a few large regions, so it compresses the way real images do. */
+    private static byte[] pattern(int edge, int seed) {
+        byte[] pixels = new byte[edge * edge * edge];
+        double c = edge / 2.0, r = edge * (0.30 + 0.02 * seed);
+        int i = 0;
+        for (int z = 0; z < edge; z++) {
+            for (int y = 0; y < edge; y++) {
+                for (int x = 0; x < edge; x++, i++) {
+                    double d = (x - c) * (x - c) + (y - c) * (y - c) + (z - c) * (z - c);
+                    pixels[i] = (byte) (d < r * r ? 1 : 0);
+                }
+            }
+        }
+        return pixels;
+    }
+
+    public static void main(String[] args) throws Exception {
+        int count = args.length > 0 ? Integer.parseInt(args[0]) : 11;
+        int edge = args.length > 1 ? Integer.parseInt(args[1]) : 220;
+
+        boolean soft = Boolean.parseBoolean(System.getProperty("vcell.image.softPixelCache", "true"));
+        long pixelsEach = (long) edge * edge * edge;
+
+        System.out.printf("soft pixel cache: %s%n", soft ? "ON" : "OFF");
+        System.out.printf("max heap        : %s%n", fmt(Runtime.getRuntime().maxMemory()));
+        System.out.printf("%d images x %,d px = %s if all held inflated%n%n",
+                count, pixelsEach, fmt(count * pixelsEach));
+
+        List<VCImageCompressed> images = new ArrayList<>();
+        try {
+            for (int i = 0; i < count; i++) {
+                VCImageCompressed img = new VCImageCompressed(new VCImageUncompressed(
+                        null, pattern(edge, i), new Extent(1, 1, 1), edge, edge, edge));
+                images.add(img);
+                // touch the pixels, as parsing a geometry does
+                long checksum = 0;
+                byte[] px = img.getPixels();
+                for (int k = 0; k < px.length; k += 4096) checksum += px[k];
+                System.out.printf("  image %2d/%d  compressed %-10s  heap now %-11s  (checksum %d)%n",
+                        i + 1, count, fmt(img.getPixelsCompressed().length), fmt(usedHeap()), checksum);
+            }
+        } catch (OutOfMemoryError e) {
+            System.out.printf("%nOUT OF MEMORY after %d of %d images — this is the incident%n",
+                    images.size(), count);
+            System.exit(3);
+        }
+
+        // Everything is still reachable and still correct.
+        long total = 0;
+        for (VCImageCompressed img : images) {
+            total += img.getPixels().length;
+        }
+        System.out.printf("%nCOMPLETED all %d images; re-read %s of pixels on demand%n",
+                count, fmt(total));
+        System.out.printf("final heap: %s%n", fmt(usedHeap()));
+    }
+}

--- a/vcell-core/src/test/java/cbit/image/VCImageCompressedSoftCacheTest.java
+++ b/vcell-core/src/test/java/cbit/image/VCImageCompressedSoftCacheTest.java
@@ -1,0 +1,155 @@
+package cbit.image;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.vcell.util.Extent;
+
+import java.lang.ref.Reference;
+import java.lang.ref.SoftReference;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@link VCImageCompressed} holds its inflated pixels through a {@link SoftReference}, so the
+ * collector can reclaim them under memory pressure and they are re-inflated on demand. Real
+ * geometry images compress 50-100x, so what stays resident between uses is about 1 MB rather than
+ * 62 MB for the image that exhausted a prod api heap (#2021).
+ *
+ * The distinction these tests defend is soft versus weak. A weak reference is cleared at the next
+ * GC whatever the heap looks like, which would make an image in active use re-inflate on
+ * essentially every collection. Nothing about the class's ordinary behaviour would look wrong if
+ * someone changed it, so {@link #ordinaryGcDoesNotDiscardThePixels} exists to fail if they do.
+ */
+@Tag("Fast")
+public class VCImageCompressedSoftCacheTest {
+
+    private static final int EDGE = 40;                     // 64,000 px
+
+    @AfterEach
+    public void clearOverride() {
+        System.clearProperty(VCImageCompressed.PROPERTY_SOFT_PIXEL_CACHE);
+    }
+
+    private static byte[] pattern() {
+        byte[] pixels = new byte[EDGE * EDGE * EDGE];
+        for (int i = 0; i < pixels.length; i++) {
+            pixels[i] = (byte) ((i / 97) % 5);              // segmented-ish, so it compresses
+        }
+        return pixels;
+    }
+
+    private static VCImageCompressed image() throws Exception {
+        return new VCImageCompressed(new VCImageUncompressed(
+                null, pattern(), new Extent(1, 1, 1), EDGE, EDGE, EDGE));
+    }
+
+    private static void collect() {
+        for (int i = 0; i < 6; i++) {
+            System.gc();
+            try {
+                Thread.sleep(30);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Test
+    public void thePixelsAreCorrect() throws Exception {
+        assertArrayEquals(pattern(), image().getPixels(),
+                "inflating must reproduce the original pixels");
+    }
+
+    @Test
+    public void repeatedCallsReturnTheSameArrayWhileItIsCached() throws Exception {
+        VCImageCompressed image = image();
+        assertSame(image.getPixels(), image.getPixels(),
+                "a cached inflate must not be repeated on every call");
+    }
+
+    /**
+     * Soft, not weak. An ordinary collection must NOT discard the pixels — if this fails, someone
+     * has changed the reference type and every geometry in use will re-inflate on every GC.
+     */
+    @Test
+    public void ordinaryGcDoesNotDiscardThePixels() throws Exception {
+        VCImageCompressed image = image();
+        byte[] first = image.getPixels();
+        int identity = System.identityHashCode(first);
+        first = null;
+
+        collect();                                          // no memory pressure
+
+        assertEquals(identity, System.identityHashCode(image.getPixels()),
+                "a plain GC must not clear the cache — SoftReference, not WeakReference");
+    }
+
+    /**
+     * When the reference IS cleared, the pixels come back correctly. Cleared explicitly rather than
+     * by exhausting the heap: forcing a real OutOfMemoryError inside a shared test JVM to make the
+     * collector clear soft references would put every other test in the run at risk.
+     */
+    @Test
+    public void clearedPixelsAreReinflatedCorrectly() throws Exception {
+        VCImageCompressed image = image();
+        byte[] before = image.getPixels().clone();
+
+        clearSoftReference(image);
+
+        byte[] after = image.getPixels();
+        assertNotNull(after);
+        assertArrayEquals(before, after, "re-inflating must reproduce the same pixels");
+    }
+
+    @Test
+    public void nullifyStillWorks() throws Exception {
+        VCImageCompressed image = image();
+        byte[] before = image.getPixels().clone();
+        image.nullifyUncompressedPixels();
+        assertArrayEquals(before, image.getPixels(),
+                "nullifyUncompressedPixels must drop the cache without losing the pixels");
+    }
+
+    @Test
+    public void theCompressedFormIsAlwaysHeld() throws Exception {
+        VCImageCompressed image = image();
+        image.getPixels();
+        clearSoftReference(image);
+        assertNotNull(image.getPixelsCompressed(),
+                "the compressed bytes must be held strongly — they are what makes rehydration possible");
+        assertTrue(image.getPixelsCompressed().length < EDGE * EDGE * EDGE,
+                "the whole point is that the retained form is smaller than the inflated one");
+    }
+
+    @Test
+    public void softCachingCanBeSwitchedOff() throws Exception {
+        System.setProperty(VCImageCompressed.PROPERTY_SOFT_PIXEL_CACHE, "false");
+        VCImageCompressed image = image();
+        byte[] pixels = image.getPixels();
+
+        // With the escape hatch set the pixels are held strongly, so clearing the soft reference
+        // must make no difference at all.
+        clearSoftReference(image);
+        assertSame(pixels, image.getPixels(),
+                "with soft caching off the array must be held strongly");
+    }
+
+    /**
+     * Clear the reference the way the collector would, without needing memory pressure.
+     *
+     * Typed as {@link Reference}, not {@link SoftReference}, on purpose. When the field's type was
+     * temporarily switched to WeakReference to check that these tests detect it, this helper threw
+     * ClassCastException and turned two unrelated tests into errors -- burying the one failure that
+     * actually explains the problem, {@link #ordinaryGcDoesNotDiscardThePixels}.
+     */
+    private static void clearSoftReference(VCImageCompressed image) throws Exception {
+        Field f = VCImageCompressed.class.getDeclaredField("softPixels");
+        f.setAccessible(true);
+        Reference<?> ref = (Reference<?>) f.get(image);
+        if (ref != null) {
+            ref.clear();
+        }
+    }
+}


### PR DESCRIPTION
Implements §5.3b of #2025. **Stacked on #2026** — the diff below is this commit only; softening this
cache does nothing on its own while `GeometrySpec` holds a second strong reference to the same array.

`VCImageCompressed` kept its inflated pixels in a strong `transient` field, so once an image had been
read its **62 MB stayed resident for as long as the image object did** — even though the compressed
form it can be rebuilt from is about **1 MB**. Real geometry images compress **50–100×** (measured
across 62 images in the VCML corpus: median 73.6×, 63.5× for those over 1 MP; #2025 §3.7).

The inflated array now hangs off a `SoftReference`, and `getPixels()` re-inflates on demand at
~700–950 MB/s.

## Demonstrated under the shape of the incident

`SoftPixelCacheDemo` (included), 11 images all reachable at once, **256 MB heap**:

```
soft cache OFF   OUT OF MEMORY after 9 of 11 images
soft cache ON    completed all 11
                 heap 246 MB -> 63 MB at image 10 as the collector reclaims
                 283 MB of pixels then re-read on demand
```

It's a `main`, not a test — driving a JVM to the edge of its heap doesn't belong in a shared test run.

## Soft, not weak — the whole design

A `WeakReference` is cleared at the next GC *whatever the heap looks like*, so an image in active use
would re-inflate on essentially every collection: ~90 ms of CPU, repeatedly, for nothing. Soft
references are cleared only under real pressure.

Nothing about ordinary behaviour would look wrong if someone swapped the type, so
`ordinaryGcDoesNotDiscardThePixels` exists to fail if they do. **Verified** by temporarily switching
to `WeakReference`:

```
ordinaryGcDoesNotDiscardThePixels
  a plain GC must not clear the cache — SoftReference, not WeakReference
  ==> expected: <1527214863> but was: <172699023>
```

That control also improved the tests: with `WeakReference` in place my reflection helper threw
`ClassCastException` and turned two unrelated tests into *errors*, burying the one failure that
actually explains the problem. The helper is now typed `Reference<?>`.

## Two details worth review

**A race in `getPixels()` that had to be designed out.** It takes a strong local reference once and
holds it for the whole method. Reading the `SoftReference` twice would let the collector clear it
between the null check and the return, handing the caller a **null array** — rare,
non-deterministic, and extremely unpleasant to diagnose.

**Two loops hoisted, two deliberately not.** `ClientRequestManager:1169` (reached as
`getGeometrySpec().getImage()` — the stored image) and `ImageFile:149/153` call `getPixels()` every
iteration and *can* receive a compressed image; under the very pressure that clears a soft reference
they would have re-inflated per iteration. `ROIMultiPaintManager:2036` and `ITextWriter:544` are
**not** touched — their receivers are locally built `VCImageUncompressed` instances, which hold
pixels in a `final` field and never inflate. (I nearly rewrote the `ITextWriter` index arithmetic
before checking; it would have been risk for no benefit.)

## Escape hatch

`vcell.image.softPixelCache=false` restores strong caching.

## Verification

- `VCImageCompressedSoftCacheTest`: 7/7 — content correctness, cache identity, soft-vs-weak,
  re-inflation after clearing, `nullifyUncompressedPixels`, the compressed form staying held, and
  the escape hatch.
- **`MathGen_IT`: 1045 tests, 0 failures, 0 errors** (705 math-generation comparisons over real
  stored VCML).
- `vcell-core` Fast: 587 run, 0 failures, 8 errors — the `MathOverrideRoundTripTest` /
  `VCellDataTest` errors `docs/BUILDING.md` documents for a worktree without the Poetry
  environments.
- Line endings checked: all three modified files are CRLF and stayed CRLF (`git diff --stat` reads
  59 insertions / 11 deletions, not a whole-file rewrite).

## What this does not address

The **per-pixel** access path. `VCImage.getPixel(x,y,z)` is `getPixels()[index]`, and
`ImageSubVolume.isInside` goes through `GeometrySpec.getUncompressedPixels()` one pixel at a time.
Both are cold today (#2025 §3.8 traced the only live caller to a 100-point curve check), but if
either ever becomes hot they want a bulk or hoisted accessor rather than a per-call fetch.

Refs #2021, #2025, #2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kr8SbzXtwW3gMVUgMfDDt
