### PR TITLE
fix: register the time-series progress listener before the blocking call

### DIFF
--- a/vcell-client/src/main/java/cbit/vcell/client/data/PDEDataViewer.java
+++ b/vcell-client/src/main/java/cbit/vcell/client/data/PDEDataViewer.java
@@ -272,10 +272,14 @@ public class PDEDataViewer extends DataViewer implements DataJobListenerHolder {
 			DataJobListener djl = null;
 			try {
 				TimeSeriesJobSpec timeSeriesJobSpec = (TimeSeriesJobSpec)hashTable.get(StringKey_timeSeriesJobSpec);
-				TimeSeriesJobResults timeSeriesJobResults = myPDEDataContext.getTimeSeriesValues(timeSeriesJobSpec);
-				hashTable.put(StringKey_timeSeriesJobResults, timeSeriesJobResults);
+				// Register before the call, not after: getTimeSeriesValues() blocks, and the server
+				// fires the DATA_PROGRESS events for this job while it runs. Registering afterwards
+				// (as this did once getTimeSeriesValues became a blocking rpc) meant the progress
+				// was computed, sent and then dropped, and the dialog never advanced.
 				djl = new TimeSeriesDataJobListener(timeSeriesJobSpec.getVcDataJobID(), hashTable, getClientTaskStatusSupport());
 				dataJobListenerHolder.addDataJobListener(djl);
+				TimeSeriesJobResults timeSeriesJobResults = myPDEDataContext.getTimeSeriesValues(timeSeriesJobSpec);
+				hashTable.put(StringKey_timeSeriesJobResults, timeSeriesJobResults);
 //				while (true) {
 //					Throwable timeSeriesJobFailed = (Throwable)hashTable.get(StringKey_timeSeriesJobException);
 //					if (timeSeriesJobFailed != null) {

--- a/vcell-client/src/test/java/cbit/vcell/client/data/TimeSeriesDataRetrievalTaskTest.java
+++ b/vcell-client/src/test/java/cbit/vcell/client/data/TimeSeriesDataRetrievalTaskTest.java
@@ -23,6 +23,7 @@ import org.vcell.util.UserCancelException;
 
 import java.util.Hashtable;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -103,6 +104,32 @@ public class TimeSeriesDataRetrievalTaskTest {
 				.run(newHash()));
 		assertTrue(holder.added <= holder.removed + 1,
 			"a listener added before the failure must be removed again");
+	}
+
+	/**
+	 * The server fires DATA_PROGRESS for this job while getTimeSeriesValues() blocks, so the
+	 * listener has to be registered before the call. It was registered after it for years - ever
+	 * since getTimeSeriesValues became a blocking rpc in 1c16cce - so the progress was computed,
+	 * serialised, sent and then dropped, and the task dialog never advanced.
+	 */
+	@Test
+	public void theProgressListenerIsRegisteredBeforeTheBlockingCall() throws Exception {
+		RecordingHolder holder = new RecordingHolder();
+		boolean[] wasRegisteredWhenTheCallRan = new boolean[1];
+		PDEDataContext context = new StubPDEDataContext() {
+			@Override
+			public TimeSeriesJobResults getTimeSeriesValues(TimeSeriesJobSpec spec) {
+				wasRegisteredWhenTheCallRan[0] = holder.added > 0;
+				return new TSJobResultsNoStats(
+					new String[]{"s0"}, new int[][]{{0}}, new double[]{0.0}, new double[][][]{{{0.0}}});
+			}
+		};
+
+		new PDEDataViewer.TimeSeriesDataRetrievalTask("t", holder, context).run(newHash());
+
+		assertTrue(wasRegisteredWhenTheCallRan[0],
+			"progress events fired during the call are dropped unless the listener is already registered");
+		assertEquals(holder.added, holder.removed, "the listener must be removed again");
 	}
 
 	private static Hashtable<String, Object> newHash() {


### PR DESCRIPTION
Follow-up to #2063, from looking into the commented-out handlers in `TimeSeriesDataJobListener`.

## The commented-out code is fine — leave it

`1c16cce796` (2018-03-27, *"simplify DataJobEvent:complete, getTimeSeriesValues() rpc blocks"*)
deliberately removed the results and the exception from `DataJobEvent`: *"the COMPLETE and FAILURE
events no longer hold the results and the exception (instead managed by the invoking process of
the rpc call)"*. `DataJobEvent` today carries only `eventType`, `progress`, `dataKey`,
`dataIdString`, `vcDataJobID` — there is nothing left for those two handlers to write, and
restoring them would not compile. **No change here.**

## But that commit left the registration in the wrong place

It made `getTimeSeriesValues()` blocking and disabled the polling loop, without moving the
listener registration:

```java
TimeSeriesJobResults results = myPDEDataContext.getTimeSeriesValues(spec);  // blocks
hashTable.put(StringKey_timeSeriesJobResults, results);
djl = new TimeSeriesDataJobListener(...);        // registered only AFTER the work is done
dataJobListenerHolder.addDataJobListener(djl);   // ...and removed in finally
```

So the one handler still live — `DATA_PROGRESS` — could never fire:

- `DataSetControllerImpl` fires `DATA_PROGRESS` from **five** sites during the computation, with a real percentage
- gated on `vcDataJobID.isBackgroundTask()`, which these jobs always are — the callers assert it
- the only `TimeSeriesDataJobListener` construction in the codebase is that line, after the rpc
- the delivery path is live: `PDEDataViewer.dataJobMessage` fans out to `dataJobListenerList`

The progress was computed server-side, serialised, shipped to the client and dropped on arrival.
The user got a task dialog that never advanced during exactly the long retrievals #2063 was
about — that reporter was pulling a time plot from a still-running simulation.

## The fix

Move the two lines above the call. The existing `finally` already removes the listener, and the
listener only touches `ClientTaskStatusSupport` (its `hashTable` field is dead now), so there is
nothing else to reorder and no new threading concern.

## Tests

One test added to `TimeSeriesDataRetrievalTaskTest`: the stub context records whether the
listener was registered at the moment the retrieval ran. Checked against the old ordering — it
fails there and passes here, so it pins the ordering rather than just passing.

`vcell-client` Fast: 37 tests, 0 failures, 0 errors.

## Deliberately not included

That 2018 commit named *"remove the .isBackgroundTask mode"* as the next step, and it is the
switch gating these events. That is a larger change and a design call, so it is untouched here,
as are the stale commented block and the now-unused `hashTable` field on the listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx