### PR TITLE
ci: judge a new branch by the whole branch, not its last commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,19 @@ jobs:
             echo "run=$1" >> "$GITHUB_OUTPUT"
             echo "reason=$2" >> "$GITHUB_OUTPUT"
             echo "::notice::CI $( [ "$1" = true ] && echo runs || echo skipped ): $2"
+            # A skip is otherwise indistinguishable from a pass on the PR, so say it plainly
+            # somewhere a reader will look (issue #2034).
+            {
+              if [ "$1" = true ]; then
+                echo "### CI lane: **running**"
+              else
+                echo "### CI lane: **SKIPPED** - nothing was compiled or tested"
+              fi
+              echo ""
+              echo "Reason: $2"
+              echo ""
+              echo "Base for the comparison: \`${base:-<none>}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           }
 
@@ -72,13 +85,26 @@ jobs:
             fi
           fi
 
-          # Documentation-only. Compare against what was there before this push; fall back to
-          # the first parent, which for a merge commit is exactly the PR's contents.
+          # Documentation-only. What matters is picking a base that spans everything this ref
+          # has that the default branch does not - judging a whole branch by its final commit
+          # silently skipped the lane for branches whose last commit happened to be docs
+          # (issue #2034).
           base=""
-          if [ -n "${GITHUB_EVENT_BEFORE:-}" ] && git rev-parse -q --verify "${GITHUB_EVENT_BEFORE}^{commit}" >/dev/null 2>&1; then
-            base="${GITHUB_EVENT_BEFORE}"
-          elif git rev-parse -q --verify "HEAD^1" >/dev/null 2>&1; then
+          before="${GITHUB_EVENT_BEFORE:-}"
+          if [ -n "${before}" ] && [ -n "${before//0/}" ] \
+             && git rev-parse -q --verify "${before}^{commit}" >/dev/null 2>&1; then
+            # Push to an existing ref: the previous tip is the most precise base there is.
+            # An all-zeros "before" means the ref did NOT exist before, so it is not one.
+            base="${before}"
+          elif git rev-parse -q --verify "HEAD^2" >/dev/null 2>&1; then
+            # A merge commit (pull_request, merge_group): the first parent IS the base, and
+            # the diff against it is exactly the PR's contents.
             base="HEAD^1"
+          elif git rev-parse -q --verify "origin/${DEFAULT_BRANCH}^{commit}" >/dev/null 2>&1; then
+            # A new branch: "before" is all-zeros and HEAD^1 is only the previous COMMIT, which
+            # is what made this skip whole branches. The merge base spans the branch however
+            # many commits it has, and reduces to HEAD^1 for a single-commit branch.
+            base="$(git merge-base "origin/${DEFAULT_BRANCH}" HEAD || true)"
           fi
           if [ -n "${base}" ]; then
             changed="$(git diff --name-only "${base}" HEAD)"
@@ -90,6 +116,7 @@ jobs:
           decide true "changes may affect the build or the tests"
         env:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'master' }}
 
   # ---------------------------------------------------------------------------
   # BUILD: compile the monorepo (no tests), run the Python package tests, and

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -157,6 +157,26 @@ assuming it went missing.
 
 See issue [#2038](https://github.com/virtualcell/vcell/issues/2038).
 
+## A green fast lane can mean "nothing ran"
+
+The `should-run` gate in `ci.yml` skips the fast lane when a change touched only
+documentation, and reports the aggregate `CI-Test-group-Fast` as **pass** when it does.
+That is intended, but it means a green check has two meanings: "the tests passed" and
+"there were no tests to run".
+
+To tell them apart, open the `should-run` job. It writes its decision to the run summary:
+
+```
+### CI lane: SKIPPED - nothing was compiled or tested
+Reason: only documentation changed (docs/MESSAGING.md)
+Base for the comparison: `a1b2c3d`
+```
+
+It used to be worth checking this by hand, because the gate judged a whole new branch by
+its final commit — a branch ending in a docs commit skipped everything and looked green
+(issue #2034, fixed). The summary line exists so that class of thing is visible rather
+than inferred.
+
 ## Each git worktree is its own build environment
 
 `git worktree` gives you an isolated checkout, and the build state is isolated with


### PR DESCRIPTION
Fixes #2034.

## The bug

The `should-run` gate skips the fast lane when a push changed only documentation. It picked its comparison base like this:

```
github.event.before, if it resolves   ->  the previous tip of this ref
otherwise HEAD^1                      ->  the previous COMMIT
```

On a push that **creates** a branch, `github.event.before` is all-zeros and does not resolve, so it fell through to `HEAD^1` and judged the **entire branch by its final commit**. A branch ending in a docs commit skipped `build`, every Fast shard and Quarkus — and reported `CI-Test-group-Fast` as **pass in about two seconds**.

PR #2033 shipped exactly that way: four commits, three of them Java across `vcell-server`, a docs commit last.

It is the bad kind of failure — silent, indistinguishable from a pass, and since `regression.yml` does not run on `pull_request` either, the merge queue was the first place that code would ever be compiled. It also gets **more** likely with better commit hygiene, because ending a branch with a docs commit is a normal shape.

## The fix

Base selection now distinguishes three cases rather than two:

| situation | base | why |
|---|---|---|
| push to an existing ref | `github.event.before` | most precise answer there is. All-zeros now fails this test **explicitly** — it means the ref did not exist, so it is not a base |
| merge commit (`pull_request`, `merge_group`) | `HEAD^1` | the first parent is exactly the PR's contents, as before |
| **new branch** | `git merge-base` with the default branch | spans the branch however many commits it has, and reduces to `HEAD^1` for a single-commit branch |

## Verified against a scratch repository

| scenario | old | fixed |
|---|---|---|
| new branch, code then **docs last** | **SKIP** ❌ | **RUN** ✅ |
| new branch, genuinely docs-only | SKIP | **SKIP** ✅ optimisation preserved |
| push to existing branch, docs-only push | SKIP | **SKIP** ✅ `before` still wins |
| merge commit | RUN | **RUN** ✅ first parent still used |

## This PR is its own regression test

The last commit is **deliberately docs-only**. Under the bug this branch would have skipped everything and reported green; with the fix the lane runs, because the branch as a whole touches `ci.yml`.

So: **if the fast lane runs on this PR, the fix works.**

## Also

A skip was indistinguishable from a pass, which is what let this go unnoticed. The gate now writes its decision and its comparison base to the job summary:

```
### CI lane: SKIPPED - nothing was compiled or tested
Reason: only documentation changed (docs/MESSAGING.md)
Base for the comparison: `a1b2c3d`
```

`docs/BUILDING.md` records that a green fast lane has two meanings and where to look to tell them apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx