### PR TITLE
feat(client): let a simulation results window be detached from its document window

### DIFF
--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -119,22 +119,25 @@ jobs:
       - name: what the client actually logged
         if: always()
         run: |
+          # Collect into the workspace: the upload action does not run through this shell,
+          # so it never expands "~" and reads a Git Bash "/tmp/..." literally, which is not
+          # a valid Windows path - that failed the upload even though the test had passed.
+          mkdir -p client-e2e-logs
+          cp /tmp/vcell-debug-launch.out client-e2e-logs/ 2>/dev/null || true
+          find "$HOME/.vcell/logs" -name 'vcellrun*.log' -exec cp {} client-e2e-logs/ \; 2>/dev/null || true
           echo "--- launcher (pre-redirect) ---"
-          cat /tmp/vcell-debug-launch.out 2>/dev/null || echo "(none)"
+          cat client-e2e-logs/vcell-debug-launch.out 2>/dev/null || echo "(none)"
           echo
           echo "--- client log ---"
-          # the client redirects its own stdout/stderr here; the launcher output above
-          # only carries what happened before that redirect took effect
-          find "$HOME/.vcell/logs" -name 'vcellrun*.log' -exec tail -n 200 {} + 2>/dev/null \
-            || echo "(no client log)"
+          # the client redirects its own stdout/stderr there; the launcher output above only
+          # carries what happened before that redirect took effect
+          tail -n 200 client-e2e-logs/vcellrun*.log 2>/dev/null || echo "(no client log)"
 
       - name: upload logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: client-e2e-${{ matrix.os }}
-          path: |
-            /tmp/vcell-debug-launch.out
-            ~/.vcell/logs/
+          path: client-e2e-logs/
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -90,7 +90,14 @@ jobs:
           -Dproject.build.sourceEncoding=UTF-8
 
       - name: launch the client with the debug bridge
-        run: tools/debug-bridge/launch-client.sh
+        # The client validates that vcell.installDir is a real directory
+        # (PropertyLoader.validateSystemProperties) and exits if it is not. On a developer
+        # machine that is the local install4j installation; a runner has none, so give it an
+        # empty one. $HOME rather than $RUNNER_TEMP: under Git Bash the latter is a Windows
+        # path with backslashes, which this shell mangles.
+        run: |
+          mkdir -p "$HOME/vcell-install"
+          VCELL_INSTALL_DIR="$HOME/vcell-install" tools/debug-bridge/launch-client.sh
 
       - name: detach/reattach scenario
         run: tools/debug-bridge/scenarios/detach-window.sh

--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -106,11 +106,6 @@ jobs:
         # dependency:copy-dependencies populates target/maven-jars, which the packaged
         # launcher and Dockerfile both expect, so the build here matches the documented one.
         #
-        # -Dproject.build.sourceEncoding=UTF-8: the root pom does not set it, so javac falls
-        # back to the platform encoding and Windows reads UTF-8 sources as windows-1252
-        # ("unmappable character (0x9D)"). Worth fixing in the pom itself; set here so this
-        # workflow does not depend on that landing first.
-        #
         # -Daether.connector.resumeDownloads=false: the first Windows run failed the build
         # with a wall of ChecksumFailureException (REMOTE_EXTERNAL) - resumed/partial
         # downloads landing corrupt in a cold local repository. Retry once from a clean
@@ -120,7 +115,6 @@ jobs:
           build() {
             mvn -B --no-transfer-progress install dependency:copy-dependencies \
               -pl vcell-client -am -DskipTests \
-              -Dproject.build.sourceEncoding=UTF-8 \
               -Daether.connector.resumeDownloads=false
           }
           if ! build; then

--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -12,6 +12,12 @@
 name: Client E2E
 
 on:
+  # A GUI run is expensive, so it is opt-in on a PR: add the "client-e2e" label and it
+  # runs; without the label the job is skipped and costs nothing. (workflow_dispatch alone
+  # would not do - GitHub only offers it for workflows already on the default branch, so a
+  # branch that ADDS this workflow could never trigger its own first run.)
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
       os:
@@ -28,6 +34,9 @@ concurrency:
 jobs:
   detach-window:
     name: detach/reattach (${{ matrix.os }})
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || contains(github.event.pull_request.labels.*.name, 'client-e2e')
     runs-on: ${{ matrix.os }}
     # A GUI app on a fresh runner is slow to start; fail fast rather than hang the queue.
     timeout-minutes: 30

--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -84,10 +84,24 @@ jobs:
         # back to the platform encoding and Windows reads UTF-8 sources as windows-1252
         # ("unmappable character (0x9D)"). Worth fixing in the pom itself; set here so this
         # workflow does not depend on that landing first.
-        run: >-
-          mvn -B --no-transfer-progress install dependency:copy-dependencies
-          -pl vcell-client -am -DskipTests
-          -Dproject.build.sourceEncoding=UTF-8
+        #
+        # -Daether.connector.resumeDownloads=false: the first Windows run failed the build
+        # with a wall of ChecksumFailureException (REMOTE_EXTERNAL) - resumed/partial
+        # downloads landing corrupt in a cold local repository. Retry once from a clean
+        # repository if it happens anyway, since a corrupt artifact is sticky and would
+        # otherwise fail every subsequent run identically.
+        run: |
+          build() {
+            mvn -B --no-transfer-progress install dependency:copy-dependencies \
+              -pl vcell-client -am -DskipTests \
+              -Dproject.build.sourceEncoding=UTF-8 \
+              -Daether.connector.resumeDownloads=false
+          }
+          if ! build; then
+            echo "::warning::build failed; clearing the local repository and retrying once"
+            rm -rf "$HOME/.m2/repository"
+            build
+          fi
 
       - name: launch the client with the debug bridge
         # The client validates that vcell.installDir is a real directory

--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -23,9 +23,9 @@ on:
       os:
         description: Which runners to use
         required: false
-        default: both
+        default: all
         type: choice
-        options: [both, windows, macos]
+        options: [all, linux, windows, macos]
 
 concurrency:
   group: client-e2e-${{ github.ref }}
@@ -47,7 +47,8 @@ jobs:
           ${{ fromJSON(
             inputs.os == 'windows' && '["windows-latest"]'
             || inputs.os == 'macos' && '["macos-latest"]'
-            || '["windows-latest","macos-latest"]') }}
+            || inputs.os == 'linux' && '["ubuntu-latest"]'
+            || '["ubuntu-latest","windows-latest","macos-latest"]') }}
 
     defaults:
       run:
@@ -64,10 +65,32 @@ jobs:
           java-version: '17'
           cache: maven
 
+      - name: give Linux a desktop to draw on
+        if: runner.os == 'Linux'
+        # A Linux runner has no display at all. Xvfb alone is not enough: minimizing is a
+        # WINDOW MANAGER function, and with no WM running the iconify request would go
+        # nowhere and the test would fail for a reason that has nothing to do with VCell.
+        # openbox is small, starts instantly, and implements the parts that matter here -
+        # iconification and stacking.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb openbox >/dev/null
+          Xvfb :99 -screen 0 1600x1200x24 >/tmp/xvfb.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if xdpyinfo -display :99 >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          xdpyinfo -display :99 >/dev/null 2>&1 || { echo "Xvfb never came up"; cat /tmp/xvfb.log; exit 1; }
+          DISPLAY=:99 openbox >/tmp/openbox.log 2>&1 &
+          sleep 2
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
+          echo "Xvfb + openbox ready on :99"
+
       - name: report the desktop the client will be drawing on
         run: |
           echo "runner:  $RUNNER_OS"
           echo "shell:   $(uname -s)"
+          echo "display: ${DISPLAY:-(native window server)}"
           echo "java:    $(java -version 2>&1 | head -1)"
           for p in python3 python py; do
             command -v "$p" >/dev/null 2>&1 && echo "python:  $p -> $($p --version 2>&1)" && break

--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -12,12 +12,12 @@
 name: Client E2E
 
 on:
-  # A GUI run is expensive, so it is opt-in on a PR: add the "client-e2e" label and it
-  # runs; without the label the job is skipped and costs nothing. (workflow_dispatch alone
-  # would not do - GitHub only offers it for workflows already on the default branch, so a
-  # branch that ADDS this workflow could never trigger its own first run.)
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
+  # Nightly, and on demand. Deliberately NOT on pull_request: it starts a GUI on three
+  # runners, so it is far too heavy and too slow to sit in front of a merge. Nightly is
+  # enough for behaviour that changes rarely, and workflow_dispatch covers the case that
+  # matters - someone about to touch window ownership or the logical-window framework.
+  schedule:
+    - cron: "40 7 * * *"    # after the other nightlies at 07:00, to spread runner load
   workflow_dispatch:
     inputs:
       os:
@@ -34,9 +34,6 @@ concurrency:
 jobs:
   detach-window:
     name: detach/reattach (${{ matrix.os }})
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      || contains(github.event.pull_request.labels.*.name, 'client-e2e')
     runs-on: ${{ matrix.os }}
     # A GUI app on a fresh runner is slow to start; fail fast rather than hang the queue.
     timeout-minutes: 30

--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -74,7 +74,20 @@ jobs:
           done
 
       - name: build the client
-        run: mvn -B --no-transfer-progress compile -pl vcell-client -am -DskipTests
+        # INSTALL, not compile: launch-client.sh resolves vcell-client's dependency
+        # classpath with `dependency:build-classpath -pl vcell-client` (no -am), so the
+        # sibling 0.0.1-SNAPSHOT artifacts have to be in the local repository already.
+        # dependency:copy-dependencies populates target/maven-jars, which the packaged
+        # launcher and Dockerfile both expect, so the build here matches the documented one.
+        #
+        # -Dproject.build.sourceEncoding=UTF-8: the root pom does not set it, so javac falls
+        # back to the platform encoding and Windows reads UTF-8 sources as windows-1252
+        # ("unmappable character (0x9D)"). Worth fixing in the pom itself; set here so this
+        # workflow does not depend on that landing first.
+        run: >-
+          mvn -B --no-transfer-progress install dependency:copy-dependencies
+          -pl vcell-client -am -DskipTests
+          -Dproject.build.sourceEncoding=UTF-8
 
       - name: launch the client with the debug bridge
         run: tools/debug-bridge/launch-client.sh

--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -1,0 +1,97 @@
+# End-to-end checks for the desktop client's WINDOW BEHAVIOUR.
+#
+# Why a separate workflow, and why not headless: whether a window can be minimized, and
+# whether the OS pins it above its owner, are decided by the window manager rather than by
+# our code. There is nothing to assert in a headless JVM - the questions only have answers
+# on a real desktop session. So this runs the actual client on real macOS and Windows
+# runners and asserts on what those systems report back.
+#
+# It is deliberately NOT part of the PR gate: it starts a GUI, it is slower and inherently
+# more fragile than a unit test, and the behaviour it covers changes rarely. Run it by hand
+# when touching window ownership, parenting, or the logical-window framework.
+name: Client E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: Which runners to use
+        required: false
+        default: both
+        type: choice
+        options: [both, windows, macos]
+
+concurrency:
+  group: client-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detach-window:
+    name: detach/reattach (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    # A GUI app on a fresh runner is slow to start; fail fast rather than hang the queue.
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: >-
+          ${{ fromJSON(
+            inputs.os == 'windows' && '["windows-latest"]'
+            || inputs.os == 'macos' && '["macos-latest"]'
+            || '["windows-latest","macos-latest"]') }}
+
+    defaults:
+      run:
+        # Git Bash on Windows, so one script serves both platforms.
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: report the desktop the client will be drawing on
+        run: |
+          echo "runner:  $RUNNER_OS"
+          echo "shell:   $(uname -s)"
+          echo "java:    $(java -version 2>&1 | head -1)"
+          for p in python3 python py; do
+            command -v "$p" >/dev/null 2>&1 && echo "python:  $p -> $($p --version 2>&1)" && break
+          done
+
+      - name: build the client
+        run: mvn -B --no-transfer-progress compile -pl vcell-client -am -DskipTests
+
+      - name: launch the client with the debug bridge
+        run: tools/debug-bridge/launch-client.sh
+
+      - name: detach/reattach scenario
+        run: tools/debug-bridge/scenarios/detach-window.sh
+
+      - name: what the client actually logged
+        if: always()
+        run: |
+          echo "--- launcher (pre-redirect) ---"
+          cat /tmp/vcell-debug-launch.out 2>/dev/null || echo "(none)"
+          echo
+          echo "--- client log ---"
+          # the client redirects its own stdout/stderr here; the launcher output above
+          # only carries what happened before that redirect took effect
+          find "$HOME/.vcell/logs" -name 'vcellrun*.log' -exec tail -n 200 {} + 2>/dev/null \
+            || echo "(no client log)"
+
+      - name: upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: client-e2e-${{ matrix.os }}
+          path: |
+            /tmp/vcell-debug-launch.out
+            ~/.vcell/logs/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -74,13 +74,19 @@ jobs:
         # iconification and stacking.
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq xvfb openbox >/dev/null
+          # x11-utils provides xdpyinfo, which is how the readiness check below knows the
+          # display is actually serving rather than merely that Xvfb was spawned.
+          sudo apt-get install -y -qq xvfb openbox x11-utils >/dev/null
           Xvfb :99 -screen 0 1600x1200x24 >/tmp/xvfb.log 2>&1 &
           for _ in $(seq 1 30); do
             if xdpyinfo -display :99 >/dev/null 2>&1; then break; fi
             sleep 1
           done
-          xdpyinfo -display :99 >/dev/null 2>&1 || { echo "Xvfb never came up"; cat /tmp/xvfb.log; exit 1; }
+          if ! xdpyinfo -display :99 >/dev/null 2>&1; then
+            echo "Xvfb never came up (or xdpyinfo is missing)"
+            cat /tmp/xvfb.log 2>/dev/null || true
+            exit 1
+          fi
           DISPLAY=:99 openbox >/tmp/openbox.log 2>&1 &
           sleep 2
           echo "DISPLAY=:99" >> "$GITHUB_ENV"

--- a/tools/debug-bridge/bridge.sh
+++ b/tools/debug-bridge/bridge.sh
@@ -20,6 +20,7 @@
 #   menu "<Menu>Item[>Sub]" [window]
 #   highlight <selector> [ms]
 #   iconify <selector> [true|false]   minimize/restore a window; reports what the OS did
+#   wbounds <selector> x y w h       move/resize a window
 # Synchronize / assert (exit 0 on success, 1 on failure):
 #   wait   [find opts] [--state showing|enabled|gone] [--timeout MS] [--interval MS]
 #   assert [find opts] [--gone]
@@ -148,6 +149,7 @@ case "$cmd" in
   listeners) get listeners --data-urlencode "path=$1" | pretty ;;
   highlight) get highlight --data-urlencode "path=$1" --data-urlencode "ms=${2:-2000}" | pretty ;;
   iconify)   get iconify --data-urlencode "path=$1" --data-urlencode "iconified=${2:-true}" | pretty ;;
+  wbounds)   get windowBounds --data-urlencode "path=$1" --data-urlencode "x=$2" --data-urlencode "y=$3" --data-urlencode "w=$4" --data-urlencode "h=$5" | pretty ;;
 
   help|*)
     sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'

--- a/tools/debug-bridge/bridge.sh
+++ b/tools/debug-bridge/bridge.sh
@@ -19,6 +19,7 @@
 #   trow <selector> <row> [col]   dtrow <selector> <row> [col]   rtrow <selector> <row> [col]
 #   menu "<Menu>Item[>Sub]" [window]
 #   highlight <selector> [ms]
+#   iconify <selector> [true|false]   minimize/restore a window; reports what the OS did
 # Synchronize / assert (exit 0 on success, 1 on failure):
 #   wait   [find opts] [--state showing|enabled|gone] [--timeout MS] [--interval MS]
 #   assert [find opts] [--gone]
@@ -146,6 +147,7 @@ case "$cmd" in
   props)     get props --data-urlencode "path=$1" | pretty ;;
   listeners) get listeners --data-urlencode "path=$1" | pretty ;;
   highlight) get highlight --data-urlencode "path=$1" --data-urlencode "ms=${2:-2000}" | pretty ;;
+  iconify)   get iconify --data-urlencode "path=$1" --data-urlencode "iconified=${2:-true}" | pretty ;;
 
   help|*)
     sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'

--- a/tools/debug-bridge/launch-client.sh
+++ b/tools/debug-bridge/launch-client.sh
@@ -59,9 +59,25 @@ fi
 # --- classpath: module classes first, then the dependency jars --------------
 MODULES=(vcell-client vcell-core vcell-util vcell-math vcell-api-types
          vcell-apiclient vcell-restclient vcell-server vcell-api)
+
+# Under Git Bash / MSYS the java on PATH is a WINDOWS binary: it wants ';' between
+# classpath entries and native C:\... paths, not the ':' and /c/... this shell uses.
+# cygpath does that translation; everywhere else the POSIX form is already right.
+CPSEP=":"
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) CPSEP=";" ;;
+esac
+winpath() {
+  if [ "$CPSEP" = ";" ] && command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$1"
+  else
+    printf '%s' "$1"
+  fi
+}
+
 CP=""
 for m in "${MODULES[@]}"; do
-  CP+="$REPO/$m/target/classes:"
+  CP+="$(winpath "$REPO/$m/target/classes")$CPSEP"
 done
 
 if [ ! -d "$REPO/vcell-client/target/classes" ]; then
@@ -74,14 +90,14 @@ DEP_CP_FILE="$REPO/vcell-client/target/debug-bridge-deps-cp.txt"
 if $REFRESH_CP || [ ! -s "$DEP_CP_FILE" ]; then
   echo "resolving vcell-client dependency classpath (cached at $DEP_CP_FILE)..." >&2
   (cd "$REPO" && mvn -q dependency:build-classpath -pl vcell-client \
-      -Dmdep.outputFile="$DEP_CP_FILE")
+      -Dmdep.outputFile="$(winpath "$DEP_CP_FILE")")
 fi
 CP+="$(cat "$DEP_CP_FILE")"
 
 # --- JVM options mirrored from the install4j launcher ------------------------
 vmopts=(
   --add-exports java.desktop/sun.awt.image=ALL-UNNAMED
-  "-Dvcell.installDir=$INSTALL_DIR"
+  "-Dvcell.installDir=$(winpath "$INSTALL_DIR")"
   -Dvcell.autoflushlog=true
   "-Dvcell.softwareVersion=$VERSION"
   "-Dvcell.serverHost=$API_HOST"

--- a/tools/debug-bridge/scenarios/detach-window.sh
+++ b/tools/debug-bridge/scenarios/detach-window.sh
@@ -46,6 +46,23 @@ PAUSE="${PAUSE:-0}"
 CHILD_TITLE="View VCell Properties"
 OPEN_MENU="Help>VCell Properties ..."
 
+# JSON parsing. Git Bash on Windows ships curl and sed but no Python, and where Python
+# is installed it is often "python" rather than "python3" - so resolve it once and say
+# so plainly if it is missing, rather than failing later with an empty result that looks
+# like a test failure.
+PY=""
+for candidate in python3 python py; do
+  if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c "import json,sys" >/dev/null 2>&1; then
+    PY="$candidate"
+    break
+  fi
+done
+if [ -z "$PY" ]; then
+  echo "ERROR: need python3 (or python) on PATH to read the bridge's JSON." >&2
+  echo "       On Windows, install Python or run this from WSL." >&2
+  exit 2
+fi
+
 pass=0
 fail=0
 
@@ -64,7 +81,7 @@ check() { # check <description> <expected> <actual>
 
 # field <json> <key>  -- reads one field of the child window's entry in /windows
 field() {
-  "$BRIDGE" windows | python3 -c "
+  "$BRIDGE" windows | "$PY" -c "
 import json,sys
 key=sys.argv[1]
 for w in json.load(sys.stdin):
@@ -78,7 +95,7 @@ else:
 }
 
 bounds() {
-  "$BRIDGE" windows | python3 -c "
+  "$BRIDGE" windows | "$PY" -c "
 import json,sys
 for w in json.load(sys.stdin):
     if w.get('text','') == sys.argv[1]:
@@ -90,7 +107,7 @@ else:
 
 # the child window's own path in /windows, so nothing is hard-coded to an index
 child_path() {
-  "$BRIDGE" windows | python3 -c "
+  "$BRIDGE" windows | "$PY" -c "
 import json,sys
 for w in json.load(sys.stdin):
     if w.get('text','') == sys.argv[1]:
@@ -102,7 +119,7 @@ else:
 
 # ask the real window manager to minimize, and report only what it says happened
 try_minimize() {
-  "$BRIDGE" iconify "$(child_path)" "$1" | python3 -c "
+  "$BRIDGE" iconify "$(child_path)" "$1" | "$PY" -c "
 import json,sys
 d=json.load(sys.stdin)
 print(str(d.get('iconified')).lower() if 'iconified' in d else 'ERROR')
@@ -119,7 +136,7 @@ TOGGLE=DetachWindowToggle
 # it happened for real once the window-list control was removed and nothing else was left
 # in the bar to hold the row open.
 icon_fits() {
-  "$BRIDGE" find --name "$TOGGLE" | python3 -c "
+  "$BRIDGE" find --name "$TOGGLE" | "$PY" -c "
 import json,sys
 d=json.load(sys.stdin)
 if not d:
@@ -132,7 +149,7 @@ else:
 
 # which action the tooltip currently offers: "Detach" or "Reattach"
 toggle_offers() {
-  "$BRIDGE" find --name "$TOGGLE" | python3 -c "
+  "$BRIDGE" find --name "$TOGGLE" | "$PY" -c "
 import json,sys
 d=json.load(sys.stdin)
 if not d:
@@ -146,7 +163,7 @@ else:
 # does the CHILD window carry the window-list (hamburger) control? Scoped to the child's
 # own subtree - the document window has one of its own, which a global search would hit.
 has_window_menu() {
-  "$BRIDGE" find --type JMenu --limit 50 | python3 -c "
+  "$BRIDGE" find --type JMenu --limit 50 | "$PY" -c "
 import json,sys
 d=json.load(sys.stdin)
 prefix = sys.argv[1] + '/'
@@ -168,7 +185,7 @@ echo ok
 # "version mismatch" warning over everything. Dismiss it rather than requiring the
 # person running this to get there first.
 step "dismiss the version-mismatch warning if present"
-warn_ok=$("$BRIDGE" find --type JButton --text OK --limit 20 | python3 -c "
+warn_ok=$("$BRIDGE" find --type JButton --text OK --limit 20 | "$PY" -c "
 import json,sys
 d=json.load(sys.stdin)
 # only a button inside a dialog, i.e. not in window 0, the document window
@@ -176,6 +193,9 @@ print(next((c['id'] for c in d if isinstance(c,dict) and not c.get('path','').st
 ")
 if [ -n "$warn_ok" ]; then
   "$BRIDGE" click "$warn_ok" >/dev/null
+  # Wait for it to be really gone, not just clicked. Menu activations that land while a
+  # modal dialog is still tearing down are swallowed, which cost several confusing runs.
+  "$BRIDGE" wait --type JButton --text OK --state gone --timeout 15000 >/dev/null || true
   echo "  dismissed"
 else
   echo "  none showing"
@@ -188,7 +208,7 @@ pause
 # than assuming one attempt takes.
 step "open a modeless child window ($OPEN_MENU)"
 opened=no
-for attempt in 1 2 3 4 5; do
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
   if [ "$(field owner)" != "WINDOW-NOT-FOUND" ]; then
     opened=yes
     [ "$attempt" = 1 ] && echo "  already open, reusing it" || echo "  opened on attempt $attempt"

--- a/tools/debug-bridge/scenarios/detach-window.sh
+++ b/tools/debug-bridge/scenarios/detach-window.sh
@@ -156,7 +156,7 @@ if not d:
     print('CONTROL-NOT-FOUND')
 else:
     tip = d[0].get('tooltip') or ''
-    print(tip.split()[0] if tip else 'NO-TOOLTIP')
+    print(tip.split()[0].rstrip(':,.-') if tip else 'NO-TOOLTIP')
 "
 }
 
@@ -238,8 +238,16 @@ step "ATTACHED: owned by the document window, and cannot be minimized"
 owner=$(field owner)
 check "owner is a window (not null)"      "yes"   "$([ "$owner" = null ] && echo no || echo yes)"
 check "canIconify"                        "false" "$(field canIconify)"
+# Move it somewhere a user might have dragged it to. This matters: a window left where
+# it opened already sits where "helpfully" re-centring it would put it back, so a test
+# that never moves the window cannot see a re-centring bug at all. One did exist - the
+# logical-window framework repositions in componentShown, after setBounds - and it went
+# unnoticed here until someone dragged the window by hand.
+"$BRIDGE" wbounds "$(child_path)" 80 90 640 300 >/dev/null
+"$BRIDGE" idle >/dev/null
 before=$(bounds)
-echo "  bounds: $before"
+echo "  bounds after moving it off-centre: $before"
+check "window went where it was put"      "80,90,640,300" "$before"
 # the user's actual complaint: asking an owned dialog to minimize does nothing
 check "minimize request refused"          "false" "$(try_minimize true)"
 pause

--- a/tools/debug-bridge/scenarios/detach-window.sh
+++ b/tools/debug-bridge/scenarios/detach-window.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# Detach/reattach scenario for modeless child windows.
+#
+# WHY THIS EXISTS
+#   Modeless child windows (simulation results, geometry viewers, ...) are OWNED
+#   dialogs, so the OS keeps them above their document window and gives them no
+#   taskbar/dock button. A Dialog also has no iconified state at all, so it cannot
+#   be minimized. On a small screen there is then no way to get a results window
+#   out of the way. "Detach Window" swaps the owned dialog for an un-owned frame,
+#   trading the z-order guarantee for a window the user can minimize and arrange.
+#
+#   That behaviour is a property of the OS, not of our Java code, so it has to be
+#   checked against a running client on each platform. This script does that with
+#   plain assertions on the bridge's JSON - no screenshots, no image diffing, and
+#   nothing for a human to eyeball in order to get a pass/fail.
+#
+#   A human CAN watch it: it drives the real UI, and PAUSE=<seconds> slows it down.
+#
+# WHAT IS ASSERTED
+#   attached  ->  owner is the document window   AND  canIconify == false
+#   detached  ->  owner is null                  AND  canIconify == true
+#                 AND an actual minimize request is honoured by the OS
+#   reattached->  owned again, and bounds are unchanged across the whole round trip
+#
+#   canIconify/owner come straight from the live AWT objects; the minimize check
+#   asks the real window manager and reports what it actually did, so a platform
+#   that refuses would fail here rather than pass silently.
+#
+# PREREQ  a client running with the bridge enabled:
+#           tools/debug-bridge/launch-client.sh     (from target/classes)
+#           ./vcell.sh --debug-bridge               (from packaged jars)
+#
+# USAGE   scenarios/detach-window.sh [port]
+#         PAUSE=1 scenarios/detach-window.sh        # slow enough to watch
+#
+# PLATFORMS  macOS and Linux out of the box. On Windows run it from Git Bash or
+#            WSL - it is plain POSIX shell plus curl, which both provide.
+
+set -euo pipefail
+
+BRIDGE="$(cd "$(dirname "$0")/.." && pwd)/bridge.sh"
+export BRIDGE_PORT="${1:-${BRIDGE_PORT:-9123}}"
+PAUSE="${PAUSE:-0}"
+
+CHILD_TITLE="View VCell Properties"
+OPEN_MENU="Help>VCell Properties ..."
+
+pass=0
+fail=0
+
+step()  { echo; echo "== $* =="; }
+pause() { [ "$PAUSE" = 0 ] || sleep "$PAUSE"; }
+
+check() { # check <description> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    echo "  PASS  $1 (= $3)"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL  $1 -- expected '$2', got '$3'"
+    fail=$((fail + 1))
+  fi
+}
+
+# field <json> <key>  -- reads one field of the child window's entry in /windows
+field() {
+  "$BRIDGE" windows | python3 -c "
+import json,sys
+key=sys.argv[1]
+for w in json.load(sys.stdin):
+    if w.get('text','') == sys.argv[2]:
+        v = w.get(key)
+        print('null' if v is None else (str(v).lower() if isinstance(v,bool) else v))
+        break
+else:
+    print('WINDOW-NOT-FOUND')
+" "$1" "$CHILD_TITLE"
+}
+
+bounds() {
+  "$BRIDGE" windows | python3 -c "
+import json,sys
+for w in json.load(sys.stdin):
+    if w.get('text','') == sys.argv[1]:
+        b=w['bounds']; print('%d,%d,%d,%d'%(b['x'],b['y'],b['w'],b['h'])); break
+else:
+    print('WINDOW-NOT-FOUND')
+" "$CHILD_TITLE"
+}
+
+# the child window's own path in /windows, so nothing is hard-coded to an index
+child_path() {
+  "$BRIDGE" windows | python3 -c "
+import json,sys
+for w in json.load(sys.stdin):
+    if w.get('text','') == sys.argv[1]:
+        print(w['path']); break
+else:
+    print('WINDOW-NOT-FOUND')
+" "$CHILD_TITLE"
+}
+
+# ask the real window manager to minimize, and report only what it says happened
+try_minimize() {
+  "$BRIDGE" iconify "$(child_path)" "$1" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(str(d.get('iconified')).lower() if 'iconified' in d else 'ERROR')
+"
+}
+
+# id of the attach/detach menu item, whichever way it currently reads
+toggle_id() {
+  "$BRIDGE" find --contains "$1" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(d[0]['id'] if d else 'MENU-ITEM-NOT-FOUND')
+"
+}
+
+step "bridge is answering"
+"$BRIDGE" health >/dev/null
+echo ok
+
+step "wait for the client to finish starting"
+"$BRIDGE" wait --type JFrame --contains VCell --timeout 90000 >/dev/null
+"$BRIDGE" wait --type JMenu --text Help --timeout 30000 >/dev/null
+echo ok
+
+# A source build reports a different version than the server, so the client opens a
+# "version mismatch" warning over everything. Dismiss it rather than requiring the
+# person running this to get there first.
+step "dismiss the version-mismatch warning if present"
+warn_ok=$("$BRIDGE" find --type JButton --text OK --limit 20 | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+# only a button inside a dialog, i.e. not in window 0, the document window
+print(next((c['id'] for c in d if isinstance(c,dict) and not c.get('path','').startswith('0/')), ''))
+")
+if [ -n "$warn_ok" ]; then
+  "$BRIDGE" click "$warn_ok" >/dev/null
+  echo "  dismissed"
+else
+  echo "  none showing"
+fi
+"$BRIDGE" idle >/dev/null
+pause
+
+# The first menu activation immediately after a modal dialog is dismissed is swallowed
+# (the click lands while the dialog is still tearing down), so open with a retry rather
+# than assuming one attempt takes.
+step "open a modeless child window ($OPEN_MENU)"
+opened=no
+for attempt in 1 2 3 4 5; do
+  if [ "$(field owner)" != "WINDOW-NOT-FOUND" ]; then
+    opened=yes
+    [ "$attempt" = 1 ] && echo "  already open, reusing it" || echo "  opened on attempt $attempt"
+    break
+  fi
+  "$BRIDGE" menu "$OPEN_MENU" >/dev/null || true
+  "$BRIDGE" idle >/dev/null || true
+  sleep 1
+done
+if [ "$opened" != yes ]; then
+  echo "  FAIL  could not open '$CHILD_TITLE' via $OPEN_MENU"
+  exit 1
+fi
+"$BRIDGE" wait --type JMenuItem --contains "etach Window" --timeout 20000 >/dev/null
+pause
+
+step "normalize: make sure we start attached"
+if [ "$(field owner)" = "null" ]; then
+  "$BRIDGE" click "$(toggle_id 'Reattach Window')" >/dev/null
+  "$BRIDGE" wait --type JMenuItem --contains "Detach Window" --timeout 10000 >/dev/null
+  echo "  was detached from a previous run; reattached"
+else
+  echo "  ok"
+fi
+
+step "ATTACHED: owned by the document window, and cannot be minimized"
+owner=$(field owner)
+check "owner is a window (not null)"      "yes"   "$([ "$owner" = null ] && echo no || echo yes)"
+check "canIconify"                        "false" "$(field canIconify)"
+before=$(bounds)
+echo "  bounds: $before"
+# the user's actual complaint: asking an owned dialog to minimize does nothing
+check "minimize request refused"          "false" "$(try_minimize true)"
+pause
+
+step "click 'Detach Window'"
+"$BRIDGE" click "$(toggle_id 'Detach Window')" >/dev/null
+"$BRIDGE" wait --type JMenuItem --contains "Reattach Window" --timeout 10000 >/dev/null
+pause
+
+step "DETACHED: un-owned, and the OS really does minimize it"
+check "owner is null"                     "null"  "$(field owner)"
+check "canIconify"                        "true"  "$(field canIconify)"
+check "bounds unchanged by detaching"     "$before" "$(bounds)"
+
+# the crux: ask the real window manager, and believe only what it reports back
+check "minimize request honoured"         "true"  "$(try_minimize true)"
+check "restored"                          "false" "$(try_minimize false)"
+pause
+
+step "click 'Reattach Window'"
+"$BRIDGE" click "$(toggle_id 'Reattach Window')" >/dev/null
+"$BRIDGE" wait --type JMenuItem --contains "Detach Window" --timeout 10000 >/dev/null
+pause
+
+step "REATTACHED: owned again, nothing moved"
+owner=$(field owner)
+check "owner is a window again"           "yes"   "$([ "$owner" = null ] && echo no || echo yes)"
+check "canIconify"                        "false" "$(field canIconify)"
+check "bounds unchanged over round trip"  "$before" "$(bounds)"
+
+echo
+echo "-------------------------------------------"
+echo "  passed: $pass    failed: $fail"
+echo "-------------------------------------------"
+[ "$fail" -eq 0 ] || exit 1
+echo "DETACH OK"

--- a/tools/debug-bridge/scenarios/detach-window.sh
+++ b/tools/debug-bridge/scenarios/detach-window.sh
@@ -109,13 +109,50 @@ print(str(d.get('iconified')).lower() if 'iconified' in d else 'ERROR')
 "
 }
 
-# id of the attach/detach menu item, whichever way it currently reads
-toggle_id() {
-  "$BRIDGE" find --contains "$1" | python3 -c "
+# The detach/reattach control is an icon with a tooltip - no text to match on - so it is
+# selected by component name. Its tooltip is what tells the user which way it will go, so
+# the script asserts on that too: an icon whose tooltip did not flip would be a silent lie.
+TOGGLE=DetachWindowToggle
+
+# Is the control big enough to actually draw its 16px icon? The icon is clipped rather
+# than scaled if the menu bar squashes the item, which no functional assertion notices -
+# it happened for real once the window-list control was removed and nothing else was left
+# in the bar to hold the row open.
+icon_fits() {
+  "$BRIDGE" find --name "$TOGGLE" | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
-print(d[0]['id'] if d else 'MENU-ITEM-NOT-FOUND')
+if not d:
+    print('CONTROL-NOT-FOUND')
+else:
+    b=d[0]['bounds']
+    print('yes' if b['h'] >= 16 and b['w'] >= 16 else 'no (%dx%d)'%(b['w'],b['h']))
 "
+}
+
+# which action the tooltip currently offers: "Detach" or "Reattach"
+toggle_offers() {
+  "$BRIDGE" find --name "$TOGGLE" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+if not d:
+    print('CONTROL-NOT-FOUND')
+else:
+    tip = d[0].get('tooltip') or ''
+    print(tip.split()[0] if tip else 'NO-TOOLTIP')
+"
+}
+
+# does the CHILD window carry the window-list (hamburger) control? Scoped to the child's
+# own subtree - the document window has one of its own, which a global search would hit.
+has_window_menu() {
+  "$BRIDGE" find --type JMenu --limit 50 | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+prefix = sys.argv[1] + '/'
+print('yes' if any(isinstance(c,dict) and c.get('name')=='WindowIconMenu'
+                   and c.get('path','').startswith(prefix) for c in d) else 'no')
+" "$(child_path)"
 }
 
 step "bridge is answering"
@@ -165,13 +202,13 @@ if [ "$opened" != yes ]; then
   echo "  FAIL  could not open '$CHILD_TITLE' via $OPEN_MENU"
   exit 1
 fi
-"$BRIDGE" wait --type JMenuItem --contains "etach Window" --timeout 20000 >/dev/null
+"$BRIDGE" wait --name "$TOGGLE" --timeout 20000 >/dev/null
 pause
 
 step "normalize: make sure we start attached"
 if [ "$(field owner)" = "null" ]; then
-  "$BRIDGE" click "$(toggle_id 'Reattach Window')" >/dev/null
-  "$BRIDGE" wait --type JMenuItem --contains "Detach Window" --timeout 10000 >/dev/null
+  "$BRIDGE" click "name=$TOGGLE" >/dev/null
+  "$BRIDGE" idle >/dev/null
   echo "  was detached from a previous run; reattached"
 else
   echo "  ok"
@@ -187,9 +224,13 @@ echo "  bounds: $before"
 check "minimize request refused"          "false" "$(try_minimize true)"
 pause
 
-step "click 'Detach Window'"
-"$BRIDGE" click "$(toggle_id 'Detach Window')" >/dev/null
-"$BRIDGE" wait --type JMenuItem --contains "Reattach Window" --timeout 10000 >/dev/null
+step "click the detach control (icon + tooltip, no text)"
+check "tooltip offers detaching"          "Detach"   "$(toggle_offers)"
+check "icon not clipped by the menu bar"  "yes"      "$(icon_fits)"
+check "no window-list control while attached" "no" "$(has_window_menu)"
+"$BRIDGE" click "name=$TOGGLE" >/dev/null
+"$BRIDGE" wait --name "$TOGGLE" --timeout 10000 >/dev/null
+"$BRIDGE" idle >/dev/null
 pause
 
 step "DETACHED: un-owned, and the OS really does minimize it"
@@ -202,9 +243,13 @@ check "minimize request honoured"         "true"  "$(try_minimize true)"
 check "restored"                          "false" "$(try_minimize false)"
 pause
 
-step "click 'Reattach Window'"
-"$BRIDGE" click "$(toggle_id 'Reattach Window')" >/dev/null
-"$BRIDGE" wait --type JMenuItem --contains "Detach Window" --timeout 10000 >/dev/null
+step "click the reattach control"
+check "tooltip now offers reattaching"    "Reattach" "$(toggle_offers)"
+check "icon not clipped by the menu bar"  "yes"      "$(icon_fits)"
+check "window-list control appears once detached" "yes" "$(has_window_menu)"
+"$BRIDGE" click "name=$TOGGLE" >/dev/null
+"$BRIDGE" wait --name "$TOGGLE" --timeout 10000 >/dev/null
+"$BRIDGE" idle >/dev/null
 pause
 
 step "REATTACHED: owned again, nothing moved"

--- a/vcell-client/src/main/java/cbit/vcell/client/ChildWindowManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ChildWindowManager.java
@@ -215,8 +215,15 @@ public class ChildWindowManager {
 	 * @param modality not null
 	 * @return implementing class
 	 */
-	private LWFrameOrDialog createContainerImplementation(String title,LWModality modality, boolean parentCentered, boolean detached) {
-		LWTraits traits = parentCentered ? new LWTraits(InitialPosition.CENTERED_ON_PARENT) : new LWTraits(InitialPosition.STAGGERED_ON_PARENT);
+	private LWFrameOrDialog createContainerImplementation(String title,LWModality modality, boolean parentCentered,
+			boolean detached, boolean keepPosition) {
+		// LWManager positions a window in componentShown, i.e. AFTER setBounds and after the
+		// caller has had its say. That is right for a window opening for the first time and
+		// wrong when we are rebuilding one the user has already placed: it would drag the
+		// window back onto its parent. NOT_LW_MANAGED opts out of that.
+		LWTraits traits = keepPosition ? new LWTraits(InitialPosition.NOT_LW_MANAGED)
+				: parentCentered ? new LWTraits(InitialPosition.CENTERED_ON_PARENT)
+						: new LWTraits(InitialPosition.STAGGERED_ON_PARENT);
 		if (owner == null) {
 			// every ChildWindowManager host is an LWTopFrame, so findLWOwner(parent) always resolves an
 			// owner. A null owner would mean a non-LW host was introduced — fail loudly rather than fall
@@ -400,7 +407,7 @@ public class ChildWindowManager {
 				LG.debug(ExecutionTrace.justClassName(ChildWindowManager.this) + " making a child window.  My parent is a "+ this.getParent().getName());
 			}	
 			shownModality = modality;
-			impl = createContainerImplementation(title,modality,isCenteredOnParent,detached);
+			impl = createContainerImplementation(title,modality,isCenteredOnParent,detached,rememberedBounds != null);
 			impl.addWindowListener(windowListener);
 			{ //assemble pieces
 				Container cp = impl.getContentPane();
@@ -515,9 +522,8 @@ public class ChildWindowManager {
 			// the debug-bridge scenario selects it by, now that there is no text to match on.
 			item.setName(ATTACHMENT_TOGGLE_NAME);
 			item.setToolTipText(detached
-					? "Reattach this window: keep it in front of its document window again"
-					: "Detach this window: let it be minimized and arranged freely, at the cost "
-							+ "of it no longer being kept in front of its document window");
+					? "Reattach: keep in front of the document window"
+					: "Detach: allow minimizing, but no longer kept in front");
 			// A JMenuItem in a JMenuBar is stretched to fill the bar by the bar's BoxLayout,
 			// which would turn every bit of empty menu-bar space into a detach button. Clamp
 			// the WIDTH only: clamping the height too squashed the item to 9px - under the

--- a/vcell-client/src/main/java/cbit/vcell/client/ChildWindowManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ChildWindowManager.java
@@ -1,6 +1,12 @@
 package cbit.vcell.client;
 
 import java.awt.BorderLayout;
+import java.awt.RenderingHints;
+import java.awt.Graphics2D;
+import java.awt.Graphics;
+import java.awt.Color;
+import java.awt.ComponentOrientation;
+import java.awt.BasicStroke;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dialog.ModalityType;
@@ -17,6 +23,7 @@ import java.util.Objects;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JMenuBar;
+import javax.swing.Icon;
 import javax.swing.JMenuItem;
 
 import org.apache.logging.log4j.LogManager;
@@ -45,6 +52,9 @@ import edu.uchc.connjur.wb.ExecutionTrace;
 
 
 public class ChildWindowManager {
+	/** component name of the detach/reattach control; selected by name in debug-bridge scenarios */
+	public static final String ATTACHMENT_TOGGLE_NAME = "DetachWindowToggle";
+
 	private final ArrayList<ChildWindow> childWindows = new ArrayList<ChildWindow>();
 	
 	private JFrame parent = null;
@@ -136,6 +146,70 @@ public class ChildWindowManager {
 		
 	}
 	
+	/**
+	 * The detach/reattach affordance, drawn rather than shipped as a bitmap so it follows the
+	 * look and feel's foreground colour and stays crisp on a HiDPI display.
+	 *
+	 * A window outline with an arrow leaving it (detach available) or returning to it
+	 * (reattach available). Direction is the whole message, so the two states read
+	 * differently at a glance instead of relying on the tooltip alone.
+	 */
+	@SuppressWarnings("serial")
+	private static class AttachmentIcon implements Icon {
+		private static final int SIZE = 16;
+		private final boolean bOut;      // true = arrow leaving the window, i.e. "detach"
+
+		private AttachmentIcon(boolean bOut) {
+			this.bOut = bOut;
+		}
+
+		@Override
+		public int getIconWidth() {
+			return SIZE;
+		}
+
+		@Override
+		public int getIconHeight() {
+			return SIZE;
+		}
+
+		@Override
+		public void paintIcon(Component c, Graphics g, int x, int y) {
+			Graphics2D g2 = (Graphics2D) g.create();
+			try {
+				g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+				g2.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+				g2.translate(x, y);
+				Color fg = (c == null || c.getForeground() == null) ? Color.DARK_GRAY : c.getForeground();
+				g2.setColor(c != null && !c.isEnabled() ? Color.GRAY : fg);
+				g2.setStroke(new BasicStroke(1.2f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+
+				// A window outline left open at the top-right, where the arrow passes. This is
+				// the familiar "open in new window" mark, so detaching reads without a legend.
+				// No title bar: at 16px the extra line only muddies it.
+				g2.drawLine(1, 6, 6, 6);
+				g2.drawLine(1, 6, 1, 14);
+				g2.drawLine(1, 14, 10, 14);
+				g2.drawLine(10, 14, 10, 9);
+
+				if (bOut) {
+					// leaving: tip at the far corner, head legs folding back down the shaft
+					g2.drawLine(7, 8, 14, 1);
+					g2.drawLine(14, 1, 9, 1);
+					g2.drawLine(14, 1, 14, 6);
+				} else {
+					// returning: the mirror, with the tip placed IN the opening rather than
+					// inside the outline - overlapping the edge turns it to mush at this size
+					g2.drawLine(15, 1, 9, 7);
+					g2.drawLine(9, 7, 14, 7);
+					g2.drawLine(9, 7, 9, 2);
+				}
+			} finally {
+				g2.dispose();
+			}
+		}
+	}
+
 	/**
 	 * @param title not null
 	 * @param modality not null
@@ -331,8 +405,16 @@ public class ChildWindowManager {
 			{ //assemble pieces
 				Container cp = impl.getContentPane();
 				cp.setLayout(new BorderLayout());
-				JMenuBar mb = LWNamespace.createRightSideIconMenuBar();
+				// The window-list control earns its place only once this window is detached.
+				// While it is attached it is pinned above its owner, so jumping to another
+				// window from here does not actually reveal that window - it stays underneath.
+				// Detached, the window is independent and can be minimized, and the list is
+				// then the way back to it.
+				JMenuBar mb = (detached || modality != LWModality.MODELESS)
+						? LWNamespace.createRightSideIconMenuBar()
+						: new JMenuBar();
 				if (modality == LWModality.MODELESS) {
+					mb.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
 					mb.add(createAttachmentMenuItem());
 				}
 				cp.add(mb,BorderLayout.NORTH);
@@ -428,15 +510,21 @@ public class ChildWindowManager {
 		}
 
 		private JMenuItem createAttachmentMenuItem() {
-			final JMenuItem item = new JMenuItem();
-			item.setText(detached ? "Reattach Window" : "Detach Window");
-			// a JMenuItem in a JMenuBar is stretched to fill the bar by the bar's BoxLayout,
-			// which would turn every bit of empty menu-bar space into a detach button.
-			item.setMaximumSize(item.getPreferredSize());
+			final JMenuItem item = new JMenuItem(new AttachmentIcon(!detached));
+			// icon only, matching the window-list control alongside it. The name is the handle
+			// the debug-bridge scenario selects it by, now that there is no text to match on.
+			item.setName(ATTACHMENT_TOGGLE_NAME);
 			item.setToolTipText(detached
-					? "Keep this window in front of its document window again"
-					: "Let this window be minimized and arranged freely, at the cost of it no "
-							+ "longer being kept in front of its document window");
+					? "Reattach this window: keep it in front of its document window again"
+					: "Detach this window: let it be minimized and arranged freely, at the cost "
+							+ "of it no longer being kept in front of its document window");
+			// A JMenuItem in a JMenuBar is stretched to fill the bar by the bar's BoxLayout,
+			// which would turn every bit of empty menu-bar space into a detach button. Clamp
+			// the WIDTH only: clamping the height too squashed the item to 9px - under the
+			// icon's 16 - and clipped the glyph, but only once this was the sole control in
+			// the bar, with nothing else to hold the row open.
+			Dimension pref = item.getPreferredSize();
+			item.setMaximumSize(new Dimension(pref.width, Integer.MAX_VALUE));
 			item.addActionListener(e -> setDetached(!detached));
 			return item;
 		}

--- a/vcell-client/src/main/java/cbit/vcell/client/ChildWindowManager.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/ChildWindowManager.java
@@ -5,6 +5,7 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dialog.ModalityType;
 import java.awt.Dimension;
+import java.awt.Rectangle;
 import java.awt.HeadlessException;
 import java.awt.Window;
 import java.awt.event.WindowAdapter;
@@ -16,6 +17,7 @@ import java.util.Objects;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -81,6 +83,41 @@ public class ChildWindowManager {
 			return childWindowManager; 
 		}
 	}
+	/**
+	 * The DETACHED counterpart of {@link ModelessChild}: an un-owned {@link LWChildFrame}.
+	 *
+	 * Owning a child window buys OS-guaranteed z-order (see ModelessChild), but the price is
+	 * paid by the user: a Dialog has no taskbar/dock button and, not being a Frame, has no
+	 * iconified state at all, so it cannot be minimised; and because the OS keeps it above its
+	 * owner, on a small screen it can cover the document window with no way to raise that
+	 * window above it. Detaching trades the z-order guarantee back for an ordinary top-level
+	 * window the user can minimise, stack and arrange freely.
+	 *
+	 * Still a logical-window child, so it keeps its place in the Window menu and in
+	 * {@link ChildWindowManager#findChildWindowManager(Component)} - only the NATIVE ownership
+	 * is given up, not the logical parentage.
+	 */
+	@SuppressWarnings("serial")
+	private static class DetachedModelessChild extends LWChildFrame implements ManagedChild {
+		private final ChildWindowManager childWindowManager;
+		private DetachedModelessChild(ChildWindowManager cwm, LWContainerHandle parent, String title, LWTraits tr) throws HeadlessException {
+			super(parent, title);
+			Objects.requireNonNull(cwm);
+			childWindowManager = cwm;
+			traits = tr;
+		}
+
+		@Override
+		public String menuDescription() {
+			return getTitle();
+		}
+
+		@Override
+		public ChildWindowManager getChildWindowManager() {
+			return childWindowManager;
+		}
+	}
+
 	@SuppressWarnings("serial")
 	private static class ParentModalChild extends LWTitledDialog implements ManagedChild {
 		private final ChildWindowManager childWindowManager;
@@ -104,7 +141,7 @@ public class ChildWindowManager {
 	 * @param modality not null
 	 * @return implementing class
 	 */
-	private LWFrameOrDialog createContainerImplementation(String title,LWModality modality, boolean parentCentered) {
+	private LWFrameOrDialog createContainerImplementation(String title,LWModality modality, boolean parentCentered, boolean detached) {
 		LWTraits traits = parentCentered ? new LWTraits(InitialPosition.CENTERED_ON_PARENT) : new LWTraits(InitialPosition.STAGGERED_ON_PARENT);
 		if (owner == null) {
 			// every ChildWindowManager host is an LWTopFrame, so findLWOwner(parent) always resolves an
@@ -115,7 +152,10 @@ public class ChildWindowManager {
 		}
 		switch (modality) {
 		case MODELESS:
-			return new ModelessChild(this,owner, title,traits);
+			// detach is only meaningful for modeless windows; a parent-modal window that the
+			// user could send behind its parent would be a trap (unreachable modal blocker).
+			return detached ? new DetachedModelessChild(this,owner, title,traits)
+							: new ModelessChild(this,owner, title,traits);
 		case PARENT_ONLY:
 			return new ParentModalChild(this,owner, title,traits);
 		}
@@ -152,6 +192,10 @@ public class ChildWindowManager {
 		private Boolean pack = null;
 		private Dimension size = null;
 		private Boolean isCenteredOnParent = true;
+		private boolean detached = false;
+		/** bounds carried across a detach/reattach, which must rebuild the window */
+		private Rectangle rememberedBounds = null;
+		private LWModality shownModality = null;
 		
 		
 		private ArrayList<ChildWindowListener> listeners = new ArrayList<ChildWindowListener>();
@@ -281,12 +325,16 @@ public class ChildWindowManager {
 			if (LG.isDebugEnabled()) {
 				LG.debug(ExecutionTrace.justClassName(ChildWindowManager.this) + " making a child window.  My parent is a "+ this.getParent().getName());
 			}	
-			impl = createContainerImplementation(title,modality,isCenteredOnParent);
+			shownModality = modality;
+			impl = createContainerImplementation(title,modality,isCenteredOnParent,detached);
 			impl.addWindowListener(windowListener);
 			{ //assemble pieces
 				Container cp = impl.getContentPane();
 				cp.setLayout(new BorderLayout());
-				JMenuBar mb = LWNamespace.createRightSideIconMenuBar(); 
+				JMenuBar mb = LWNamespace.createRightSideIconMenuBar();
+				if (modality == LWModality.MODELESS) {
+					mb.add(createAttachmentMenuItem());
+				}
 				cp.add(mb,BorderLayout.NORTH);
 				cp.add(contentPane, BorderLayout.CENTER);
 			}
@@ -309,7 +357,12 @@ public class ChildWindowManager {
 				impl.setSize(size);
 			}
 
-			if (isCenteredOnParent != null) {
+			if (rememberedBounds != null) {
+				// coming back from a detach/reattach: keep the window exactly where the user
+				// had it rather than re-centring it on the parent.
+				impl.self().setBounds(rememberedBounds);
+				rememberedBounds = null;
+			} else if (isCenteredOnParent != null) {
 				impl.setLocationRelativeTo(impl.getParent());
 			}
 			impl.toFront();
@@ -334,6 +387,58 @@ public class ChildWindowManager {
 		 */
 		public void showModal() {
 			show(LWModality.PARENT_ONLY);
+		}
+
+		public boolean isDetached() {
+			return detached;
+		}
+
+		/**
+		 * Detach this window from its document window, or re-attach it.
+		 *
+		 * A window's native owner is fixed when it is created, so this cannot be flipped in
+		 * place - the window is rebuilt. That is cheap here only because ChildWindow already
+		 * keeps the caller's contentPane separate from the window it is currently sitting in,
+		 * and rebuilds that window on every show(). The content pane, and therefore all viewer
+		 * state, is carried across untouched; the user sees the window's frame change, not its
+		 * contents reload.
+		 *
+		 * Position and size are carried across too, so a detach does not move the window out
+		 * from under the mouse.
+		 */
+		public void setDetached(boolean bDetached) {
+			if (detached == bDetached) {
+				return;
+			}
+			if (shownModality != null && shownModality != LWModality.MODELESS) {
+				throw new IllegalStateException("only a MODELESS child window can be detached");
+			}
+			detached = bDetached;
+			if (impl == null) {
+				return;         // not realized yet; the flag alone is enough
+			}
+			boolean wasVisible = impl.isVisible();
+			rememberedBounds = impl.self().getBounds();
+			// take the content pane back BEFORE disposing, so it is never disposed with the window
+			impl.getContentPane().remove(contentPane);
+			dispose();
+			if (wasVisible) {
+				show(shownModality == null ? LWModality.MODELESS : shownModality);
+			}
+		}
+
+		private JMenuItem createAttachmentMenuItem() {
+			final JMenuItem item = new JMenuItem();
+			item.setText(detached ? "Reattach Window" : "Detach Window");
+			// a JMenuItem in a JMenuBar is stretched to fill the bar by the bar's BoxLayout,
+			// which would turn every bit of empty menu-bar space into a detach button.
+			item.setMaximumSize(item.getPreferredSize());
+			item.setToolTipText(detached
+					? "Keep this window in front of its document window again"
+					: "Let this window be minimized and arranged freely, at the cost of it no "
+							+ "longer being kept in front of its document window");
+			item.addActionListener(e -> setDetached(!detached));
+			return item;
 		}
 
 		public void toFront() {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
@@ -130,6 +130,7 @@ public final class SwingDebugBridge {
 			s.createContext("/menu", wrap(SwingDebugBridge::handleMenu));
 			s.createContext("/props", wrap(SwingDebugBridge::handleProps));
 			s.createContext("/highlight", wrap(SwingDebugBridge::handleHighlight));
+			s.createContext("/iconify", wrap(SwingDebugBridge::handleIconify));
 			s.createContext("/log", ex -> {
 				try {
 					respond(ex, 200, "text/plain; charset=utf-8", handleLog(ex).getBytes(StandardCharsets.UTF_8));
@@ -206,6 +207,21 @@ public final class SwingDebugBridge {
 		}
 		boolean clicked = SwingInspector.click(path);
 		return "{\"clicked\":" + clicked + ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	private static String handleIconify(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty()) {
+			return "{\"error\":\"missing 'path' query parameter\"}";
+		}
+		boolean want = Boolean.parseBoolean(q.getOrDefault("iconified", "true"));
+		Boolean actual = SwingInspector.iconify(path, want);
+		if (actual == null) {
+			return "{\"error\":\"no window at path\",\"path\":\"" + jsonEscape(path) + "\"}";
+		}
+		return "{\"requested\":" + want + ",\"iconified\":" + actual
+				+ ",\"path\":\"" + jsonEscape(path) + "\"}";
 	}
 
 	private static String handleSetText(HttpExchange ex) {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingDebugBridge.java
@@ -131,6 +131,7 @@ public final class SwingDebugBridge {
 			s.createContext("/props", wrap(SwingDebugBridge::handleProps));
 			s.createContext("/highlight", wrap(SwingDebugBridge::handleHighlight));
 			s.createContext("/iconify", wrap(SwingDebugBridge::handleIconify));
+			s.createContext("/windowBounds", wrap(SwingDebugBridge::handleWindowBounds));
 			s.createContext("/log", ex -> {
 				try {
 					respond(ex, 200, "text/plain; charset=utf-8", handleLog(ex).getBytes(StandardCharsets.UTF_8));
@@ -222,6 +223,27 @@ public final class SwingDebugBridge {
 		}
 		return "{\"requested\":" + want + ",\"iconified\":" + actual
 				+ ",\"path\":\"" + jsonEscape(path) + "\"}";
+	}
+
+	private static String handleWindowBounds(HttpExchange ex) {
+		Map<String, String> q = query(ex);
+		String path = q.get("path");
+		if (path == null || path.isEmpty()) {
+			return "{\"error\":\"missing 'path' query parameter\"}";
+		}
+		try {
+			java.awt.Rectangle r = new java.awt.Rectangle(
+					Integer.parseInt(q.get("x")), Integer.parseInt(q.get("y")),
+					Integer.parseInt(q.get("w")), Integer.parseInt(q.get("h")));
+			java.awt.Rectangle after = SwingInspector.setWindowBounds(path, r);
+			if (after == null) {
+				return "{\"error\":\"no window at path\",\"path\":\"" + jsonEscape(path) + "\"}";
+			}
+			return "{\"bounds\":{\"x\":" + after.x + ",\"y\":" + after.y
+					+ ",\"w\":" + after.width + ",\"h\":" + after.height + "}}";
+		} catch (NumberFormatException | NullPointerException e) {
+			return "{\"error\":\"need integer x, y, w, h query parameters\"}";
+		}
 	}
 
 	private static String handleSetText(HttpExchange ex) {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -15,6 +15,7 @@ import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.GraphicsEnvironment;
 import java.awt.Point;
+import java.awt.Frame;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.Window;
@@ -241,6 +242,28 @@ public final class SwingInspector {
 	 * combo/list selection, and table cell values (capped).
 	 */
 	private static void appendTypeSpecific(StringBuilder sb, Component c) {
+		if (c instanceof Window) {
+			// Window ownership and iconified state, so a scenario script can assert on the
+			// two things that actually decide whether a user can get a window out of the way:
+			//   owner     - an OWNED window is held above its owner by the OS and gets no
+			//               taskbar/dock button of its own.
+			//   canIconify- only a Frame has an iconified state at all; a Dialog cannot be
+			//               minimized, however much the user would like to.
+			Window w = (Window) c;
+			Window owner = w.getOwner();
+			comma(sb);
+			if (owner == null) {
+				sb.append("\"owner\":null");
+			} else {
+				kv(sb, "owner", nz(textOf(owner)));
+			}
+			comma(sb);
+			raw(sb, "canIconify", c instanceof Frame);
+			if (c instanceof Frame) {
+				comma(sb);
+				raw(sb, "iconified", (((Frame) c).getExtendedState() & Frame.ICONIFIED) != 0);
+			}
+		}
 		if (c instanceof JTabbedPane) {
 			JTabbedPane tp = (JTabbedPane) c;
 			sb.append(",\"tabs\":{\"selected\":").append(tp.getSelectedIndex()).append(",\"titles\":[");
@@ -976,6 +999,58 @@ public final class SwingInspector {
 	 *
 	 * @return true if a component resolved and was clicked
 	 */
+	/**
+	 * Ask a window to iconify (minimize) or restore, and report what the OS actually did.
+	 *
+	 * Deliberately NOT "did we call setExtendedState" - the caller needs to know whether the
+	 * window really minimized, because the interesting case is the one where it CANNOT. A
+	 * Dialog has no iconified state at all, so an owned child window silently refuses to
+	 * minimize; that refusal is the thing worth asserting on, and it is invisible from the
+	 * Java call alone.
+	 *
+	 * @return the window's iconified state after the attempt, or null if there is no such window
+	 */
+	public static Boolean iconify(String path, boolean iconified) {
+		Component c = findByPath(path);
+		if (!(c instanceof Window)) {
+			return null;
+		}
+		final Window w = (Window) c;
+		onEdt(() -> {
+			if (w instanceof Frame) {
+				Frame f = (Frame) w;
+				int st = f.getExtendedState();
+				f.setExtendedState(iconified ? (st | Frame.ICONIFIED) : (st & ~Frame.ICONIFIED));
+				if (!iconified) {
+					// de-iconifying is not enough on its own for every window manager
+					f.toFront();
+				}
+			}
+			// a Dialog has no iconified state; nothing to do, and that is the point
+			return null;
+		});
+		// Poll rather than sleep a fixed amount. Minimize/restore is animated and asynchronous
+		// (the macOS dock genie, Windows' own transition), and how long it takes is not ours to
+		// predict - a fixed wait either flakes on a slow machine or wastes time on a fast one.
+		// A window that is never going to honour the request simply costs the full timeout once.
+		final long deadline = System.currentTimeMillis() + 3000;
+		Boolean state;
+		do {
+			state = onEdt(() -> (w instanceof Frame)
+					&& ((((Frame) w).getExtendedState() & Frame.ICONIFIED) != 0));
+			if (state != null && state == iconified) {
+				return state;
+			}
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				break;
+			}
+		} while (System.currentTimeMillis() < deadline);
+		return state;
+	}
+
 	public static boolean click(String path) {
 		Component c = findByPath(path);
 		if (c == null) {

--- a/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
+++ b/vcell-client/src/main/java/org/vcell/client/debug/SwingInspector.java
@@ -1051,6 +1051,26 @@ public final class SwingInspector {
 		return state;
 	}
 
+	/**
+	 * Move/resize a window, so a scenario can put it somewhere the user might have dragged it
+	 * to. Worth having as a first-class action: a window that is never moved sits wherever it
+	 * was opened, which is exactly where "helpfully" re-centring it would put it back - so a
+	 * test that does not move the window cannot see that bug at all.
+	 *
+	 * @return the window's bounds afterwards, or null if there is no window at that path
+	 */
+	public static Rectangle setWindowBounds(String path, Rectangle r) {
+		Component c = findByPath(path);
+		if (!(c instanceof Window)) {
+			return null;
+		}
+		final Window w = (Window) c;
+		return onEdt(() -> {
+			w.setBounds(r);
+			return w.getBounds();
+		});
+	}
+
 	public static boolean click(String path) {
 		Component c = findByPath(path);
 		if (c == null) {

--- a/vcell-client/src/test/java/cbit/vcell/client/ChildWindowDetachTest.java
+++ b/vcell-client/src/test/java/cbit/vcell/client/ChildWindowDetachTest.java
@@ -1,0 +1,150 @@
+package cbit.vcell.client;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.vcell.client.logicalwindow.LWTopFrame;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
+import java.awt.Window;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.swing.SwingUtilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A detached child window must become an ordinary un-owned top level window - one the OS will
+ * give a taskbar button and let the user minimise - while carrying its contents across intact.
+ *
+ * Background: modeless child windows were made OWNED dialogs in ec0ed8478a to fix them hiding
+ * behind the document window, since an un-owned frame can only be raised with a best-effort
+ * toFront() that macOS 13.3+ and Windows foreground-lock refuse. The accepted price was no
+ * taskbar button and no way to get the window out of the way, which is what users hit on a
+ * small screen. Detaching pays that price back on demand.
+ *
+ * What matters and is asserted here:
+ *   - attached   => a Dialog, owned (cannot be minimised; OS keeps it above its owner)
+ *   - detached   => a Frame, un-owned (minimisable, independently stackable)
+ *   - the caller's content pane is the SAME component afterwards, not a rebuilt one
+ *   - position and size survive, so the window does not jump out from under the mouse
+ */
+@Tag("Fast")
+@DisabledIf("isHeadless")
+public class ChildWindowDetachTest {
+
+    static boolean isHeadless() {
+        return GraphicsEnvironment.isHeadless();
+    }
+
+    @SuppressWarnings("serial")
+    private static class TestTopFrame extends LWTopFrame {
+        @Override
+        public String menuDescription() {
+            return "test top frame";
+        }
+    }
+
+    /** runs the body on the EDT and rethrows whatever it threw */
+    private static void onEdt(ThrowingRunnable body) throws Exception {
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                body.run();
+            } catch (Exception e) {
+                failure.set(e);
+            }
+        });
+        if (failure.get() != null) {
+            throw failure.get();
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    @Test
+    public void detachGivesAnUnownedFrameAndKeepsTheContents() throws Exception {
+        onEdt(() -> {
+            TestTopFrame top = new TestTopFrame();
+            top.setBounds(50, 50, 400, 300);
+            ChildWindowManager cwm = new ChildWindowManager(top);
+
+            JPanel viewer = new JPanel();
+            viewer.add(new JLabel("pretend simulation results"));
+            ChildWindowManager.ChildWindow child = cwm.addChildWindow(viewer, new Object(), "Results");
+            child.setSize(320, 240);
+            child.show();
+
+            // ---- attached: an owned dialog, which is why it cannot be minimised
+            Window attached = SwingUtilities.getWindowAncestor(viewer);
+            assertNotNull(attached, "child window should be realized");
+            assertTrue(attached instanceof Dialog,
+                    "attached child should be a Dialog, was " + attached.getClass().getName());
+            assertSame(top, attached.getOwner(), "attached child should be owned by the document window");
+            assertFalse(child.isDetached());
+
+            attached.setBounds(new Rectangle(120, 140, 360, 260));
+            Rectangle before = attached.getBounds();
+
+            // ---- detach
+            child.setDetached(true);
+            assertTrue(child.isDetached());
+
+            Window detached = SwingUtilities.getWindowAncestor(viewer);
+            assertNotNull(detached, "detached child should still be realized");
+            assertTrue(detached instanceof Frame,
+                    "detached child must be a Frame so the OS gives it a taskbar button and lets "
+                            + "the user minimise it, was " + detached.getClass().getName());
+            assertEquals(null, detached.getOwner(),
+                    "detached child must be un-owned, otherwise the OS still pins it above the "
+                            + "document window - the whole point of detaching");
+
+            // the viewer itself was carried across, not rebuilt
+            assertSame(viewer, findLabelHolder(detached),
+                    "the caller's content pane must be the same component after detaching");
+            assertEquals(before, detached.getBounds(),
+                    "detaching must not move or resize the window");
+
+            // ---- and back again
+            child.setDetached(false);
+            assertFalse(child.isDetached());
+            Window reattached = SwingUtilities.getWindowAncestor(viewer);
+            assertTrue(reattached instanceof Dialog, "reattaching should restore an owned dialog");
+            assertSame(top, reattached.getOwner());
+            assertEquals(before, reattached.getBounds(), "reattaching must not move the window either");
+
+            child.close();
+            top.dispose();
+        });
+    }
+
+    private static java.awt.Component findLabelHolder(Window w) {
+        return find(w, JPanel.class);
+    }
+
+    private static java.awt.Component find(java.awt.Container c, Class<?> type) {
+        for (java.awt.Component comp : c.getComponents()) {
+            if (type.isInstance(comp) && comp instanceof JPanel
+                    && ((JPanel) comp).getComponentCount() == 1
+                    && ((JPanel) comp).getComponent(0) instanceof JLabel) {
+                return comp;
+            }
+            if (comp instanceof java.awt.Container) {
+                java.awt.Component found = find((java.awt.Container) comp, type);
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Boris, on a small screen:

> windows with sim results cannot be minimized to the computer display bar, and when they obscure other model windows, those widows loose focus completely.

## This is the accepted trade-off, now biting

Both symptoms are direct consequences of `ec0ed8478a`, which made every MODELESS child window an **owned** dialog. That commit says so itself:

> Trade-off accepted (per maintainer): owned windows have no independent taskbar button and travel with their owner under Spaces/Stage Manager/Snap.

- **"cannot be minimized"** — an owned `JDialog` gets no taskbar/dock button, and a `Dialog` is not a `Frame`, so it has *no iconified state at all*. It cannot be minimized. There is no workaround.
- **"lose focus completely"** — the OS keeps it above its owner by construction, so a results window overlapping the document window cannot be sent behind it. Clicking the document window raises it logically but it still draws underneath.

On a large screen you move the window aside and never notice. On a small one there is nowhere to move it to.

It is **not revertible**: un-owning it brings back the bug `ec0ed8478a` fixed, where an un-owned frame can only be raised by a best-effort `toFront()` that modern macOS cooperative activation and the Windows foreground lock refuse for a non-foreground app.

## So make the trade-off the user's, per window

A **"Detach Window"** item in the child window's menu bar swaps the owned dialog for an un-owned `LWChildFrame`: the OS then gives it a real taskbar button, it minimizes, and it stacks freely — at the cost of no longer being pinned in front of its document window. **"Reattach Window"** puts it back. Attached remains the default, so nothing changes for anyone who does not go looking.

Offered for MODELESS windows only — a parent-modal window the user could send behind its parent would be an unreachable modal blocker.

### Why this is a small change

A window's native owner is fixed at construction, so this rebuilds the window rather than flipping a flag. That is cheap only because `ChildWindow` **already** keeps the caller's `contentPane` separate from the window it currently sits in, and **already** rebuilds that window on every `show()` — title/size/resizable are cached fields for exactly that purpose. The viewer component and all its state carry across untouched; bounds carry across too, so the window does not jump.

## Verification

Whether a window can be minimized is a property of the window manager, not of our Java code. It cannot be asserted headlessly.

**`tools/debug-bridge/scenarios/detach-window.sh`** — drives the real client and asserts on JSON. No screenshots, no image diffing, no judgement call:

```
== ATTACHED ==
  PASS  owner is a window (not null)      PASS  canIconify (= false)
  PASS  minimize request refused (= false)      <- the reported bug, asserted
== DETACHED ==
  PASS  owner is null                     PASS  canIconify (= true)
  PASS  minimize request honoured (= true)
  PASS  bounds unchanged by detaching
== REATTACHED ==
  PASS  owner is a window again           PASS  canIconify (= false)
  PASS  bounds unchanged over round trip
  passed: 11    failed: 0                 DETACH OK   (exit 0)
```

To support it, the bridge now reports what it previously left to inference — `/windows` carries `owner`, `canIconify` and `iconified`; a new `/iconify` asks the real window manager and **reports what actually happened**, not that we called `setExtendedState`. The interesting case is the one where the request is refused.

**Confirmed it can go red.** With the detach stubbed out, 3 assertions fail naming exactly what broke (owner still the document window, `canIconify` false, minimize refused). Runs clean twice in a row and normalizes state first.

`ChildWindowDetachTest` additionally covers the mechanics as a unit test — owned Dialog vs un-owned Frame, same content-pane instance, bounds preserved. It needs a display, so **it is skipped in headless CI**; the scenario script is what actually stands behind this change.

## Caught by running it

The `JMenuItem` was being stretched by the menu bar's layout to **616px in a 650px window**, making every bit of empty menu-bar space a live detach target. Pinned to preferred size; now 128px. A compile and a headless test would never have shown that.

Also worth recording: my first attempt at proving the z-order half used `AXRaise` and produced two **byte-identical** captures, because `AXRaise` reorders regardless of ownership. That is exactly why the verification is now built on OS-reported state rather than pixels.

## Not verified

**Windows.** The script is plain POSIX shell plus curl, so it runs from Git Bash or WSL. Worth a run before this ships, since the Windows foreground lock is half the reason the owned-window change existed. Reporting from the OS rather than from pixels is what makes that run meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx
