### PR TITLE
build: declare UTF-8 source encoding, so Windows reads the sources correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,24 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 
+		<!--
+		  Source encoding. Without this the compiler uses the PLATFORM default charset, which
+		  is UTF-8 on Linux and macOS but windows-1252 on Windows - so the same sources become
+		  different text depending on who builds them. See issue #2046.
+
+		  Five files then fail outright ("unmappable character (0x9D) for encoding
+		  windows-1252"), and - the part that is easy to miss - 109 more compile CLEANLY as
+		  windows-1252 and yield the wrong characters, including in user-visible strings:
+		  new JButton("\u25B6") becomes a button labelled "\u00E2\u2013\u00B6", with a green build.
+
+		  This declares what is already true rather than converting anything: every one of
+		  those 114 files decodes cleanly as UTF-8 today. Released artifacts were never
+		  affected, because release builds run on Linux; this is for anyone building on
+		  Windows, and for the Windows lane of the client E2E workflow.
+		-->
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
 		<!-- NB: Disable javadoc doclint -->
 		<doclint>none</doclint>
 


### PR DESCRIPTION
Closes #2046.

One property. The root `pom.xml` set no source encoding, so `maven-compiler-plugin` used the **platform default charset** — UTF-8 on Linux and macOS, `windows-1252` on Windows. The same sources became different text depending on who built them.

Surfaced when the client E2E workflow (#2045) compiled this repo on a `windows-latest` runner — the first time it has been built on Windows in CI.

## Two failure modes, and the quiet one matters more

**Five files fail outright:**

```
[ERROR] .../org/vcell/pathway/PathwayModel.java:[237,136]
        unmappable character (0x9D) for encoding windows-1252
```

**109 more compile cleanly and produce the wrong characters.** Their bytes all happen to be defined in `windows-1252`, so javac never complains — it just decodes them as something else, and it reaches user-visible strings:

```java
new JButton("▶")   ->   a button labelled "â–¶"
```

Fixing only the five loud ones would leave a developer with a corrupted client and no signal that anything was wrong.

## Verified, not assumed

I can't run Windows here, so I forced the charset javac would default to there (`MAVEN_OPTS=-Dfile.encoding=windows-1252`) and read the **compiled class**, not the build log:

| | unmappable errors | compiled play-button constant |
|---|---|---|
| without the fix | 1 — `PathwayModel.java:237`, the exact CI error | mojibake `â–¶` |
| with the fix | **0** | correct `U+25B6` |

Both categories, both directions.

## Risk

Low, and asymmetric. This **declares what is already true** rather than converting anything — all 114 affected files decode cleanly as UTF-8 today. On Linux and macOS nothing changes, because UTF-8 was already the default there; the normal build passes unchanged.

**Released artifacts were never affected**, since release builds run on Linux. This is for anyone building on Windows, and for the Windows lane of the client E2E.

`project.reporting.outputEncoding` is set alongside it for the same reason, and because Maven warns about it once the source encoding is declared.

## Follow-up

`.github/workflows/client-e2e.yml` (in #2045) passes `-Dproject.build.sourceEncoding=UTF-8` on the command line as a local workaround. That line becomes redundant once this lands and should be deleted — whichever of the two merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx
