### PR TITLE
fix(db): stop one large biomodel failing a user's whole model listing (ORA-01489)

### DIFF
--- a/vcell-server/pom.xml
+++ b/vcell-server/pom.xml
@@ -88,6 +88,15 @@
 			<version>1.21.4</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- BioModelRepsOverflowTest exercises the biomodel listing on BOTH dialects: the
+		     ORA-01489 overflow it guards against is Oracle-only, but the same Java path serves
+		     PostgreSQL and must keep returning the same rows. -->
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>1.21.4</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ojdbc11</artifactId>

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/BioModelDbDriver.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/BioModelDbDriver.java
@@ -553,20 +553,20 @@ public BioModelRep[] getBioModelReps(Connection con, User user, String condition
 //	System.out.println(sql);
 	bioModelTable.setPreparedStatement_BioModelReps(stmt, user, startRow, numRows, dbSyntax);
 
-	ArrayList<BioModelRep> bioModelReps = new ArrayList<BioModelRep>();
+	// issue #2036: collect the scalar rows first, then attach every row's simulation keys,
+	// simulation-context keys and group members in a few batched queries. They used to be three
+	// correlated LISTAGG subqueries in the statement above, which Oracle caps at 4000 bytes -
+	// one model with enough simulations raised ORA-01489 and failed the whole listing.
+	ArrayList<BioModelTable.BioModelRepRow> rows = new ArrayList<BioModelTable.BioModelRepRow>();
 	try {
 		ResultSet rset = stmt.executeQuery();
-
-		//showMetaData(rset);
-
 		while (rset.next()) {
-			BioModelRep bioModelRep = bioModelTable.getBioModelRep(user,rset,dbSyntax);
-			bioModelReps.add(bioModelRep);
+			rows.add(bioModelTable.getBioModelRepRow(rset,dbSyntax));
 		}
 	} finally {
 		stmt.close(); // Release resources include resultset
 	}
-	return bioModelReps.toArray(new BioModelRep[bioModelReps.size()]);
+	return BioModelTable.attachChildKeys(con, dbSyntax, rows);
 }
 
 	/**

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/BioModelTable.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/BioModelTable.java
@@ -15,8 +15,13 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 
 import org.vcell.db.DatabaseSyntax;
 import org.vcell.util.DataAccessException;
@@ -225,15 +230,9 @@ public String getSQLValueList(BioModelMetaData bioModelMetaData, String serialBM
 public String getPreparedStatement_BioModelReps(String conditions, OrderBy orderBy, int startRow, int numRows, DatabaseSyntax dbSyntax){
 
 	BioModelTable bmTable = BioModelTable.table;
-	BioModelSimulationLinkTable bmsimTable = BioModelSimulationLinkTable.table;
-	BioModelSimContextLinkTable bmscTable = BioModelSimContextLinkTable.table;
 	GroupTable groupTable = GroupTable.table;
 	UserTable userTable = UserTable.table;
 
-	String concat_function_name = (dbSyntax==DatabaseSyntax.ORACLE) ? "listagg" : "string_agg";
-	String concat_second_arg = (dbSyntax==DatabaseSyntax.ORACLE) ? ", ','" : ", ','";
-	String string_cast = (dbSyntax==DatabaseSyntax.ORACLE) ? "" : "::varchar(255)";
-	
 	String subquery = 			
 		"select " +
 		    bmTable.id.getQualifiedColName()+", "+
@@ -245,22 +244,14 @@ public String getPreparedStatement_BioModelReps(String conditions, OrderBy order
 		    bmTable.versionBranchID.getQualifiedColName()+", "+
 		    bmTable.modelRef.getQualifiedColName()+", "+
 		    bmTable.ownerRef.getQualifiedColName()+", "+
-		    UserTable.table.userid.getQualifiedColName()+", "+
+		    UserTable.table.userid.getQualifiedColName()+" "+
 		
-		   "(select '['||"+concat_function_name+"("+"SQ1_"+bmsimTable.simRef.getQualifiedColName()+string_cast+concat_second_arg+")||']' "+
-		   "   from "+bmsimTable.getTableName()+" SQ1_"+bmsimTable.getTableName()+" "+
-		   "   where SQ1_"+bmsimTable.bioModelRef.getQualifiedColName()+" = "+bmTable.id.getQualifiedColName()+") simKeys,  "+
-		
-		   "(select '['||"+concat_function_name+"("+"SQ2_"+bmscTable.simContextRef.getQualifiedColName()+string_cast+concat_second_arg+")||']' "+
-		   "   from "+bmscTable.getTableName()+"  SQ2_"+bmscTable.getTableName()+" "+
-		   "   where SQ2_"+bmscTable.bioModelRef.getQualifiedColName()+ " = " + bmTable.id.getQualifiedColName()+") simContextKeys,  "+
-		
-		   "(select '['||"+concat_function_name+"(SQ3_"+groupTable.userRef.getQualifiedColName()+string_cast+"||':'||SQ3_"+userTable.userid.getQualifiedColName()+concat_second_arg+")||']'  "+
-	   	   "   from "+groupTable.getTableName()+" SQ3_"+groupTable.getTableName()+", "+
-		   "        "+userTable.getTableName()+"  SQ3_"+userTable.getTableName()+" "+
-		   "   where SQ3_"+groupTable.groupid.getQualifiedColName()+" = "+bmTable.privacy.getQualifiedColName()+" "+
-		   "   and   SQ3_"+userTable.id.getQualifiedColName()+" = "+groupTable.userRef.getQualifiedColName()+" "+
-		   "   and   "+bmTable.privacy.getQualifiedColName()+" > 1) groupMembers "+
+		// issue #2036: simKeys, simContextKeys and groupMembers used to be three correlated LISTAGG
+		// subqueries in this select list. Oracle LISTAGG returns VARCHAR2, capped at 4000 bytes, so
+		// ONE model with enough simulations raised ORA-01489 and failed the ENTIRE listing - the user
+		// could not see any of their models. They are now batch-fetched as raw rows and grouped in
+		// Java by attachChildKeys(), which has no length limit. Same approach already taken for the
+		// vcInfoContainer path (see stitchSimKeys, issue #1746).
 		
 		"from "+bmTable.getTableName()+", "+userTable.getTableName()+", "+groupTable.getTableName()+" "+
 		"where "+bmTable.ownerRef.getQualifiedColName()+" = "+userTable.id.getQualifiedColName()+" "+
@@ -342,7 +333,33 @@ public void setPreparedStatement_BioModelReps(PreparedStatement stmt, User user,
 	}
 }
 
-public BioModelRep getBioModelRep(User user, ResultSet rset, DatabaseSyntax dbSyntax) throws IllegalArgumentException, SQLException {
+/**
+ * One row of the BioModelRep listing, scalars only.
+ *
+ * The child key lists are deliberately NOT read here: they are no longer columns of the query.
+ * Rows are collected first, then attachChildKeys() fetches every row's children in a few
+ * batched queries. See the note in getPreparedStatement_BioModelReps and issue #2036.
+ */
+public static final class BioModelRepRow {
+	private final KeyValue bmKey;
+	private final String name;
+	private final int privacy;
+	private final int versionFlag;
+	private final Date date;
+	private final String annot;
+	private final BigDecimal branchID;
+	private final KeyValue modelRef;
+	private final User owner;
+
+	private BioModelRepRow(KeyValue bmKey, String name, int privacy, int versionFlag, Date date,
+			String annot, BigDecimal branchID, KeyValue modelRef, User owner) {
+		this.bmKey = bmKey; this.name = name; this.privacy = privacy; this.versionFlag = versionFlag;
+		this.date = date; this.annot = annot; this.branchID = branchID; this.modelRef = modelRef;
+		this.owner = owner;
+	}
+}
+
+public BioModelRepRow getBioModelRepRow(ResultSet rset, DatabaseSyntax dbSyntax) throws IllegalArgumentException, SQLException {
 	KeyValue bmKey = new KeyValue(rset.getBigDecimal(table.id.toString()));
 	String name = rset.getString(table.name.toString());
 	int privacy = rset.getInt(table.privacy.toString());
@@ -354,50 +371,99 @@ public BioModelRep getBioModelRep(User user, ResultSet rset, DatabaseSyntax dbSy
 	KeyValue ownerRef = new KeyValue(rset.getBigDecimal(table.ownerRef.toString()));
 	String ownerName = rset.getString(UserTable.table.userid.toString());
 	User owner = new User(ownerName,ownerRef);
-	
-	String simKeysString = rset.getString("simKeys");
-	if (simKeysString == null){
-		simKeysString = "[]";
-	}
-	ArrayList<KeyValue> simKeyList = new ArrayList<KeyValue>();
-	String[] simKeys = simKeysString.replace("[", "").replace("]", "").split(",");
-	for (String simKey : simKeys) {
-		if (simKey!=null && simKey.length()>0){
-			simKeyList.add(new KeyValue(simKey));
-		}
-	}
-	KeyValue[] simKeyArray = simKeyList.toArray(new KeyValue[0]);
+	return new BioModelRepRow(bmKey,name,privacy,versionFlag,date,annot,branchID,modelRef,owner);
+}
 
-	String simContextsString = rset.getString("simContextKeys");
-	if (simContextsString == null){
-		simContextsString = "[]";
+/**
+ * issue #2036 (ORA-01489 fix): attach each row's simulation keys, simulation-context keys and
+ * group members by batch-fetching raw rows and grouping them in Java.
+ *
+ * Replaces three correlated LISTAGG subqueries. Besides removing the 4000-byte VARCHAR2 cap
+ * that failed the whole listing for one oversized model, this runs O(N/1000) grouped queries
+ * instead of evaluating three subqueries per row.
+ *
+ * BioModelRep's child arrays are final, so the reps are constructed here - once, with
+ * everything - rather than mutated after the fact.
+ */
+public static BioModelRep[] attachChildKeys(Connection con, DatabaseSyntax dbSyntax, List<BioModelRepRow> rows) throws SQLException {
+	if (rows == null || rows.isEmpty()) {
+		return new BioModelRep[0];
 	}
-	ArrayList<KeyValue> simContextKeyList = new ArrayList<KeyValue>();
-	String[] simContextKeys = simContextsString.replace("[", "").replace("]", "").split(",");
-	for (String simContextKey : simContextKeys) {
-		if (simContextKey!=null && simContextKey.length()>0){
-			simContextKeyList.add(new KeyValue(simContextKey));
-		}
-	}
-	KeyValue[] simContextKeyArray = simContextKeyList.toArray(new KeyValue[0]);
+	BioModelSimulationLinkTable bmsimTable = BioModelSimulationLinkTable.table;
+	BioModelSimContextLinkTable bmscTable = BioModelSimContextLinkTable.table;
+	GroupTable groupTable = GroupTable.table;
+	UserTable userTable = UserTable.table;
 
-	String groupMembers = rset.getString("groupMembers");
-	if (groupMembers == null){
-		groupMembers = "[]";
-	}
-	ArrayList<User> groupUsers = new ArrayList<User>();
-	String[] groupUserStrings = groupMembers.replace("[", "").replace("]", "").split(",");
-	for (String groupUserString : groupUserStrings) {
-		if (groupUserString!=null && groupUserString.length()>0){
-			String[] groupUserTokens = groupUserString.split(":");
-			KeyValue groupUserKey = new KeyValue(groupUserTokens[0]);
-			String  groupUserid = groupUserTokens[1];
-			groupUsers.add(new User(groupUserid,groupUserKey));
+	LinkedHashSet<String> bmIds = new LinkedHashSet<String>();
+	LinkedHashSet<String> groupIds = new LinkedHashSet<String>();
+	for (BioModelRepRow row : rows) {
+		bmIds.add(row.bmKey.toString());
+		// groupMembers was gated on privacy > 1 in the old subquery; keep that
+		if (row.privacy > 1) {
+			groupIds.add(Integer.toString(row.privacy));
 		}
 	}
-	User[] groupUserArray = groupUsers.toArray(new User[0]);
-		
-	
-	return new BioModelRep(bmKey,name,privacy,versionFlag,groupUserArray,date,annot,branchID,modelRef,owner,simKeyArray,simContextKeyArray);
+
+	Map<String,List<KeyValue>> simKeysByBm = fetchKeysByParent(con, bmsimTable.getTableName(),
+			bmsimTable.bioModelRef.getUnqualifiedColName(), bmsimTable.simRef.getUnqualifiedColName(), bmIds);
+	Map<String,List<KeyValue>> simCtxKeysByBm = fetchKeysByParent(con, bmscTable.getTableName(),
+			bmscTable.bioModelRef.getUnqualifiedColName(), bmscTable.simContextRef.getUnqualifiedColName(), bmIds);
+
+	Map<String,List<User>> groupUsersByGroupId = new HashMap<String,List<User>>();
+	List<String> groupIdList = new ArrayList<String>(groupIds);
+	for (int start = 0; start < groupIdList.size(); start += IN_LIST_CHUNK) {
+		List<String> chunk = groupIdList.subList(start, Math.min(start+IN_LIST_CHUNK, groupIdList.size()));
+		String sql = "SELECT G."+groupTable.groupid.getUnqualifiedColName()+" GROUPID_, "+
+				"G."+groupTable.userRef.getUnqualifiedColName()+" USERREF_, "+
+				"U."+userTable.userid.getUnqualifiedColName()+" USERID_ "+
+				"FROM "+groupTable.getTableName()+" G, "+userTable.getTableName()+" U "+
+				"WHERE U."+userTable.id.getUnqualifiedColName()+" = G."+groupTable.userRef.getUnqualifiedColName()+" "+
+				"AND G."+groupTable.groupid.getUnqualifiedColName()+" IN ("+String.join(",", chunk)+")";
+		try (Statement stmt = con.createStatement(); ResultSet rset = stmt.executeQuery(sql)) {
+			while (rset.next()) {
+				String groupId = rset.getBigDecimal("GROUPID_").toBigInteger().toString();
+				KeyValue userKey = new KeyValue(rset.getBigDecimal("USERREF_"));
+				String userid = rset.getString("USERID_");
+				groupUsersByGroupId.computeIfAbsent(groupId, k -> new ArrayList<User>()).add(new User(userid, userKey));
+			}
+		}
+	}
+
+	BioModelRep[] reps = new BioModelRep[rows.size()];
+	for (int i = 0; i < rows.size(); i++) {
+		BioModelRepRow row = rows.get(i);
+		String bmId = row.bmKey.toString();
+		List<KeyValue> simKeys = simKeysByBm.get(bmId);
+		List<KeyValue> simCtxKeys = simCtxKeysByBm.get(bmId);
+		List<User> groupUsers = (row.privacy > 1) ? groupUsersByGroupId.get(Integer.toString(row.privacy)) : null;
+		reps[i] = new BioModelRep(row.bmKey, row.name, row.privacy, row.versionFlag,
+				groupUsers == null ? new User[0] : groupUsers.toArray(new User[0]),
+				row.date, row.annot, row.branchID, row.modelRef, row.owner,
+				simKeys == null ? new KeyValue[0] : simKeys.toArray(new KeyValue[0]),
+				simCtxKeys == null ? new KeyValue[0] : simCtxKeys.toArray(new KeyValue[0]));
+	}
+	return reps;
+}
+
+/** Oracle caps a literal IN list at 1000 entries, so parent ids are fetched in chunks. */
+private static final int IN_LIST_CHUNK = 1000;
+
+private static Map<String,List<KeyValue>> fetchKeysByParent(Connection con, String tableName,
+		String parentCol, String childCol, LinkedHashSet<String> parentIds) throws SQLException {
+	Map<String,List<KeyValue>> byParent = new HashMap<String,List<KeyValue>>();
+	List<String> idList = new ArrayList<String>(parentIds);
+	for (int start = 0; start < idList.size(); start += IN_LIST_CHUNK) {
+		List<String> chunk = idList.subList(start, Math.min(start+IN_LIST_CHUNK, idList.size()));
+		String sql = "SELECT "+parentCol+", "+childCol+" FROM "+tableName+
+				" WHERE "+parentCol+" IN ("+String.join(",", chunk)+")";
+		try (Statement stmt = con.createStatement(); ResultSet rset = stmt.executeQuery(sql)) {
+			while (rset.next()) {
+				String parent = rset.getBigDecimal(parentCol).toBigInteger().toString();
+				byParent.computeIfAbsent(parent, k -> new ArrayList<KeyValue>())
+						.add(new KeyValue(rset.getBigDecimal(childCol)));
+			}
+		}
+	}
+	return byParent;
 }
 }

--- a/vcell-server/src/test/java/cbit/vcell/modeldb/BioModelRepsOverflowTest.java
+++ b/vcell-server/src/test/java/cbit/vcell/modeldb/BioModelRepsOverflowTest.java
@@ -1,0 +1,231 @@
+package cbit.vcell.modeldb;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.vcell.db.DatabaseSyntax;
+import org.vcell.util.document.KeyValue;
+import org.vcell.util.document.User;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * issue #2036: one biomodel with enough simulations used to fail the ENTIRE biomodel listing.
+ *
+ * The listing aggregated each row's child keys with three correlated LISTAGG subqueries. Oracle
+ * LISTAGG returns VARCHAR2, capped at 4000 bytes in SQL, so a user with one large model got
+ * ORA-01489 and could not list ANY of their models - which is what happened in production to
+ * owner mblinov.
+ *
+ * This has to run against a real Oracle: the cap is Oracle's, and PostgreSQL's string_agg
+ * returns text with no such limit, so the bug is invisible on the dev/test database. Both
+ * dialects are exercised here because the same Java path serves both and the fix must not
+ * change what either returns.
+ *
+ * Tagged Oracle_IT (regression group, not the fast lane) because it needs the Oracle image -
+ * same reasoning as DatabaseCleanupOracleSqlTest.
+ */
+@Tag("Oracle_IT")
+public class BioModelRepsOverflowTest {
+
+	private static final String ORACLE_IMAGE = "gvenzl/oracle-free:23-slim-faststart";
+	private static final String POSTGRES_IMAGE = "postgres:15";
+	private static final String PASSWORD = "vcelltest";
+
+	/** comfortably past the 4000-byte LISTAGG cap: ~700 nine-digit keys plus separators */
+	private static final int BIG_MODEL_SIM_COUNT = 700;
+	private static final long BIG_BM_ID = 100_000_001L;
+	private static final long SMALL_BM_ID = 100_000_002L;
+	private static final long OWNER_ID = 555_000_001L;
+	private static final long SIM_KEY_BASE = 900_000_000L;
+
+	private static GenericContainer<?> oracle;
+	private static PostgreSQLContainer<?> postgres;
+	private static String oracleUrl;
+
+	@BeforeAll
+	public static void startDatabases() throws Exception {
+		Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(),
+				"needs Docker for the Oracle and PostgreSQL containers");
+
+		oracle = new GenericContainer<>(ORACLE_IMAGE)
+				.withExposedPorts(1521)
+				.withEnv("ORACLE_PASSWORD", PASSWORD)
+				.waitingFor(Wait.forLogMessage(".*DATABASE IS READY TO USE!.*\\n", 1)
+						.withStartupTimeout(Duration.ofMinutes(10)));
+		oracle.start();
+		oracleUrl = "jdbc:oracle:thin:@//" + oracle.getHost() + ":" + oracle.getMappedPort(1521) + "/FREEPDB1";
+		try (Connection con = oracleConnection()) {
+			seed(con, DatabaseSyntax.ORACLE);
+		}
+
+		postgres = new PostgreSQLContainer<>(POSTGRES_IMAGE)
+				.withUsername("vcell").withPassword(PASSWORD).withDatabaseName("vcelltest");
+		postgres.start();
+		try (Connection con = postgresConnection()) {
+			seed(con, DatabaseSyntax.POSTGRES);
+		}
+	}
+
+	@AfterAll
+	public static void stopDatabases() {
+		if (oracle != null) oracle.stop();
+		if (postgres != null) postgres.stop();
+	}
+
+	private static Connection oracleConnection() throws Exception {
+		Connection con = DriverManager.getConnection(oracleUrl, "system", PASSWORD);
+		con.setAutoCommit(false);
+		return con;
+	}
+
+	private static Connection postgresConnection() throws Exception {
+		Connection con = DriverManager.getConnection(postgres.getJdbcUrl(), "vcell", PASSWORD);
+		con.setAutoCommit(false);
+		return con;
+	}
+
+	/**
+	 * Only the columns the listing query touches. What is under test is the query and the Java
+	 * that stitches child keys onto its rows, not the real schema.
+	 */
+	private static void seed(Connection con, DatabaseSyntax dbSyntax) throws SQLException {
+		boolean oracleSyntax = dbSyntax == DatabaseSyntax.ORACLE;
+		String num = oracleSyntax ? "NUMBER" : "NUMERIC";
+		String str = oracleSyntax ? "VARCHAR2(255)" : "VARCHAR(255)";
+		String ts = oracleSyntax ? "DATE" : "TIMESTAMP";
+		String now = oracleSyntax ? "SYSDATE" : "CURRENT_TIMESTAMP";
+
+		try (Statement stmt = con.createStatement()) {
+			stmt.executeUpdate("CREATE TABLE vc_userinfo (id "+num+" PRIMARY KEY, userid "+str+")");
+			stmt.executeUpdate("CREATE TABLE vc_group (groupid "+num+", userRef "+num+")");
+			stmt.executeUpdate("CREATE TABLE vc_biomodel (id "+num+" PRIMARY KEY, name "+str+", privacy "+num+
+					", versionFlag "+num+", versionDate "+ts+", versionAnnot "+str+
+					", versionBranchID "+num+", modelRef "+num+", ownerRef "+num+")");
+			stmt.executeUpdate("CREATE TABLE vc_biomodelsim (biomodelRef "+num+", simRef "+num+")");
+			stmt.executeUpdate("CREATE TABLE vc_biomodelsimcontext (biomodelRef "+num+", simContextRef "+num+")");
+			stmt.executeUpdate("CREATE TABLE vc_softwareversion (versionableRef "+num+", softwareVersion "+str+")");
+
+			stmt.executeUpdate("INSERT INTO vc_userinfo (id, userid) VALUES ("+OWNER_ID+", 'mblinov_test')");
+			// privacy 0 == public; group membership is only consulted for privacy > 1
+			stmt.executeUpdate("INSERT INTO vc_group (groupid, userRef) VALUES (0, "+OWNER_ID+")");
+
+			for (long bmId : new long[]{BIG_BM_ID, SMALL_BM_ID}) {
+				stmt.executeUpdate("INSERT INTO vc_biomodel " +
+						"(id, name, privacy, versionFlag, versionDate, versionAnnot, versionBranchID, modelRef, ownerRef) " +
+						"VALUES ("+bmId+", 'model_"+bmId+"', 0, 0, "+now+", 'annot', 1, 1, "+OWNER_ID+")");
+			}
+			// the model that overflowed LISTAGG, and a small one alongside it to prove the
+			// listing still returns the others rather than failing wholesale
+			for (int i = 0; i < BIG_MODEL_SIM_COUNT; i++) {
+				stmt.executeUpdate("INSERT INTO vc_biomodelsim (biomodelRef, simRef) VALUES ("+BIG_BM_ID+", "+(SIM_KEY_BASE+i)+")");
+				stmt.executeUpdate("INSERT INTO vc_biomodelsimcontext (biomodelRef, simContextRef) VALUES ("+BIG_BM_ID+", "+(SIM_KEY_BASE+i)+")");
+			}
+			stmt.executeUpdate("INSERT INTO vc_biomodelsim (biomodelRef, simRef) VALUES ("+SMALL_BM_ID+", 1)");
+			stmt.executeUpdate("INSERT INTO vc_biomodelsim (biomodelRef, simRef) VALUES ("+SMALL_BM_ID+", 2)");
+		}
+		con.commit();
+	}
+
+	/** The production path: build the statement, read the rows, stitch the child keys on. */
+	private static List<BioModelRep> listReps(Connection con, DatabaseSyntax dbSyntax) throws SQLException {
+		User user = new User("mblinov_test", new KeyValue(Long.toString(OWNER_ID)));
+		String sql = BioModelTable.table.getPreparedStatement_BioModelReps(null, null, 1, 1000, dbSyntax);
+		List<BioModelTable.BioModelRepRow> rows = new ArrayList<>();
+		try (PreparedStatement stmt = con.prepareStatement(sql)) {
+			BioModelTable.table.setPreparedStatement_BioModelReps(stmt, user, 1, 1000, dbSyntax);
+			try (ResultSet rset = stmt.executeQuery()) {
+				while (rset.next()) {
+					rows.add(BioModelTable.table.getBioModelRepRow(rset, dbSyntax));
+				}
+			}
+		}
+		return Arrays.asList(BioModelTable.attachChildKeys(con, dbSyntax, rows));
+	}
+
+	private static BioModelRep byKey(List<BioModelRep> reps, long id) {
+		return reps.stream().filter(r -> r.getBmKey().toString().equals(Long.toString(id))).findFirst().orElse(null);
+	}
+
+	private static void assertListingIsComplete(Connection con, DatabaseSyntax dbSyntax) throws SQLException {
+		List<BioModelRep> reps = listReps(con, dbSyntax);
+		assertEquals(2, reps.size(), "both models should be listed");
+
+		BioModelRep big = byKey(reps, BIG_BM_ID);
+		assertNotNull(big, "the large model should be listed");
+		assertEquals(BIG_MODEL_SIM_COUNT, big.getSimKeyList().length,
+				"every simulation key should come back, with no 4000-byte ceiling");
+		assertEquals(BIG_MODEL_SIM_COUNT, big.getSimContextKeyList().length);
+
+		Set<String> expected = new HashSet<>();
+		for (int i = 0; i < BIG_MODEL_SIM_COUNT; i++) expected.add(Long.toString(SIM_KEY_BASE + i));
+		Set<String> actual = new HashSet<>();
+		for (KeyValue k : big.getSimKeyList()) actual.add(k.toString());
+		assertEquals(expected, actual, "the keys themselves should be right, not merely the count");
+
+		BioModelRep small = byKey(reps, SMALL_BM_ID);
+		assertNotNull(small, "the small model should be listed alongside the large one");
+		assertEquals(2, small.getSimKeyList().length);
+	}
+
+	@Test
+	public void listingSurvivesAModelWithManySimulations_oracle() throws Exception {
+		try (Connection con = oracleConnection()) {
+			assertListingIsComplete(con, DatabaseSyntax.ORACLE);
+		}
+	}
+
+	@Test
+	public void listingSurvivesAModelWithManySimulations_postgres() throws Exception {
+		try (Connection con = postgresConnection()) {
+			assertListingIsComplete(con, DatabaseSyntax.POSTGRES);
+		}
+	}
+
+	/**
+	 * The bug itself, so this test is known to be capable of catching it.
+	 *
+	 * Runs the aggregate the listing used to use. If Oracle ever stopped raising ORA-01489 here,
+	 * the test above would still pass but would no longer be testing anything.
+	 */
+	@Test
+	public void theOldListaggStillOverflows_oracle() throws Exception {
+		String listagg =
+				"select (select '['||listagg(SQ1_vc_biomodelsim.simRef, ',')||']' " +
+				"          from vc_biomodelsim SQ1_vc_biomodelsim " +
+				"         where SQ1_vc_biomodelsim.biomodelRef = vc_biomodel.id) simKeys " +
+				"  from vc_biomodel where vc_biomodel.id = " + BIG_BM_ID;
+		try (Connection con = oracleConnection(); Statement stmt = con.createStatement()) {
+			SQLException e = assertThrows(SQLException.class, () -> {
+				try (ResultSet rset = stmt.executeQuery(listagg)) {
+					rset.next();
+					rset.getString("simKeys");
+				}
+			}, "this many simulations should still overflow Oracle's LISTAGG");
+			assertTrue(e.getMessage().contains("ORA-01489"),
+					"expected ORA-01489, got: " + e.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2036.

## Still happening

Prod api pod, **today**, 8 failures in a four-minute window — all `GET /api/v0/biomodel?…&owner=mblinov`:

```
org.vcell.rest.server.BiomodelsServerResource:197
cbit.vcell.modeldb.BioModelDbDriver.getBioModelReps(BioModelDbDriver.java:558)
  java.sql.SQLException: ORA-01489: result of string concatenation is too long
```

Not one model missing from the list — **the entire listing fails**, so he cannot see any of his models.

## Cause

`getPreparedStatement_BioModelReps` aggregated each row's child keys with three correlated `LISTAGG` subqueries — `simKeys`, `simContextKeys`, `groupMembers`. Oracle's `LISTAGG` returns `VARCHAR2`, capped at 4000 bytes in SQL, so **one** model with enough simulations raised ORA-01489 and took the whole query with it. Sim keys are ~9 digits plus a separator, so roughly 400 simulations on a single model is enough.

PostgreSQL's `string_agg` returns `text` and has no such cap — which is why this never appeared on dev or test.

## Fix

Batch-fetch the child keys as raw rows and group them in Java. No length limit, and it replaces three subquery evaluations **per row** with O(N/1000) grouped queries.

This is the same approach already taken for the `vcInfoContainer` path in `a475da4d10` (issue #1746) — **that path was fixed, this one was missed.** Worth noting for anyone tracing the history: the desktop client's listing has been fine since 8.0.10.01; it is the `/api/v0/` and `/api/v1/` listings that still fail.

`BioModelRep`'s child arrays are `final`, so rows are collected first and the reps constructed once with everything, rather than making the value object mutable.

## Verified against real databases, both dialects

The limit is the database's, so a mock cannot express it. `BioModelRepsOverflowTest` (`Oracle_IT`, already wired into the regression group for `vcell-server`) runs against Oracle and PostgreSQL testcontainers:

| | |
|---|---|
| **Oracle** | a model with 700 simulations lists correctly — all 700 keys present **by value**, not merely by count — alongside a second small model |
| **PostgreSQL** | same, since the same Java path serves both and must keep returning the same rows |
| **control** | runs the **old** `LISTAGG` aggregate against Oracle and asserts it *still* raises ORA-01489 |

That third test is what makes the first two meaningful: without it they could pass vacuously if Oracle's behaviour ever changed.

I also confirmed the assertions genuinely execute rather than the containers being skipped — with the expected key count deliberately set to 701, both dialect tests fail with `expected: <701> but was: <700>`.

## Not addressed here

`BiomodelsServerResource` swallows the typed exception into a bare `RuntimeException`, so this surfaced as a generic "unexpected condition" 500 with the cause only in the logs. Noted in #2036; worth fixing separately rather than widening this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx
