### PR TITLE
docs(release): 8.1.6.01 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,74 @@ followed by flat Keep-a-Changelog categories. API consumers should scan
 
 _(Release-manager scratchpad. Populated at release-cut time.)_
 
+## [8.1.6.01] - 2026-09-07
+
+**Highlights.** SpringSaLaD has user documentation for the first time. VCell
+has been able to build and run SpringSaLaD models for over a year — a
+particle-based application, the Langevin solver, a molecular structure editor
+and a 3D trajectory viewer — with nothing in the help explaining any of it.
+Six help pages now cover it, including two errors that are hard to get past
+without knowing what they mean. Alongside that, three fixes to things that
+told you the wrong story: a progress bar that never moved, an error that named
+the wrong cause, and a species name VCell accepted and then could not read.
+
+### Added
+- SpringSaLaD user documentation — six pages in the help, reachable from
+  Rule-Based Features and from Specifications. They cover the modelling
+  framework, creating a SpringSaLaD application and the geometry it builds for
+  you, laying out a molecule's sites and the springs between them, the five
+  reaction subtypes, reading results and the 3D trajectory viewer, and `.ssld`
+  import and export. Two explanations are worth knowing about in advance,
+  because both are errors you meet before you meet the concept: what *"the
+  forward rate Kf is too large"* means and what to do about it, and the fact
+  that a transition condition changes name between SpringSaLaD and VCell —
+  SpringSaLaD's "None" is VCell's **Any**, and its "Free" is VCell's
+  **Unbound**. (#2073, #2060)
+
+### Fixed
+- The progress dialog now advances while a time course is retrieved from a
+  spatial simulation. The server was computing the progress and sending it, and
+  the client was dropping it: the listener that receives those events was
+  registered after the call that waits for them, not before. The dialog had sat
+  at zero ever since that call became a blocking one. (#2066)
+- A failure retrieving time-series data now reports what actually went wrong.
+  The failure was recorded and the task chain carried on, so the next step ran
+  against a result that was never produced and the error you saw was an
+  unrelated `NullPointerException` in a plotting step — with the real cause
+  gone. Cancelling the retrieval did the same thing. (#2065, #2063)
+- A SpringSaLaD site's Y or Z position can be set to a value equal to its X.
+  All three coordinate fields compared against X, so an edit to Y or Z was
+  silently discarded whenever the two happened to match — no error, no change,
+  the old value still in the cell. Sites are routinely laid out along an axis
+  with x = 0, which made "put this site at z = 0" impossible. (#2073)
+
+### Changed
+- A species name must be one the expression parser can read. Name checking
+  accepted any Unicode letter while the parser accepts only `a-z`, `A-Z` and
+  `_`, so a name such as `PROTEÍNA_A` was accepted and saved, and the
+  application then failed to generate math with an error naming an expression
+  and nothing pointing at the species. The check now uses one definition of a
+  legal identifier, shared with the grammar, and suggests a replacement name.
+  **Models already saved with such a name still open** — refusing them would
+  take away the only way to rename the species — and report the offending name
+  as a problem instead. (#2064, #2062)
+- Internal: all ten outdated tutorial documents on vcell.org, and the
+  standalone SpringSaLaD guide, are now reproduced as scripts that drive a real
+  client, so it is visible when a documented workflow stops working. Six
+  documentation findings were filed from them. (#2067, #2073, #2069)
+- Internal: UI interactions can be recorded as replayable scripts, for demos
+  and for scaffolding help pages. (#2059)
+- Internal: CI decides whether to run the test lanes by looking at everything a
+  branch changed, rather than only its most recent commit — which had let a
+  branch skip lanes its earlier commits needed. (#2061)
+
+### Notes for API consumers
+No API changes. One behaviour change worth noting for anything that creates
+model symbols programmatically: a name containing non-ASCII letters is now
+rejected at creation with a `ModelPropertyVetoException` naming a legal
+replacement, where it was previously accepted and failed later during math
+generation. Reading such a name back from VCML or the database still succeeds.
+
 ## [8.1.5.01] - 2026-09-03
 
 **Highlights.** Saving a model no longer fails because the connection to the

--- a/release-notes/major/8.1.md
+++ b/release-notes/major/8.1.md
@@ -66,6 +66,38 @@ solver exited (code=124)", which describes a crash, when in fact the
 run was healthy and had simply used the time it was given — a
 distinction that cost one user four days of waiting to discover.
 
+### SpringSaLaD documentation (8.1.6.01)
+
+SpringSaLaD Applications have user documentation for the first time.
+VCell has been able to build and run these models for over a year — the
+application itself, the Langevin solver, the molecular structure editor
+and the 3D trajectory viewer — with nothing in the help explaining any
+of it.
+
+Six pages now cover the modelling framework, creating a SpringSaLaD
+application and the geometry it builds for you, laying out a molecule's
+sites and the springs between them, the five reaction subtypes, reading
+results and the trajectory viewer, and `.ssld` import and export. They
+are in the in-app help under **Rule-Based Features** and under
+**Specifications**.
+
+Two of the explanations are there because they are errors you meet
+before you meet the concept:
+
+- **"The forward rate Kf is too large."** The rate you write down is the
+  one you would measure, and it already contains two steps in series:
+  the molecules finding each other, and reacting once they have
+  collided. That means it can never be faster than diffusion alone
+  allows. The solver needs the second part on its own, because it
+  simulates the collisions rather than assuming them — and if your rate
+  exceeds the diffusion limit, no such value exists. Raise the diffusion
+  rates or radii of the sites involved, or lower the rate.
+- **A transition condition changes name.** If you are coming from the
+  standalone SpringSaLaD program, note that its "None" — meaning no
+  condition — is VCell's **Any**, and its "Free" — meaning the site must
+  be unbound — is VCell's **Unbound**. Only "Bound" is called the same
+  thing in both.
+
 ### Browser-based 3D field viewer — experimental (8.0.9.01)
 
 An experimental viewer for spatial simulation results in the browser,
@@ -253,6 +285,28 @@ _(Per-build detail is in `CHANGELOG.md`.)_
   outright, though nothing was wrong with the model or the server. If you saw this,
   check whether the model was in fact saved before saving again — the server may have
   completed it and only the reply was lost (8.1.5.01).
+
+- The progress bar now moves while a time course is being retrieved from a spatial
+  simulation. The server was working out the progress and sending it, and the client was
+  throwing it away, so the dialog sat at zero however long the retrieval took
+  (8.1.6.01).
+
+- When retrieving time-series data fails, or you cancel it, VCell now tells you what
+  actually happened. The failure used to be swallowed and the next step run anyway, so
+  what you saw was an unrelated internal error from a plotting step and the real cause
+  was gone (8.1.6.01).
+
+- A species can no longer be given a name that VCell cannot then read. Names containing
+  accented or non-Latin letters — `PROTEÍNA_A`, for instance — were accepted and saved,
+  and the application then refused to generate math, with an error that named an
+  expression and nothing that pointed at the species. Such names are now rejected as you
+  type them, with a legal replacement suggested. **Models already saved with one still
+  open**, and report the name as a problem so you can change it (8.1.6.01).
+
+- A SpringSaLaD site's Y or Z position can be set to a value equal to its X. Whenever the
+  two matched, the edit was discarded with no error and the old value left in place —
+  which made it impossible to place a site at z = 0 on a molecule laid out along an axis
+  at x = 0, a very ordinary arrangement (8.1.6.01).
 
 ## API and integration changes
 


### PR DESCRIPTION
Release-cut docs for **8.1.6.01**, per `docs/RELEASING.md` — landed before tagging so the
tag points at a self-describing tree.

Covers everything on master since `8.1.5.01`: #2059, #2061, #2064, #2065, #2066, #2067,
#2073.

**Highlight:** SpringSaLaD user documentation, which did not exist. Six help pages,
including explanations of the two errors a modeller meets before they meet the concept —
"the forward rate Kf is too large", and the transition condition that is called something
different in VCell than in the standalone program.

**Three fixes, grouped because they share a shape** — each reported something other than
what happened: a progress dialog that sat at zero while progress was being computed and
sent (#2066); a failed or cancelled time-series retrieval that surfaced as an unrelated
`NullPointerException` in a plotting step (#2065); and a species named `PROTEÍNA_A` that
was accepted, saved, and then failed math generation with an error naming an expression and
nothing pointing at the species (#2064).

That last one is under **Changed**, not Fixed, and the "Notes for API consumers" section
says why: a name that used to be accepted is now rejected at creation. Models already saved
with one still open — refusing them would take away the only way to rename the species —
and report the name as a problem instead.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HAnpFxkzf9LmxBayDSANf