### PR TITLE
fix(client): restore retry on a recycled connection, lost when saves moved to /api/v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           - name: core
             modules: vcell-core
           - name: other
-            modules: vcell-util,vcell-math,vcell-server,vcell-cli,vcell-client,vcell-admin,vcell-apiclient
+            modules: vcell-util,vcell-math,vcell-server,vcell-cli,vcell-client,vcell-admin,vcell-apiclient,vcell-restclient
     steps:
       - uses: actions/checkout@v4
 

--- a/vcell-apiclient/src/main/java/org/vcell/api/client/VCellApiClient.java
+++ b/vcell-apiclient/src/main/java/org/vcell/api/client/VCellApiClient.java
@@ -218,7 +218,9 @@ public class VCellApiClient implements AutoCloseable {
 	
 	public void createDefaultQuarkusClient(boolean bIgnoreCertProblems){
 		apiClient = new ApiClient(){{
-			if (bIgnoreCertProblems){setHttpClientBuilder(CustomApiClientCode.createInsecureHttpClientBuilder());};
+			// always, not only for insecure certs: the builder also carries the HTTP/1.1
+			// retry workaround for issue #2051
+			setHttpClientBuilder(CustomApiClientCode.createHttpClientBuilder(bIgnoreCertProblems));
 			setHost(quarkusURL.getHost());
 			setPort(quarkusURL.getPort());
 			setBasePath(quarkusURL.getPath());

--- a/vcell-restclient/pom.xml
+++ b/vcell-restclient/pom.xml
@@ -286,4 +286,23 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- The Java version VCell SHIPS, which is what decides whether the issue
+                             #2051 retry workaround is still required. Deliberately NOT the JDK a
+                             developer happens to build with: HttpClientRetryWorkaroundTest asks for
+                             the workaround to be removed once the SHIPPED runtime reaches 24, and
+                             keying that off the local JDK would fail the build for anyone on a newer
+                             one while CI, on the shipped version, stayed green. -->
+                        <vcell.shipped.java.target>${maven.compiler.target}</vcell.shipped.java.target>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/vcell-restclient/src/main/java/org/vcell/restclient/CustomApiClientCode.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/CustomApiClientCode.java
@@ -7,6 +7,64 @@ import java.net.http.HttpClient;
 import java.security.cert.X509Certificate;
 
 public class CustomApiClientCode {
+
+    /**
+     * issue #2051 - restore the retry behaviour the desktop client had
+     * before its save/delete calls were migrated from /api/v0 to /api/v1.
+     *
+     * Those calls used to go through Apache HttpClient 4 over HTTP/1.1, whose default
+     * DefaultHttpRequestRetryHandler transparently retried a request sent into a connection
+     * the server had already recycled. The generated client uses java.net.http, which
+     * defaults to HTTP/2, and there:
+     *
+     *   - a GOAWAY surfaces as a plain IOException, NOT a ConnectionExpiredException, so
+     *     MultiExchange.retryOnFailure() rejects it before idempotency is even considered -
+     *     nothing is retried, whatever the method;
+     *   - nginx sends GOAWAY as routine housekeeping (keepalive_requests 1000), so an
+     *     ordinary long session hits it.
+     *
+     * The result was a failed "save biomodel" with no server-side fault. Two changes together
+     * restore the old semantics, and NEITHER is sufficient alone:
+     *
+     *   1. HTTP/1.1, so a recycled connection raises ConnectionExpiredException, which
+     *      java.net.http does consider retryable;
+     *   2. jdk.httpclient.enableAllMethodRetry, because otherwise only GET and HEAD are
+     *      retried - and every affected call is a POST or a DELETE.
+     *
+     * TEMPORARY. JDK 24 added retryAsUnprocessed/isUnprocessedByPeer, which retries streams a
+     * GOAWAY reports the peer never processed, regardless of method - the correct HTTP/2
+     * behaviour and a better fix than this one. Once VCell ships on Java 24+, delete this and
+     * let the JDK handle it. HttpClientRetryWorkaroundTest fails on Java 24+ to make sure that
+     * happens rather than being forgotten.
+     */
+    static {
+        // read once into a static final in MultiExchange, so it must be set before the first
+        // HttpClient is built - which is why it lives here, on the path every client takes.
+        if (System.getProperty("jdk.httpclient.enableAllMethodRetry") == null) {
+            System.setProperty("jdk.httpclient.enableAllMethodRetry", "true");
+        }
+    }
+
+    /** True while the HTTP/1.1 + all-method-retry workaround is still needed (see above). */
+    public static boolean isRetryWorkaroundNeeded() {
+        return Runtime.version().feature() < 24;
+    }
+
+    /**
+     * The builder every VCell ApiClient should use.
+     *
+     * @param ignoreSSLCertProblems trust any certificate (test sites with self-signed certs)
+     */
+    public static HttpClient.Builder createHttpClientBuilder(boolean ignoreSSLCertProblems) {
+        HttpClient.Builder builder = ignoreSSLCertProblems
+                ? createInsecureHttpClientBuilder()
+                : HttpClient.newBuilder();
+        if (isRetryWorkaroundNeeded()) {
+            builder.version(HttpClient.Version.HTTP_1_1);
+        }
+        return builder;
+    }
+
     public static HttpClient.Builder createInsecureHttpClientBuilder() {
         try {
             HttpClient.Builder customBuilder = HttpClient.newBuilder();

--- a/vcell-restclient/src/main/java/org/vcell/restclient/auth/AuthApiClient.java
+++ b/vcell-restclient/src/main/java/org/vcell/restclient/auth/AuthApiClient.java
@@ -41,7 +41,9 @@ public class AuthApiClient extends ApiClient {
     }
 
     public AuthApiClient(URI apiBaseUrl, URI oidcProviderTokenEndpoint, AccessToken accessToken, RefreshToken refreshToken, boolean ignoreSSLCertProblems) {
-        if (ignoreSSLCertProblems) {setHttpClientBuilder(CustomApiClientCode.createInsecureHttpClientBuilder());}
+        // always, not only for insecure certs: the builder also carries the HTTP/1.1 retry
+        // workaround for issue #2051
+        setHttpClientBuilder(CustomApiClientCode.createHttpClientBuilder(ignoreSSLCertProblems));
         this.oidcProviderTokenEndpoint = oidcProviderTokenEndpoint;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;

--- a/vcell-restclient/src/test/java/org/vcell/restclient/HttpClientRetryWorkaroundTest.java
+++ b/vcell-restclient/src/test/java/org/vcell/restclient/HttpClientRetryWorkaroundTest.java
@@ -1,0 +1,92 @@
+package org.vcell.restclient;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Guards the issue #2051 workaround, and — deliberately — FAILS once it is no longer needed.
+ *
+ * Background. The desktop client's save and delete calls moved from /api/v0 (Apache
+ * HttpClient 4, HTTP/1.1) to /api/v1 (java.net.http, HTTP/2) when those endpoints were
+ * migrated. The old stack retried a request sent into a connection the server had already
+ * recycled; the new one does not, so nginx's routine GOAWAY (keepalive_requests 1000) began
+ * surfacing to users as a failed save. 13 write operations are affected — every save and
+ * every delete the client performs.
+ *
+ * The workaround is HTTP/1.1 plus jdk.httpclient.enableAllMethodRetry. Both are required:
+ * on HTTP/2 a GOAWAY arrives as a plain IOException, which MultiExchange.retryOnFailure()
+ * rejects before idempotency is considered, so the flag alone changes nothing; and on
+ * HTTP/1.1 without the flag only GET and HEAD are retried, so a POST still fails.
+ *
+ * Why this test expires. JDK 24 added retryAsUnprocessed / Stream.isUnprocessedByPeer(),
+ * which retries streams a GOAWAY reports the peer never processed — regardless of method.
+ * That is the correct HTTP/2 behaviour and strictly better than forcing HTTP/1.1 on every
+ * call. So when VCell ships on Java 24+ the workaround should be REMOVED, and this test
+ * fails at that point to make that a decision rather than an oversight.
+ *
+ * Verified against the JDK sources: absent in 17, 21 and 23; present in 24 and 25.
+ */
+@Tag("Fast")
+public class HttpClientRetryWorkaroundTest {
+
+    /** The release that made the workaround unnecessary. */
+    private static final int JDK_WITH_UNPROCESSED_RETRY = 24;
+
+    /**
+     * The Java version VCell SHIPS (from maven.compiler.target, passed by surefire), not the
+     * JDK this test happens to run on. Keying the reminder off the running JDK would fail the
+     * build for any developer on a newer one while CI, on the shipped version, stayed green.
+     */
+    private static int shippedJavaTarget() {
+        String v = System.getProperty("vcell.shipped.java.target");
+        return v == null ? Runtime.version().feature() : Integer.parseInt(v.trim());
+    }
+
+    @Test
+    public void removeTheWorkaroundOnceVCellShipsJava24OrLater() {
+        int shipped = shippedJavaTarget();
+        if (shipped >= JDK_WITH_UNPROCESSED_RETRY) {
+            fail("VCell now ships Java " + shipped + ". Since Java " + JDK_WITH_UNPROCESSED_RETRY
+                    + " the JDK retries streams a GOAWAY reports as unprocessed, regardless of HTTP "
+                    + "method — the correct HTTP/2 behaviour, and better than forcing HTTP/1.1 on "
+                    + "every call.\n\n"
+                    + "REMOVE the workaround in CustomApiClientCode (the HTTP_1_1 pin, the "
+                    + "jdk.httpclient.enableAllMethodRetry static block, and isRetryWorkaroundNeeded), "
+                    + "put both call sites back to configuring the builder only for certificates, "
+                    + "and delete this test. See issue #2051.\n\n"
+                    + "Re-test a real save against a deployed server first: the Java 24+ conclusion "
+                    + "was read from the JDK source, not observed.");
+        }
+    }
+
+    @Test
+    public void theClientMatchesWhatTheWorkaroundClaims() {
+        // isRetryWorkaroundNeeded() keys off the RUNNING JDK, which is right: a developer on
+        // Java 24+ already has the JDK's own fix and should not be pinned to HTTP/1.1.
+        boolean needed = CustomApiClientCode.isRetryWorkaroundNeeded();
+        assertEquals(Runtime.version().feature() < JDK_WITH_UNPROCESSED_RETRY, needed,
+                "the workaround should report itself needed exactly on JDKs below "
+                        + JDK_WITH_UNPROCESSED_RETRY);
+
+        HttpClient secure = CustomApiClientCode.createHttpClientBuilder(false).build();
+        HttpClient insecure = CustomApiClientCode.createHttpClientBuilder(true).build();
+        if (needed) {
+            assertEquals(HttpClient.Version.HTTP_1_1, secure.version(),
+                    "HTTP/2 GOAWAY is never retried, so the client must speak HTTP/1.1 (issue #2051)");
+            assertEquals(HttpClient.Version.HTTP_1_1, insecure.version(),
+                    "the ignore-certificates client must carry the same workaround");
+            assertEquals("true", System.getProperty("jdk.httpclient.enableAllMethodRetry"),
+                    "only GET and HEAD are retried without this, and every affected call is a "
+                            + "POST or a DELETE");
+        } else {
+            assertEquals(HttpClient.Version.HTTP_2, secure.version(),
+                    "on a JDK that retries unprocessed streams, leave HTTP/2 alone");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2051 — short-term, with a test that expires itself.

## What broke

```
java.io.IOException: /192.168.214.155:49708: GOAWAY received
```

A regression from the `/api/v0` → `/api/v1` migration. `67af4b9577` moved `saveBioModel` from the RPC path (**Apache HttpClient 4, HTTP/1.1**) to the generated client (**`java.net.http`, HTTP/2**). Apache's default retry handler had transparently retried a request sent into a connection the server had already recycled; the new stack has no equivalent, and nginx sends GOAWAY as routine housekeeping (`keepalive_requests 1000`).

**13 operations** are affected, not one — every save and delete across BioModel, MathModel, Geometry, VcImage and FieldData.

## The fix, and why the obvious one doesn't work

Read from the JDK sources; **neither change is sufficient alone**:

| | why it's needed |
|---|---|
| **HTTP/1.1** | On HTTP/2 a GOAWAY is a plain `IOException`, not `ConnectionExpiredException`, so `MultiExchange.retryOnFailure()` rejects it *before* idempotency is considered — nothing is retried, whatever the method or flags |
| **`enableAllMethodRetry`** | Only GET and HEAD are retried otherwise, and every affected call is a POST or DELETE |

My first recommendation in the issue was `enableAllMethodRetry` alone. That would have shipped as a non-fix — it only relaxes the inner gate, which a GOAWAY never reaches.

Both live in `CustomApiClientCode`, which is hand-maintained and **survives client regeneration**; patching `ApiClient.java` directly would be silently reverted by `tools/openapi-clients.sh`.

## The expiring test

JDK 24 added `retryAsUnprocessed` / `isUnprocessedByPeer()`, which retries streams a GOAWAY reports the peer never processed — correct HTTP/2 semantics and better than pinning HTTP/1.1. So this workaround should die at the Java 25 upgrade.

`HttpClientRetryWorkaroundTest` **fails once VCell ships Java 24+**, naming exactly what to delete. `isRetryWorkaroundNeeded()` keys off the *running* JDK, so anyone already on 24+ gets the JDK's own fix and is not pinned.

One design note worth reading: my first version keyed the reminder off the **running** JDK. It failed immediately on my machine (Maven runs Java 25) while CI on Java 17 would have stayed green — a broken build for developers on newer JDKs and no reminder where it mattered. It now keys off `maven.compiler.target` passed through surefire.

## Verified, all four directions

- Java 17: client pinned to HTTP/1.1, property set — **passes**
- pin removed: **fails** with `must speak HTTP/1.1`
- shipped target forced to 25: removal reminder **fires**
- Java 25 with target 17: passes, client left on HTTP/2

## Still true after this

A request the server **did** process, whose response was lost, cannot be safely retried by anyone. The "check before re-saving" guidance in #2051 stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx