### PR TITLE
docs(release): record 8.1.4.01, which was tagged without a changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,39 @@ followed by flat Keep-a-Changelog categories. API consumers should scan
 
 _(Release-manager scratchpad. Populated at release-cut time.)_
 
+## [8.1.4.01] - 2026-09-02
+
+**Highlights.** SpringSaLaD runs get the processors they were asked for. The
+background process that watches a run was quietly taking one of the simulation
+slots, and the whole batch was pinned to a single machine, which capped it at
+about 20 simulations at once however many were requested.
+
+### Fixed
+- A SpringSaLaD batch no longer loses one simulation slot to its own watchdog.
+  The number of parallel tasks requested from the cluster counted only the
+  simulations, but the watchdog runs as a task too — so a run asking for four
+  parallel simulations got three. The request now accounts for it, and the batch
+  script derives the simulation count from what was actually allocated. (#2049)
+- A SpringSaLaD run can use more than one machine. The batch requested exactly
+  one node regardless of size, so concurrency was capped at roughly 20
+  simulations no matter what was asked for; the number of nodes is now computed
+  from the concurrency requested. (#2049)
+- Runs asking for fewer simulations than the concurrency limit no longer request
+  resources they cannot use — concurrency is clamped to the number of
+  simulations in the run. (#2049)
+- A test-site prefix (`V_TEST2_`) was hard-coded into the generated batch script
+  when clearing a run's log, so on any other site it truncated a path that did
+  not correspond to the running job. The prefix now comes from the job. (#2049)
+
+### Changed
+- New optional setting `vcell.slurm.langevin.maxNumConcurrentTasks` caps parallel
+  tasks for a SpringSaLaD batch, counting the watchdog. Defaults to 31 — 30
+  simulations plus the watchdog, which is two nodes — and is unset in every
+  deployment, so behaviour is the default unless someone tunes it. (#2049)
+
+### Notes for API consumers
+No API changes.
+
 ## [8.1.3.01] - 2026-09-02
 
 **Highlights.** Two things that made VCell unusable for the people who hit them.

--- a/release-notes/major/8.1.md
+++ b/release-notes/major/8.1.md
@@ -243,6 +243,11 @@ _(Per-build detail is in `CHANGELOG.md`.)_
   held twice over and never released; a 62-megapixel image had been enough to take
   down production API servers (8.1.2.01).
 
+- SpringSaLaD runs use the parallelism they were given. The process that watches a
+  run had been taking one of the simulation slots for itself, and the whole batch was
+  pinned to a single machine, capping it at around 20 simulations at once however many
+  were requested (8.1.4.01).
+
 ## API and integration changes
 
 - `getVCInfoContainer` moved from the legacy RPC transport to REST


### PR DESCRIPTION
8.1.4.01 was cut on 2026-09-02 with **no CHANGELOG section and an empty release body** — a hole immediately above the 8.1.2.01 gap backfilled earlier the same day.

The release body is already fixed in place (`gh release edit`); this lands the matching CHANGELOG section and folds the user-facing item into the 8.1 narrative, per `docs/RELEASING.md`.

## What 8.1.4.01 actually contains

Read from the diff, not the commit titles. It is #2049 (`dan-ss-slurm2`), and it is more interesting than "expand max concurrent tasks":

- **The watchdog was eating a simulation slot.** `--ntasks` counted only the simulations, but the watchdog runs as a task too — so a run asking for N parallel simulations got **N-1**. Now `--ntasks = simulations + 1`, and the batch script derives `max_concurrent_jobs` from `SLURM_NTASKS - 1`.
- **The batch was pinned to one node.** `#SBATCH --nodes=1` was hard-coded, capping concurrency at ~20 regardless of the request. Now `nodes = ceil(concurrentTasks / 20)`.
- **Over-requesting on small runs** — concurrency is now clamped to `min(totalJobs, max-1)`.
- **A hard-coded `V_TEST2_` site prefix** reached the generated batch script when clearing a run's log. On any other site that truncated a path belonging to no running job. The prefix now comes from the job name.

## On the new setting

`vcell.slurm.langevin.maxNumConcurrentTasks` is **optional**, defaults to `"31"` (30 simulations + watchdog, i.e. two nodes), and is **unset in every overlay** — I checked. So deployed behaviour is the default unless someone tunes it, and there is no missing-configuration landmine.

## Note

I did not cut this release and cannot vouch for its testing — this is documentation of what shipped, written from the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx