### PR TITLE
docs(release): cut 8.1.3.01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,87 @@ followed by flat Keep-a-Changelog categories. API consumers should scan
 
 _(Release-manager scratchpad. Populated at release-cut time.)_
 
+## [8.1.3.01] - 2026-09-02
+
+**Highlights.** Two things that made VCell unusable for the people who hit them.
+A user with a large model could not list their models at all — not one row
+missing, the whole listing failed — and a reaction parameter could vanish from
+the math overrides table with no error and no way to tell why, purely because of
+what it was named. Alongside those, simulation results windows can now be
+detached, so they can be minimized and moved out of the way on a small screen.
+
+### Added
+- Simulation results windows can be detached from their document window. A
+  detached window gets a taskbar or dock entry, minimizes, and can be stacked
+  freely, at the cost of no longer being kept in front of the model it belongs
+  to; "Reattach" puts it back. Attached remains the default. Results windows are
+  held in front of their document window by the operating system, which is what
+  keeps them from hiding behind it — but it also means they cannot be minimized
+  at all, and on a small screen there is nowhere to move them to. (#2045)
+
+### Fixed
+- Listing biomodels no longer fails because one model has many simulations. The
+  listing gathered each model's simulation keys into a single string inside the
+  database, which Oracle caps at 4000 bytes; roughly 400 simulations on one model
+  exceeded it and returned a 500 for the entire request, so an affected user could
+  not see any of their models. The keys are now collected without that limit.
+  (#2048, #2036)
+- A reaction's local parameter no longer disappears from a simulation's math
+  overrides because of its name. Parameters were matched against the list of
+  reserved physical constants by substring, so a parameter called `kon_R_R_in`
+  was discarded as if it were `_R_`, the gas constant. Any name containing `_R_`,
+  `_T_`, `_F_` or `_PI_` was affected. (#2043)
+- A detached or reattached window stays where you put it, instead of jumping back
+  onto the document window. (#2045)
+
+### Changed
+- Internal: the build declares UTF-8 source encoding. Without it the compiler used
+  the platform default, so on Windows five files failed to compile and 109 more
+  compiled to the wrong characters — including text VCell displays — with no
+  warning. Released builds were never affected, since they are built on Linux.
+  (#2047, #2046)
+- Internal: the `scijava` Maven repository is no longer used. It served exactly one
+  artifact, now vendored in the tree. While it was returning 503s for the metadata
+  files Maven generates, builds failed on artifacts it had nothing to do with.
+  (#2037)
+
+### Notes for API consumers
+No API changes. `GET /api/v0/biomodel` and `GET /api/v1/bioModel` return the same
+shape as before; they simply no longer fail when a model has many simulations.
+
+## [8.1.2.01] - 2026-08-28
+
+**Highlights.** A large geometry image no longer costs far more memory than it
+should. A 62-megapixel image had taken two production API pods down, and the cause
+was the same inflated pixel array being held twice over and never released; it is
+now held once, and softly, so the collector can reclaim it.
+
+### Fixed
+- A geometry no longer pins a second copy of its image's pixels in memory.
+  `GeometrySpec` cached the same inflated array the image already caches, so the
+  pixels stayed reachable for as long as the geometry did — 62 MB per geometry at
+  the size that took down two production API pods. (#2026, #2021)
+
+### Changed
+- Inflated image pixels are now held softly, so the heap can reclaim them and
+  re-inflate on demand. Geometry images compress 50–100× (median 73.6× measured
+  across the VCML corpus), so keeping the inflated form resident cost far more than
+  rebuilding it. Under the shape of the incident — 11 images reachable at once in a
+  256 MB heap — this is the difference between running out of memory at the ninth
+  image and completing all eleven. (#2027, #2021)
+- SpringSaLaD simulations run on the Langevin 1.4.13 solver. (#2002)
+- Security: dependency updates closing 4 Maven advisories (jsoup, jose4j, and the
+  removal of an unused htmlunit) and 166 Python advisories, by dropping Jupyter as a
+  runtime dependency of three packages. (#2018, #2019)
+
+### Added
+- Geometry surface generation is pinned by golden tests, including fixtures taken
+  from real corpus models, so a change in generated surfaces has to be deliberate.
+  (#2028, #2029)
+
+### Notes for API consumers
+No API changes.
+
 ## [8.1.1.01] - 2026-08-21
 
 **Highlights.** When VCell hits an error and you agree to send a report, that

--- a/release-notes/major/8.1.md
+++ b/release-notes/major/8.1.md
@@ -74,6 +74,13 @@ value-under-mouse picking and click-to-plot time courses. It is off by
 default and invisible in normal use; it is noted here because it is
 where spatial visualization is heading, not because it is ready.
 
+- **Simulation results windows can be detached.** A results window is normally held
+  in front of the model it belongs to, which stops it hiding behind the model window
+  — but it also means it cannot be minimized, and on a small screen there is nowhere
+  to move it to. Detaching gives it an ordinary taskbar or dock entry so it can be
+  minimized and arranged freely; reattaching puts it back. Windows stay attached
+  unless you say otherwise (8.1.3.01).
+
 ## Improvements
 
 - Error reports are worth reading. When you agree to send a report after an
@@ -222,6 +229,19 @@ _(Per-build detail is in `CHANGELOG.md`.)_
   native library with no arm64 build, so on those machines the export simply failed. The
   writing is pure Java now, which also takes 24 MB of platform binaries out of every
   installer. The files themselves are unchanged (8.0.28.01).
+
+- Listing your models no longer fails when one of them has many simulations. Past
+  roughly 400 simulations on a single model the listing returned an error for the
+  whole request, so an affected user could not see any of their models — not just
+  the large one (8.1.3.01).
+- A reaction's local parameter no longer disappears from a simulation's math
+  overrides because of what it is named. A parameter whose name contained `_R_`,
+  `_T_`, `_F_` or `_PI_` — the names of reserved physical constants — was treated as
+  one of those constants and hidden, with no error to explain it. A parameter called
+  `kon_R_R_in` was one real example (8.1.3.01).
+- A large geometry image costs much less memory. The inflated pixels of an image were
+  held twice over and never released; a 62-megapixel image had been enough to take
+  down production API servers (8.1.2.01).
 
 ## API and integration changes
 


### PR DESCRIPTION
Release-cut docs for **8.1.3.01**, per `docs/RELEASING.md` — landed before tagging so the tag points at a self-describing tree.

Contents (6 merges since 8.1.2.01):

| | |
|---|---|
| Added | #2045 detachable simulation results windows |
| Fixed | #2048 biomodel listing 500 (ORA-01489) — the one hitting mblinov |
| Fixed | #2043 math-override parameter dropped by name (`kon_R_R_in`) |
| Changed | #2047 UTF-8 source encoding |
| Changed | #2037 drop the scijava repo, vendor n5 |
| Docs | #2040 `BUILDING.md` `-X` tip |

Also **backfills 8.1.2.01**, which was tagged 2026-08-28 with no CHANGELOG entry. Its geometry-memory work is worth recording — the inflated pixel array held twice over is what took down two production API pods — and a hole between 8.1.1.01 and 8.1.3.01 would make the file misleading rather than merely incomplete.

Both sections were written from each merge's diff and commit body, not its title.

Preconditions for the tag are met: regression passed on master (run 33671610231), including `Oracle_IT`, where the new `BioModelRepsOverflowTest` ran 3/3 against real Oracle and PostgreSQL containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx