### PR TITLE
build(deps): exclude two narayana artifacts that exist in no repository

### DIFF
--- a/vcell-rest/pom.xml
+++ b/vcell-rest/pom.xml
@@ -77,6 +77,30 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-agroal</artifactId>
+      <!--
+        issue #2041: org.jboss.narayana.jts:narayana-jts-integration, reached through
+        quarkus-narayana-jta, declares these two as `provided` - and neither exists in ANY
+        repository. Every repository 404s them and Maven shrugs, so builds work by accident.
+
+        That accident ended on 2026-08-27: maven.scijava.org answered 503 instead of 404, and
+        because Maven treats a 503 as a hard transfer error rather than "not here, ask the next
+        one", the whole dependency collection failed and no module could build (#2036 era, fixed
+        by dropping that repository in #2037).
+
+        Excluding them removes the exposure rather than relying on five third parties all
+        answering 404 correctly. Nothing is lost: they are `provided`, so they were never going
+        to reach our classpath, and they do not exist to be fetched.
+      -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.narayana.jts</groupId>
+          <artifactId>idlj-idl-openjdk</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.narayana.jts</groupId>
+          <artifactId>jtax</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Fixes #2041.

`narayana-jts-integration` (via `quarkus-agroal` → `quarkus-narayana-jta`) declares **`idlj-idl-openjdk`** and **`jtax`** as `provided`. Neither exists in **any** repository — Central, jitpack and terracotta all 404 them, Maven shrugs, and builds have worked by accident.

That accident ended on 2026-08-27, when `maven.scijava.org` answered **503** instead of 404. Maven treats a 503 as a hard transfer error rather than "not here, ask the next one", so dependency collection failed outright and nothing could build. Dropping that repository (#2037) fixed the instance; this removes the mechanism, so we no longer depend on five third parties all continuing to answer 404 correctly.

## Nothing is lost — measured, not assumed

| | |
|---|---|
| resolved runtime classpath for `vcell-rest` | **471 jars before, 471 after** |
| removed | **nothing** |
| added | nothing |

They are `provided` scope, so they were never reaching our classpath, and they do not exist to be fetched.

## Effect

Resolution attempts for the two artifacts, via `mvn -X -pl vcell-rest validate`:

| | attempts |
|---|---|
| before | **6** (20 against a cold local repository) |
| after | **0** |

Every build currently asks up to five repositories for two artifacts that cannot exist. Now it asks none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx