### PR TITLE
fix(docker): move the admin and clientgen images off Debian bullseye

### DIFF
--- a/docker/build/Dockerfile-admin-dev
+++ b/docker/build/Dockerfile-admin-dev
@@ -10,7 +10,7 @@ RUN $JAVA_HOME/bin/jlink \
          --output /javaruntime
 
 # Define base image and copy in jlink created minimal Java 17 environment
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME

--- a/docker/build/Dockerfile-clientgen-dev
+++ b/docker/build/Dockerfile-clientgen-dev
@@ -10,7 +10,7 @@ RUN $JAVA_HOME/bin/jlink \
          --output /javaruntime
 
 # Define base image and copy in jlink created minimal Java 17 environment
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME


### PR DESCRIPTION
**The admin and clientgen images cannot currently be built at all.** Both are
`FROM debian:bullseye-slim`:

```
E: Release file for .../debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 3min 16s). Updates for this repository will not be applied.
```

Debian 11 LTS ended **2026-08-31**. Its final security `Release` file was published that
day with `Valid-Until: Mon, 07 Sep 2026 21:13:04 UTC`, and apt refuses an expired Release
file rather than silently using stale indices.

## It went permanent mid-release, which is why it read as transient at first

That deadline passed **during the 8.1.6.01 release**, and the two failures either side of
it look like different bugs:

| time (UTC) | what failed | how it reads |
|---|---|---|
| 21:10 | `404 Not Found` fetching `libexpat1_2.2.10-2+deb11u7` | mirror churn — the transient we have seen before |
| 21:13:04 | — | `bullseye-security` Release expires |
| 21:16 | `Release file ... is expired` | permanent |

I reran the first one as a transient. The rerun is what showed the real cause.

`clientgen` is green in that run **only because it built before 21:13**. It is the
release-critical image — the desktop installers come out of it — so leaving this would
have turned the next release into the same stall with no warning.

## Why bookworm rather than disabling the check

`-o Acquire::Check-Valid-Until=false` would build, and would keep building against a
security suite that is frozen and will never receive another update. A base-image bump is
the smaller thing to ship. `bookworm-security` was refreshed today
(`Valid-Until: Mon, 14 Sep 2026`), and `pythonCopasiOpt` already builds on bookworm.

## Verified locally, both directions

On `linux/amd64`, with each image's exact apt lines:

- **`bullseye-slim` reproduces the failure** — *"invalid since 5min 48s"*. Negative
  control, so this is the cause rather than a plausible story about it.
- **`bookworm-slim` builds both clean**, including clientgen's install4j download.

No package names changed; every package these two install exists in bookworm.

## After this lands

`8.1.6.01` is tagged and released, but its `admin` image can never be built, so that
build number is not deployable. The follow-up is a **`8.1.6.02`** build of the same
content — BUILD bump, per `docs/RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HAnpFxkzf9LmxBayDSANf