### PR TITLE
Skip pathwayDownloadTest when Reactome answers 200 with an error body

### DIFF
--- a/vcell-core/src/test/java/cbit/vcell/pathway/PathwaySearchTest.java
+++ b/vcell-core/src/test/java/cbit/vcell/pathway/PathwaySearchTest.java
@@ -176,9 +176,7 @@ public class PathwaySearchTest {
 
         String ERROR_CODE_TAG = "error_code";
         String contentString = downloadOrSkip(url, "Reactome");      // download, or skip if Reactome is down
-
-        // assert response is XML
-        assertTrue(contentString.trim().startsWith("<?xml"), "Response does not start with XML declaration");
+        assumeXmlOrSkip(contentString, "Reactome");                  // a 200 from here can still carry their error text
 
         // parse XML
         org.jdom2.Document jdomDocument = XmlUtil.stringToXML(contentString, null);
@@ -475,6 +473,28 @@ public class PathwaySearchTest {
                 new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
             return r.lines().collect(Collectors.joining("\n"));
         }
+    }
+
+    /**
+     * Skips when a service answered HTTP 200 with something that is not XML.
+     *
+     * <p>Needed because Reactome's legacy BioPAX exporter reports its own failures with
+     * HTTP 200 and a plain-text body — as of 2026-09-11 every pathway id returns
+     * {@code "Error in biopax exporter: No operations allowed after connection closed."},
+     * a fault in their backend. The status line therefore cannot tell an outage from a
+     * good response the way {@link #statusOrSkip} assumes, so the body has to: at this
+     * endpoint anything that is not XML is their failure, because a request of ours that
+     * was wrong would come back 404 and still fail the test.
+     */
+    private static void assumeXmlOrSkip(String body, String serviceName) {
+        String trimmed = body.trim();
+        if (trimmed.startsWith("<?xml")) {
+            return;
+        }
+        String excerpt = trimmed.substring(0, Math.min(200, trimmed.length()));
+        lg.warn(serviceName + " answered HTTP 200 with a non-XML body: " + excerpt);
+        Assumptions.abort(serviceName + " returned HTTP 200 with a non-XML body — remote service"
+                + " outage, skipping test. Response began: " + excerpt);
     }
 
     // isDatabaseAvailable(String) was removed deliberately. It probed a URL the test did


### PR DESCRIPTION
## What is failing

`PathwaySearchTest.pathwayDownloadTest` fails on every branch right now, including
[#2080's run](https://github.com/virtualcell/vcell/actions/runs/34639636102/job/103396081339), which does not touch pathway code:

```
PathwaySearchTest.pathwayDownloadTest:83->pathwayDownload:181
  Response does not start with XML declaration ==> expected: <true> but was: <false>
```

## Why

Reactome's legacy BioPAX exporter is broken on their side — every pathway id, Level2 and Level3:

```
$ curl -i https://reactome.org/ReactomeRESTfulAPI/RESTfulWS/biopaxExporter/Level2/5683177
HTTP/2 200
content-type: text/plain;charset=UTF-8

Error in biopax exporter: No operations allowed after connection closed.
```

That is a dead database connection in their backend, reported as **200 instead of 5xx**, so the
outage-skip contract from 2c7def7734 / b44f4c0660 cannot see it: `statusOrSkip` passes the status
through and the content assertion on the next line fails the build. Master was last green on
2026-09-08, so this broke sometime after that.

The test carries the `Fast` tag, so it is in the required `CI-Test-group-Fast` check — while
Reactome stays in this state, no PR in the repo can merge without an admin override.

## The change

The body decides what the status line cannot: at this endpoint a response that is not XML is
their failure, because a request of *ours* that was wrong comes back 404 and still fails.
Nothing else is relaxed — the parse, `xml:base`, namespace, `owl:imports` and `bp:pathway`
assertions are untouched.

## Verification

Against a local server through the real helpers, using the checked-in
`insulinPathway-5683177.xml` fixture as the good response:

| response | result |
|---|---|
| 200 + BioPAX XML | **passes** all assertions |
| 200 + the plain-text error | **skipped** |
| 404 | **fails** (`Unexpected HTTP status`) |
| 200 + well-formed but wrong XML | **fails** (`Missing xml:base`) |

Against the live services the class now reports 3 run, 2 skipped, 0 failures — PathwayCommons
`/pc2/search` is also timing out today, which the existing guard already handled.

## Separately worth knowing

The same broken endpoint backs the desktop client's Reactome import
(`vcell-client/src/main/java/cbit/vcell/client/desktop/biomodel/BioModelEditorPathwayCommonsPanel.java:386`),
so that feature is currently broken for users. Reactome's newer ContentService has no drop-in
BioPAX replacement (`/ContentService/exporter/event/{id}.biopax2` → 404), so this needs its own
decision; this PR only stops a third party's outage from failing our build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D71LBYmQNf5J94wPqr81Jx