### PR TITLE
fix: reject names the expression parser cannot read (#2062)

### DIFF
--- a/vcell-core/src/main/java/cbit/vcell/model/Model.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/Model.java
@@ -4465,6 +4465,24 @@ public class Model implements Versionable, Matchable, Relatable, PropertyChangeL
         }
     }
 
+    private transient boolean restoringFromPersistedContent = false;
+
+    /**
+     * While true, {@link #validateNamingConflicts} skips the check that a symbol name is a legal
+     * expression identifier. Naming <em>conflicts</em> are still checked.
+     *
+     * Until the ASCII fix in {@link TokenMangler}, that check passed any name built from Unicode
+     * letters, so models were saved holding names such as PROTE&Iacute;NA_A that the expression
+     * parser cannot read (issue #2062). Those models are already unrunnable; refusing to load them
+     * would also take away the user's only way to rename the species, so a read from VCML or the
+     * database restores the name as saved and SpeciesContext.gatherIssues() reports it instead.
+     *
+     * Set only for the duration of a read, and always cleared in a finally block.
+     */
+    public void setRestoringFromPersistedContent(boolean restoring){
+        this.restoringFromPersistedContent = restoring;
+    }
+
     /**
      * if newSTE is null, then newName is the proposed name of a reaction
      * else newSTE is the symbol to be added.
@@ -4480,7 +4498,11 @@ public class Model implements Versionable, Matchable, Relatable, PropertyChangeL
         if(newSymbolName.length() < 1){
             throw new ModelPropertyVetoException(symbolDescription + " name is empty (zero length).", e);
         }
-        if(!newSymbolName.equals(TokenMangler.fixTokenStrict(newSymbolName))){
+        // One definition of "legal identifier" for the whole model, shared with the expression
+        // grammar - see TokenMangler.isValidExpressionIdentifier. This used to be spelled
+        // "equals(fixTokenStrict(name))", which was correct in shape but inherited the mangler's
+        // Unicode-wide notion of a letter and so let unparseable names through (#2062).
+        if(!restoringFromPersistedContent && !TokenMangler.isValidExpressionIdentifier(newSymbolName)){
             throw new ModelPropertyVetoException(symbolDescription + " '" + newSymbolName + "' not legal identifier, try '" + TokenMangler.fixTokenStrict(newSymbolName) + "'.", e);
         }
 

--- a/vcell-core/src/main/java/cbit/vcell/model/SpeciesContext.java
+++ b/vcell-core/src/main/java/cbit/vcell/model/SpeciesContext.java
@@ -71,14 +71,42 @@ public class SpeciesContext implements Cacheable, Matchable, Relatable, Editable
 	// store SBML unit for speciesContext from SBML species.
 //	private transient VCUnitDefinition sbmlSpeciesUnit = null;
 
+	/** False only while a persisted name is being restored - see {@link #fromPersistedContent}. */
+	private transient boolean checkNameIsIdentifier = true;
+
 	
 public SpeciesContext(KeyValue key, String name, Species species, Structure structure, SpeciesPattern speciesPattern) {
+	this(key, name, species, structure, speciesPattern, true);
+}
+
+/**
+ * Rebuild a species context from persisted content (VCML or the database).
+ *
+ * Names are only checked against the expression-identifier rule for edits the user makes now.
+ * Models saved before that rule was enforced may hold a name the expression parser cannot read
+ * (see issue #2062); such a model must still open, so this entry point relaxes the check and
+ * {@link #gatherIssues} reports the offending name instead, giving the user something to act on.
+ */
+public static SpeciesContext fromPersistedContent(KeyValue key, String name, Species species, Structure structure, SpeciesPattern speciesPattern) {
+	return new SpeciesContext(key, name, species, structure, speciesPattern, false);
+}
+
+/** @see #fromPersistedContent(KeyValue, String, Species, Structure, SpeciesPattern) */
+public static SpeciesContext fromPersistedContent(KeyValue key, String name, Species species, Structure structure) {
+	return fromPersistedContent(key, name, species, structure, null);
+}
+
+private SpeciesContext(KeyValue key, String name, Species species, Structure structure, SpeciesPattern speciesPattern, boolean checkNameIsIdentifier) {
 	this.key = key;
 	addVetoableChangeListener(this);
+	this.checkNameIsIdentifier = checkNameIsIdentifier;
 	try {
 		setName(name);
 	}catch (PropertyVetoException e){
 		throw new RuntimeException(e.getMessage(), e);
+	}finally {
+		// only construction may relax the rule; any later rename is validated normally
+		this.checkNameIsIdentifier = true;
 	}
 	this.species = species;
 	setStructure(structure);
@@ -359,12 +387,19 @@ public void vetoableChange(PropertyChangeEvent e) throws PropertyVetoException {
 			if (newName.length()<1){
 				throw new PropertyVetoException("species context name is zero length",e);
 			}
-			if (!Character.isJavaIdentifierStart(newName.charAt(0))){
-				throw new PropertyVetoException("species context name '"+newName+"' can't start with a '"+newName.charAt(0)+"'",e);
-			}
-			for (int i=1;i<newName.length();i++){
-				if (!Character.isJavaIdentifierPart(newName.charAt(i))){
-					throw new PropertyVetoException("species context name '"+newName+"' can't include a '"+newName.charAt(i)+"'",e);
+			// The rule is TokenMangler's ASCII identifier rule, not Character.isJavaIdentifier*:
+			// the latter accepts any Unicode letter, so a name like PROTEINA_A with an accent used
+			// to be accepted here and then failed to parse during math generation, leaving the
+			// application with no generated math and an error that named an expression rather than
+			// the species (issue #2062).
+			if (checkNameIsIdentifier){
+				int illegalAt = TokenMangler.indexOfFirstIllegalIdentifierChar(newName);
+				if (illegalAt >= 0){
+					char illegalChar = newName.charAt(illegalAt);
+					String what = (illegalAt == 0)
+						? "species context name '"+newName+"' can't start with a '"+illegalChar+"'"
+						: "species context name '"+newName+"' can't include a '"+illegalChar+"'";
+					throw new PropertyVetoException(what+" - "+TokenMangler.IDENTIFIER_RULE_DESCRIPTION,e);
 				}
 			}	
 		} else if(e.getPropertyName().equals("sbmlName")) {
@@ -470,6 +505,13 @@ public boolean hasSpeciesPattern() {
 
 public void gatherIssues(IssueContext issueContext, List<Issue> issueList) {
 	issueContext = issueContext.newChildContext(ContextType.SpeciesContext, this);
+	// A name restored from a model saved before the identifier rule was enforced (see #2062).
+	// Math generation will fail on it, so say so here rather than at generation time, where the
+	// error names an expression and not the species.
+	if(getName() != null && !TokenMangler.isValidExpressionIdentifier(getName())) {
+		String msg = "Species '"+getName()+"' cannot be used to generate math: "+TokenMangler.IDENTIFIER_RULE_DESCRIPTION+". Rename it.";
+		issueList.add(new Issue(this, issueContext, IssueCategory.Identifiers, msg, Issue.Severity.ERROR));
+	}
 	if(species == null) {
 		issueList.add(new Issue(this, issueContext, IssueCategory.Identifiers, "Species is null", Issue.SEVERITY_WARNING));
 	} else {

--- a/vcell-core/src/main/java/cbit/vcell/xml/XmlReader.java
+++ b/vcell-core/src/main/java/cbit/vcell/xml/XmlReader.java
@@ -4491,6 +4491,10 @@ public RateRuleVariable[] getRateRuleVariables(Element rateRuleVarsElement, Mode
             }
         }
 
+        // A model saved before the identifier rule was enforced may hold a name the expression
+        // parser cannot read (#2062). It must still open, so relax the lexicon check for the read
+        // and let Model/SpeciesContext.gatherIssues() report the name instead.
+        newmodel.setRestoringFromPersistedContent(true);
         try {
             //Set attributes
             newmodel.setName(unMangle(param.getAttributeValue(XMLTags.NameAttrTag)));
@@ -4604,6 +4608,8 @@ public RateRuleVariable[] getRateRuleVariables(Element rateRuleVarsElement, Mode
             throw new XmlParseException(e);
         } catch(ModelException e){
             lg.error(e);
+        } finally {
+            newmodel.setRestoringFromPersistedContent(false);
         }
 
         // model param expresions are not bound when they are read in, since they could be functions of each other or structures/speciesContexts.
@@ -6963,7 +6969,8 @@ public RateRuleVariable[] getRateRuleVariables(Element rateRuleVarsElement, Mode
         }
         //---try to create the speciesContext---
         SpeciesContext speciecontext = null;
-        speciecontext = new SpeciesContext(key, name, specieref, structureref, sp);
+        // persisted content: an illegal name is reported by gatherIssues, not thrown here (#2062)
+        speciecontext = SpeciesContext.fromPersistedContent(key, name, specieref, structureref, sp);
         try {
             speciecontext.setSbmlName(sbmlName);
         } catch(PropertyVetoException e){        // can't happen here, whatever we saved must have been correct

--- a/vcell-core/src/test/java/cbit/vcell/model/SpeciesContextNameTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/model/SpeciesContextNameTest.java
@@ -1,0 +1,231 @@
+package cbit.vcell.model;
+
+import cbit.vcell.biomodel.BioModel;
+import cbit.vcell.parser.Expression;
+import cbit.vcell.parser.ExpressionException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.vcell.util.Issue;
+import org.vcell.util.IssueContext;
+import cbit.vcell.xml.XmlHelper;
+import cbit.vcell.xml.XMLSource;
+import org.vcell.util.TokenMangler;
+
+import java.beans.PropertyVetoException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Locks the name rule enforced by {@link SpeciesContext} to what the expression grammar in
+ * Parser.jjt actually accepts.
+ *
+ * These drifted apart once already: name validation used Character.isJavaIdentifier*, which
+ * accepts any Unicode letter, while the grammar's LETTER is ["a"-"z","_","A"-"Z"]. A species
+ * named PROTEINA_A with an accent was therefore accepted at entry, saved, and then failed math
+ * generation with "Parse Error while parsing expression", leaving the application with no
+ * generated math (issue #2062). The first test below is the one that keeps them together: it
+ * asserts agreement by actually parsing, so tightening or loosening either side without the
+ * other fails here.
+ */
+@Tag("Fast")
+public class SpeciesContextNameTest {
+
+	/** Names that must be legal, and names that must not be. */
+	private static final String[] LEGAL = {
+		"s0", "S", "_", "_s", "Ca_cyt", "sC1", "x2y3", "ABC_123",
+	};
+	private static final String[] ILLEGAL = {
+		// non-ASCII letters: accepted by Character.isJavaIdentifierPart, rejected by the grammar
+		"PROTE\u00cdNA_A", "UNI\u00d3N", "\u00f1u", "\u53d7\u5bb9\u4f53", "\u0431\u0435\u043b\u043e\u043a",
+		// plain ASCII violations
+		"1abc", "a b", "a-b", "a+b", "", "a/b",
+	};
+
+	/**
+	 * '.' is the one character the parser accepts that a name still may not contain. The grammar's
+	 * IDENTIFIER token is (&lt;ID&gt; ".")* &lt;ID&gt;, so a dot separates name-scope qualifiers
+	 * (application.parameter) rather than forming part of a single name. A species may therefore
+	 * not be called "a.b" even though "a.b" parses.
+	 */
+	private static final String[] ILLEGAL_BUT_PARSEABLE_AS_QUALIFIED_NAME = {
+		"a.b", "app.param",
+	};
+
+	@Test
+	public void identifierRuleAgreesWithTheExpressionParser() {
+		for (String name : LEGAL) {
+			assertTrue(TokenMangler.isValidExpressionIdentifier(name),
+				"expected '" + name + "' to be a legal identifier");
+			assertTrue(parsesAsSingleIdentifier(name),
+				"'" + name + "' is accepted by TokenMangler but the expression parser rejects it");
+		}
+		for (String name : ILLEGAL) {
+			assertFalse(TokenMangler.isValidExpressionIdentifier(name),
+				"expected '" + name + "' to be rejected as an identifier");
+			assertFalse(parsesAsSingleIdentifier(name),
+				"'" + name + "' is rejected by TokenMangler but the expression parser accepts it");
+		}
+		for (String name : ILLEGAL_BUT_PARSEABLE_AS_QUALIFIED_NAME) {
+			assertFalse(TokenMangler.isValidExpressionIdentifier(name),
+				"a dot-qualified name is not a legal single identifier: '" + name + "'");
+			assertTrue(parsesAsSingleIdentifier(name),
+				"the grammar is expected to read '" + name + "' as one qualified reference");
+		}
+	}
+
+	private static boolean parsesAsSingleIdentifier(String name) {
+		try {
+			Expression exp = new Expression(name);
+			String[] symbols = exp.getSymbols();
+			return symbols != null && symbols.length == 1 && symbols[0].equals(name);
+		} catch (ExpressionException e) {
+			return false;
+		} catch (RuntimeException e) {
+			return false;
+		}
+	}
+
+	@Test
+	public void renameToNonAsciiNameIsRejectedWithAUsefulMessage() throws Exception {
+		SpeciesContext sc = newSpeciesContext("Ca_cyt");
+		PropertyVetoException ex = assertThrows(PropertyVetoException.class,
+			() -> sc.setName("PROTE\u00cdNA_A"));
+		assertTrue(ex.getMessage().contains("PROTE\u00cdNA_A"), "message should quote the rejected name");
+		assertTrue(ex.getMessage().contains(TokenMangler.IDENTIFIER_RULE_DESCRIPTION),
+			"message should state the rule, was: " + ex.getMessage());
+		assertEquals("Ca_cyt", sc.getName(), "a rejected rename must not change the name");
+	}
+
+	@Test
+	public void constructingWithANonAsciiNameIsRejected() {
+		assertThrows(RuntimeException.class, () -> newSpeciesContext("PROTE\u00cdNA_A"));
+	}
+
+	@Test
+	public void aDottedNameIsRejectedEvenThoughItParses() throws Exception {
+		SpeciesContext sc = newSpeciesContext("Ca_cyt");
+		assertThrows(PropertyVetoException.class, () -> sc.setName("app.Ca"),
+			"'.' is the name-scope separator and may not appear inside a name");
+	}
+
+	@Test
+	public void aLegalRenameStillWorks() throws Exception {
+		SpeciesContext sc = newSpeciesContext("Ca_cyt");
+		sc.setName("Ca_ext");
+		assertEquals("Ca_ext", sc.getName());
+	}
+
+	/**
+	 * A model saved before the rule was enforced must still open - it is already unrunnable, and
+	 * refusing to load it would take away the user's only way to rename the species.
+	 */
+	@Test
+	public void persistedNameLoadsButIsReportedAsAnIssue() throws Exception {
+		SpeciesContext sc = SpeciesContext.fromPersistedContent(
+			null, "PROTE\u00cdNA_A", new Species("PROTE\u00cdNA_A", null), new Feature("c0"));
+		assertEquals("PROTE\u00cdNA_A", sc.getName(), "persisted name must survive the load");
+
+		List<Issue> issues = new ArrayList<>();
+		sc.gatherIssues(new IssueContext(), issues);
+		Issue nameIssue = null;
+		for (Issue issue : issues) {
+			if (issue.getMessage() != null && issue.getMessage().contains("PROTE\u00cdNA_A")) {
+				nameIssue = issue;
+			}
+		}
+		assertNotNull(nameIssue, "loading an illegal persisted name must raise an issue");
+		assertEquals(Issue.Severity.ERROR, nameIssue.getSeverity());
+	}
+
+	/** Once loaded, the relaxation must not persist: a later rename is validated normally. */
+	@Test
+	public void aPersistedContextStillValidatesLaterRenames() throws PropertyVetoException {
+		SpeciesContext sc = SpeciesContext.fromPersistedContent(
+			null, "PROTE\u00cdNA_A", new Species("PROTE\u00cdNA_A", null), new Feature("c0"));
+		assertThrows(PropertyVetoException.class, () -> sc.setName("OTRA_PROTE\u00cdNA"));
+	}
+
+	/**
+	 * The real regression: a model saved with a name the parser cannot read must still open.
+	 * Refusing to load it would be worse than the bug being fixed - it would take away the only
+	 * way the user has to rename the species - so XmlReader restores such a name and the problem
+	 * is reported as an issue instead.
+	 */
+	@Test
+	public void aVcmlModelHoldingAnIllegalNameStillLoads() throws Exception {
+		BioModel bioModel = new BioModel(null);
+		bioModel.setName("issue2062");
+		Model model = bioModel.getModel();
+		Feature cytosol = model.addFeature("cytosol");
+		model.addSpecies(new Species("LEGAL_NAME", null));
+		model.addSpeciesContext(model.getSpecies("LEGAL_NAME"), cytosol);
+
+		// stand in for a model saved before the rule was enforced
+		String vcml = XmlHelper.bioModelToXML(bioModel).replace("LEGAL_NAME", "PROTE\u00cdNA_A");
+		assertTrue(vcml.contains("PROTE\u00cdNA_A"), "test setup: the name should be in the VCML");
+
+		BioModel reloaded = XmlHelper.XMLToBioModel(new XMLSource(vcml));
+		// the species context is auto-named <species>_<structure>, so match on the species name
+		SpeciesContext sc = null;
+		for (SpeciesContext candidate : reloaded.getModel().getSpeciesContexts()) {
+			if (candidate.getName().contains("PROTE\u00cdNA_A")) {
+				sc = candidate;
+			}
+		}
+		assertNotNull(sc, "the species context should have loaded under its persisted name");
+		assertFalse(TokenMangler.isValidExpressionIdentifier(sc.getName()),
+			"test setup: the loaded name should still be the illegal one");
+
+		List<Issue> issues = new ArrayList<>();
+		sc.gatherIssues(new IssueContext(), issues);
+		boolean reported = false;
+		for (Issue issue : issues) {
+			if (issue.getSeverity() == Issue.Severity.ERROR
+					&& issue.getMessage() != null && issue.getMessage().contains(sc.getName())) {
+				reported = true;
+			}
+		}
+		assertTrue(reported, "the illegal name should be reported as an error issue, issues were: " + issues);
+	}
+
+	/**
+	 * The importers mangle externally supplied names into identifiers with TokenMangler; that
+	 * mangling used the same Unicode-wide predicates and so passed non-ASCII letters through
+	 * untouched, producing a token that does not parse.
+	 */
+	@Test
+	public void tokenManglerProducesParseableIdentifiers() {
+		for (String name : ILLEGAL) {
+			if (name.isEmpty()) {
+				continue;
+			}
+			String fixed = TokenMangler.fixToken(name);
+			assertTrue(TokenMangler.isValidExpressionIdentifier(fixed),
+				"fixToken('" + name + "') returned '" + fixed + "', which is not a legal identifier");
+			String strict = TokenMangler.fixTokenStrict(name);
+			assertTrue(TokenMangler.isValidExpressionIdentifier(strict),
+				"fixTokenStrict('" + name + "') returned '" + strict + "', which is not a legal identifier");
+		}
+	}
+
+	@Test
+	public void firstIllegalCharPointsAtTheOffendingCharacter() {
+		assertEquals(5, TokenMangler.indexOfFirstIllegalIdentifierChar("PROTE\u00cdNA_A"));
+		assertEquals(0, TokenMangler.indexOfFirstIllegalIdentifierChar("1abc"));
+		assertEquals(1, TokenMangler.indexOfFirstIllegalIdentifierChar("a b"));
+		assertEquals(-1, TokenMangler.indexOfFirstIllegalIdentifierChar("Ca_cyt"));
+		// a digit is legal everywhere but at the start, so the position matters
+		assertEquals(-1, TokenMangler.indexOfFirstIllegalIdentifierChar("a1"));
+		assertEquals(0, TokenMangler.indexOfFirstIllegalIdentifierChar("1a"));
+	}
+
+	private static SpeciesContext newSpeciesContext(String name) throws PropertyVetoException {
+		return new SpeciesContext(null, name, new Species(name, null), new Feature("c0"));
+	}
+}

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/ModelDbDriver.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/ModelDbDriver.java
@@ -443,7 +443,7 @@ private SpeciesContext getSpeciesContext(QueryHashtable dbc, Connection con, Res
 	//
 	Structure structure = reactStepDB.getStructure(dbc, con,structKey);
 	Species species = reactStepDB.getSpecies(dbc, con,speciesKey);
-	speciesContext = new SpeciesContext(scKey,speciesContext.getName(),species,structure);
+	speciesContext = SpeciesContext.fromPersistedContent(scKey,speciesContext.getName(),species,structure);
 	speciesContext.setSpeciesPatternString(speciesPatternString);
 	try {
 		speciesContext.setSbmlName(sbmlNameString);

--- a/vcell-server/src/main/java/cbit/vcell/modeldb/SpeciesContextModelTable.java
+++ b/vcell-server/src/main/java/cbit/vcell/modeldb/SpeciesContextModelTable.java
@@ -72,7 +72,7 @@ public SpeciesContext getSpeciesContext(java.sql.ResultSet rset, KeyValue keyVal
 		}
 		SpeciesContext speciesContext = null;
 		try {
-			speciesContext = new SpeciesContext(keyValue,nameStr,null,null);
+			speciesContext = SpeciesContext.fromPersistedContent(keyValue,nameStr,null,null);
 			
 			String sbmlNameStr = rset.getString(sbmlName.toString());
 			if(!rset.wasNull()) {

--- a/vcell-util/src/main/java/org/vcell/util/TokenMangler.java
+++ b/vcell-util/src/main/java/org/vcell/util/TokenMangler.java
@@ -20,6 +20,63 @@ import java.beans.PropertyVetoException;
  * This type was created in VisualAge.
  */
 public class TokenMangler {
+
+/**
+ * The characters an identifier may be built from, as defined by the expression grammar in
+ * vcell-math/src/main/java/cbit/vcell/parser/Parser.jjt:
+ * <pre>
+ *   &lt;#ID:     &lt;LETTER&gt; (&lt;LETTER&gt;|&lt;DIGIT&gt;)* &gt;
+ *   &lt;#LETTER: ["a"-"z", "_", "A"-"Z"] &gt;
+ *   &lt;#DIGIT:  ["0"-"9"] &gt;
+ * </pre>
+ * Deliberately ASCII-only, and therefore <b>narrower</b> than
+ * {@link Character#isJavaIdentifierPart(char)}, which accepts any Unicode letter. Validating
+ * names with the Java predicates let names such as PROTE&Iacute;NA_A be accepted at entry and
+ * then fail to parse during math generation, leaving the application with no generated math
+ * (issue #2062). Any name that has to survive a round trip through cbit.vcell.parser.Expression
+ * must be checked here rather than with Character.isJavaIdentifier*.
+ */
+private static boolean isIdentifierStart(char c) {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+}
+
+private static boolean isIdentifierPart(char c) {
+	return isIdentifierStart(c) || (c >= '0' && c <= '9');
+}
+
+/**
+ * @return true if name is a legal expression identifier: non-empty, starting with an ASCII
+ * letter or '_', and otherwise containing only ASCII letters, digits and '_'.
+ */
+public static boolean isValidExpressionIdentifier(String name) {
+	return name != null && name.length() > 0 && indexOfFirstIllegalIdentifierChar(name) < 0;
+}
+
+/**
+ * @return the index of the first character of name that may not appear at that position in an
+ * expression identifier, or -1 if name is a legal identifier. A digit is legal everywhere except
+ * at index 0, so the position matters and not just the character. Used to tell the user which
+ * character to remove.
+ */
+public static int indexOfFirstIllegalIdentifierChar(String name) {
+	if (name == null || name.length() == 0){
+		return -1;
+	}
+	if (!isIdentifierStart(name.charAt(0))){
+		return 0;
+	}
+	for (int i = 1; i < name.length(); i++){
+		if (!isIdentifierPart(name.charAt(i))){
+			return i;
+		}
+	}
+	return -1;
+}
+
+/** Human-readable statement of the identifier rule, for veto and validation messages. */
+public static final String IDENTIFIER_RULE_DESCRIPTION =
+	"it may contain only the letters a-z and A-Z, the digits 0-9 and '_', and may not start with a digit";
+
 	/**
  * This method was created in VisualAge.
  * @return java.lang.String
@@ -33,11 +90,14 @@ public static String fixToken(String name) {
 		return "";
 	}
 	StringBuilder newString = new StringBuilder(string);
-	if (Character.isJavaIdentifierStart(newString.charAt(0))==false){
+	// ASCII-only, to match the expression grammar. Character.isJavaIdentifier* would let
+	// accented and other non-ASCII letters through unmangled, yielding a token that does not
+	// parse - see isValidExpressionIdentifier.
+	if (isIdentifierStart(newString.charAt(0))==false){
 		newString.insert(0,'_');
 	}
 	for (int i=1;i<newString.length();i++){
-		if (Character.isJavaIdentifierPart(newString.charAt(i))==false){
+		if (isIdentifierPart(newString.charAt(i))==false){
 			newString.setCharAt(i,'_');
 		}
 	}
@@ -68,12 +128,13 @@ public static String fixTokenStrict(String name, int maxLength) {
 	}
 	StringBuilder newString = new StringBuilder(string);
 	char charAt0 = newString.charAt(0);
-	if (!Character.isLetter(charAt0) && charAt0 != '_'){
+	// ASCII-only - see the note in fixToken(String).
+	if (!isIdentifierStart(charAt0)){
 		newString.insert(0,'_');
 	}
 	for (int i=1;i<newString.length();i++){
 		char charAtI = newString.charAt(i);
-		if (!Character.isLetterOrDigit(charAtI) && charAtI != '_'){
+		if (!isIdentifierPart(charAtI)){
 			newString.setCharAt(i,'_');
 		}
 	}


### PR DESCRIPTION
Fixes #2062.

## What was wrong

Name validation and the expression grammar disagreed on what an identifier is:

- validation used `Character.isJavaIdentifierStart/Part`, which accept **any Unicode letter**
- `Parser.jjt` defines `#LETTER` as `["a"-"z", "_", "A"-"Z"]` — **ASCII only**

So a species named `PROTEÍNA_A` was accepted, saved, and then failed math generation with
`Parse Error while parsing expression 'PROTEÍNA_A'` → *"Application has no generated Math"*.
The error names an expression, so nothing pointed at the species. Three Contact-Us crash
reports from one Spanish-language model.

## The root cause is narrower than the issue says

`Model.validateNamingConflicts` **already** required a legal identifier and already produced a
good message with a suggested replacement:

```java
if(!newSymbolName.equals(TokenMangler.fixTokenStrict(newSymbolName))){
    throw new ModelPropertyVetoException(... " not legal identifier, try '" + ... + "'.", e);
}
```

The guard was correct in shape. It never fired because `fixTokenStrict` used
`Character.isLetterOrDigit`, so it considered `Í` a letter and returned the name unchanged. The
manglers that exist precisely to turn external names into legal identifiers were passing
non-ASCII letters straight through.

I've updated the issue with this correction.

## The fix

1. **`TokenMangler`** gains one definition of the rule — `isValidExpressionIdentifier` /
   `indexOfFirstIllegalIdentifierChar` — and `fixToken` / `fixTokenStrict` now use it.
   Behaviour is unchanged for any name that is already ASCII, i.e. every name these manglers
   previously handled correctly.
2. **`Model.validateNamingConflicts`** asks that predicate directly, so the existing guard now
   works for every model symbol, not just species contexts. **This is what actually fixes the
   reported bug.**
3. **`SpeciesContext.vetoableChange`** gets the same rule, and its message now states what a
   name may contain instead of only naming the offending character.

## Keeping already-saved models openable

Models saved with such a name are unrunnable today, but they *do* open — and opening them is
the user's only way to rename the species. Enforcing the rule on the read path would have taken
that away, turning "opens but won't run" into "won't open", which is worse than the bug.

Reads from VCML and from the database therefore go through
`SpeciesContext.fromPersistedContent` / `Model.setRestoringFromPersistedContent`, which relax
the *lexicon* check for the duration of the read only — naming conflicts are still checked. The
illegal name is then reported by `SpeciesContext.gatherIssues` as an error the user can act on.

I found this the right way: the round-trip test failed, which is also how I found the
`Model`-level guard I'd missed on the first pass.

## Tests

New `SpeciesContextNameTest` (10 tests, `Fast`). The central one asserts the rule and the parser
agree **by actually parsing** — every accepted name must parse as a single identifier equal to
itself, every rejected name must not — so tightening or loosening either side alone fails here.
That is the check whose absence let the two drift apart.

It also covers the real round trip (a VCML holding an unreadable name still loads, keeps the
name, and is reported as an error issue) and records one thing worth knowing: `.` is the single
character the grammar accepts inside an `IDENTIFIER` — as a name-scope qualifier,
`(<ID> ".")* <ID>` — that a name still may not contain.

## Verification

- `SpeciesContextNameTest` — 10/10
- `vcell-core` Fast — 606 tests, 1 error, and that one is the documented Poetry/`VCellDataTest`
  environmental failure, present before this change
- `vcell-util` Fast 42/42 · `vcell-math` Fast 6545/6545 · `vcell-client` Fast 31/31
- full `mvn compile test-compile` across all modules — clean

`vcell-server` Fast was still running locally when I stopped it; every class it had reported was
green. Worth watching the SBML/SEDML regression suites in the merge queue, since re-arming the
mangler could change how an imported model with non-ASCII names is renamed on import — that is
the intended behaviour, but it is the one place the blast radius extends past the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx