### PR TITLE
Stop a broker restart from silently killing a service's JMS consumer

### DIFF
--- a/docs/MESSAGING.md
+++ b/docs/MESSAGING.md
@@ -316,8 +316,19 @@ redelivery policies, advisory watchdogs, DLQ tooling. Effort there has a shelf l
   `kubectl exec … tail /var/log/activemq/activemq.log`, which rotates after ~14 h.
   Making these brokers log to stdout is an easy, worthwhile fix.
 - `VCMessagingServiceActiveMQ` uses a **bounded** failover URL so a wedged transport cannot
-  retry forever; `JmsFailoverWatchdog` runs a terminal action (in production, JVM exit so K8s
-  recycles the pod) when failover gives up.
+  retry forever; `JmsFailoverWatchdog` runs a terminal action when failover gives up. The four
+  long-lived consumer services (submit, sched, data, db) build theirs with
+  `createForLongLivedConsumerService()`, which sets that action to JVM exit so K8s recycles the
+  pod. Everything else — short-lived batch processes, the API server — keeps the `logOnly()`
+  default. Getting this wiring wrong is silent: for two releases every service was on
+  `logOnly()`, so the terminal condition was detected, logged at FATAL, and then ignored
+  (issue #2031).
+- A consumer can also lose its session without the transport noticing. `ConsumerContextJms`
+  routes that through `JmsFailoverWatchdog.onTerminalFailure(…)` rather than ending its poll
+  loop, because a consumer thread that exits leaves a process which consumes nothing and still
+  reports healthy. Note that `attach()` installs its `TransportListener` only for an
+  `ActiveMQConnection`. Both impls use the OpenWire client today so both are covered, but a move
+  to an AMQP client would leave this caller-side route as the *only* path to the terminal action.
 - `transportResumed` fires on a *first connect* as well as after an interruption. A resumed
   count with zero interruptions means new connections, not reconnects — a distinction that once
   cost a misdiagnosis.

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/ConsumerContextJms.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/ConsumerContextJms.java
@@ -75,10 +75,26 @@ public class ConsumerContextJms implements Runnable {
 //						lg.info(toString()+"no message received within "+CONSUMER_POLLING_INTERVAL_MS+" ms");
 				}
 			} catch (JMSException e) {
-				if (!bProcessing || e instanceof javax.jms.IllegalStateException){
-					// close() unblocks a thread parked in receive(); that is shutdown, not a
-					// failure. Logging it as one and looping would spin on the closed consumer.
+				if (!bProcessing){
+					// stop() has already been requested, and close() unblocks a thread parked
+					// in receive(); that is shutdown, not a failure. Logging it as one and
+					// looping would spin on the closed consumer. Every deliberate shutdown
+					// path (closeAll(), stopAndClose()) clears bProcessing before close(),
+					// so this test alone identifies them.
 					lg.debug(toString()+" consumer closed while polling", e);
+					break;
+				}
+				if (e instanceof javax.jms.IllegalStateException){
+					// The session died underneath a consumer we are still meant to be polling:
+					// a broker restart, or the failover transport exhausting its reconnect
+					// budget. receive() throws immediately from here on, so looping would spin
+					// -- but leaving quietly is worse. It leaves a process that consumes
+					// nothing, logs nothing and still reports healthy, which is how dev's
+					// submit service sat dead for 6h50m before anyone noticed (issue #2031).
+					// Escalate instead, and let the wiring decide what a lost broker means
+					// for this process.
+					vcMessagingServiceJms.getFailoverWatchdog()
+							.onTerminalFailure("consumer session for "+vcConsumer.getVCDestination(), e);
 					break;
 				}
 				onException(e);

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/JmsFailoverWatchdog.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/JmsFailoverWatchdog.java
@@ -48,6 +48,25 @@ public final class JmsFailoverWatchdog {
 		return new JmsFailoverWatchdog(() -> {});
 	}
 
+	/**
+	 * Escalate a failure the caller detected for itself and cannot recover from in
+	 * place -- e.g. a consumer whose session died while it was still meant to be
+	 * polling. The {@link TransportListener} installed by {@link #attach} covers the
+	 * failures the failover layer reports; this covers the ones only the caller can
+	 * see. Both end in the same terminal action, so how a process responds to a lost
+	 * broker stays a single wiring decision.
+	 *
+	 * This route matters for more than tidiness: {@link #attach} installs a listener
+	 * only for {@link ActiveMQConnection}, so for any other provider it is the only
+	 * path to the terminal action at all.
+	 *
+	 * @param what short description of what was lost, e.g. {@code "transport"}
+	 */
+	public void onTerminalFailure(String what, Throwable cause) {
+		lg.fatal("JMS " + what + " unrecoverable, invoking terminal handler", cause);
+		onTerminal.run();
+	}
+
 	public void attach(Connection connection) {
 		if (!(connection instanceof ActiveMQConnection)) {
 			lg.warn("no failover watchdog for connection type {} -- a wedged transport will not "
@@ -63,8 +82,7 @@ public final class JmsFailoverWatchdog {
 			}
 			@Override
 			public void onException(IOException error) {
-				lg.fatal("JMS transport unrecoverable, invoking terminal handler", error);
-				onTerminal.run();
+				onTerminalFailure("transport", error);
 			}
 			@Override
 			public void transportInterupted() {

--- a/vcell-server/src/main/java/cbit/vcell/message/jms/activeMQ/VCMessagingServiceActiveMQ.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/jms/activeMQ/VCMessagingServiceActiveMQ.java
@@ -13,6 +13,7 @@ import cbit.vcell.message.VCMessageSelector;
 import cbit.vcell.message.VCMessagingException;
 import cbit.vcell.message.VCMessagingService;
 import cbit.vcell.message.VCellQueue;
+import cbit.vcell.message.jms.JmsFailoverWatchdog;
 import cbit.vcell.message.jms.VCMessagingServiceJms;
 import cbit.vcell.resource.PropertyLoader;
 
@@ -21,6 +22,28 @@ public class VCMessagingServiceActiveMQ extends VCMessagingServiceJms implements
 
 	public VCMessagingServiceActiveMQ() {
 		super();
+	}
+
+	/**
+	 * A messaging service for a long-lived server process whose only job is to consume
+	 * from the broker (submit, sched, data, db).
+	 *
+	 * The failover transport gives up after {@code maxReconnectAttempts} (set in
+	 * jmsUrl below), which is deliberate -- in K8s a pod restart is the right response
+	 * to a sustained broker outage. That only holds if something acts on it, so these
+	 * processes exit on a terminal failure and let K8s recycle them. Without it the
+	 * process stays up around a connection that can never be used again: dev's submit
+	 * service ran for 6h50m in that state, consuming nothing and still reporting healthy
+	 * (issue #2031).
+	 *
+	 * Short-lived batch processes (SolverPreprocessor, SolverPostprocessor,
+	 * JavaSimulationExecutable) and the API server keep the log-only default -- they
+	 * outlive neither the broker outage nor their own task.
+	 */
+	public static VCMessagingServiceActiveMQ createForLongLivedConsumerService() {
+		VCMessagingServiceActiveMQ service = new VCMessagingServiceActiveMQ();
+		service.setFailoverWatchdog(JmsFailoverWatchdog.jvmExitOnTerminal());
+		return service;
 	}
 	
 	@Override

--- a/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/batch/sim/HtcSimulationWorker.java
@@ -87,12 +87,12 @@ public class HtcSimulationWorker implements HtcProxy.HtcProxyFactory  {
 public HtcSimulationWorker() {
 	this.htcProxy = SlurmProxy.createRemoteProxy();
 
-	this.vcMessagingService_int = new VCMessagingServiceActiveMQ();
+	this.vcMessagingService_int = VCMessagingServiceActiveMQ.createForLongLivedConsumerService();
 	String jmshost_int = PropertyLoader.getRequiredProperty(PropertyLoader.jmsIntHostInternal);
 	int jmsport_int = Integer.parseInt(PropertyLoader.getRequiredProperty(PropertyLoader.jmsIntPortInternal));
 	this.vcMessagingService_int.setConfiguration(new ServerMessagingDelegate(), jmshost_int, jmsport_int);
 
-	this.vcMessagingService_sim = new VCMessagingServiceActiveMQ();
+	this.vcMessagingService_sim = VCMessagingServiceActiveMQ.createForLongLivedConsumerService();
 	String jmshost_sim = PropertyLoader.getRequiredProperty(PropertyLoader.jmsSimHostInternal);
 	int jmsport_sim = Integer.parseInt(PropertyLoader.getRequiredProperty(PropertyLoader.jmsSimPortInternal));
 	this.vcMessagingService_sim.setConfiguration(new ServerMessagingDelegate(), jmshost_sim, jmsport_sim);

--- a/vcell-server/src/main/java/cbit/vcell/message/server/data/SimDataServer.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/data/SimDataServer.java
@@ -66,7 +66,7 @@ public SimDataServer() throws Exception {
 
 	this.dataServerImpl = new DataServerImpl(dataSetControllerImpl, exportServiceImpl);
 
-	this.vcMessagingService_int = new VCMessagingServiceActiveMQ();
+	this.vcMessagingService_int = VCMessagingServiceActiveMQ.createForLongLivedConsumerService();
 	String jmshost = PropertyLoader.getRequiredProperty(PropertyLoader.jmsIntHostInternal);
 	int jmsport = Integer.parseInt(PropertyLoader.getRequiredProperty(PropertyLoader.jmsIntPortInternal));
 	this.vcMessagingService_int.setConfiguration(new ServerMessagingDelegate(), jmshost, jmsport);

--- a/vcell-server/src/main/java/cbit/vcell/message/server/db/DatabaseServer.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/db/DatabaseServer.java
@@ -90,7 +90,7 @@ public DatabaseServer() throws SQLException, DataAccessException {
 	KeyFactory keyFactory = conFactory.getKeyFactory();
 	this.databaseServerImpl = new DatabaseServerImpl(conFactory, keyFactory);
 
-	this.vcMessagingService_int = new VCMessagingServiceActiveMQ();
+	this.vcMessagingService_int = VCMessagingServiceActiveMQ.createForLongLivedConsumerService();
 	String jmshost = PropertyLoader.getRequiredProperty(PropertyLoader.jmsIntHostInternal);
 	int jmsport = Integer.parseInt(PropertyLoader.getRequiredProperty(PropertyLoader.jmsIntPortInternal));
 	this.vcMessagingService_int.setConfiguration(new ServerMessagingDelegate(), jmshost, jmsport);

--- a/vcell-server/src/main/java/cbit/vcell/message/server/dispatcher/SimulationDispatcher.java
+++ b/vcell-server/src/main/java/cbit/vcell/message/server/dispatcher/SimulationDispatcher.java
@@ -702,12 +702,12 @@ public class SimulationDispatcher {
 		AdminDBTopLevel adminDbTopLevel = new AdminDBTopLevel(conFactory);
 		SimulationDatabase simulationDatabase = new SimulationDatabaseDirect(adminDbTopLevel, databaseServerImpl, true);
 
-		VCMessagingService vcMessagingServiceInternal = new VCMessagingServiceActiveMQ();
+		VCMessagingService vcMessagingServiceInternal = VCMessagingServiceActiveMQ.createForLongLivedConsumerService();
 		String jmshost_int = PropertyLoader.getRequiredProperty(PropertyLoader.jmsIntHostInternal);
 		int jmsport_int = Integer.parseInt(PropertyLoader.getRequiredProperty(PropertyLoader.jmsIntPortInternal));
 		vcMessagingServiceInternal.setConfiguration(new ServerMessagingDelegate(), jmshost_int, jmsport_int);
 
-		VCMessagingService vcMessagingServiceSim = new VCMessagingServiceActiveMQ();
+		VCMessagingService vcMessagingServiceSim = VCMessagingServiceActiveMQ.createForLongLivedConsumerService();
 		String jmshost_sim = PropertyLoader.getRequiredProperty(PropertyLoader.jmsSimHostInternal);
 		int jmsport_sim = Integer.parseInt(PropertyLoader.getRequiredProperty(PropertyLoader.jmsSimPortInternal));
 		vcMessagingServiceSim.setConfiguration(new ServerMessagingDelegate(), jmshost_sim, jmsport_sim);

--- a/vcell-server/src/test/java/cbit/vcell/message/jms/ConsumerContextJmsTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/message/jms/ConsumerContextJmsTest.java
@@ -1,0 +1,261 @@
+package cbit.vcell.message.jms;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
+import javax.jms.Session;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import cbit.vcell.message.VCDestination;
+import cbit.vcell.message.VCMessageSelector;
+import cbit.vcell.message.VCMessageSession;
+import cbit.vcell.message.VCQueueConsumer;
+import cbit.vcell.message.VCellQueue;
+
+/**
+ * What the polling loop in {@link ConsumerContextJms} does when {@code receive()} fails.
+ *
+ * The distinction that matters is between a session closed because we asked for it and a
+ * session that died underneath a consumer we were still meant to be polling. Both surface
+ * as {@link javax.jms.IllegalStateException}; only the first is shutdown. Treating both as
+ * shutdown is what left dev's submit service running for 6h50m consuming nothing, with a
+ * pod that still reported healthy -- issue #2031.
+ */
+@Tag("Fast")
+@ResourceLock("activemqBrokerRegistry")
+public class ConsumerContextJmsTest {
+
+	private static final String BROKER_NAME = "ConsumerContextJmsTestBroker";
+	private static final VCellQueue TEST_QUEUE = new VCellQueue("ConsumerContextJmsTestQueue");
+
+	private BrokerService broker;
+	private TestMessagingService service;
+	/** counts down the first time the watchdog's terminal action runs */
+	private CountDownLatch terminal;
+
+	@BeforeEach
+	public void startBroker() throws Exception {
+		broker = new BrokerService();
+		// never "localhost": BrokerRegistry is JVM-global and other tests run their own -- issue #1852
+		broker.setBrokerName(BROKER_NAME);
+		broker.setPersistent(false);
+		broker.setUseJmx(false);
+		broker.setUseShutdownHook(false);
+		broker.start();
+		broker.waitUntilStarted();
+
+		terminal = new CountDownLatch(1);
+		service = new TestMessagingService();
+		service.setFailoverWatchdog(new JmsFailoverWatchdog(terminal::countDown));
+	}
+
+	@AfterEach
+	public void stopBroker() throws Exception {
+		if (service != null) {
+			try { service.close(); } catch (Exception ignored) { }
+		}
+		if (broker != null) {
+			broker.stop();
+			broker.waitUntilStopped();
+		}
+	}
+
+	/**
+	 * The regression. A session that dies under a live consumer has to be escalated, not
+	 * swallowed.
+	 *
+	 * The failure is injected at the consumer rather than by stopping the broker on purpose:
+	 * stopping the broker also drives the failover transport to its own terminal handler, so
+	 * the test would pass on the broken code for the wrong reason. Here the transport stays
+	 * healthy and the consumer's own escalation is the only thing that can fire the latch.
+	 */
+	@Test
+	public void aSessionLostWhileStillPollingIsEscalated() throws Exception {
+		CountDownLatch delivered = new CountDownLatch(1);
+		VCQueueConsumer consumer = new VCQueueConsumer(TEST_QUEUE,
+				(vcMessage, session) -> delivered.countDown(),
+				null, "ConsumerContextJmsTest consumer", 1);
+		service.addMessageConsumer(consumer);
+
+		// prove the consumer is genuinely polling before breaking it
+		sendOneMessage();
+		assertTrue(delivered.await(30, TimeUnit.SECONDS), "the consumer should be live to begin with");
+
+		service.sessionIsDead.set(true);
+
+		assertTrue(terminal.await(30, TimeUnit.SECONDS),
+				"a consumer whose session died while it was still processing must reach the "
+						+ "terminal handler, not exit quietly");
+	}
+
+	/**
+	 * The negative control for the test above: an ordinary shutdown looks the same at
+	 * receive() and must stay silent. Without this, escalating everything would pass.
+	 */
+	@Test
+	public void anOrdinaryShutdownIsNotEscalated() throws Exception {
+		CountDownLatch delivered = new CountDownLatch(1);
+		VCQueueConsumer consumer = new VCQueueConsumer(TEST_QUEUE,
+				(vcMessage, session) -> delivered.countDown(),
+				null, "ConsumerContextJmsTest shutdown consumer", 1);
+		service.addMessageConsumer(consumer);
+
+		sendOneMessage();
+		assertTrue(delivered.await(30, TimeUnit.SECONDS), "the consumer should be live to begin with");
+
+		// closeAll() clears bProcessing, waits out a poll interval, then closes the session --
+		// exactly the ordering that makes !bProcessing sufficient to recognise shutdown
+		service.close();
+
+		assertFalse(terminal.await(2, TimeUnit.SECONDS),
+				"stopping a consumer on purpose must not invoke the terminal handler");
+	}
+
+	/**
+	 * A JMSException that is not a lost session is a transient failure of one poll. The loop
+	 * reports it and keeps going; it must not be escalated and must not end the thread.
+	 */
+	@Test
+	public void aTransientPollFailureIsNotEscalated() throws Exception {
+		CountDownLatch delivered = new CountDownLatch(1);
+		VCQueueConsumer consumer = new VCQueueConsumer(TEST_QUEUE,
+				(vcMessage, session) -> delivered.countDown(),
+				null, "ConsumerContextJmsTest transient consumer", 1);
+		service.addMessageConsumer(consumer);
+
+		service.transientFailures.set(2);
+		// receive() returns every CONSUMER_POLLING_INTERVAL_MS, so two failures need two
+		// turns of the loop plus room for scheduling
+		assertTrue(service.transientFailuresConsumed.await(30, TimeUnit.SECONDS),
+				"the poll loop should have hit both transient failures");
+
+		sendOneMessage();
+		assertTrue(delivered.await(30, TimeUnit.SECONDS),
+				"the consumer should still be polling after a transient receive() failure");
+		assertFalse(terminal.await(1, TimeUnit.SECONDS),
+				"a transient receive() failure must not invoke the terminal handler");
+	}
+
+	private void sendOneMessage() throws Exception {
+		VCMessageSession producerSession = service.createProducerSession();
+		try {
+			producerSession.sendQueueMessage(TEST_QUEUE,
+					producerSession.createTextMessage("ping"), Boolean.FALSE, 60000L);
+		} finally {
+			producerSession.close();
+		}
+	}
+
+	/**
+	 * A messaging service on an in-VM broker whose consumers can be told to fail, so a lost
+	 * session can be reproduced without taking the broker (and with it the transport) down.
+	 */
+	private final class TestMessagingService extends VCMessagingServiceJms {
+		/** once set, every receive() reports the session as gone, as a real one would */
+		final AtomicBoolean sessionIsDead = new AtomicBoolean(false);
+		/** how many further receive() calls should fail with an unrelated, transient JMSException */
+		final AtomicInteger transientFailures = new AtomicInteger(0);
+		final CountDownLatch transientFailuresConsumed = new CountDownLatch(1);
+
+		@Override
+		public ConnectionFactory createConnectionFactory() {
+			ActiveMQConnectionFactory factory =
+					new ActiveMQConnectionFactory("vm://" + BROKER_NAME + "?create=false");
+			factory.setTrustedPackages(Arrays.asList("java.lang", "java.util", "java.math", "cbit.vcell", "org.vcell"));
+			// mirror production, see VCMessagingServiceActiveMQ and issue #1863
+			factory.setWatchTopicAdvisories(false);
+			return factory;
+		}
+
+		@Override
+		public MessageConsumer createConsumer(Session jmsSession, VCDestination vcDestination,
+				VCMessageSelector vcSelector, int prefetchLimit) throws JMSException {
+			Destination destination = (vcDestination instanceof VCellQueue)
+					? jmsSession.createQueue(vcDestination.getName())
+					: jmsSession.createTopic(vcDestination.getName());
+			MessageConsumer delegate = (vcSelector == null)
+					? jmsSession.createConsumer(destination)
+					: jmsSession.createConsumer(destination, vcSelector.getSelectionString());
+			return new FailableConsumer(delegate);
+		}
+
+		private final class FailableConsumer implements MessageConsumer {
+			private final MessageConsumer delegate;
+
+			FailableConsumer(MessageConsumer delegate) {
+				this.delegate = delegate;
+			}
+
+			private void failIfAsked() throws JMSException {
+				if (sessionIsDead.get()) {
+					// what ActiveMQ raises once the session behind a consumer is gone;
+					// ConnectionClosedException extends javax.jms.IllegalStateException
+					throw new javax.jms.IllegalStateException("The Session is closed");
+				}
+				if (transientFailures.getAndUpdate(n -> n > 0 ? n - 1 : 0) > 0) {
+					if (transientFailures.get() == 0) {
+						transientFailuresConsumed.countDown();
+					}
+					throw new JMSException("simulated transient poll failure");
+				}
+			}
+
+			@Override
+			public Message receive(long timeout) throws JMSException {
+				failIfAsked();
+				return delegate.receive(timeout);
+			}
+
+			@Override
+			public Message receive() throws JMSException {
+				failIfAsked();
+				return delegate.receive();
+			}
+
+			@Override
+			public Message receiveNoWait() throws JMSException {
+				failIfAsked();
+				return delegate.receiveNoWait();
+			}
+
+			@Override
+			public String getMessageSelector() throws JMSException {
+				return delegate.getMessageSelector();
+			}
+
+			@Override
+			public MessageListener getMessageListener() throws JMSException {
+				return delegate.getMessageListener();
+			}
+
+			@Override
+			public void setMessageListener(MessageListener listener) throws JMSException {
+				delegate.setMessageListener(listener);
+			}
+
+			@Override
+			public void close() throws JMSException {
+				delegate.close();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2031.

A broker restart could kill a service's JMS consumer thread permanently while the process stayed
up and the pod stayed `Ready`. Dev's `submit` service ran for **6h50m** on 2026-08-24 in exactly
that state, consuming nothing.

## What actually happened

The dev logs give the whole sequence, and it turned out to be two defects rather than one:

```
19:51:15.914Z  WARN   JmsFailoverWatchdog  JMS transport interrupted, failover reconnecting   (x3)
19:59:16.954Z  ERROR  ConsumerContextJms   Connection refused
19:59:16.957Z  FATAL  JmsFailoverWatchdog  JMS transport unrecoverable, invoking terminal handler
19:59:16.959Z  ERROR  ConsumerContextJms   Connection refused
19:59:16.960Z  INFO   ConsumerContextJms   ConsumerContextJms@6796aa72 consumer thread exiting.
```

481 seconds between interrupt and giving up, matching `maxReconnectAttempts=20` with the 1s→30s
backoff. Then nothing at all for six hours.

**1. The consumer misread a dead session as shutdown.** `ConsumerContextJms` treated every
`javax.jms.IllegalStateException` out of `receive()` as deliberate shutdown and broke out of the
poll loop. Half of that is right — `close()` unblocks a thread parked in `receive()`, and looping
on a closed consumer would spin. But the provider raises the same exception when the session dies
underneath a consumer we are still meant to be polling, which is the case that most needs
reporting.

**2. The terminal condition was detected and then ignored.** `d58cd1292e` bounded the failover
reconnect budget on the reasoning that in K8s a pod restart is the right response to a sustained
broker outage, added `jvmExitOnTerminal()` as the escape hatch, and left every service on
`logOnly()` for a future caller to take up. `git log -S setFailoverWatchdog` returns exactly that
one commit — nobody ever did. So the FATAL above invoked a no-op.

Either defect alone is enough to produce the zombie: fixing only (1) leaves the process alive
around a connection it can never use again, and fixing only (2) leaves the consumer thread dying
silently wherever the watchdog is not attached — `attach()` installs nothing for a
non-`ActiveMQConnection`, which matters if the Artemis work ever moves off the OpenWire client.

## The change

- `JmsFailoverWatchdog.onTerminalFailure(what, cause)` — a route to the terminal action for a
  failure the caller detected itself. The existing transport path folds through it; passing
  `"transport"` reproduces today's log line exactly.
- `ConsumerContextJms` now tests `bProcessing` alone to recognise shutdown (both `closeAll()` and
  `stopAndClose()` clear it before `close()`, so it is sufficient), and escalates a session lost
  while still processing instead of exiting quietly.
- `submit`, `sched`, `data` and `db` build their messaging service with
  `createForLongLivedConsumerService()`, taking the escape hatch. Short-lived batch processes
  (`SolverPreprocessor`, `SolverPostprocessor`, `JavaSimulationExecutable`, `OptimizationBatchServer`)
  and the API server keep the log-only default — they outlive neither the broker outage nor their
  own task.
- `docs/MESSAGING.md` §8 said the watchdog exits the JVM in production. That was the intent, not
  the behaviour; it now says who opts in.

A restarted pod does **not** crash-loop while the broker is still down: `startupMaxReconnectAttempts=-1`
leaves the initial connect unbounded, so the process waits at boot and picks up when the broker
returns.

## Tests

`ConsumerContextJmsTest` — one regression case and two controls.

The failure is injected at the consumer rather than by stopping the broker on purpose. Stopping
the broker also drives the failover transport to the same terminal handler, so that version of
the test passes on the broken code for the wrong reason; here the transport stays healthy and the
consumer's own escalation is the only thing that can fire the latch.

Verified against the pre-fix bytecode (`javap`-checked, not just assumed):

| | before | after |
|---|---|---|
| `aSessionLostWhileStillPollingIsEscalated` | **fails** | passes |
| `anOrdinaryShutdownIsNotEscalated` | passes | passes |
| `aTransientPollFailureIsNotEscalated` | passes | passes |

`vcell-server` `Fast` group is otherwise unchanged.

## Not covered here

Nothing outside the process would still have noticed. #2032 tracks the missing `livenessProbe` on
these four services — worth doing regardless, since this fix covers one way a consumer can die and
a probe covers all of them.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFAraxXXN2KvRqgo9GPmv5
